### PR TITLE
feat: LAN Bridge 局域网远程连接 + 移动端 Web 前端

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,49 @@
+name: Build Windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to build'
+        required: true
+        default: 'feat/lan-bridge-mobile'
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows-x64:
+    name: Build Windows x64
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build Electron app
+        run: bun run electron:build
+
+      - name: Package (Windows)
+        run: npx electron-builder --win --x64 --publish never
+        working-directory: apps/electron
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Proma-win-x64
+          path: apps/electron/out/*.exe

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -134,6 +134,10 @@ registerBridge({
   stop: () => wechatBridge.stop(),
 })
 
+// LAN Bridge 在注册时内部动态导入 agentEventBus，避免循环依赖
+import { lanBridgeRegistration } from './lib/lan-bridge/lan-bridge'
+registerBridge(lanBridgeRegistration)
+
 let mainWindow: BrowserWindow | null = null
 
 /** 获取主窗口实例（供其他模块使用） */

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { join, resolve, sep, dirname } from 'node:path'
 import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, isPromaPermissionMode } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, LAN_BRIDGE_IPC_CHANNELS, isPromaPermissionMode } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
@@ -3550,4 +3550,20 @@ export function registerIpcHandlers(): void {
       return win && !win.isDestroyed() ? win.isMaximized() : false
     }
   )
+
+  // ===== LAN Bridge IPC Handlers =====
+
+  const { getLanBridgeStatus, startLanBridge, stopLanBridge, getConfig: getLanBridgeConfig, updateConfig: updateLanBridgeConfig } = require('./lib/lan-bridge/lan-bridge')
+  const { getCurrentPin, refreshPin } = require('./lib/lan-bridge/lan-bridge-auth')
+
+  ipcMain.handle(LAN_BRIDGE_IPC_CHANNELS.GET_CONFIG, async () => getLanBridgeConfig())
+  ipcMain.handle(LAN_BRIDGE_IPC_CHANNELS.UPDATE_CONFIG, async (_event, updates) => updateLanBridgeConfig(updates))
+  ipcMain.handle(LAN_BRIDGE_IPC_CHANNELS.GET_STATUS, async () => getLanBridgeStatus())
+  ipcMain.handle(LAN_BRIDGE_IPC_CHANNELS.START, async () => {
+    const { agentEventBus } = require('./lib/agent-service') as { agentEventBus: import('./lib/agent-event-bus').AgentEventBus }
+    await startLanBridge(agentEventBus)
+  })
+  ipcMain.handle(LAN_BRIDGE_IPC_CHANNELS.STOP, async () => stopLanBridge())
+  ipcMain.handle(LAN_BRIDGE_IPC_CHANNELS.GET_PIN, async () => getCurrentPin())
+  ipcMain.handle(LAN_BRIDGE_IPC_CHANNELS.REFRESH_PIN, async () => refreshPin())
 }

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -180,6 +180,13 @@ function filterHistory(
 
 // ===== 核心流式函数 =====
 
+export type ChatStreamEvent =
+  | { type: 'chunk'; conversationId: string; delta?: string }
+  | { type: 'reasoning'; conversationId: string; delta?: string }
+  | { type: 'tool_activity'; conversationId: string; activity: ChatToolActivity }
+  | { type: 'error'; conversationId: string; error: string }
+  | { type: 'complete'; conversationId: string; model: string; messageId?: string }
+
 /**
  * 发送消息并流式返回 AI 响应
  *
@@ -188,10 +195,12 @@ function filterHistory(
  *
  * @param input 发送参数
  * @param webContents 渲染进程的 webContents 实例（用于推送事件）
+ * @param onEvent 可选的事件回调（LAN Bridge 等 non-webContents 场景使用）
  */
 export async function sendMessage(
   input: ChatSendInput,
-  webContents: WebContents,
+  webContents: WebContents | null,
+  onEvent?: (event: ChatStreamEvent) => void,
 ): Promise<void> {
   const {
     conversationId, userMessage, channelId,
@@ -199,11 +208,25 @@ export async function sendMessage(
     thinkingEnabled, enabledToolIds,
   } = input
 
+  const emit = onEvent
+    ? (ch: string, data: object) => {
+        const mapping: Record<string, ChatStreamEvent> = {
+          [CHAT_IPC_CHANNELS.STREAM_CHUNK]: { type: 'chunk', conversationId, delta: (data as any).delta },
+          [CHAT_IPC_CHANNELS.STREAM_REASONING]: { type: 'reasoning', conversationId, delta: (data as any).delta },
+          [CHAT_IPC_CHANNELS.STREAM_ERROR]: { type: 'error', conversationId, error: (data as any).error },
+          [CHAT_IPC_CHANNELS.STREAM_COMPLETE]: { type: 'complete', conversationId, model: modelId, messageId: (data as any).messageId },
+          [CHAT_IPC_CHANNELS.STREAM_TOOL_ACTIVITY]: { type: 'tool_activity', conversationId, activity: (data as any).activity },
+        }
+        const event = mapping[ch]
+        if (event) onEvent(event)
+      }
+    : (ch: string, data: object) => { webContents!.send(ch, data) }
+
   // 1. 查找渠道
   const channels = listChannels()
   const channel = channels.find((c) => c.id === channelId)
   if (!channel) {
-    webContents.send(CHAT_IPC_CHANNELS.STREAM_ERROR, {
+    emit(CHAT_IPC_CHANNELS.STREAM_ERROR, {
       conversationId,
       error: '渠道不存在',
     })
@@ -215,7 +238,7 @@ export async function sendMessage(
   try {
     apiKey = decryptApiKey(channelId)
   } catch {
-    webContents.send(CHAT_IPC_CHANNELS.STREAM_ERROR, {
+    emit(CHAT_IPC_CHANNELS.STREAM_ERROR, {
       conversationId,
       error: '解密 API Key 失败',
     })
@@ -278,14 +301,14 @@ export async function sendMessage(
       switch (event.type) {
         case 'chunk':
           accumulatedContent += event.delta ?? ''
-          webContents.send(CHAT_IPC_CHANNELS.STREAM_CHUNK, {
+          emit(CHAT_IPC_CHANNELS.STREAM_CHUNK, {
             conversationId,
             delta: event.delta,
           })
           break
         case 'reasoning':
           accumulatedReasoning += event.delta ?? ''
-          webContents.send(CHAT_IPC_CHANNELS.STREAM_REASONING, {
+          emit(CHAT_IPC_CHANNELS.STREAM_REASONING, {
             conversationId,
             delta: event.delta,
           })
@@ -296,7 +319,7 @@ export async function sendMessage(
             toolName: event.toolName!,
             type: 'start',
           })
-          webContents.send(CHAT_IPC_CHANNELS.STREAM_TOOL_ACTIVITY, {
+          emit(CHAT_IPC_CHANNELS.STREAM_TOOL_ACTIVITY, {
             conversationId,
             activity: { type: 'start', toolName: event.toolName!, toolCallId: event.toolCallId! },
           })
@@ -341,7 +364,7 @@ export async function sendMessage(
       const lastUserMsg = fullHistory.filter((m) => m.role === 'user').at(-1)
       const lastAssistantMsg = fullHistory.filter((m) => m.role === 'assistant').at(-1)
       const toolResults = await executeToolCalls(toolCalls, {
-        webContents,
+        webContents: webContents as WebContents,
         conversationId,
         currentAttachments: attachments,
         previousUserAttachments: lastUserMsg?.attachments,
@@ -433,7 +456,7 @@ export async function sendMessage(
       console.warn(`[聊天服务] 模型返回空内容且无生成附件，跳过保存 (对话 ${conversationId})`)
     }
 
-    webContents.send(CHAT_IPC_CHANNELS.STREAM_COMPLETE, {
+    emit(CHAT_IPC_CHANNELS.STREAM_COMPLETE, {
       conversationId,
       model: modelId,
       messageId: (accumulatedContent.trim() || accumulatedGeneratedAttachments.length > 0) ? assistantMsgId : undefined,
@@ -464,13 +487,13 @@ export async function sendMessage(
           // 索引更新失败不影响主流程
         }
 
-        webContents.send(CHAT_IPC_CHANNELS.STREAM_COMPLETE, {
+        emit(CHAT_IPC_CHANNELS.STREAM_COMPLETE, {
           conversationId,
           model: modelId,
           messageId: assistantMsgId,
         })
       } else {
-        webContents.send(CHAT_IPC_CHANNELS.STREAM_COMPLETE, {
+        emit(CHAT_IPC_CHANNELS.STREAM_COMPLETE, {
           conversationId,
           model: modelId,
         })
@@ -504,7 +527,7 @@ export async function sendMessage(
       }
     }
 
-    webContents.send(CHAT_IPC_CHANNELS.STREAM_ERROR, {
+    emit(CHAT_IPC_CHANNELS.STREAM_ERROR, {
       conversationId,
       error: errorMessage,
     })

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge-auth.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge-auth.ts
@@ -1,0 +1,115 @@
+/**
+ * LAN Bridge 认证管理
+ *
+ * PIN 码 + HMAC-SHA256 Token 认证。
+ * PIN 在服务启动时生成，Token 绑定客户端 IP，24h 有效。
+ */
+
+import { randomBytes, createHmac, timingSafeEqual } from 'node:crypto'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { getConfigDir } from '../config-paths'
+
+const TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000 // 24 hours
+const PIN_LENGTH = 6
+
+/** Token payload 结构 */
+interface TokenPayload {
+  /** 签发时间 (ms) */
+  iat: number
+  /** 绑定的客户端 IP */
+  ip: string
+}
+
+let currentPin = ''
+let hmacKey = ''
+
+/** 初始化认证：生成 PIN 和 HMAC 密钥 */
+export function initAuth(): string {
+  currentPin = generatePin()
+  hmacKey = randomBytes(32).toString('hex')
+  console.log(`[LAN Bridge] PIN 码: ${currentPin}`)
+  try { writeFileSync(join(getConfigDir(), 'lan-bridge-pin.txt'), currentPin) } catch {}
+  return currentPin
+}
+
+/** 获取当前 PIN 码 */
+export function getCurrentPin(): string {
+  return currentPin
+}
+
+/** 刷新 PIN 码 */
+export function refreshPin(): string {
+  currentPin = generatePin()
+  console.log(`[LAN Bridge] PIN 码已刷新: ${currentPin}`)
+  return currentPin
+}
+
+/** 验证 PIN 码 */
+export function verifyPin(pin: string): boolean {
+  const a = Buffer.from(pin)
+  const b = Buffer.from(currentPin)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+/** 生成 Token */
+export function generateToken(ip: string): { token: string; expiresIn: number } {
+  const payload: TokenPayload = { iat: Date.now(), ip }
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const signature = sign(payloadB64)
+  return {
+    token: `${payloadB64}.${signature}`,
+    expiresIn: TOKEN_EXPIRY_MS,
+  }
+}
+
+/** 验证 Token，返回是否有效 */
+export function verifyToken(token: string, ip: string): boolean {
+  try {
+    const [payloadB64, signature] = token.split('.')
+    if (!payloadB64 || !signature) return false
+
+    // 验证签名
+    const expectedSig = sign(payloadB64)
+    const sigBuf = Buffer.from(signature)
+    const expectBuf = Buffer.from(expectedSig)
+    if (sigBuf.length !== expectBuf.length) return false
+    if (!timingSafeEqual(sigBuf, expectBuf)) return false
+
+    // 解析 payload
+    const payload: TokenPayload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8'))
+
+    // 检查过期
+    if (Date.now() - payload.iat > TOKEN_EXPIRY_MS) return false
+
+    // 检查 IP 绑定
+    if (payload.ip !== ip) return false
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** 刷新 Token（验证旧 Token 后签发新的） */
+export function refreshToken(token: string, ip: string): { token: string; expiresIn: number } | null {
+  if (!verifyToken(token, ip)) return null
+  return generateToken(ip)
+}
+
+// ===== 内部工具 =====
+
+function generatePin(): string {
+  const digits = '0123456789'
+  let pin = ''
+  const bytes = randomBytes(PIN_LENGTH)
+  for (let i = 0; i < PIN_LENGTH; i++) {
+    pin += digits[bytes[i]! % digits.length]
+  }
+  return pin
+}
+
+function sign(data: string): string {
+  return createHmac('sha256', hmacKey).update(data).digest('base64url')
+}

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge-config.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge-config.ts
@@ -1,0 +1,32 @@
+/**
+ * LAN Bridge 配置管理
+ *
+ * 读写 ~/.proma/lan-bridge.json
+ */
+
+import { join } from 'node:path'
+import { getConfigDir } from '../config-paths'
+import { writeJsonFileAtomic, readJsonFileSafe } from '../safe-file'
+import { DEFAULT_LAN_BRIDGE_CONFIG } from '@proma/shared'
+import type { LanBridgeConfig } from '@proma/shared'
+
+const CONFIG_FILENAME = 'lan-bridge.json'
+
+function getConfigPath(): string {
+  return join(getConfigDir(), CONFIG_FILENAME)
+}
+
+/** 获取 LAN Bridge 配置 */
+export function getLanBridgeConfig(): LanBridgeConfig {
+  const config = readJsonFileSafe<Partial<LanBridgeConfig>>(getConfigPath())
+  if (!config) return { ...DEFAULT_LAN_BRIDGE_CONFIG }
+  return { ...DEFAULT_LAN_BRIDGE_CONFIG, ...config }
+}
+
+/** 更新 LAN Bridge 配置（合并） */
+export function updateLanBridgeConfig(updates: Partial<LanBridgeConfig>): LanBridgeConfig {
+  const current = getLanBridgeConfig()
+  const updated = { ...current, ...updates }
+  writeJsonFileAtomic(getConfigPath(), updated)
+  return updated
+}

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge-handlers.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge-handlers.ts
@@ -1,0 +1,388 @@
+/**
+ * LAN Bridge 命令处理器
+ *
+ * 调用已有服务实现各个 WS 命令。
+ */
+
+import { BrowserWindow } from 'electron'
+import { AGENT_IPC_CHANNELS } from '@proma/shared'
+import { registerRoute, sendError } from './lan-bridge-router'
+import { verifyPin, generateToken, verifyToken, refreshToken } from './lan-bridge-auth'
+import type { ClientConnection } from './lan-bridge-types'
+import { listConversations, searchConversationMessages, getConversationMessages } from '../conversation-manager'
+import { listAgentSessions, searchAgentSessionMessages, getAgentSessionMessages, createAgentSession } from '../agent-session-manager'
+import { listAgentWorkspaces } from '../agent-workspace-manager'
+import { isAgentSessionActive, runAgentHeadless, stopAgent } from '../agent-service'
+import { getSettings } from '../settings-service'
+import { listChannels } from '../channel-manager'
+import { sendMessage as chatSendMessage, stopGeneration as chatStopGeneration, type ChatStreamEvent } from '../chat-service'
+import { getSessionManager } from './lan-bridge'
+
+// ===== 注册所有路由 =====
+
+registerRoute('auth.pair', handlePair)
+registerRoute('auth.verify', handleVerify)
+registerRoute('auth.refresh', handleRefresh)
+registerRoute('ping', handlePing)
+registerRoute('conversations.list', handleListConversations)
+registerRoute('conversations.messages', handleConversationMessages)
+registerRoute('conversations.search', handleSearch)
+registerRoute('agent.sessions', handleAgentSessions)
+registerRoute('agent.sessions.messages', handleAgentSessionMessages)
+registerRoute('agent.sessions.search', handleAgentSearch)
+registerRoute('workspaces.list', handleWorkspaces)
+registerRoute('subscribe', handleSubscribe)
+registerRoute('unsubscribe', handleUnsubscribe)
+registerRoute('agent.send', handleAgentSend)
+registerRoute('agent.stop', handleAgentStop)
+registerRoute('conversations.send', handleConversationSend)
+registerRoute('conversations.stop', handleConversationStop)
+registerRoute('settings.get', handleSettingsGet)
+registerRoute('settings.channels', handleSettingsChannels)
+
+// ===== 认证 =====
+
+function handlePair(client: ClientConnection, data: Record<string, unknown>) {
+  const pin = data.pin as string | undefined
+  if (!pin || !verifyPin(pin)) {
+    throw Object.assign(new Error('Invalid PIN'), { errorCode: 'AUTH_FAILED' })
+  }
+  client.authenticated = true
+  return generateToken(client.ip)
+}
+
+function handleVerify(client: ClientConnection, data: Record<string, unknown>) {
+  const token = data.token as string | undefined
+  if (!token) return { valid: false }
+  return { valid: verifyToken(token, client.ip) }
+}
+
+function handleRefresh(client: ClientConnection, data: Record<string, unknown>) {
+  const token = data.token as string | undefined
+  if (!token) {
+    throw Object.assign(new Error('Token required'), { errorCode: 'AUTH_REQUIRED' })
+  }
+  const result = refreshToken(token, client.ip)
+  if (!result) {
+    throw Object.assign(new Error('Token invalid or expired'), { errorCode: 'TOKEN_EXPIRED' })
+  }
+  client.authenticated = true
+  return result
+}
+
+// ===== 心跳 =====
+
+function handlePing(_client: ClientConnection, _data: Record<string, unknown>) {
+  return { pong: true }
+}
+
+// ===== 数据查询 =====
+
+function handleListConversations(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  return { conversations: listConversations() }
+}
+
+function handleConversationMessages(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const conversationId = data.conversationId as string
+  if (!conversationId) {
+    throw Object.assign(new Error('conversationId required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+  const allMessages = getConversationMessages(conversationId)
+  const limit = typeof data.limit === 'number' ? data.limit : 100
+  const messages = limit > 0 ? allMessages.slice(-limit) : allMessages
+  return { messages, total: allMessages.length }
+}
+
+function handleSearch(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const query = data.query as string
+  if (!query) {
+    throw Object.assign(new Error('Query required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+  const sessionType = data.sessionType as string | undefined
+  const now = Date.now()
+  const results: Array<{ id: string; title: string; snippet: string; type: 'chat' | 'agent'; matchedAt: number }> = []
+  if (!sessionType || sessionType === 'chat') {
+    for (const r of searchConversationMessages(query)) {
+      results.push({ id: r.conversationId, title: r.title ?? '', snippet: r.snippet, type: 'chat', matchedAt: now })
+    }
+  }
+  if (!sessionType || sessionType === 'agent') {
+    for (const r of searchAgentSessionMessages(query)) {
+      results.push({ id: r.sessionId, title: r.title ?? '', snippet: r.snippet, type: 'agent', matchedAt: now })
+    }
+  }
+  return { results }
+}
+
+function handleAgentSessions(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const sessions = listAgentSessions()
+  return { sessions }
+}
+
+function handleAgentSessionMessages(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const sessionId = data.sessionId as string
+  if (!sessionId) {
+    throw Object.assign(new Error('sessionId required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+  const allMessages = getAgentSessionMessages(sessionId)
+  const limit = typeof data.limit === 'number' ? data.limit : 100
+  const messages = limit > 0 ? allMessages.slice(-limit) : allMessages
+  return { messages, total: allMessages.length }
+}
+
+function handleAgentSearch(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const query = data.query as string
+  if (!query) {
+    throw Object.assign(new Error('Query required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+  const results = searchAgentSessionMessages(query)
+  return { results }
+}
+
+function handleWorkspaces(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  return { workspaces: listAgentWorkspaces() }
+}
+
+// ===== 订阅 =====
+
+function handleSubscribe(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const id = (data.sessionId ?? data.conversationId) as string | undefined
+  if (!id) {
+    throw Object.assign(new Error('sessionId or conversationId required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+  client.subscriptions.add(id)
+  return { subscribed: id }
+}
+
+function handleUnsubscribe(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const id = (data.sessionId ?? data.conversationId) as string | undefined
+  if (id) {
+    client.subscriptions.delete(id)
+  }
+  return { unsubscribed: id }
+}
+
+// ===== Agent 交互 =====
+
+function handleAgentSessionCreate(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const title = data.title as string | undefined
+  const workspaceId = (data.workspaceId as string | undefined) || getSettings().agentWorkspaceId
+  const session = createAgentSession(title, undefined, workspaceId)
+
+  // 通知桌面端刷新会话列表（复用 TITLE_UPDATED 通道，与飞书 Bridge 保持一致）
+  const win = BrowserWindow.getAllWindows()[0]
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
+      sessionId: session.id,
+      title: session.title,
+    })
+  }
+
+  return { session }
+}
+registerRoute('agent.session.create', handleAgentSessionCreate)
+
+function handleAgentSend(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const sessionId = data.sessionId as string | undefined
+  const userMessage = data.userMessage as string | undefined
+  if (!sessionId || !userMessage) {
+    throw Object.assign(new Error('sessionId and userMessage required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+
+  if (isAgentSessionActive(sessionId)) {
+    throw Object.assign(new Error('Agent session is already running'), { errorCode: 'SESSION_ACTIVE' })
+  }
+
+  const settings = getSettings()
+
+  const permissionMode = data.permissionMode as string | undefined
+  const validModes = ['auto', 'bypassPermissions', 'plan']
+  const permissionModeOverride = (permissionMode && validModes.includes(permissionMode))
+    ? permissionMode as 'auto' | 'bypassPermissions' | 'plan'
+    : 'bypassPermissions' as const
+
+  const input = {
+    sessionId,
+    userMessage,
+    channelId: settings.agentChannelId || '',
+    modelId: data.modelId as string | undefined || settings.agentModelId,
+    workspaceId: (data.workspaceId as string | undefined) || settings.agentWorkspaceId,
+    permissionModeOverride,
+  };
+  console.log(`[LAN Bridge] agent.send 开始: sessionId=${sessionId.slice(0, 12)} channelId=${settings.agentChannelId || '(空)'}`);
+  const pushToSubs = (msg: object) => {
+    const mgr = getSessionManager()
+    if (!mgr) return
+    for (const c of mgr.getSubscribers(sessionId)) {
+      mgr.send(c, msg)
+    }
+  };
+  runAgentHeadless(input, {
+    onError: (err) => {
+      console.error(`[LAN Bridge] agent.send error:`, err)
+      pushToSubs({ type: 'stream.error', data: { sessionId, error: err } })
+      pushToSubs({ type: 'stream.complete', data: { sessionId } })
+    },
+    onComplete: () => {
+      console.log(`[LAN Bridge] agent.send complete`)
+      pushToSubs({ type: 'stream.complete', data: { sessionId } })
+    },
+    onTitleUpdated: (title) => {
+      console.log(`[LAN Bridge] agent.send title:`, title)
+      pushToSubs({ type: 'session.updated', data: { sessionId, title } })
+    },
+  }).catch((err: unknown) => {
+    console.error(`[LAN Bridge] agent.send 异常:`, err)
+    const errMsg = err instanceof Error ? err.message : String(err)
+    pushToSubs({ type: 'stream.error', data: { sessionId, error: errMsg } })
+    pushToSubs({ type: 'stream.complete', data: { sessionId } })
+  });
+
+  return { sent: true, sessionId }
+}
+
+function handleAgentStop(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const sessionId = data.sessionId as string | undefined
+  if (!sessionId) {
+    throw Object.assign(new Error('sessionId required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+  stopAgent(sessionId)
+  return { stopped: true, sessionId }
+}
+
+// ===== Chat 对话发送 =====
+
+function handleConversationSend(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const conversationId = data.conversationId as string | undefined
+  const userMessage = data.userMessage as string | undefined
+  if (!conversationId || !userMessage) {
+    throw Object.assign(new Error('conversationId and userMessage required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+
+  const settings = getSettings()
+  const channelId = data.channelId as string | undefined || settings.agentChannelId
+  const modelId = data.modelId as string | undefined || settings.agentModelId
+  if (!channelId || !modelId) {
+    throw Object.assign(new Error('channelId and modelId required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+
+  const pushToSubs = (event: ChatStreamEvent) => {
+    const mgr = getSessionManager()
+    if (!mgr) return
+    let wsType = ''
+    let wsData: Record<string, unknown> = { conversationId }
+    switch (event.type) {
+      case 'chunk':
+        wsType = 'stream.chunk'
+        wsData = { conversationId, text: event.delta ?? '' }
+        break
+      case 'reasoning':
+        wsType = 'stream.reasoning'
+        wsData = { conversationId, text: event.delta ?? '' }
+        break
+      case 'complete':
+        wsType = 'stream.complete'
+        break
+      case 'error':
+        wsType = 'stream.error'
+        wsData = { conversationId, error: event.error }
+        break
+      default:
+        return
+    }
+    for (const c of mgr.getSubscribers(conversationId)) {
+      mgr.send(c, { type: wsType, data: wsData })
+    }
+  }
+
+  const history = getConversationMessages(conversationId)
+
+  // 获取 webContents 用于 sendMessage 签名（实际走 onEvent 回调，不使用 webContents）
+  const win = BrowserWindow.getAllWindows()[0]
+
+  chatSendMessage(
+    {
+      conversationId,
+      userMessage,
+      messageHistory: history,
+      channelId,
+      modelId,
+    },
+    win?.webContents ?? null,
+    pushToSubs,
+  ).catch((err: unknown) => {
+    const errMsg = err instanceof Error ? err.message : String(err)
+    pushToSubs({ type: 'error', conversationId, error: errMsg })
+    pushToSubs({ type: 'complete', conversationId, model: modelId })
+  })
+
+  return { sent: true, conversationId }
+}
+
+function handleConversationStop(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const conversationId = data.conversationId as string | undefined
+  if (!conversationId) {
+    throw Object.assign(new Error('conversationId required'), { errorCode: 'VALIDATION_ERROR' })
+  }
+  chatStopGeneration(conversationId)
+  return { stopped: true, conversationId }
+}
+
+// ===== 设置 =====
+
+function handleSettingsGet(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const settings = getSettings()
+  let channelBaseUrl: string | null = null
+  if (settings.agentChannelId) {
+    const ch = listChannels().find(c => c.id === settings.agentChannelId)
+    if (ch) channelBaseUrl = ch.baseUrl || null
+  }
+  return {
+    agentWorkspaceId: settings.agentWorkspaceId || null,
+    agentModelId: settings.agentModelId || null,
+    agentChannelId: settings.agentChannelId || null,
+    channelBaseUrl,
+  }
+}
+
+function handleSettingsChannels(client: ClientConnection, data: Record<string, unknown>) {
+  requireAuth(client, data)
+  const channels = listChannels()
+    .filter(c => c.enabled)
+    .map(c => ({
+      id: c.id,
+      name: c.name,
+      provider: c.provider,
+      baseUrl: c.baseUrl,
+      models: c.models.filter(m => m.enabled),
+    }))
+  return { channels }
+}
+
+// ===== 工具 =====
+
+function requireAuth(client: ClientConnection, data: Record<string, unknown>): void {
+  if (client.authenticated) return
+  const token = data.token as string | undefined
+  if (token && verifyToken(token, client.ip)) {
+    client.authenticated = true
+    return
+  }
+  throw Object.assign(new Error('Authentication required'), { errorCode: 'AUTH_REQUIRED' })
+}
+

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge-router.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge-router.ts
@@ -1,0 +1,70 @@
+/**
+ * LAN Bridge 命令路由
+ *
+ * 将 WS 消息的 type 字段路由到对应的 handler。
+ */
+
+import type { ClientConnection, RouteHandler } from './lan-bridge-types'
+import type { LanBridgeResponse } from '@proma/shared'
+
+const routes = new Map<string, RouteHandler>()
+
+/** 注册路由 */
+export function registerRoute(type: string, handler: RouteHandler): void {
+  routes.set(type, handler)
+}
+
+/** 分发请求到对应 handler */
+export async function dispatch(
+  client: ClientConnection,
+  type: string,
+  data: Record<string, unknown>,
+  id?: string,
+): Promise<void> {
+  const handler = routes.get(type)
+  if (!handler) {
+    sendError(client, type, id, `Unknown command: ${type}`, 'NOT_FOUND')
+    return
+  }
+
+  try {
+    const result = await handler(client, data, id)
+    const response: LanBridgeResponse = {
+      type,
+      id,
+      ok: true,
+      data: result,
+    }
+    try {
+      client.ws.send(JSON.stringify(response))
+    } catch (e) {
+      console.error(`[LAN Bridge] dispatch send error: type=${type} id=${id}`, e)
+    }
+  } catch (err: any) {
+    const message = err instanceof Error ? err.message : 'Internal error'
+    const errorCode = (err as any)?.errorCode ?? 'INTERNAL_ERROR'
+    console.error(`[LAN Bridge] dispatch error: type=${type} id=${id}`, message, errorCode)
+    sendError(client, type, id, message, errorCode)
+  }
+}
+
+/** 发送错误响应 */
+export function sendError(
+  client: ClientConnection,
+  type: string,
+  id: string | undefined,
+  error: string,
+  errorCode: string,
+): void {
+  const response: LanBridgeResponse = { type, id, ok: false, error, errorCode }
+  try {
+    client.ws.send(JSON.stringify(response))
+  } catch (e) {
+    console.error(`[LAN Bridge] sendError send fail: type=${type} id=${id}`, e)
+  }
+}
+
+/** 获取已注册的路由数量（调试用） */
+export function getRouteCount(): number {
+  return routes.size
+}

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge-session.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge-session.ts
@@ -1,0 +1,171 @@
+/**
+ * LAN Bridge 客户端连接管理
+ *
+ * 管理所有 WS 客户端的连接、认证、心跳、速率限制。
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { WebSocket } from 'ws'
+import type { ClientConnection } from './lan-bridge-types'
+import { verifyToken } from './lan-bridge-auth'
+
+const RATE_LIMIT_WINDOW_MS = 60_000 // 1 minute
+const RATE_LIMIT_MAX_MESSAGES = 60
+const HEARTBEAT_INTERVAL_MS = 30_000
+const HEARTBEAT_TIMEOUT_MS = 20_000
+
+export class LanBridgeSessionManager {
+  private clients = new Map<string, ClientConnection>()
+  private maxConnections: number
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+
+  constructor(maxConnections: number) {
+    this.maxConnections = maxConnections
+  }
+
+  /** 添加新连接 */
+  addClient(ws: WebSocket, ip: string): ClientConnection | null {
+    if (this.clients.size >= this.maxConnections) {
+      ws.close(1013, 'Max connections reached')
+      return null
+    }
+
+    const client: ClientConnection = {
+      id: randomUUID(),
+      ws,
+      ip,
+      authenticated: false,
+      subscriptions: new Set(),
+      lastActivity: Date.now(),
+      alive: true,
+      windowStart: Date.now(),
+      messageCount: 0,
+    }
+
+    this.clients.set(client.id, client)
+    console.log(`[LAN Bridge] 客户端连接: ${ip} (${client.id}), 总连接数: ${this.clients.size}`)
+    return client
+  }
+
+  /** 移除连接 */
+  removeClient(id: string): void {
+    const client = this.clients.get(id)
+    if (!client) return
+    this.clients.delete(id)
+    console.log(`[LAN Bridge] 客户端断开: ${client.ip} (${id}), 总连接数: ${this.clients.size}`)
+  }
+
+  /** 获取客户端 */
+  getClient(id: string): ClientConnection | undefined {
+    return this.clients.get(id)
+  }
+
+  /** 检查速率限制，返回 true 表示允许 */
+  checkRateLimit(client: ClientConnection): boolean {
+    const now = Date.now()
+    if (now - client.windowStart > RATE_LIMIT_WINDOW_MS) {
+      client.windowStart = now
+      client.messageCount = 0
+    }
+    client.messageCount++
+    return client.messageCount <= RATE_LIMIT_MAX_MESSAGES
+  }
+
+  /** 从请求 data 中提取并验证 token */
+  authenticateFromData(client: ClientConnection, data: Record<string, unknown>): boolean {
+    const token = data.token as string | undefined
+    if (!token) return false
+    if (verifyToken(token, client.ip)) {
+      client.authenticated = true
+      return true
+    }
+    return false
+  }
+
+  /** 获取订阅了指定 sessionId 的所有客户端 */
+  getSubscribers(sessionId: string): ClientConnection[] {
+    const subscribers: ClientConnection[] = []
+    for (const client of this.clients.values()) {
+      if (client.authenticated && client.subscriptions.has(sessionId)) {
+        subscribers.push(client)
+      }
+    }
+    return subscribers
+  }
+
+  /** 获取所有已认证客户端 */
+  getAuthenticatedClients(): ClientConnection[] {
+    return [...this.clients.values()].filter(c => c.authenticated)
+  }
+
+  /** 向所有已认证客户端广播 */
+  broadcast(message: object): void {
+    const data = JSON.stringify(message)
+    for (const client of this.clients.values()) {
+      if (client.authenticated && client.ws.readyState === 1) {
+        try { client.ws.send(data) } catch { /* ignore send errors */ }
+      }
+    }
+  }
+
+  /** 向指定客户端发送 */
+  send(client: ClientConnection, message: object): void {
+    if (client.ws.readyState === 1) {
+      try { client.ws.send(JSON.stringify(message)) } catch { /* ignore send errors */ }
+    }
+  }
+
+  /** 启动心跳检测 */
+  startHeartbeat(): void {
+    this.stopHeartbeat()
+    this.heartbeatTimer = setInterval(() => {
+      const now = Date.now()
+      for (const [id, client] of this.clients) {
+        // 检查心跳超时
+        if (!client.alive || now - client.lastActivity > HEARTBEAT_TIMEOUT_MS) {
+          console.log(`[LAN Bridge] 心跳超时，断开: ${client.ip} (${id})`)
+          client.ws.terminate()
+          this.clients.delete(id)
+          continue
+        }
+        // 发送心跳 ping
+        client.alive = false
+        if (client.ws.readyState === 1) {
+          try { client.ws.send(JSON.stringify({ type: '_heartbeat' })) } catch { /* ignore */ }
+        }
+      }
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  /** 停止心跳检测 */
+  stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  /** 关闭所有连接 */
+  closeAll(): void {
+    this.stopHeartbeat()
+    for (const client of this.clients.values()) {
+      client.ws.close(1001, 'Server shutting down')
+    }
+    this.clients.clear()
+  }
+
+  /** 获取所有客户端信息（用于 IPC 状态查询） */
+  getClientInfos(): Array<{ id: string; ip: string; authenticated: boolean; connectedAt: number; subscriptions: string[] }> {
+    return [...this.clients.values()].map(c => ({
+      id: c.id,
+      ip: c.ip,
+      authenticated: c.authenticated,
+      connectedAt: c.lastActivity,
+      subscriptions: [...c.subscriptions],
+    }))
+  }
+
+  get connectionCount(): number {
+    return this.clients.size
+  }
+}

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge-subscription.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge-subscription.ts
@@ -1,0 +1,103 @@
+/**
+ * LAN Bridge 实时订阅 — agentEventBus → WS 推送
+ *
+ * 订阅 agentEventBus 事件，将 Agent 流式输出推送给已订阅的 WS 客户端。
+ */
+
+import type { AgentStreamPayload } from '@proma/shared'
+import type { AgentEventBus } from '../agent-event-bus'
+import { getSessionManager } from './lan-bridge'
+
+let unsubscribe: (() => void) | null = null
+
+/** 启动 EventBus 订阅 */
+export function startSubscription(eventBus: AgentEventBus): void {
+  stopSubscription()
+  unsubscribe = eventBus.on(handleAgentPayload)
+}
+
+/** 停止 EventBus 订阅 */
+export function stopSubscription(): void {
+  if (unsubscribe) {
+    unsubscribe()
+    unsubscribe = null
+  }
+}
+
+function handleAgentPayload(sessionId: string, payload: AgentStreamPayload): void {
+  console.log(`[LAN Bridge 推送] sessionId=${sessionId.slice(0, 12)} kind=${payload.kind}`)
+  if (payload.kind === 'sdk_message') {
+    const msg = payload.message as Record<string, unknown>
+    console.log(`[LAN Bridge 推送] sdk_message type=${msg.type}`)
+  } else if (payload.kind === 'proma_event') {
+    const event = payload.event as Record<string, unknown>
+    console.log(`[LAN Bridge 推送] proma_event type=${event.type}`)
+  }
+  const manager = getSessionManager()
+  if (!manager) { console.log('[LAN Bridge 推送] manager 为空'); return }
+  const subscribers = manager.getSubscribers(sessionId)
+  console.log(`[LAN Bridge 推送] 订阅者: ${subscribers.length}`)
+  if (subscribers.length === 0) return
+
+  if (payload.kind === 'sdk_message') {
+    const msg = payload.message as Record<string, unknown>
+    const type = msg.type as string
+
+    if (type === 'assistant') {
+      // SDKAssistantMessage 结构: { type:'assistant', message: { content: [...] } }
+      const message = msg.message as Record<string, unknown> | undefined
+      const content = message?.content as Array<Record<string, unknown>> | undefined
+      if (content) {
+        for (const block of content) {
+          if (block.type === 'text') {
+            const text = block.text as string
+            if (text) {
+              broadcastTo(subscribers, {
+                type: 'stream.chunk',
+                data: { sessionId, text },
+              })
+            }
+          } else if (block.type === 'tool_use') {
+            broadcastTo(subscribers, {
+              type: 'stream.tool_start',
+              data: {
+                sessionId,
+                toolName: block.name as string,
+                toolInput: JSON.stringify(block.input ?? {}),
+              },
+            })
+          } else if (block.type === 'thinking') {
+            broadcastTo(subscribers, {
+              type: 'stream.thinking',
+              data: { sessionId, thinking: block.thinking as string },
+            })
+          }
+        }
+      }
+    } else if (type === 'result') {
+      broadcastTo(subscribers, {
+        type: 'stream.complete',
+        data: { sessionId },
+      })
+    }
+  } else if (payload.kind === 'proma_event') {
+    const event = payload.event as Record<string, unknown>
+    const eventType = event.type as string
+
+    if (eventType === 'file_change') {
+      broadcastTo(subscribers, {
+        type: 'session.updated',
+        data: { sessionId },
+      })
+    }
+  }
+}
+
+function broadcastTo(clients: Array<{ ws: { send: (data: string) => void; readyState: number } }>, message: object): void {
+  const data = JSON.stringify(message)
+  for (const client of clients) {
+    if (client.ws.readyState === 1) {
+      client.ws.send(data)
+    }
+  }
+}

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge-types.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge-types.ts
@@ -1,0 +1,34 @@
+/**
+ * LAN Bridge 内部类型定义
+ */
+
+import type { WebSocket } from 'ws'
+
+/** 已连接的客户端 */
+export interface ClientConnection {
+  /** 唯一 ID */
+  id: string
+  /** WebSocket 实例 */
+  ws: WebSocket
+  /** 客户端 IP */
+  ip: string
+  /** 是否已认证 */
+  authenticated: boolean
+  /** 已订阅的 sessionId 集合 */
+  subscriptions: Set<string>
+  /** 最后活跃时间 */
+  lastActivity: number
+  /** 心跳标记 */
+  alive: boolean
+  /** 消息计数（速率限制用，滑动窗口起始时间戳） */
+  windowStart: number
+  /** 消息计数 */
+  messageCount: number
+}
+
+/** 命令路由 handler 类型 */
+export type RouteHandler = (
+  client: ClientConnection,
+  data: Record<string, unknown>,
+  id?: string,
+) => Promise<unknown> | unknown

--- a/apps/electron/src/main/lib/lan-bridge/lan-bridge.ts
+++ b/apps/electron/src/main/lib/lan-bridge/lan-bridge.ts
@@ -1,0 +1,334 @@
+/**
+ * LAN Bridge — WS Server 主入口
+ *
+ * 在 Electron 主进程中内嵌 WebSocket Server，
+ * 作为新的 BridgeRegistration 接入统一生命周期管理。
+ */
+
+import { createServer, type IncomingMessage, type Server } from 'node:http'
+import { readFileSync, existsSync } from 'node:fs'
+import { join, extname, normalize } from 'node:path'
+import { networkInterfaces } from 'node:os'
+import { WebSocketServer, type WebSocket } from 'ws'
+import { getLanBridgeConfig, updateLanBridgeConfig } from './lan-bridge-config'
+import { initAuth, refreshPin, getCurrentPin } from './lan-bridge-auth'
+import { LanBridgeSessionManager } from './lan-bridge-session'
+import { dispatch } from './lan-bridge-router'
+import type { ClientConnection } from './lan-bridge-types'
+import type { LanBridgeConfig, LanBridgeRequest, LanBridgeRuntimeState } from '@proma/shared'
+import { LAN_BRIDGE_IPC_CHANNELS } from '@proma/shared'
+
+import './lan-bridge-handlers'
+import { startSubscription, stopSubscription } from './lan-bridge-subscription'
+import type { AgentEventBus } from '../agent-event-bus'
+
+// ===== 单例状态 =====
+
+let httpServer: Server | null = null
+let eventBus: AgentEventBus | null = null
+let wss: WebSocketServer | null = null
+let sessionManager: LanBridgeSessionManager | null = null
+let status: LanBridgeRuntimeState['status'] = 'stopped'
+let errorMessage: string | undefined
+
+// ===== 公开 API =====
+
+/** 启动 LAN Bridge WS Server */
+export async function startLanBridge(bus?: AgentEventBus): Promise<void> {
+  const config = getLanBridgeConfig()
+  if (status === 'running') return
+
+  status = 'starting'
+  errorMessage = undefined
+
+  try {
+    initAuth()
+
+    sessionManager = new LanBridgeSessionManager(config.maxConnections)
+
+    // 静态文件根目录: apps/mobile/dist/
+    const mobileDistDir = join(__dirname, '..', '..', 'mobile', 'dist')
+    const mimeTypes: Record<string, string> = {
+      '.html': 'text/html; charset=utf-8', '.js': 'application/javascript',
+      '.css': 'text/css', '.svg': 'image/svg+xml', '.json': 'application/json',
+      '.png': 'image/png', '.ico': 'image/x-icon',
+    }
+
+    httpServer = createServer((req: IncomingMessage, res: any) => {
+      const url = req.url === '/' ? '/index.html' : (req.url ?? '/index.html')
+      const filePath = join(mobileDistDir, url)
+
+      // 防止路径遍历：确保解析后的路径在 mobileDistDir 内
+      const safePath = normalize(filePath)
+      if (!safePath.startsWith(mobileDistDir)) {
+        res.writeHead(403, { 'Content-Type': 'text/plain' })
+        res.end('Forbidden')
+        return
+      }
+
+      if (existsSync(safePath)) {
+        const ext = extname(safePath)
+        let content = readFileSync(safePath)
+        // 注入当前 PIN 码到 HTML 页面，手机端免手动输入
+        if (ext === '.html') {
+          content = Buffer.from(content.toString('utf-8').replace('"__PROMO_PIN__"', JSON.stringify(getCurrentPin())))
+        }
+        res.writeHead(200, { 'Content-Type': mimeTypes[ext] ?? 'application/octet-stream' })
+        res.end(content)
+      } else {
+        // SPA fallback: 所有未知路径返回 index.html
+        const indexHtml = join(mobileDistDir, 'index.html')
+        if (existsSync(indexHtml)) {
+          const html = readFileSync(indexHtml).toString('utf-8').replace('"__PROMO_PIN__"', JSON.stringify(getCurrentPin()))
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(html)
+        } else {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ service: 'proma-lan-bridge', status: 'ok' }))
+        }
+      }
+    })
+
+    wss = new WebSocketServer({ noServer: true })
+
+    httpServer.on('upgrade', (req: IncomingMessage, socket: any, head: Buffer) => {
+      if (req.url === '/ws') {
+        const ip = extractIp(req)
+        if (!isPrivateIp(ip)) {
+          socket.destroy()
+          return
+        }
+        wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+          wss!.emit('connection', ws, req)
+        })
+      } else {
+        socket.destroy()
+      }
+    })
+
+    wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+      const ip = extractIp(req)
+      const client = sessionManager!.addClient(ws, ip)
+      if (!client) return
+
+      // 发送连接确认
+      sessionManager!.send(client, { type: 'connected', data: { message: 'Proma LAN Bridge' } })
+
+      ws.on('message', (raw: Buffer) => {
+        handleMessage(client!, raw)
+      })
+
+      ws.on('close', () => {
+        sessionManager?.removeClient(client!.id)
+      })
+
+      ws.on('error', () => {
+        sessionManager?.removeClient(client!.id)
+      })
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      httpServer!.listen(config.port, '0.0.0.0', () => {
+        console.log(`[LAN Bridge] WS Server 已启动，端口: ${config.port}`)
+        resolve()
+      })
+      httpServer!.on('error', reject)
+    })
+
+    sessionManager.startHeartbeat()
+
+    // 启动 EventBus 订阅
+    if (bus) {
+      eventBus = bus
+      startSubscription(bus)
+    }
+
+    status = 'running'
+    notifyStatusChanged()
+  } catch (err) {
+    status = 'error'
+    errorMessage = err instanceof Error ? err.message : String(err)
+    console.error('[LAN Bridge] 启动失败:', errorMessage)
+    cleanup()
+    throw err
+  }
+}
+
+/** 停止 LAN Bridge */
+export function stopLanBridge(): void {
+  if (status === 'stopped') return
+  cleanup()
+  status = 'stopped'
+  errorMessage = undefined
+  notifyStatusChanged()
+  console.log('[LAN Bridge] 已停止')
+}
+
+/** 获取运行时状态 */
+export function getLanBridgeStatus(): LanBridgeRuntimeState {
+  const config = getLanBridgeConfig()
+  return {
+    status,
+    pin: getCurrentPin(),
+    port: config.port,
+    localIp: getLocalIp(),
+    connectedClients: sessionManager?.getClientInfos() ?? [],
+    errorMessage,
+  }
+}
+
+/** 刷新 PIN 码 */
+export function refreshLanBridgePin(): string {
+  return refreshPin()
+}
+
+/** 获取配置 */
+export function getConfig(): LanBridgeConfig {
+  return getLanBridgeConfig()
+}
+
+/** 更新配置（如果服务正在运行且端口变更，需要重启） */
+export function updateConfig(updates: Partial<LanBridgeConfig>): LanBridgeConfig {
+  const current = getLanBridgeConfig()
+  const needsRestart = status === 'running' && updates.port !== undefined && updates.port !== current.port
+
+  const updated = updateLanBridgeConfig(updates)
+
+  if (needsRestart) {
+    stopLanBridge()
+    startLanBridge().catch(console.error)
+  }
+
+  return updated
+}
+
+// ===== BridgeRegistration 接口 =====
+
+export const lanBridgeRegistration = {
+  name: 'LAN Bridge',
+  shouldAutoStart: () => getLanBridgeConfig().enabled,
+  start: () => {
+    // 动态导入避免循环依赖
+    const { agentEventBus } = require('../agent-service') as { agentEventBus: import('../agent-event-bus').AgentEventBus }
+    return startLanBridge(agentEventBus)
+  },
+  stop: stopLanBridge,
+}
+
+// ===== 内部工具 =====
+
+function handleMessage(client: ClientConnection, raw: Buffer): void {
+  client.lastActivity = Date.now()
+  client.alive = true
+
+  if (!sessionManager!.checkRateLimit(client)) {
+    sessionManager!.send(client, {
+      type: 'error',
+      ok: false,
+      error: 'Rate limited',
+      errorCode: 'RATE_LIMITED',
+    })
+    return
+  }
+
+  let parsed: LanBridgeRequest
+  try {
+    parsed = JSON.parse(raw.toString('utf-8'))
+  } catch {
+    sessionManager!.send(client, {
+      type: 'error',
+      ok: false,
+      error: 'Invalid JSON',
+      errorCode: 'VALIDATION_ERROR',
+    })
+    return
+  }
+
+  if (!parsed.type) return
+
+  // 心跳 pong 响应
+  if (parsed.type === 'pong') {
+    return
+  }
+
+  dispatch(client, parsed.type, parsed.data ?? {}, parsed.id)
+}
+
+/** 从 HTTP 请求中提取真实客户端 IP。仅当连接来自本地回环时才信任代理头。 */
+function extractIp(req: IncomingMessage): string {
+  const socketIp = req.socket.remoteAddress?.replace('::ffff:', '') ?? 'unknown'
+  // 仅信任来自 localhost 的反向代理转发的 X-Forwarded-For
+  if (socketIp === '127.0.0.1' || socketIp === '::1') {
+    const xForwarded = req.headers['x-forwarded-for']
+    if (typeof xForwarded === 'string') {
+      const clientIp = xForwarded.split(',')[0]!.trim()
+      if (clientIp) return clientIp
+    }
+  }
+  return socketIp
+}
+
+function getLocalIp(): string {
+  const interfaces = networkInterfaces()
+  const candidates: string[] = []
+  for (const name of Object.keys(interfaces)) {
+    for (const iface of interfaces[name] ?? []) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        candidates.push(iface.address)
+      }
+    }
+  }
+  // 优先返回 192.168.x.x（家庭/办公 WiFi），其次 10.x / 172.16-31.x
+  const wifi = candidates.find(ip => ip.startsWith('192.168.'))
+  if (wifi) return wifi
+  const rfc1918 = candidates.find(ip => isPrivateIp(ip))
+  if (rfc1918) return rfc1918
+  return candidates[0] ?? '127.0.0.1'
+}
+
+/** 检查 IP 是否为 RFC 1918 私有地址或 localhost */
+function isPrivateIp(ip: string): boolean {
+  if (ip === '::1' || ip === '127.0.0.1' || ip === 'localhost') return true
+  // 10.0.0.0/8
+  if (ip.startsWith('10.')) return true
+  // 172.16.0.0/12
+  if (ip.startsWith('172.')) {
+    const second = parseInt(ip.split('.')[1], 10)
+    if (second >= 16 && second <= 31) return true
+  }
+  // 192.168.0.0/16
+  if (ip.startsWith('192.168.')) return true
+  return false
+}
+
+function cleanup(): void {
+  stopSubscription()
+  eventBus = null
+  sessionManager?.closeAll()
+  sessionManager = null
+
+  wss?.close()
+  wss = null
+
+  if (httpServer) {
+    httpServer.close()
+    httpServer = null
+  }
+}
+
+function notifyStatusChanged(): void {
+  // 通过 IPC 推送状态变更给渲染进程
+  try {
+    const { BrowserWindow } = require('electron')
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send(LAN_BRIDGE_IPC_CHANNELS.STATUS_CHANGED, getLanBridgeStatus())
+    }
+  } catch {
+    // 忽略
+  }
+}
+
+// 导出 sessionManager 供 subscription 模块使用
+export function getSessionManager(): LanBridgeSessionManager | null {
+  return sessionManager
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, LAN_BRIDGE_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
@@ -887,6 +887,17 @@ export interface ElectronAPI {
   getWeChatStatus: () => Promise<WeChatBridgeState>
   /** 订阅微信 Bridge 状态变化 */
   onWeChatStatusChanged: (callback: (state: WeChatBridgeState) => void) => () => void
+
+  // ===== LAN Bridge 局域网远程连接 =====
+
+  getLanBridgeConfig: () => Promise<import('@proma/shared').LanBridgeConfig>
+  updateLanBridgeConfig: (updates: Partial<import('@proma/shared').LanBridgeConfig>) => Promise<import('@proma/shared').LanBridgeConfig>
+  getLanBridgeStatus: () => Promise<import('@proma/shared').LanBridgeRuntimeState>
+  startLanBridge: () => Promise<void>
+  stopLanBridge: () => Promise<void>
+  getLanBridgePin: () => Promise<string>
+  refreshLanBridgePin: () => Promise<string>
+  onLanBridgeStatusChanged: (listener: (state: import('@proma/shared').LanBridgeRuntimeState) => void) => () => void
 
   /** 订阅菜单关闭标签页事件（Cmd+W 被菜单拦截后转发） */
   onMenuCloseTab: (callback: () => void) => () => void
@@ -1988,6 +1999,42 @@ const electronAPI: ElectronAPI = {
     const listener = (_event: Electron.IpcRendererEvent, state: WeChatBridgeState): void => callback(state)
     ipcRenderer.on(WECHAT_IPC_CHANNELS.STATUS_CHANGED, listener)
     return () => { ipcRenderer.removeListener(WECHAT_IPC_CHANNELS.STATUS_CHANGED, listener) }
+  },
+
+  // ===== LAN Bridge 局域网远程连接 =====
+
+  getLanBridgeConfig: () => {
+    return ipcRenderer.invoke(LAN_BRIDGE_IPC_CHANNELS.GET_CONFIG) as Promise<import('@proma/shared').LanBridgeConfig>
+  },
+
+  updateLanBridgeConfig: (updates: Partial<import('@proma/shared').LanBridgeConfig>) => {
+    return ipcRenderer.invoke(LAN_BRIDGE_IPC_CHANNELS.UPDATE_CONFIG, updates) as Promise<import('@proma/shared').LanBridgeConfig>
+  },
+
+  getLanBridgeStatus: () => {
+    return ipcRenderer.invoke(LAN_BRIDGE_IPC_CHANNELS.GET_STATUS) as Promise<import('@proma/shared').LanBridgeRuntimeState>
+  },
+
+  startLanBridge: () => {
+    return ipcRenderer.invoke(LAN_BRIDGE_IPC_CHANNELS.START) as Promise<void>
+  },
+
+  stopLanBridge: () => {
+    return ipcRenderer.invoke(LAN_BRIDGE_IPC_CHANNELS.STOP) as Promise<void>
+  },
+
+  getLanBridgePin: () => {
+    return ipcRenderer.invoke(LAN_BRIDGE_IPC_CHANNELS.GET_PIN) as Promise<string>
+  },
+
+  refreshLanBridgePin: () => {
+    return ipcRenderer.invoke(LAN_BRIDGE_IPC_CHANNELS.REFRESH_PIN) as Promise<string>
+  },
+
+  onLanBridgeStatusChanged: (listener: (state: import('@proma/shared').LanBridgeRuntimeState) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, state: import('@proma/shared').LanBridgeRuntimeState): void => listener(state)
+    ipcRenderer.on(LAN_BRIDGE_IPC_CHANNELS.STATUS_CHANGED, handler)
+    return () => { ipcRenderer.removeListener(LAN_BRIDGE_IPC_CHANNELS.STATUS_CHANGED, handler) }
   },
 
   // ===== 钉钉集成 =====

--- a/apps/electron/src/renderer/assets/models/lan.svg
+++ b/apps/electron/src/renderer/assets/models/lan.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#27272a"/>
+  <defs>
+    <linearGradient id="g" x1="16" y1="8" x2="16" y2="24" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#a1a1aa"/>
+    </linearGradient>
+  </defs>
+  <path d="M16 22h.01" stroke="url(#g)" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M6 11.82a15 15 0 0 1 20 0" stroke="url(#g)" stroke-width="2" stroke-linecap="round"/>
+  <path d="M9.5 15.86a10 10 0 0 1 13 0" stroke="url(#g)" stroke-width="2" stroke-linecap="round"/>
+  <path d="M12.75 19.43a5 5 0 0 1 6.5 0" stroke="url(#g)" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/apps/electron/src/renderer/atoms/lan-bridge-atoms.ts
+++ b/apps/electron/src/renderer/atoms/lan-bridge-atoms.ts
@@ -1,0 +1,24 @@
+/**
+ * LAN Bridge Jotai atoms
+ */
+
+import { atom } from 'jotai'
+import type { LanBridgeConfig, LanBridgeRuntimeState } from '@proma/shared'
+
+const DEFAULT_RUNTIME_STATE: LanBridgeRuntimeState = {
+  status: 'stopped',
+  pin: '',
+  port: 29888,
+  localIp: '',
+  connectedClients: [],
+}
+
+/** LAN Bridge 运行时状态 */
+export const lanBridgeStateAtom = atom<LanBridgeRuntimeState>(DEFAULT_RUNTIME_STATE)
+
+/** LAN Bridge 配置 */
+export const lanBridgeConfigAtom = atom<LanBridgeConfig>({
+  enabled: false,
+  port: 29888,
+  maxConnections: 5,
+})

--- a/apps/electron/src/renderer/components/settings/BotHubSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/BotHubSettings.tsx
@@ -12,19 +12,22 @@ import { cn } from '@/lib/utils'
 import { feishuBotStatesAtom } from '@/atoms/feishu-atoms'
 import { dingtalkBotStatesAtom } from '@/atoms/dingtalk-atoms'
 import { wechatBridgeStateAtom } from '@/atoms/wechat-atoms'
+import { lanBridgeStateAtom } from '@/atoms/lan-bridge-atoms'
 import { FeishuSettings } from './FeishuSettings'
 import { DingTalkSettings } from './DingTalkSettings'
 import { WeChatSettings } from './WeChatSettings'
+import { LanBridgeSettings } from './LanBridgeSettings'
 import { BotDefaultSettings } from './BotDefaultSettings'
 import { PromaLogoSettings } from './PromaLogoSettings'
 import feishuLogo from '@/assets/bots/feishu.png'
 import dingtalkLogo from '@/assets/bots/dingding.png'
 import wechatLogo from '@/assets/bots/wechat.png'
+import lanIcon from '@/assets/models/lan.svg'
 import promaLogo from '@/assets/models/proma.png'
 
 // ===== 类型 =====
 
-type BotPlatformId = 'feishu' | 'dingtalk' | 'wechat' | 'defaults' | 'logos'
+type BotPlatformId = 'feishu' | 'dingtalk' | 'wechat' | 'lan' | 'defaults' | 'logos'
 
 interface BotPlatformDef {
   id: BotPlatformId
@@ -45,6 +48,12 @@ const PLATFORMS: readonly BotPlatformDef[] = [
     name: '微信',
     iconSrc: wechatLogo,
     iconBgClass: 'bg-green-500/15',
+  },
+  {
+    id: 'lan',
+    name: '局域网',
+    iconSrc: lanIcon,
+    iconBgClass: 'bg-muted',
   },
   {
     id: 'feishu',
@@ -79,6 +88,9 @@ const BRIDGE_STATUS_COLORS = {
   connecting: 'bg-yellow-400 animate-pulse',
   connected: 'bg-green-500',
   error: 'bg-red-500',
+  stopped: 'bg-gray-400',
+  starting: 'bg-yellow-400 animate-pulse',
+  running: 'bg-green-500',
 } as const
 
 // ===== 子组件 =====
@@ -88,6 +100,7 @@ function PlatformStatusDot({ platformId }: { platformId: BotPlatformId }): React
   const feishuBotStates = useAtomValue(feishuBotStatesAtom)
   const dingtalkBotStates = useAtomValue(dingtalkBotStatesAtom)
   const wechatState = useAtomValue(wechatBridgeStateAtom)
+  const lanState = useAtomValue(lanBridgeStateAtom)
 
   if (platformId === 'defaults' || platformId === 'logos') return null
 
@@ -95,6 +108,7 @@ function PlatformStatusDot({ platformId }: { platformId: BotPlatformId }): React
     feishu: getPlatformStatus(feishuBotStates),
     dingtalk: getPlatformStatus(dingtalkBotStates),
     wechat: wechatState.status,
+    lan: lanState.status,
   }
   const status = statusMap[platformId] ?? 'disconnected'
   const colorClass = BRIDGE_STATUS_COLORS[status as keyof typeof BRIDGE_STATUS_COLORS] ?? 'bg-gray-400'
@@ -168,6 +182,8 @@ function renderPlatformPanel(id: BotPlatformId): React.ReactElement {
       return <DingTalkSettings />
     case 'wechat':
       return <WeChatSettings />
+    case 'lan':
+      return <LanBridgeSettings />
     case 'defaults':
       return <BotDefaultSettings />
     case 'logos':

--- a/apps/electron/src/renderer/components/settings/LanBridgeSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/LanBridgeSettings.tsx
@@ -1,0 +1,411 @@
+/**
+ * LanBridgeSettings - 局域网 Bridge 设置面板
+ *
+ * 内嵌 WS Server，让第三方客户端（lan-viewer、Web UI 等）接入 Proma。
+ * PIN 配对认证，局域网内安全访问。
+ */
+
+import * as React from 'react'
+import { useAtom } from 'jotai'
+import { toast } from 'sonner'
+import { Copy, Loader2, Power, PowerOff, RefreshCw, Wifi, Users } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { SettingsSection } from './primitives/SettingsSection'
+import { SettingsCard } from './primitives/SettingsCard'
+import { SettingsRow } from './primitives/SettingsRow'
+import { SettingsInput } from './primitives/SettingsInput'
+import { lanBridgeStateAtom, lanBridgeConfigAtom } from '@/atoms/lan-bridge-atoms'
+import type { LanBridgeConfig, LanBridgeRuntimeState } from '@proma/shared'
+
+const STATUS_CONFIG: Record<LanBridgeRuntimeState['status'], { color: string; label: string }> = {
+  stopped: { color: 'bg-gray-400', label: '已停止' },
+  starting: { color: 'bg-amber-400 animate-pulse', label: '启动中...' },
+  running: { color: 'bg-green-500', label: '运行中' },
+  error: { color: 'bg-red-500', label: '启动失败' },
+}
+
+export function LanBridgeSettings(): React.ReactElement {
+  const [runtimeState, setRuntimeState] = useAtom(lanBridgeStateAtom)
+  const [config, setConfig] = useAtom(lanBridgeConfigAtom)
+  const [loaded, setLoaded] = React.useState(false)
+  const [pin, setPin] = React.useState('')
+  const [portInput, setPortInput] = React.useState(String(config.port))
+  const [maxConnInput, setMaxConnInput] = React.useState(String(config.maxConnections))
+  const [saving, setSaving] = React.useState(false)
+
+  // 加载配置和状态
+  React.useEffect(() => {
+    Promise.all([
+      window.electronAPI.getLanBridgeConfig(),
+      window.electronAPI.getLanBridgeStatus(),
+    ]).then(([cfg, state]) => {
+      setConfig(cfg)
+      setRuntimeState(state)
+      setPortInput(String(cfg.port))
+      setMaxConnInput(String(cfg.maxConnections))
+      setLoaded(true)
+    })
+  }, [setConfig, setRuntimeState])
+
+  // 订阅状态变化
+  React.useEffect(() => {
+    const unsubscribe = window.electronAPI.onLanBridgeStatusChanged((state: LanBridgeRuntimeState) => {
+      setRuntimeState(state)
+    })
+    return unsubscribe
+  }, [setRuntimeState])
+
+  // 获取 PIN
+  React.useEffect(() => {
+    if (runtimeState.status === 'running') {
+      window.electronAPI.getLanBridgePin().then(setPin)
+    }
+  }, [runtimeState.status])
+
+  // 启动服务
+  const handleStart = React.useCallback(async () => {
+    try {
+      await window.electronAPI.startLanBridge()
+      toast.success('局域网 Bridge 已启动')
+    } catch (error) {
+      toast.error(`启动失败: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }, [])
+
+  // 停止服务
+  const handleStop = React.useCallback(async () => {
+    try {
+      await window.electronAPI.stopLanBridge()
+      setPin('')
+      toast.info('局域网 Bridge 已停止')
+    } catch (error) {
+      toast.error(`停止失败: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }, [])
+
+  // 刷新 PIN
+  const handleRefreshPin = React.useCallback(async () => {
+    try {
+      const newPin = await window.electronAPI.refreshLanBridgePin()
+      setPin(newPin)
+      toast.success('PIN 码已刷新')
+    } catch (error) {
+      toast.error(`刷新失败: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }, [])
+
+  // 保存配置
+  const handleSaveConfig = React.useCallback(async () => {
+    const port = Number(portInput)
+    const maxConnections = Number(maxConnInput)
+    if (isNaN(port) || port < 1024 || port > 65535) {
+      toast.error('端口范围: 1024-65535')
+      return
+    }
+    if (isNaN(maxConnections) || maxConnections < 1 || maxConnections > 50) {
+      toast.error('最大连接数范围: 1-50')
+      return
+    }
+    setSaving(true)
+    try {
+      const updated = await window.electronAPI.updateLanBridgeConfig({ port, maxConnections })
+      setConfig(updated)
+      toast.success('配置已保存')
+    } catch (error) {
+      toast.error(`保存失败: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      setSaving(false)
+    }
+  }, [portInput, maxConnInput, setConfig])
+
+  // 复制到剪贴板
+  const copyToClipboard = React.useCallback((text: string) => {
+    navigator.clipboard.writeText(text).then(() => toast.success('已复制'))
+  }, [])
+
+  const statusConfig = STATUS_CONFIG[runtimeState.status]
+  const isRunning = runtimeState.status === 'running'
+
+  if (!loaded) return <div />
+
+  return (
+    <div className="space-y-8">
+      {/* 服务状态 */}
+      <SettingsSection
+        title="局域网 Bridge"
+        description="在局域网内暴露 WebSocket 接口，允许第三方客户端接入 Proma"
+      >
+        <SettingsCard>
+          <SettingsRow label="服务状态">
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2">
+                <span className={`w-2 h-2 rounded-full ${statusConfig.color}`} />
+                <span className="text-sm text-muted-foreground">{statusConfig.label}</span>
+              </div>
+              {isRunning ? (
+                <Button size="sm" variant="outline" onClick={handleStop}>
+                  <PowerOff size={14} className="mr-1.5" />
+                  停止
+                </Button>
+              ) : (
+                <Button size="sm" onClick={handleStart} disabled={runtimeState.status === 'starting'}>
+                  {runtimeState.status === 'starting' ? (
+                    <Loader2 size={14} className="animate-spin mr-1.5" />
+                  ) : (
+                    <Power size={14} className="mr-1.5" />
+                  )}
+                  启动
+                </Button>
+              )}
+            </div>
+          </SettingsRow>
+        </SettingsCard>
+
+        {/* 错误信息 */}
+        {runtimeState.status === 'error' && runtimeState.errorMessage && (
+          <div className="mt-2 px-3 py-2.5 rounded-lg bg-red-500/10 text-red-700 dark:text-red-400 text-sm">
+            {runtimeState.errorMessage}
+          </div>
+        )}
+      </SettingsSection>
+
+      {/* PIN 码 */}
+      {isRunning && (
+        <SettingsSection
+          title="PIN 码配对"
+          description="客户端连接时需要输入此 PIN 码完成认证"
+        >
+          <SettingsCard>
+            <SettingsRow label="当前 PIN">
+              <div className="flex items-center gap-3">
+                <span className="text-2xl font-mono font-bold tracking-[0.5em] text-foreground select-all">
+                  {pin || '------'}
+                </span>
+                <Button size="sm" variant="ghost" onClick={handleRefreshPin}>
+                  <RefreshCw size={14} />
+                </Button>
+              </div>
+            </SettingsRow>
+          </SettingsCard>
+        </SettingsSection>
+      )}
+
+      {/* 访问地址 */}
+      {isRunning && (
+        <SettingsSection
+          title="访问地址"
+          description="第三方客户端通过以下地址连接"
+        >
+          <SettingsCard>
+            <SettingsRow label="局域网 WS">
+              <div className="flex items-center gap-2">
+                <code className="text-sm text-muted-foreground font-mono">
+                  ws://{runtimeState.localIp}:{runtimeState.port}
+                </code>
+                <Button size="sm" variant="ghost" className="h-6 px-1.5" onClick={() => copyToClipboard(`ws://${runtimeState.localIp}:${runtimeState.port}`)}>
+                  <Copy size={12} />
+                </Button>
+              </div>
+            </SettingsRow>
+            <SettingsRow label="手机端网页">
+              <div className="flex items-center gap-2">
+                <code className="text-sm text-primary font-mono font-semibold">
+                  http://{runtimeState.localIp}:{runtimeState.port}
+                </code>
+                <Button size="sm" variant="ghost" className="h-6 px-1.5" onClick={() => copyToClipboard(`http://${runtimeState.localIp}:${runtimeState.port}`)}>
+                  <Copy size={12} />
+                </Button>
+              </div>
+            </SettingsRow>
+          </SettingsCard>
+        </SettingsSection>
+      )}
+
+      {/* 已连接设备 */}
+      {isRunning && (
+        <SettingsSection
+          title="已连接设备"
+          description={`当前 ${runtimeState.connectedClients.length} 个客户端`}
+        >
+          {runtimeState.connectedClients.length > 0 ? (
+            <SettingsCard>
+              {runtimeState.connectedClients.map((client, i) => (
+                <SettingsRow key={client.id ?? i} label={client.ip}>
+                  <div className="flex items-center gap-2">
+                    <span className={`w-1.5 h-1.5 rounded-full ${client.authenticated ? 'bg-green-500' : 'bg-amber-400'}`} />
+                    <span className="text-xs text-muted-foreground">
+                      {client.authenticated ? '已认证' : '未认证'}
+                    </span>
+                  </div>
+                </SettingsRow>
+              ))}
+            </SettingsCard>
+          ) : (
+            <div className="text-sm text-muted-foreground py-3">
+              暂无连接
+            </div>
+          )}
+        </SettingsSection>
+      )}
+
+      {/* 配置 */}
+      <SettingsSection
+        title="服务配置"
+        description="修改配置后需重启服务生效"
+      >
+        <SettingsCard>
+          <SettingsRow label="端口">
+            <SettingsInput
+              value={portInput}
+              onChange={setPortInput}
+              placeholder="29888"
+              className="w-24 text-right"
+              type="number"
+            />
+          </SettingsRow>
+          <SettingsRow label="最大连接数">
+            <SettingsInput
+              value={maxConnInput}
+              onChange={setMaxConnInput}
+              placeholder="5"
+              className="w-24 text-right"
+              type="number"
+            />
+          </SettingsRow>
+        </SettingsCard>
+        <div className="mt-3 flex justify-end">
+          <Button size="sm" onClick={handleSaveConfig} disabled={saving}>
+            {saving ? <Loader2 size={14} className="animate-spin mr-1.5" /> : null}
+            保存配置
+          </Button>
+        </div>
+      </SettingsSection>
+
+      {/* 使用说明 */}
+      <SettingsSection
+        title="使用说明"
+        description="两种接入方式：内置手机端 或 对接 WS 协议"
+      >
+        <SettingsCard divided={false}>
+          <div className="px-4 py-4 space-y-6 text-sm">
+            {/* 方案一：内置手机端 */}
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-green-500/20 text-green-400 text-xs font-semibold flex items-center justify-center">📱</span>
+                <span className="font-medium text-foreground">方案一：内置手机端（开箱即用）</span>
+              </div>
+              <p className="pl-7 text-muted-foreground">
+                手机连接同一 WiFi，浏览器打开上方「手机端网页」地址，输入 PIN 码即可使用。
+                支持查看 Chat/Agent 对话、发送消息、切换模型、实时流式回复。
+              </p>
+              <div className="pl-7 space-y-1.5">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="flex-shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] font-semibold flex items-center justify-center">1</span>
+                  <span>启动服务，获取 PIN 码</span>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="flex-shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] font-semibold flex items-center justify-center">2</span>
+                  <span>手机浏览器打开 <code className="px-1 py-0.5 bg-muted rounded text-[11px]">http://{isRunning ? runtimeState.localIp : 'IP'}:{config.port}</code></span>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="flex-shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] font-semibold flex items-center justify-center">3</span>
+                  <span>输入 PIN 码，开始对话</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="border-t border-border" />
+
+            {/* 方案二：WS 协议对接 */}
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-500/20 text-blue-400 text-xs font-semibold flex items-center justify-center">🔌</span>
+                <span className="font-medium text-foreground">方案二：对接 WS 协议（自研客户端）</span>
+              </div>
+              <p className="pl-7 text-muted-foreground">
+                任何第三方（Web UI、IDE 插件、CLI 工具等）均可通过 WebSocket 协议接入 Proma，
+                实现对话查询、Agent 交互、实时流式推送等全部能力。
+              </p>
+
+              {/* 认证流程 */}
+              <div className="pl-7 space-y-1.5">
+                <span className="text-xs font-medium text-foreground/80">认证流程</span>
+                <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                  <span className="flex-shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] font-semibold flex items-center justify-center mt-0.5">1</span>
+                  <span>连接 <code className="px-1 py-0.5 bg-muted rounded text-[11px]">ws://{'{'}IP{'}'}:{config.port}</code></span>
+                </div>
+                <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                  <span className="flex-shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] font-semibold flex items-center justify-center mt-0.5">2</span>
+                  <span>发送 <code className="px-1 py-0.5 bg-muted rounded text-[11px]">{'{'} "type": "auth.pair", "data": {'{'} "pin": "123456" {'}'} {'}'}</code> 获取 Token（24h 有效）</span>
+                </div>
+                <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                  <span className="flex-shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] font-semibold flex items-center justify-center mt-0.5">3</span>
+                  <span>后续请求在 <code className="px-1 py-0.5 bg-muted rounded text-[11px]">data</code> 中携带 <code className="px-1 py-0.5 bg-muted rounded text-[11px]">token</code></span>
+                </div>
+              </div>
+
+              {/* API 列表 */}
+              <div className="pl-7 space-y-1.5">
+                <span className="text-xs font-medium text-foreground/80">可用命令</span>
+                <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  <span className="font-mono text-foreground/70">auth.pair / verify / refresh</span>
+                  <span>认证</span>
+                  <span className="font-mono text-foreground/70">conversations.list / messages</span>
+                  <span>Chat 对话</span>
+                  <span className="font-mono text-foreground/70">agent.sessions / messages</span>
+                  <span>Agent 会话</span>
+                  <span className="font-mono text-foreground/70">agent.send / stop</span>
+                  <span>Agent 交互</span>
+                  <span className="font-mono text-foreground/70">agent.session.create</span>
+                  <span>新建会话</span>
+                  <span className="font-mono text-foreground/70">workspaces.list</span>
+                  <span>工作区</span>
+                  <span className="font-mono text-foreground/70">settings.get / channels</span>
+                  <span>设置/模型</span>
+                  <span className="font-mono text-foreground/70">subscribe / unsubscribe</span>
+                  <span>实时事件</span>
+                  <span className="font-mono text-foreground/70">conversations.search</span>
+                  <span>搜索</span>
+                </div>
+              </div>
+
+              {/* 推送事件 */}
+              <div className="pl-7 space-y-1.5">
+                <span className="text-xs font-medium text-foreground/80">服务端推送事件（subscribe 后接收）</span>
+                <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  <span className="font-mono text-foreground/70">stream.chunk</span>
+                  <span>流式文本片段</span>
+                  <span className="font-mono text-foreground/70">stream.tool_start</span>
+                  <span>工具调用开始</span>
+                  <span className="font-mono text-foreground/70">stream.complete</span>
+                  <span>流式完成</span>
+                  <span className="font-mono text-foreground/70">stream.error</span>
+                  <span>流式错误</span>
+                  <span className="font-mono text-foreground/70">session.updated</span>
+                  <span>会话元数据变更</span>
+                </div>
+              </div>
+
+              {/* 消息格式 */}
+              <div className="pl-7 space-y-1.5">
+                <span className="text-xs font-medium text-foreground/80">消息格式</span>
+                <pre className="text-[11px] text-muted-foreground bg-muted/50 rounded-lg p-2.5 overflow-x-auto leading-relaxed">{`请求: { "type": "命令", "id": "可选", "data": { "token": "..." } }
+响应: { "type": "命令", "id": "...", "ok": true, "data": { ... } }
+推送: { "type": "stream.chunk", "data": { "text": "..." } }`}</pre>
+              </div>
+            </div>
+
+            <div className="p-3 rounded-lg bg-amber-500/10 text-amber-700 dark:text-amber-400 text-xs">
+              <div className="flex items-center gap-1.5 mb-1">
+                <Wifi size={12} />
+                <span className="font-medium">安全提示</span>
+              </div>
+              仅限局域网（RFC 1918 私有地址）访问，PIN + HMAC Token 双重认证，
+              API Key 不会暴露给客户端。连接限制 {config.maxConnections} 个客户端。
+            </div>
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+    </div>
+  )
+}

--- a/apps/mobile/index.html
+++ b/apps/mobile/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="zh-CN" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="theme-color" content="#09090b" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <title>Proma</title>
+</head>
+<body class="bg-background text-foreground antialiased overscroll-none">
+  <div id="root"></div>
+  <script>window.__PROMO_PIN__ = "__PROMO_PIN__"</script>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@proma/mobile",
+  "version": "0.1.0",
+  "description": "Proma mobile web frontend — served by LAN Bridge",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@proma/shared": "workspace:*",
+    "@proma/ui": "workspace:*",
+    "jotai": "^2.17.1",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/typography": "^0.5.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "tailwindcss-animate": "^1.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/mobile/postcss.config.js
+++ b/apps/mobile/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/apps/mobile/public/apple-touch-icon.png
+++ b/apps/mobile/public/apple-touch-icon.png
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" fill="none">
+  <rect width="180" height="180" rx="40" fill="#09090b"/>
+  <text x="90" y="105" text-anchor="middle" font-family="-apple-system, sans-serif" font-size="72" font-weight="700" fill="#fafafa">P</text>
+</svg>

--- a/apps/mobile/public/favicon.svg
+++ b/apps/mobile/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#09090b"/>
+  <path d="M8 16h16M16 8v16" stroke="#fafafa" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="16" cy="16" r="10" stroke="#fafafa" stroke-width="1.5" opacity="0.3"/>
+</svg>

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useCallback } from 'react'
+import { useAtom, useSetAtom, useAtomValue } from 'jotai'
+import {
+  viewAtom, tokenAtom, connectedAtom, bridgeHostAtom, bridgePortAtom,
+  conversationsAtom, workspacesAtom, activeConvAtom, messagesAtom,
+  currentWorkspaceIdAtom, type View, type ConvItem,
+} from './atoms'
+import { connect, onPush, onOpen, wsReq, close } from './lib/ws-client'
+import { AuthPage } from './components/layout/AuthPage'
+import { AppShell } from './components/layout/AppShell'
+
+declare global { interface Window { __PROMO_PIN__?: string } }
+
+interface ConvListResponse { conversations: ConvItem[] }
+interface SessionListResponse { sessions: ConvItem[] }
+interface WorkspaceListResponse { workspaces: Array<{ id: string; name: string; slug: string }> }
+interface SettingsResponse { agentModelId?: string; channelBaseUrl?: string; agentChannelId?: string; agentWorkspaceId?: string }
+
+export function App() {
+  const [view, setView] = useAtom(viewAtom)
+  const [token, setToken] = useAtom(tokenAtom)
+  const [connected, setConnected] = useAtom(connectedAtom)
+  const host = useAtomValue(bridgeHostAtom)
+  const port = useAtomValue(bridgePortAtom)
+  const setConvs = useSetAtom(conversationsAtom)
+  const setWorkspaces = useSetAtom(workspacesAtom)
+  const setActive = useSetAtom(activeConvAtom)
+  const setMessages = useSetAtom(messagesAtom)
+  const setCurrentWsId = useSetAtom(currentWorkspaceIdAtom)
+
+  // 认证过期处理
+  useEffect(() => {
+    const handler = () => { setToken(null); setConnected(false); setView('auth') }
+    window.addEventListener('proma:auth-expired', handler)
+    return () => window.removeEventListener('proma:auth-expired', handler)
+  }, [setToken, setConnected, setView])
+
+  // 页面加载时自动连接 + 智能认证（含重连后重新认证）
+  useEffect(() => {
+    const storedToken = localStorage.getItem('proma_mobile_token')
+    const storedView = localStorage.getItem('proma_mobile_view') as View | null
+
+    onOpen(async (_ws) => {
+      // 优先用已保存的 token
+      const currentToken = localStorage.getItem('proma_mobile_token')
+      if (currentToken) {
+        try {
+          const r = await wsReq('auth.verify', { token: currentToken }) as { valid: boolean }
+          if (r.valid) {
+            setToken(currentToken); setConnected(true)
+            setView('chat')
+            restoreActiveConv()
+            return
+          }
+        } catch { /* fall through */ }
+      }
+
+      // 内置页面：用注入的 PIN 自动配对
+      const injectedPin = window.__PROMO_PIN__
+      if (injectedPin && injectedPin.length === 6 && /^\d{6}$/.test(injectedPin)) {
+        try {
+          const pair = await wsReq('auth.pair', { pin: injectedPin }) as { token: string }
+          localStorage.setItem('proma_mobile_token', pair.token)
+          setToken(pair.token); setConnected(true)
+          setView('chat')
+          restoreActiveConv()
+          return
+        } catch { /* fall through to manual auth */ }
+      }
+
+      setToken(null); setConnected(false); setView('auth')
+    })
+
+    connect(host, port)
+    return () => close()
+  }, [host, port])
+
+  async function restoreActiveConv() {
+    const saved = localStorage.getItem('proma_mobile_active_conv')
+    if (saved) {
+      try { setActive(JSON.parse(saved)); return } catch {}
+    }
+    const currentToken = localStorage.getItem('proma_mobile_token')
+    if (!currentToken) return
+    try {
+      const results = await Promise.allSettled([
+        wsReq('conversations.list', { token: currentToken }),
+        wsReq('agent.sessions', { token: currentToken }),
+      ])
+      const convs: ConvItem[] = []
+      if (results[0].status === 'fulfilled') {
+        const d = results[0].value as ConvListResponse
+        for (const c of (d.conversations ?? [])) convs.push({ ...c, type: 'chat' })
+      }
+      if (results[1].status === 'fulfilled') {
+        const d = results[1].value as SessionListResponse
+        for (const s of (d.sessions ?? [])) convs.push({ ...s, type: 'agent' })
+      }
+      convs.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+      setConvs(convs)
+      if (convs.length > 0) {
+        setActive(convs[0])
+        localStorage.setItem('proma_mobile_active_conv', JSON.stringify(convs[0]))
+      }
+    } catch { /* 无对话则留空 */ }
+  }
+
+  // 全局推送处理
+  useEffect(() => {
+    const unsub = onPush((msg) => {
+      switch (msg.type) {
+        case 'connected': break
+        case 'conversations.updated':
+        case 'agent.sessions.updated':
+          loadData(setConvs, setWorkspaces, token, setCurrentWsId)
+          break
+        default: break
+      }
+    })
+    return unsub
+  }, [token, setConvs, setWorkspaces])
+
+  // 持久化 view 状态
+  useEffect(() => {
+    if (view !== 'auth') localStorage.setItem('proma_mobile_view', view)
+  }, [view])
+
+  const handleAuthSuccess = useCallback(async (newToken: string) => {
+    localStorage.setItem('proma_mobile_token', newToken)
+    setToken(newToken); setConnected(true); setView('chat')
+  }, [setToken, setConnected, setView])
+
+  if (view === 'auth') return <AuthPage onSuccess={handleAuthSuccess} />
+  return <AppShell />
+}
+
+// 共享数据加载（供各组件复用）
+export async function loadData(
+  setConvs: (v: ConvItem[]) => void,
+  setWorkspaces: (v: Array<{ id: string; name: string; slug: string }>) => void,
+  token: string | null,
+  setCurrentWsId?: (v: string | null) => void,
+) {
+  if (!token) return
+  const results = await Promise.allSettled([
+    wsReq('conversations.list', { token }),
+    wsReq('agent.sessions', { token }),
+    wsReq('workspaces.list', { token }),
+    wsReq('settings.get', { token }),
+  ])
+  const convs: ConvItem[] = []
+  if (results[0].status === 'fulfilled') {
+    const d = results[0].value as ConvListResponse
+    for (const c of (d.conversations ?? [])) convs.push({ ...c, type: 'chat' as const })
+  }
+  if (results[1].status === 'fulfilled') {
+    const d = results[1].value as SessionListResponse
+    for (const s of (d.sessions ?? [])) convs.push({ ...s, type: 'agent' as const })
+  }
+  convs.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+  setConvs(convs)
+  if (results[2].status === 'fulfilled') {
+    setWorkspaces((results[2].value as WorkspaceListResponse).workspaces ?? [])
+  }
+  if (results[3].status === 'fulfilled' && setCurrentWsId) {
+    const settings = results[3].value as SettingsResponse
+    const stored = localStorage.getItem('proma_mobile_workspace_id')
+    if (stored === null && settings.agentWorkspaceId) {
+      setCurrentWsId(settings.agentWorkspaceId)
+    } else if (stored !== null && stored !== '') {
+      setCurrentWsId(stored)
+    }
+  }
+}

--- a/apps/mobile/src/atoms/index.ts
+++ b/apps/mobile/src/atoms/index.ts
@@ -1,0 +1,152 @@
+import { atom } from 'jotai'
+
+// ===== 消息类型 =====
+
+export interface TextBlock { type: 'text'; text: string }
+export interface ThinkingBlock { type: 'thinking'; thinking: string }
+export interface ToolUseContent { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+export interface ToolResultContent { type: 'tool_result'; tool_use_id: string; content: string | TextBlock[]; is_error?: boolean }
+
+export type ContentBlock = TextBlock | ThinkingBlock | ToolUseContent | ToolResultContent
+
+export interface Message {
+  id: string
+  type?: 'user' | 'assistant'
+  role?: 'user' | 'assistant'
+  content?: string | ContentBlock[]
+  message?: { content?: string | ContentBlock[] }
+  model?: string
+  reasoning?: string
+  createdAt?: number
+}
+
+// ===== 连接状态 =====
+export const tokenAtom = atom<string | null>(localStorage.getItem('proma_mobile_token'))
+export const pinAtom = atom('')
+export const bridgeHostAtom = atom(localStorage.getItem('proma_mobile_host') || window.location.hostname)
+export const bridgePortAtom = atom(localStorage.getItem('proma_mobile_port') || '29888')
+export const connectedAtom = atom(false)
+
+// ===== 视图 =====
+export type View = 'auth' | 'chat'
+export const viewAtom = atom<View>('auth')
+
+// ===== 数据 =====
+export interface ConvItem {
+  id: string; title: string; updatedAt: number; createdAt?: number; type: 'chat' | 'agent'
+  workspaceId?: string; workspaceName?: string
+  pinned?: boolean; manualWorking?: boolean; archived?: boolean
+}
+export const conversationsAtom = atom<ConvItem[]>([])
+export const workspacesAtom = atom<Array<{ id: string; name: string; slug: string }>>([])
+
+// ===== 当前会话 =====
+export const activeConvAtom = atom<ConvItem | null>(null)
+export const messagesAtom = atom<Message[]>([])
+export const streamingAtom = atom(false)
+export const streamContentAtom = atom('')
+
+// ===== 抽屉 =====
+export const drawerOpenAtom = atom(false)
+
+// ===== Tab =====
+export type TabType = 'agent' | 'chat'
+export const activeTabAtom = atom<TabType>('agent')
+
+// ===== 工作区过滤 =====
+export const currentWorkspaceIdAtom = atom<string | null>(null) // null = 全部工作区
+
+// ===== 下拉对话切换器 =====
+export const convDropdownOpenAtom = atom(false)
+
+// ===== 设置（全局共享） =====
+export const settingsModelIdAtom = atom<string | null>(null)
+export const settingsChannelBaseUrlAtom = atom<string | null>(null)
+export const settingsChannelIdAtom = atom<string | null>(null)
+
+// ===== 权限模式 =====
+export type PermissionMode = 'auto' | 'bypassPermissions' | 'plan'
+export const PERMISSION_MODE_ORDER: PermissionMode[] = ['auto', 'bypassPermissions', 'plan']
+export const PERMISSION_MODE_CONFIG: Record<PermissionMode, { label: string; description: string; icon: string }> = {
+  auto: { label: '自动审批', description: 'SDK 内置审批器自动判断', icon: 'compass' },
+  bypassPermissions: { label: '完全自动', description: '所有工具调用自动允许', icon: 'zap' },
+  plan: { label: '计划模式', description: '仅规划不执行', icon: 'map' },
+}
+export const permissionModeAtom = atom<PermissionMode>('auto')
+
+// ===== 渠道+模型列表 =====
+export interface ChannelInfo {
+  id: string; name: string; provider: string; baseUrl: string
+  models: Array<{ id: string; name: string }>
+}
+export const channelsAtom = atom<ChannelInfo[]>([])
+
+// ===== 派生 atoms =====
+
+export interface SessionGroup {
+  key: string
+  label: string
+  convs: ConvItem[]
+}
+
+/** Agent 对话按桌面端分组：置顶 → 工作中 → 今天 → 昨天 → 更早 */
+export const agentSessionGroupsAtom = atom((get) => {
+  const convs = get(conversationsAtom)
+  const workspaces = get(workspacesAtom)
+  const currentWsId = get(currentWorkspaceIdAtom)
+  const agentConvs = convs
+    .filter(c => c.type === 'agent' && !c.archived)
+    .filter(c => !currentWsId || c.workspaceId === currentWsId)
+
+  const now = new Date()
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+  const yesterdayStart = todayStart - 86400000
+
+  const pinned: ConvItem[] = []
+  const working: ConvItem[] = []
+  const today: ConvItem[] = []
+  const yesterday: ConvItem[] = []
+  const earlier: ConvItem[] = []
+
+  for (const c of agentConvs) {
+    if (c.pinned) { pinned.push(c); continue }
+    if (c.manualWorking) { working.push(c); continue }
+    const ts = c.updatedAt ?? 0
+    if (ts >= todayStart) { today.push(c) }
+    else if (ts >= yesterdayStart) { yesterday.push(c) }
+    else { earlier.push(c) }
+  }
+
+  const sortFn = (a: ConvItem, b: ConvItem) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0)
+  pinned.sort(sortFn); working.sort(sortFn); today.sort(sortFn); yesterday.sort(sortFn); earlier.sort(sortFn)
+
+  const groups: SessionGroup[] = []
+  if (pinned.length > 0) groups.push({ key: 'pinned', label: '置顶', convs: pinned })
+  if (working.length > 0) groups.push({ key: 'working', label: '工作中', convs: working })
+  if (today.length > 0) groups.push({ key: 'today', label: '今天', convs: today })
+  if (yesterday.length > 0) groups.push({ key: 'yesterday', label: '昨天', convs: yesterday })
+  if (earlier.length > 0) groups.push({ key: 'earlier', label: '更早', convs: earlier })
+
+  return { groups, workspaces }
+})
+
+/** Chat 类型对话平铺 */
+export const chatConvsAtom = atom((get) => {
+  return get(conversationsAtom)
+    .filter(c => c.type === 'chat')
+    .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+})
+
+/** 当前工作区的对话（Chat 顶栏下拉用） */
+export const currentWorkspaceConvsAtom = atom((get) => {
+  const active = get(activeConvAtom)
+  if (!active) return []
+  if (active.type === 'agent') {
+    return get(conversationsAtom)
+      .filter(c => c.type === 'agent' && c.workspaceId === active.workspaceId)
+      .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+  }
+  return get(conversationsAtom)
+    .filter(c => c.type === 'chat')
+    .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+})

--- a/apps/mobile/src/components/conversation/ChatView.tsx
+++ b/apps/mobile/src/components/conversation/ChatView.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import {
+  activeConvAtom, messagesAtom, tokenAtom,
+  streamingAtom, streamContentAtom,
+  type Message,
+} from '../../atoms'
+import { wsReq, onPush } from '../../lib/ws-client'
+import { InputBar } from './InputBar'
+import { MessageList } from './MessageBubble'
+import { renderMd } from '../../utils/markdown'
+
+interface MessagesResponse { messages: Message[] }
+interface StreamChunk { sessionId?: string; conversationId?: string; text?: string }
+interface StreamEnd { sessionId?: string; conversationId?: string }
+
+function fetchMessages(type: string, token: string, id: string): Promise<MessagesResponse> {
+  const cmd = type === 'agent' ? 'agent.sessions.messages' : 'conversations.messages'
+  const idKey = type === 'agent' ? 'sessionId' : 'conversationId'
+  return wsReq(cmd, { token, [idKey]: id }) as Promise<MessagesResponse>
+}
+
+export function ChatView() {
+  const [active] = useAtom(activeConvAtom)
+  const [messages, setMessages] = useAtom(messagesAtom)
+  const token = useAtomValue(tokenAtom)
+  const [streaming, setStreaming] = useAtom(streamingAtom)
+  const [streamContent, setStreamContent] = useAtom(streamContentAtom)
+  const listRef = useRef<HTMLDivElement>(null)
+  const streamTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const loadMessages = () => {
+    if (!active || !token) return
+    setMessages([])
+    fetchMessages(active.type, token, active.id)
+      .then(d => setMessages(d.messages ?? []))
+      .catch(() => setMessages([]))
+    const subKey = active.type === 'agent' ? 'sessionId' : 'conversationId'
+    wsReq('subscribe', { token, [subKey]: active.id }).catch(() => {})
+  }
+
+  useEffect(() => { loadMessages() }, [active?.id, active?.type, token])
+
+  // WS 重连后重新加载
+  useEffect(() => {
+    const handler = () => { loadMessages() }
+    window.addEventListener('proma:ws-reconnected', handler)
+    return () => window.removeEventListener('proma:ws-reconnected', handler)
+  }, [active?.id, active?.type, token, setMessages])
+
+  // 流式推送
+  useEffect(() => {
+    const unsub = onPush((msg) => {
+      if (!active) return
+      const d = msg.data as StreamChunk | StreamEnd
+      const id = d.sessionId ?? d.conversationId
+      if (id && id !== active.id) return
+
+      switch (msg.type) {
+        case 'stream.chunk':
+        case 'stream.reasoning':
+          if (streamTimeoutRef.current) { clearTimeout(streamTimeoutRef.current); streamTimeoutRef.current = null }
+          if (!streaming) { setStreaming(true); setStreamContent('') }
+          setStreamContent(prev => prev + ((d as StreamChunk).text ?? ''))
+          break
+        case 'stream.complete':
+          if (streamTimeoutRef.current) { clearTimeout(streamTimeoutRef.current); streamTimeoutRef.current = null }
+          setStreaming(false)
+          if (token) {
+            fetchMessages(active.type, token, active.id)
+              .then(r => setMessages(r.messages ?? []))
+              .catch(() => {})
+          }
+          break
+        case 'stream.error':
+          if (streamTimeoutRef.current) { clearTimeout(streamTimeoutRef.current); streamTimeoutRef.current = null }
+          setStreaming(false)
+          break
+      }
+    })
+    return unsub
+  }, [active?.id, streaming, token])
+
+  useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight
+  }, [messages, streamContent])
+
+  if (!active) return null
+
+  return (
+    <div className="flex flex-col h-full">
+      <div ref={listRef} className="flex-1 overflow-y-auto overflow-x-hidden min-w-0 px-4 py-3 space-y-4">
+        <MessageList messages={messages} />
+        {streaming && streamContent && (
+          <div className="flex gap-2 min-w-0">
+            <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-500 flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0">AI</div>
+            <div className="flex-1 min-w-0 bg-muted rounded-xl rounded-tl-sm px-3 py-2 text-sm text-foreground">
+              <div className="prose prose-sm prose-invert max-w-none break-words" dangerouslySetInnerHTML={{ __html: renderMd(streamContent) }} />
+              <span className="inline-block w-1.5 h-4 bg-foreground/40 animate-pulse ml-0.5 align-middle" />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <InputBar disabled={streaming} />
+    </div>
+  )
+}

--- a/apps/mobile/src/components/conversation/ConvDropdown.tsx
+++ b/apps/mobile/src/components/conversation/ConvDropdown.tsx
@@ -1,0 +1,92 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  currentWorkspaceConvsAtom, activeConvAtom, convDropdownOpenAtom,
+  tokenAtom, conversationsAtom, drawerOpenAtom, type ConvItem,
+} from '../../atoms'
+import { loadData } from '../../App'
+import { createAgentConversation, saveActiveConv } from '../../utils/session'
+import { formatRelativeTime } from '../../utils/format'
+
+interface Props {
+  onClose: () => void
+}
+
+export function ConvDropdown({ onClose }: Props) {
+  const convs = useAtomValue(currentWorkspaceConvsAtom)
+  const active = useAtomValue(activeConvAtom)
+  const setActive = useSetAtom(activeConvAtom)
+  const setOpen = useSetAtom(convDropdownOpenAtom)
+  const token = useAtomValue(tokenAtom)
+  const setConvs = useSetAtom(conversationsAtom)
+  const setDrawerOpen = useSetAtom(drawerOpenAtom)
+
+  const handleSwitch = (conv: ConvItem) => {
+    setActive(conv)
+    saveActiveConv(conv)
+    setOpen(false)
+    onClose()
+  }
+
+  const handleCreate = async () => {
+    if (!token || !active) return
+    try {
+      const newConv = await createAgentConversation(token, active.workspaceId)
+      setActive(newConv)
+      saveActiveConv(newConv)
+      setOpen(false)
+      onClose()
+      loadData(setConvs, () => {}, token)
+    } catch { /* TODO: toast */ }
+  }
+
+  const handleViewAll = () => {
+    setOpen(false)
+    setDrawerOpen(true)
+    onClose()
+  }
+
+  return (
+    <>
+      {/* 遮罩 */}
+      <div className="fixed inset-0 z-30 transition-opacity duration-200 opacity-100"
+        onClick={() => { setOpen(false); onClose() }}
+        style={{ top: 'var(--safe-t)', bottom: 'var(--safe-b)' }} />
+
+      {/* 下拉面板 */}
+      <div className="absolute left-0 right-0 z-40 top-full mt-0 mx-2 rounded-b-xl border border-border border-t-0 bg-[#141416] shadow-lg overflow-hidden animate-dropdown-in"
+        style={{ maxHeight: '60vh' }}>
+        <div className="overflow-y-auto" style={{ maxHeight: 'calc(60vh - 48px)' }}>
+          {convs.map(c => (
+            <button key={c.id} onClick={() => handleSwitch(c)}
+              className={`w-full text-left px-4 py-2.5 border-b border-border/30 hover:bg-accent/30 transition-colors flex items-center gap-2 ${active?.id === c.id ? 'bg-accent/20' : ''}`}>
+              <span className="text-sm text-foreground truncate flex-1">{c.title || '新对话'}</span>
+              {c.updatedAt ? (
+                <span className="text-[10px] text-muted-foreground flex-shrink-0">
+                  {formatRelativeTime(c.updatedAt)}
+                </span>
+              ) : null}
+              {active?.id === c.id && (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-primary flex-shrink-0">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+            </button>
+          ))}
+          {convs.length === 0 && (
+            <p className="text-center text-muted-foreground text-xs py-4">暂无对话</p>
+          )}
+        </div>
+        <div className="flex items-center border-t border-border px-3 py-2 gap-2">
+          <button onClick={handleCreate}
+            className="flex-1 text-xs text-center py-1.5 rounded-lg bg-primary/10 text-primary hover:bg-primary/20 transition-colors">
+            + 新建对话
+          </button>
+          <button onClick={handleViewAll}
+            className="flex-1 text-xs text-center py-1.5 rounded-lg bg-muted text-muted-foreground hover:bg-accent/20 transition-colors">
+            查看全部
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/mobile/src/components/conversation/InputBar.tsx
+++ b/apps/mobile/src/components/conversation/InputBar.tsx
@@ -1,0 +1,244 @@
+import { useState, useRef, useCallback, KeyboardEvent, useEffect } from 'react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import {
+  activeConvAtom, tokenAtom, streamingAtom, streamContentAtom, messagesAtom,
+  settingsModelIdAtom, settingsChannelBaseUrlAtom, settingsChannelIdAtom, channelsAtom,
+  permissionModeAtom, PERMISSION_MODE_ORDER, PERMISSION_MODE_CONFIG, type PermissionMode,
+} from '../../atoms'
+import { wsReq } from '../../lib/ws-client'
+import { formatModel, getProviderIcon } from '../../utils/format'
+
+export function InputBar({ disabled }: { disabled?: boolean }) {
+  const [text, setText] = useState('')
+  const active = useAtomValue(activeConvAtom)
+  const token = useAtomValue(tokenAtom)
+  const [streaming, setStreaming] = useAtom(streamingAtom)
+  const setStreamContent = useSetAtom(streamContentAtom)
+  const setMessages = useSetAtom(messagesAtom)
+  const [modelId, setModelId] = useAtom(settingsModelIdAtom)
+  const [channelBaseUrl, setChannelBaseUrl] = useAtom(settingsChannelBaseUrlAtom)
+  const [channelId, setChannelId] = useAtom(settingsChannelIdAtom)
+  const [permMode, setPermMode] = useAtom(permissionModeAtom)
+  const channels = useAtomValue(channelsAtom)
+  const taRef = useRef<HTMLTextAreaElement>(null)
+  const [modelPickerOpen, setModelPickerOpen] = useState(false)
+
+  const handleSend = useCallback(async () => {
+    const msg = text.trim()
+    if (!msg || !active || !token) return
+    setText('')
+    if (taRef.current) { taRef.current.style.height = 'auto' }
+
+    setMessages(prev => [...prev, { id: 'local-' + Date.now(), role: 'user', content: msg, createdAt: Date.now() }])
+
+    setStreaming(true)
+    setStreamContent('')
+    try {
+      if (active.type === 'agent') {
+        await wsReq('agent.send', {
+          token,
+          sessionId: active.id,
+          userMessage: msg,
+          modelId: modelId || undefined,
+          permissionMode: permMode,
+        }, 15000)
+      } else {
+        await wsReq('conversations.send', {
+          token,
+          conversationId: active.id,
+          userMessage: msg,
+          channelId: channelId || undefined,
+          modelId: modelId || undefined,
+        }, 15000)
+      }
+    } catch (e: any) {
+      setStreaming(false)
+    }
+  }, [text, active, token, modelId, channelId, permMode])
+
+  const handleStop = useCallback(async () => {
+    if (!active || !token) return
+    try {
+      if (active.type === 'agent') {
+        await wsReq('agent.stop', { token, sessionId: active.id })
+      } else {
+        await wsReq('conversations.stop', { token, conversationId: active.id })
+      }
+    } catch {}
+    setStreaming(false)
+  }, [active, token])
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault()
+      handleSend()
+    }
+  }, [handleSend])
+
+  useEffect(() => {
+    if (taRef.current && text) {
+      taRef.current.style.height = 'auto'
+      taRef.current.style.height = Math.min(taRef.current.scrollHeight, 120) + 'px'
+    }
+  }, [text])
+
+  const cyclePermMode = useCallback(() => {
+    const idx = PERMISSION_MODE_ORDER.indexOf(permMode)
+    setPermMode(PERMISSION_MODE_ORDER[(idx + 1) % PERMISSION_MODE_ORDER.length])
+  }, [permMode, setPermMode])
+
+  const handleSelectModel = useCallback((chId: string, mId: string, mName: string) => {
+    setChannelId(chId)
+    setModelId(mId)
+    const ch = channels.find(c => c.id === chId)
+    setChannelBaseUrl(ch?.baseUrl ?? null)
+    setModelPickerOpen(false)
+  }, [channels, setChannelId, setModelId, setChannelBaseUrl])
+
+  const modelName = formatModel(modelId)
+  const modelIcon = getProviderIcon(modelId, channelBaseUrl)
+  const permConfig = PERMISSION_MODE_CONFIG[permMode]
+
+  return (
+    <div className="px-2.5 pb-2.5 flex-shrink-0 relative" style={{ paddingBottom: 'calc(var(--safe-b, 0px) + 10px)' }}>
+      {/* 大圆角卡片容器 */}
+      <div className="rounded-2xl border border-border bg-background/80 focus-within:border-foreground/20 transition-colors">
+        {/* 文本输入 */}
+        <textarea
+          ref={taRef}
+          value={text}
+          onChange={e => { setText(e.target.value) }}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder={active?.type === 'agent' ? '发送消息给 Agent...' : '输入消息...'}
+          rows={1}
+          className="w-full bg-transparent px-4 pt-3 pb-1 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none resize-none"
+          style={{ minHeight: '44px', maxHeight: '120px' }}
+        />
+
+        {/* 底部工具栏 */}
+        <div className="flex items-center justify-between px-2 py-1.5 gap-2">
+          {/* 左侧工具 */}
+          <div className="flex items-center gap-0.5 min-w-0 flex-1">
+            {/* 模型选择器按钮 */}
+            <button onClick={() => setModelPickerOpen(!modelPickerOpen)}
+              className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/30 transition-colors">
+              <span className="text-xs">{modelIcon}</span>
+              <span className="truncate max-w-[72px]">{modelName || '选择模型'}</span>
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><polyline points="6 9 12 15 18 9" /></svg>
+            </button>
+
+            {/* 权限模式切换 */}
+            <button onClick={cyclePermMode}
+              className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/30 transition-colors"
+              title={`${permConfig.label}：${permConfig.description}`}>
+              <ModeIcon mode={permMode} />
+              <span>{permConfig.label}</span>
+            </button>
+          </div>
+
+          {/* 右侧发送/停止 */}
+          {streaming ? (
+            <button onClick={handleStop}
+              className="w-9 h-9 rounded-full bg-red-500/15 text-red-400 hover:bg-red-500/25 transition-colors flex items-center justify-center flex-shrink-0">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>
+            </button>
+          ) : (
+            <button onClick={handleSend} disabled={!text.trim() || disabled}
+              className="w-9 h-9 rounded-full bg-foreground text-background hover:opacity-90 disabled:opacity-20 transition-opacity flex items-center justify-center flex-shrink-0">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 模型选择弹窗 */}
+      {modelPickerOpen && (
+        <>
+          <div className="fixed inset-0 z-30" onClick={() => setModelPickerOpen(false)}
+            style={{ top: 'var(--safe-t)', bottom: 'var(--safe-b)' }} />
+          <div className="absolute bottom-full left-0 right-0 mb-2 mx-2.5 z-40 rounded-2xl border border-border bg-[#141416] shadow-xl overflow-hidden animate-dropdown-in"
+            style={{ maxHeight: '50vh' }}>
+            <ModelPicker channelId={channelId} modelId={modelId} channels={channels} onSelect={handleSelectModel} />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ===== 模型选择面板 =====
+
+function ModelPicker({ channelId, modelId, channels, onSelect }: {
+  channelId: string | null; modelId: string | null
+  channels: Array<{ id: string; name: string; provider: string; baseUrl: string; models: Array<{ id: string; name: string }> }>
+  onSelect: (channelId: string, modelId: string, modelName: string) => void
+}) {
+  const [search, setSearch] = useState('')
+  const query = search.toLowerCase()
+
+  const filtered = channels
+    .map(ch => ({
+      ...ch,
+      models: ch.models.filter(m => !query || m.name.toLowerCase().includes(query) || m.id.toLowerCase().includes(query)),
+    }))
+    .filter(ch => ch.models.length > 0)
+
+  return (
+    <div className="flex flex-col" style={{ maxHeight: '50vh' }}>
+      {/* 搜索栏 */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border/60 flex-shrink-0">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-muted-foreground flex-shrink-0">
+          <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>
+        <input type="text" value={search} onChange={e => setSearch(e.target.value)}
+          placeholder="搜索模型..." autoFocus
+          className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50" />
+      </div>
+
+      {/* 模型列表 */}
+      <div className="overflow-y-auto">
+        {filtered.length === 0 ? (
+          <p className="text-center text-muted-foreground text-xs py-6">未找到模型</p>
+        ) : filtered.map(ch => (
+          <div key={ch.id}>
+            {/* 供应商标题 */}
+            <div className="flex items-center gap-2 px-4 py-1.5 bg-muted/40 border-b border-border/30">
+              <span className="text-xs">{getProviderIcon(null, ch.baseUrl)}</span>
+              <span className="text-xs font-medium text-muted-foreground truncate">{ch.name}</span>
+            </div>
+            {/* 模型列表 */}
+            {ch.models.map(m => {
+              const selected = ch.id === channelId && m.id === modelId
+              return (
+                <button key={m.id} onClick={() => onSelect(ch.id, m.id, m.name)}
+                  className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 transition-colors ${selected ? 'bg-primary/10 text-primary border-l-3 border-l-primary' : 'text-foreground/80 hover:bg-accent/30'}`}>
+                  <span className="text-xs">{getProviderIcon(m.id, ch.baseUrl)}</span>
+                  <span className="truncate flex-1">{m.name}</span>
+                  {selected && (
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-primary flex-shrink-0">
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ===== 权限模式图标 =====
+
+function ModeIcon({ mode }: { mode: PermissionMode }) {
+  if (mode === 'auto') {
+    return <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10"/><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"/></svg>
+  }
+  if (mode === 'bypassPermissions') {
+    return <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+  }
+  // plan
+  return <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg>
+}

--- a/apps/mobile/src/components/conversation/MessageBubble.tsx
+++ b/apps/mobile/src/components/conversation/MessageBubble.tsx
@@ -1,0 +1,163 @@
+import { ToolUseBlock } from './ToolUseBlock'
+import { renderMd } from '../../utils/markdown'
+import type { Message, ContentBlock, ToolUseContent, ToolResultContent } from '../../atoms'
+
+function getContent(m: Message): ContentBlock[] | string | undefined {
+  if (m.message?.content) return m.message.content
+  return m.content
+}
+
+function asBlocks(content: ContentBlock[] | string | undefined): ContentBlock[] {
+  if (Array.isArray(content)) return content
+  return []
+}
+
+function extractText(m: Message): string {
+  const content = getContent(m)
+  if (Array.isArray(content)) {
+    return content
+      .filter((c): c is typeof c & { text: string } => c.type === 'text' && 'text' in c)
+      .map(c => c.text)
+      .join('\n')
+  }
+  if (typeof content === 'string') return content
+  return ''
+}
+
+function extractThinking(m: Message): string {
+  const content = getContent(m)
+  if (Array.isArray(content)) {
+    return content
+      .filter((c): c is typeof c & { thinking: string } => c.type === 'thinking' && 'thinking' in c)
+      .map(c => c.thinking)
+      .join('\n')
+  }
+  return m.reasoning ?? ''
+}
+
+function extractToolUse(m: Message): ToolUseContent[] {
+  return asBlocks(getContent(m)).filter((c): c is ToolUseContent => c.type === 'tool_use')
+}
+
+function hasToolResult(m: Message): boolean {
+  return asBlocks(getContent(m)).some((c): c is ToolResultContent => c.type === 'tool_result')
+}
+
+export function MessageBubble({ message: m, resultMap }: { message: Message; resultMap: Map<string, ToolResultContent> }) {
+  const isUser = m.type === 'user' || m.role === 'user'
+  const text = extractText(m)
+  const reasoning = !isUser ? extractThinking(m) : ''
+
+  if (isUser && hasToolResult(m) && !text) return null
+
+  const toolUses = !isUser ? extractToolUse(m) : []
+
+  if (!isUser && !text && !reasoning && toolUses.length > 0) {
+    return (
+      <div className="flex gap-2 min-w-0">
+        <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-500 flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0">AI</div>
+        <div className="flex-1 min-w-0 space-y-1">
+          {toolUses.map(tu => (
+            <ToolUseBlock key={tu.id} toolUse={tu} result={resultMap.get(tu.id)} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (!isUser && !text && toolUses.length === 0 && reasoning) {
+    return (
+      <div className="flex gap-2 min-w-0">
+        <div className="w-7 h-7 rounded-lg flex items-center justify-center text-[10px] font-bold flex-shrink-0 bg-gradient-to-br from-indigo-500 to-purple-500 text-white">AI</div>
+        <div className="flex-1 min-w-0">
+          <div className="rounded-xl px-3 py-2 text-sm bg-muted text-foreground rounded-tl-sm">
+            <details>
+              <summary className="text-xs text-purple-400 cursor-pointer">🧠 思考过程</summary>
+              <div className="mt-1 text-xs text-muted-foreground border-l-2 border-purple-500/30 pl-2 overflow-x-auto" dangerouslySetInnerHTML={{ __html: renderMd(reasoning) }} />
+            </details>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!text && !reasoning && toolUses.length === 0) return null
+
+  if (!isUser) {
+    return (
+      <div className="flex gap-2 min-w-0">
+        <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-500 flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0">AI</div>
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="text-[11px] font-medium text-foreground/60">{m.model || 'AI 助手'}</span>
+            {m.createdAt && <span className="text-[10px] text-muted-foreground">{new Date(m.createdAt).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })}</span>}
+          </div>
+          {toolUses.map(tu => (
+            <ToolUseBlock key={tu.id} toolUse={tu} result={resultMap.get(tu.id)} />
+          ))}
+          {reasoning && (
+            <div className="rounded-xl px-3 py-2 text-sm bg-muted text-foreground rounded-tl-sm">
+              <details>
+                <summary className="text-xs text-purple-400 cursor-pointer">🧠 思考过程</summary>
+                <div className="mt-1 text-xs text-muted-foreground border-l-2 border-purple-500/30 pl-2 overflow-x-auto" dangerouslySetInnerHTML={{ __html: renderMd(reasoning) }} />
+              </details>
+            </div>
+          )}
+          {text && (
+            <div className="rounded-xl px-3 py-2 text-sm bg-muted text-foreground rounded-tl-sm">
+              <div className="prose prose-sm prose-invert max-w-none break-words overflow-x-auto" dangerouslySetInnerHTML={{ __html: renderMd(text) }} />
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  if (isUser && hasToolResult(m) && text) {
+    return (
+      <div className="flex gap-2 flex-row-reverse min-w-0">
+        <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-amber-500 to-orange-500 flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0">我</div>
+        <div className="flex flex-col items-end min-w-0" style={{ maxWidth: 'calc(100% - 36px)' }}>
+          <div className="bg-primary/10 text-foreground rounded-xl rounded-tr-sm px-3 py-2 text-sm">
+            <div className="prose prose-sm prose-invert max-w-none break-words" dangerouslySetInnerHTML={{ __html: renderMd(text) }} />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-2 flex-row-reverse min-w-0">
+      <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-amber-500 to-orange-500 flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0">我</div>
+      <div className="flex flex-col items-end min-w-0" style={{ maxWidth: 'calc(100% - 36px)' }}>
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-[11px] font-medium text-foreground/60">我</span>
+          {m.createdAt && <span className="text-[10px] text-muted-foreground">{new Date(m.createdAt).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })}</span>}
+        </div>
+        <div className="bg-primary/10 text-foreground rounded-xl rounded-tr-sm px-3 py-2 text-sm">
+          <div className="prose prose-sm prose-invert max-w-none break-words" dangerouslySetInnerHTML={{ __html: renderMd(text) }} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function MessageList({ messages }: { messages: Message[] }) {
+  const resultMap = new Map<string, ToolResultContent>()
+  for (const m of messages) {
+    const blocks = asBlocks(getContent(m))
+    for (const block of blocks) {
+      if (block.type === 'tool_result') {
+        resultMap.set(block.tool_use_id, block as ToolResultContent)
+      }
+    }
+  }
+
+  return (
+    <>
+      {messages.map((m, i) => (
+        <MessageBubble key={m.id || i} message={m} resultMap={resultMap} />
+      ))}
+    </>
+  )
+}

--- a/apps/mobile/src/components/conversation/ToolUseBlock.tsx
+++ b/apps/mobile/src/components/conversation/ToolUseBlock.tsx
@@ -1,0 +1,78 @@
+import type { ToolUseContent, ToolResultContent, TextBlock } from '../../atoms'
+
+const TOOL_NAMES: Record<string, string> = {
+  Read: '读取文件', Edit: '编辑文件', Write: '写入文件', Bash: '执行命令',
+  Grep: '搜索内容', Glob: '搜索文件', WebSearch: '网络搜索', WebFetch: '获取网页',
+  Agent: '调用子代理', TaskCreate: '创建任务', TaskUpdate: '更新任务',
+  TaskGet: '获取任务', TaskList: '列出任务', NotebookEdit: '编辑笔记本',
+}
+
+const TOOL_ICONS: Record<string, string> = {
+  Read: '📄', Edit: '✏️', Write: '📝', Bash: '⌨️',
+  Grep: '🔍', Glob: '📂', WebSearch: '🌐', WebFetch: '🔗',
+  Agent: '🤖', TaskCreate: '📋', TaskUpdate: '✅',
+}
+
+function getToolSummary(name: string, input: Record<string, unknown>): string {
+  const displayName = TOOL_NAMES[name] || name.replace(/^mcp__/, '').replace(/__/g, ' → ')
+  if (name === 'Read' || name === 'Edit' || name === 'Write') {
+    const path = String(input.file_path ?? '').split('/').pop() || ''
+    return `${displayName} ${path}`
+  }
+  if (name === 'Bash') {
+    const cmd = String(input.command ?? '').slice(0, 60)
+    return `${displayName}: ${cmd}`
+  }
+  if (name === 'Grep') return `${displayName}: ${input.pattern ?? ''}`
+  if (name === 'Glob') return `${displayName}: ${input.pattern ?? ''}`
+  if (name === 'WebSearch') return `${displayName}: ${input.query ?? ''}`
+  return displayName
+}
+
+export function getToolResultText(block: ToolResultContent): string {
+  const content = block.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .filter((c): c is TextBlock => c.type === 'text')
+      .map(c => c.text || '')
+      .join('\n')
+  }
+  return ''
+}
+
+export function ToolUseBlock({ toolUse, result }: { toolUse: ToolUseContent; result?: ToolResultContent }) {
+  const name = toolUse.name
+  const input = toolUse.input ?? {}
+  const summary = getToolSummary(name, input)
+  const resultText = result ? getToolResultText(result) : ''
+  const hasError = result?.is_error === true
+  const resultPreview = resultText.slice(0, 500)
+
+  return (
+    <details className="group rounded-lg bg-muted/60 border border-border/40 overflow-hidden">
+      <summary className="flex items-center gap-2 px-2.5 py-1.5 text-xs cursor-pointer select-none hover:bg-muted/80 transition-colors">
+        <span className="text-muted-foreground transition-transform group-open:rotate-90">▸</span>
+        <span className="text-xs">{TOOL_ICONS[name] || '🔧'}</span>
+        <span className="text-foreground/80 flex-1 truncate">{summary}</span>
+        {result && (
+          <span className={`text-[10px] ${hasError ? 'text-red-400' : 'text-green-400'}`}>
+            {hasError ? '✗' : '✓'}
+          </span>
+        )}
+      </summary>
+      {resultPreview && (
+        <div className="px-3 py-2 border-t border-border/30">
+          {hasError ? (
+            <pre className="text-[11px] text-red-400/90 whitespace-pre-wrap break-all font-mono">{resultPreview}</pre>
+          ) : (
+            <pre className="text-[11px] text-muted-foreground whitespace-pre-wrap break-all font-mono">{resultPreview}</pre>
+          )}
+          {resultText.length > 500 && (
+            <span className="text-[10px] text-muted-foreground/60">...共 {resultText.length} 字符</span>
+          )}
+        </div>
+      )}
+    </details>
+  )
+}

--- a/apps/mobile/src/components/layout/AppShell.tsx
+++ b/apps/mobile/src/components/layout/AppShell.tsx
@@ -1,0 +1,109 @@
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import {
+  viewAtom, drawerOpenAtom, activeConvAtom, convDropdownOpenAtom,
+  tokenAtom, conversationsAtom, workspacesAtom, currentWorkspaceIdAtom,
+  settingsModelIdAtom, settingsChannelBaseUrlAtom, settingsChannelIdAtom, channelsAtom,
+  type ChannelInfo,
+} from '../../atoms'
+import { Drawer } from './Drawer'
+import { ChatView } from '../conversation/ChatView'
+import { ConvDropdown } from '../conversation/ConvDropdown'
+import { useEffect, useCallback } from 'react'
+import { wsReq } from '../../lib/ws-client'
+import { loadData } from '../../App'
+
+interface SettingsResponse { agentModelId?: string; channelBaseUrl?: string; agentChannelId?: string }
+interface ChannelsResponse { channels: ChannelInfo[] }
+
+export function AppShell() {
+  const [view] = useAtom(viewAtom)
+  const [drawerOpen, setDrawerOpen] = useAtom(drawerOpenAtom)
+  const [active] = useAtom(activeConvAtom)
+  const [dropdownOpen, setDropdownOpen] = useAtom(convDropdownOpenAtom)
+  const token = useAtomValue(tokenAtom)
+  const setConvs = useSetAtom(conversationsAtom)
+  const setWorkspaces = useSetAtom(workspacesAtom)
+  const setCurrentWsId = useSetAtom(currentWorkspaceIdAtom)
+  const [modelId, setModelId] = useAtom(settingsModelIdAtom)
+  const [channelBaseUrl, setChannelBaseUrl] = useAtom(settingsChannelBaseUrlAtom)
+  const setChannelId = useSetAtom(settingsChannelIdAtom)
+  const setChannels = useSetAtom(channelsAtom)
+
+  useEffect(() => {
+    if (!token || view !== 'chat') return
+    wsReq('settings.get', { token }).then(d => {
+      const s = d as SettingsResponse
+      setModelId(s.agentModelId || null)
+      setChannelBaseUrl(s.channelBaseUrl || null)
+      setChannelId(s.agentChannelId || null)
+    }).catch(() => {})
+    wsReq('settings.channels', { token }).then(d => {
+      setChannels((d as ChannelsResponse).channels ?? [])
+    }).catch(() => {})
+  }, [token, view])
+
+  const isInChat = view === 'chat' && active
+
+  const refreshData = useCallback(() => {
+    if (token) loadData(setConvs, setWorkspaces, token, setCurrentWsId)
+  }, [token, setConvs, setWorkspaces, setCurrentWsId])
+
+  const handleOpenDrawer = () => {
+    setDrawerOpen(true)
+    refreshData()
+  }
+
+  const handleToggleDropdown = () => {
+    const next = !dropdownOpen
+    setDropdownOpen(next)
+    if (next) refreshData()
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-background" style={{ paddingTop: 'var(--safe-t)', paddingBottom: 'var(--safe-b)' }}>
+      {/* 全局顶部栏 */}
+      <header className="relative flex items-center gap-2 px-3 py-3 border-b border-border bg-muted/30 flex-shrink-0">
+        {/* 汉堡菜单 — 始终可见 */}
+        <button onClick={handleOpenDrawer}
+          className="text-muted-foreground hover:text-foreground p-1 flex-shrink-0">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </button>
+
+        {isInChat ? (
+          <>
+            {/* 可点击标题 → 下拉切换同工作区对话 */}
+            <button onClick={handleToggleDropdown}
+              className="flex items-center justify-center gap-1 flex-1 min-w-0">
+              <span className="text-base font-semibold text-foreground truncate">{active.title}</span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+                className={`text-muted-foreground flex-shrink-0 transition-transform duration-200 ${dropdownOpen ? 'rotate-180' : ''}`}>
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+            {dropdownOpen && <ConvDropdown onClose={() => setDropdownOpen(false)} />}
+          </>
+        ) : (
+          <h1 className="text-base font-semibold text-foreground truncate mx-2 flex-1 text-center">Proma</h1>
+        )}
+      </header>
+
+      {/* 侧边栏遮罩 + 抽屉 */}
+      <div
+        className={`fixed inset-0 z-40 flex transition-opacity duration-300 ${drawerOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+        style={{ top: 'var(--safe-t)', bottom: 'var(--safe-b)' }}
+      >
+        <div className="absolute inset-0 bg-black/50" onClick={() => setDrawerOpen(false)} />
+        <div className={`transition-transform duration-300 ease-out ${drawerOpen ? 'translate-x-0' : '-translate-x-full'}`}>
+          <Drawer onClose={() => setDrawerOpen(false)} />
+        </div>
+      </div>
+
+      {/* 主内容 */}
+      <main className="flex-1 overflow-hidden min-w-0">
+        {view === 'chat' && <ChatView />}
+      </main>
+    </div>
+  )
+}

--- a/apps/mobile/src/components/layout/AuthPage.tsx
+++ b/apps/mobile/src/components/layout/AuthPage.tsx
@@ -1,0 +1,78 @@
+import { useState, useCallback, FormEvent } from 'react'
+import { useAtom } from 'jotai'
+import { pinAtom, bridgeHostAtom, bridgePortAtom } from '../../atoms'
+import { wsReq } from '../../lib/ws-client'
+
+interface Props {
+  onSuccess: (token: string) => void
+}
+
+export function AuthPage({ onSuccess }: Props) {
+  const [pin, setPin] = useAtom(pinAtom)
+  const [host, setHost] = useAtom(bridgeHostAtom)
+  const [port, setPort] = useAtom(bridgePortAtom)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = useCallback(async (e: FormEvent) => {
+    e.preventDefault()
+    if (!pin || pin.length !== 6) { setError('请输入 6 位 PIN 码'); return }
+    setError(''); setLoading(true)
+    try {
+      const r = await wsReq('auth.pair', { pin }) as { token: string }
+      localStorage.setItem('proma_mobile_host', host)
+      localStorage.setItem('proma_mobile_port', port)
+      onSuccess(r.token)
+    } catch (err: unknown) {
+      setError(err instanceof Error && err.message === 'timeout' ? '连接超时，请检查地址和 PIN 码' : 'PIN 码错误或服务不可用')
+    } finally {
+      setLoading(false)
+    }
+  }, [pin, host, port, onSuccess])
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-full px-6 bg-background" style={{ paddingTop: 'var(--safe-t)', paddingBottom: 'var(--safe-b)' }}>
+      <div className="w-full max-w-sm">
+        <h1 className="text-2xl font-bold text-foreground text-center mb-2">Proma</h1>
+        <p className="text-muted-foreground text-sm text-center mb-8">连接到电脑端 Proma</p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-muted-foreground mb-1">地址</label>
+            <input
+              type="text" value={host} onChange={e => setHost(e.target.value)}
+              className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              placeholder="192.168.x.x"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-muted-foreground mb-1">端口</label>
+            <input
+              type="text" value={port} onChange={e => setPort(e.target.value)}
+              className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              placeholder="29888"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-muted-foreground mb-1">PIN 码</label>
+            <input
+              type="text" inputMode="numeric" maxLength={6} autoFocus
+              value={pin} onChange={e => setPin(e.target.value.replace(/\D/g, '').slice(0, 6))}
+              className="w-full rounded-lg border border-border bg-muted px-3 py-2.5 text-foreground text-lg tracking-[0.3em] text-center font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+              placeholder="000000"
+            />
+          </div>
+          {error && <p className="text-red-400 text-xs text-center">{error}</p>}
+          <button
+            type="submit" disabled={loading}
+            className="w-full rounded-lg bg-primary text-primary-foreground py-3 font-medium text-sm hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
+            {loading ? '连接中...' : '连接'}
+          </button>
+        </form>
+        <p className="text-muted-foreground/40 text-xs text-center mt-6">
+          在电脑端 Proma → 设置 → 远程连接 → 局域网 查看 PIN 码
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/mobile/src/components/layout/Drawer.tsx
+++ b/apps/mobile/src/components/layout/Drawer.tsx
@@ -1,0 +1,160 @@
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import {
+  viewAtom, tokenAtom, connectedAtom, activeConvAtom,
+  conversationsAtom, agentSessionGroupsAtom, chatConvsAtom,
+  type ConvItem, activeTabAtom, type TabType, currentWorkspaceIdAtom,
+} from '../../atoms'
+import { close as closeWS } from '../../lib/ws-client'
+import { loadData } from '../../App'
+import { formatRelativeTime } from '../../utils/format'
+import { createAgentConversation, saveActiveConv } from '../../utils/session'
+import { STORAGE_KEYS, removeStorage } from '../../utils/storage'
+
+interface Props { onClose: () => void }
+
+export function Drawer({ onClose }: Props) {
+  const setView = useSetAtom(viewAtom)
+  const [token, setToken] = useAtom(tokenAtom)
+  const setConnected = useSetAtom(connectedAtom)
+  const [active, setActive] = useAtom(activeConvAtom)
+  const setConvs = useSetAtom(conversationsAtom)
+  const [tab, setTab] = useAtom(activeTabAtom)
+
+  const { groups: agentGroups, workspaces } = useAtomValue(agentSessionGroupsAtom)
+  const chatConvs = useAtomValue(chatConvsAtom)
+  const [wsId, setWsId] = useAtom(currentWorkspaceIdAtom)
+
+  const handleOpen = (conv: ConvItem) => {
+    setActive(conv)
+    saveActiveConv(conv)
+    setView('chat')
+    onClose()
+  }
+
+  const handleCreate = async (workspaceId?: string) => {
+    if (!token) return
+    try {
+      const newConv = await createAgentConversation(token, workspaceId)
+      setActive(newConv)
+      saveActiveConv(newConv)
+      setView('chat')
+      onClose()
+      loadData(setConvs, () => {}, token)
+    } catch { /* TODO: toast */ }
+  }
+
+  const handleDisconnect = () => {
+    removeStorage(STORAGE_KEYS.token)
+    setToken(null); setConnected(false); setView('auth')
+    closeWS()
+    onClose()
+  }
+
+  const handleRefresh = async () => {
+    if (!token) return
+    await loadData(setConvs, () => {}, token, setWsId)
+  }
+
+  return (
+    <nav className="w-72 max-w-[80vw] bg-[#141416] border-r border-border h-full z-50 flex flex-col shadow-xl">
+      {/* 头部 */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
+        <h2 className="text-sm font-semibold text-foreground">Proma</h2>
+        <button onClick={onClose} className="text-muted-foreground hover:text-foreground p-1">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+        </button>
+      </div>
+
+      {/* Tab 切换 */}
+      <div className="px-3 py-2 border-b border-border flex-shrink-0">
+        <div className="flex rounded-lg bg-muted p-0.5">
+          {(['agent', 'chat'] as TabType[]).map(t => (
+            <button key={t} onClick={() => setTab(t)}
+              className={`flex-1 py-1.5 text-xs font-medium rounded-md transition-colors ${tab === t ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground'}`}
+            >{t === 'agent' ? 'Agent' : 'Chat'}</button>
+          ))}
+        </div>
+      </div>
+
+      {/* 工作区选择器 */}
+      {tab === 'agent' && workspaces.length > 1 && (
+        <div className="px-3 py-1.5 border-b border-border flex-shrink-0 flex gap-1 overflow-x-auto">
+          <button onClick={() => setWsId(null)}
+            className={`px-2 py-1 text-[10px] rounded-md whitespace-nowrap transition-colors ${!wsId ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'}`}>
+            全部
+          </button>
+          {workspaces.map(ws => (
+            <button key={ws.id} onClick={() => setWsId(ws.id)}
+              className={`px-2 py-1 text-[10px] rounded-md whitespace-nowrap transition-colors ${wsId === ws.id ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'}`}>
+              {ws.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* 列表内容 */}
+      <div className="flex-1 overflow-y-auto min-w-0">
+        {tab === 'agent' ? (
+          <div className="py-1">
+            <button onClick={() => handleCreate(wsId ?? undefined)}
+              className="w-full text-left px-4 py-2.5 text-sm text-primary hover:bg-accent/30 transition-colors flex items-center gap-2">
+              <span className="text-base">+</span> 新建对话
+            </button>
+
+            {agentGroups.map(g => (
+              <div key={g.key}>
+                <div className="px-4 py-1.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+                  {g.label}
+                </div>
+                {g.convs.map(c => (
+                  <button key={c.id} onClick={() => handleOpen(c)}
+                    className={`w-full text-left px-4 py-2 text-sm transition-colors flex items-center gap-2 ${active?.id === c.id ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-accent/20'}`}>
+                    <span className="truncate flex-1">
+                      {c.pinned && <span className="text-yellow-400 mr-1">📌</span>}
+                      {c.manualWorking && <span className="text-blue-400 mr-1">●</span>}
+                      {c.title || '新对话'}
+                    </span>
+                    {c.updatedAt ? (
+                      <span className="text-[10px] text-muted-foreground flex-shrink-0">{formatRelativeTime(c.updatedAt)}</span>
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+            ))}
+
+            {agentGroups.length === 0 && (
+              <p className="text-center text-muted-foreground text-xs py-6">暂无 Agent 对话</p>
+            )}
+          </div>
+        ) : (
+          <div className="py-1">
+            {chatConvs.map(c => (
+              <button key={c.id} onClick={() => handleOpen(c)}
+                className={`w-full text-left px-4 py-2.5 text-sm transition-colors flex items-center gap-2 border-b border-border/30 ${active?.id === c.id ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-accent/20'}`}>
+                <span className="truncate flex-1">{c.title || '新对话'}</span>
+                {c.updatedAt ? (
+                  <span className="text-[10px] text-muted-foreground flex-shrink-0">{formatRelativeTime(c.updatedAt)}</span>
+                ) : null}
+              </button>
+            ))}
+            {chatConvs.length === 0 && (
+              <p className="text-center text-muted-foreground text-xs py-6">暂无 Chat 对话</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 底部操作 */}
+      <div className="border-t border-border px-3 py-2 flex gap-2 flex-shrink-0">
+        <button onClick={handleRefresh}
+          className="flex-1 text-xs text-center py-1.5 rounded-lg bg-muted text-muted-foreground hover:bg-accent/20 transition-colors">
+          刷新
+        </button>
+        <button onClick={handleDisconnect}
+          className="flex-1 text-xs text-center py-1.5 rounded-lg text-red-400 hover:bg-red-400/10 transition-colors">
+          断开
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/apps/mobile/src/index.css
+++ b/apps/mobile/src/index.css
@@ -1,0 +1,52 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 7%;
+  --foreground: 0 0% 98%;
+  --muted: 0 0% 14.9%;
+  --muted-foreground: 0 0% 63.9%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 0 0% 9%;
+  --secondary: 0 0% 14.9%;
+  --secondary-foreground: 0 0% 98%;
+  --accent: 0 0% 40%;
+  --accent-foreground: 0 0% 98%;
+  --border: 0 0% 20%;
+  --input: 0 0% 20%;
+  --ring: 0 0% 83.9%;
+  --radius: 0.5rem;
+  --safe-b: env(safe-area-inset-bottom, 0px);
+  --safe-t: env(safe-area-inset-top, 0px);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  height: 100%;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+body {
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: pan-y;
+}
+
+/* 自定义滚动条 */
+::-webkit-scrollbar { width: 4px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: hsl(var(--muted-foreground) / 0.3); border-radius: 2px; }
+
+/* 下拉框弹入动画 */
+@keyframes dropdown-in {
+  from { opacity: 0; transform: translateY(-8px) scaleY(0.95); }
+  to { opacity: 1; transform: translateY(0) scaleY(1); }
+}
+.animate-dropdown-in { animation: dropdown-in 0.18s ease-out; }

--- a/apps/mobile/src/lib/ws-client.ts
+++ b/apps/mobile/src/lib/ws-client.ts
@@ -1,0 +1,110 @@
+export interface WSRequest {
+  type: string
+  id?: string
+  data?: Record<string, unknown>
+}
+
+export interface WSResponse {
+  type: string
+  id?: string
+  ok: boolean
+  data?: unknown
+  error?: string
+  errorCode?: string
+}
+
+type PushHandler = (msg: WSResponse) => void
+type OpenHandler = (ws: WebSocket) => void
+
+let msgId = 0
+const reqMap = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>()
+const pushHandlers = new Set<PushHandler>()
+let openHandler: OpenHandler | null = null
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let reconnectDelay = 1000
+let _ws: WebSocket | null = null
+let _host = ''
+let _port = ''
+let _isReconnect = false
+
+export function onOpen(handler: OpenHandler): void {
+  openHandler = handler
+}
+
+export function connect(host: string, port: string): WebSocket {
+  close()
+  _host = host; _port = port
+  const protocol = port === '443' ? 'wss' : 'ws'
+  const ws = new WebSocket(`${protocol}://${host}:${port}/ws`)
+  _ws = ws
+
+  ws.onopen = () => {
+    reconnectDelay = 1000
+    if (_isReconnect) {
+      window.dispatchEvent(new CustomEvent('proma:ws-reconnected'))
+    }
+    _isReconnect = true
+    openHandler?.(ws)
+  }
+
+  ws.onmessage = (e) => {
+    try {
+      const msg: WSResponse = JSON.parse(e.data)
+      // 心跳处理
+      if (msg.type === '_heartbeat') { ws.send(JSON.stringify({ type: 'pong' })); return }
+      // 请求响应
+      if (msg.id && reqMap.has(msg.id)) {
+        const p = reqMap.get(msg.id)!
+        reqMap.delete(msg.id)
+        if (msg.ok) p.resolve(msg.data ?? {})
+        else {
+          p.reject(new Error(msg.error ?? 'Unknown error'))
+          if (msg.errorCode === 'TOKEN_EXPIRED' || msg.errorCode === 'AUTH_REQUIRED') {
+            localStorage.removeItem('proma_mobile_token')
+            window.dispatchEvent(new CustomEvent('proma:auth-expired'))
+          }
+        }
+        return
+      }
+      // 推送给所有处理器
+      for (const h of pushHandlers) { try { h(msg) } catch {} }
+    } catch { /* parse error */ }
+  }
+
+  ws.onclose = () => {
+    if (reconnectTimer) return
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      reconnectDelay = Math.min(reconnectDelay * 1.5, 15000)
+      connect(_host, _port)
+    }, reconnectDelay)
+  }
+
+  ws.onerror = () => { /* onclose will handle */ }
+
+  return ws
+}
+
+export function close(): void {
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+  _isReconnect = false
+  if (_ws) { try { _ws.close() } catch {}; _ws = null }
+}
+
+export function onPush(handler: PushHandler): () => void {
+  pushHandlers.add(handler)
+  return () => { pushHandlers.delete(handler) }
+}
+
+export function wsReq(type: string, data?: Record<string, unknown>, timeout = 15000): Promise<unknown> {
+  const ws = _ws
+  if (!ws || ws.readyState !== WebSocket.OPEN) return Promise.reject(new Error('Not connected'))
+  return new Promise((resolve, reject) => {
+    const id = String(++msgId)
+    reqMap.set(id, { resolve, reject })
+    ws.send(JSON.stringify({ type, id, data: data ?? {} }))
+    setTimeout(() => {
+      if (reqMap.has(id)) { reqMap.delete(id); reject(new Error('timeout')) }
+    }, timeout)
+  })
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/apps/mobile/src/utils/format.ts
+++ b/apps/mobile/src/utils/format.ts
@@ -1,0 +1,39 @@
+// ===== 统一的时间/模型格式化 + Provider 图标 =====
+
+export function formatRelativeTime(ts: number): string {
+  const diff = Date.now() - ts
+  if (diff < 60000) return '刚刚'
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}分钟前`
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}小时前`
+  if (diff < 604800000) return `${Math.floor(diff / 86400000)}天前`
+  return new Date(ts).toLocaleDateString('zh-CN', { month: 'numeric', day: 'numeric' })
+}
+
+const MODEL_ID_ICONS: Array<[RegExp, string]> = [
+  [/gpt-image/i, '🟢'], [/gpt-3/i, '🟢'], [/gpt-4/i, '🟢'], [/gpt-5-mini/i, '🟢'],
+  [/(claude|anthropic-)/i, '🟣'],
+  [/deepseek/i, '🔵'], [/deepgemini/i, '🔷'], [/gemini/i, '🔷'], [/(qwen|qwq|qvq|wan-)/i, '🟠'],
+  [/grok/i, '⚪'], [/kimi/i, '🌙'], [/(doubao|ep-202|seed)/i, '🟡'], [/zhipu/i, '💜'],
+  [/minimax/i, '🟤'], [/mistral/i, '🟤'], [/llama/i, '🦙'],
+]
+
+const URL_ICONS: Array<[RegExp, string]> = [
+  [/proma\.cool/i, '⭐'], [/moonshot\.cn|kimi/i, '🌙'], [/bigmodel\.cn|zhipuai/i, '💜'],
+  [/dashscope|aliyuncs/i, '🟠'], [/deepseek/i, '🔵'], [/anthropic/i, '🟣'], [/openai\.com/i, '🟢'],
+  [/googleapis|generativelanguage/i, '🔷'], [/grok|x\.ai/i, '⚪'], [/volcengine|volces/i, '🟡'],
+]
+
+export function getProviderIcon(modelId: string | null, baseUrl: string | null): string {
+  if (modelId) { for (const [re, icon] of MODEL_ID_ICONS) { if (re.test(modelId)) return icon } }
+  if (baseUrl) { for (const [re, icon] of URL_ICONS) { if (re.test(baseUrl)) return icon } }
+  return '🤖'
+}
+
+export function formatModel(modelId: string | null): string {
+  if (!modelId) return ''
+  const map: Record<string, string> = { 'claude-sonnet-4-6': 'Sonnet 4.6', 'claude-opus-4-7': 'Opus 4.7', 'claude-haiku-4-5-20251001': 'Haiku 4.5' }
+  if (map[modelId]) return map[modelId]
+  const m = modelId.match(/claude-(sonnet|opus|haiku)-([\d-]+)/)
+  if (m) return `${m[1].charAt(0).toUpperCase() + m[1].slice(1)} ${m[2].replace(/-/g, '.')}`
+  return modelId.length > 20 ? modelId.slice(0, 18) + '…' : modelId
+}

--- a/apps/mobile/src/utils/markdown.ts
+++ b/apps/mobile/src/utils/markdown.ts
@@ -1,0 +1,21 @@
+// ===== 简易 Markdown 渲染（从 ChatView 提取）=====
+
+export function renderMd(text: string): string {
+  if (!text) return ''
+  return String(text)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/```(\w*)\n?([\s\S]*?)```/g, '<pre class="bg-black/30 rounded-lg p-3 my-2 overflow-x-auto text-xs"><code>$2</code></pre>')
+    .replace(/`([^`]+)`/g, '<code class="bg-foreground/10 px-1 py-0.5 rounded text-xs">$1</code>')
+    .replace(/^### (.+)$/gm, '<h3 class="text-sm font-semibold mt-3 mb-1">$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2 class="text-base font-semibold mt-3 mb-1">$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1 class="text-lg font-semibold mt-3 mb-1 border-b border-border pb-1">$1</h1>')
+    .replace(/^\- (.+)$/gm, '<li class="ml-4 text-sm">• $1</li>')
+    .replace(/^> (.+)$/gm, '<blockquote class="border-l-2 border-primary/50 pl-3 my-1 text-muted-foreground italic">$1</blockquote>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\n\n/g, '</p><p class="my-1">')
+    .replace(/\n/g, '<br/>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
+      if (/^(https?:\/\/|mailto:)/i.test(url)) return `<a href="${url}" class="text-blue-400 underline" target="_blank" rel="noopener">${text}</a>`
+      return `<span class="text-muted-foreground">${text}</span>`
+    })
+}

--- a/apps/mobile/src/utils/session.ts
+++ b/apps/mobile/src/utils/session.ts
@@ -1,0 +1,26 @@
+// ===== 对话创建 + 活跃对话持久化（统一从 Drawer/ConvDropdown 提取）=====
+
+import type { ConvItem } from '../atoms'
+import { wsReq } from '../lib/ws-client'
+import { STORAGE_KEYS, writeStorage } from './storage'
+
+export function saveActiveConv(conv: ConvItem): void {
+  writeStorage(STORAGE_KEYS.activeConv, conv)
+}
+
+export async function createAgentConversation(
+  token: string,
+  workspaceId?: string,
+): Promise<ConvItem> {
+  const data: Record<string, string> = { token }
+  if (workspaceId) data.workspaceId = workspaceId
+  const r = await wsReq('agent.session.create', data) as any
+  const session = r.session
+  return {
+    id: session.id,
+    title: session.title || '新对话',
+    type: 'agent',
+    workspaceId,
+    updatedAt: Date.now(),
+  }
+}

--- a/apps/mobile/src/utils/storage.ts
+++ b/apps/mobile/src/utils/storage.ts
@@ -1,0 +1,28 @@
+// ===== localStorage 统一 key 管理 =====
+
+const PREFIX = 'proma_mobile_'
+
+export const STORAGE_KEYS = {
+  token: PREFIX + 'token',
+  host: PREFIX + 'host',
+  port: PREFIX + 'port',
+  activeConv: PREFIX + 'active_conv',
+  view: PREFIX + 'view',
+} as const
+
+export function readStorage<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw ? JSON.parse(raw) : fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function writeStorage(key: string, value: unknown): void {
+  localStorage.setItem(key, JSON.stringify(value))
+}
+
+export function removeStorage(key: string): void {
+  localStorage.removeItem(key)
+}

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -1,0 +1,36 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border) / <alpha-value>)',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background) / <alpha-value>)',
+        foreground: 'hsl(var(--foreground) / <alpha-value>)',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('tailwindcss-animate'),
+  ],
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/shared" },
+    { "path": "../../packages/ui" }
+  ]
+}

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { resolve } from 'node:path'
+
+export default defineConfig({
+  plugins: [react()],
+  root: __dirname,
+  base: '/',
+  build: {
+    outDir: resolve(__dirname, 'dist'),
+    emptyOutDir: true,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    port: 5176,
+    strictPort: false,
+  },
+})

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -50,3 +50,6 @@ export * from './dingtalk'
 
 // 微信集成相关类型
 export * from './wechat'
+
+// LAN Bridge 局域网远程连接相关类型
+export * from './lan-bridge'

--- a/packages/shared/src/types/lan-bridge.ts
+++ b/packages/shared/src/types/lan-bridge.ts
@@ -1,0 +1,280 @@
+/**
+ * LAN Bridge — 局域网远程连接标准接口类型定义
+ *
+ * 基于 WebSocket 双向通信，支持 PIN 码认证、数据查询、实时订阅和 Agent 交互。
+ * 配置持久化到 ~/.proma/lan-bridge.json。
+ */
+
+// ===== WS 消息格式 =====
+
+/** WS 请求消息（客户端 → Proma） */
+export interface LanBridgeRequest {
+  /** 消息类型，如 'auth.pair', 'conversations.list' */
+  type: string
+  /** 请求 ID，用于匹配 request/response */
+  id?: string
+  /** 请求参数 */
+  data?: Record<string, unknown>
+}
+
+/** WS 响应消息（Proma → 客户端） */
+export interface LanBridgeResponse {
+  /** 响应类型，与请求 type 一致 */
+  type: string
+  /** 对应请求的 ID */
+  id?: string
+  /** 是否成功 */
+  ok: boolean
+  /** 响应数据（成功时） */
+  data?: unknown
+  /** 错误信息（失败时） */
+  error?: string
+  /** 错误码 */
+  errorCode?: LanBridgeErrorCode
+}
+
+/** WS 推送消息（Proma → 客户端，服务端主动） */
+export interface LanBridgePush {
+  /** 推送类型 */
+  type: string
+  /** 推送数据 */
+  data: unknown
+}
+
+/** 错误码 */
+export type LanBridgeErrorCode =
+  | 'AUTH_REQUIRED'
+  | 'AUTH_FAILED'
+  | 'TOKEN_EXPIRED'
+  | 'TOKEN_INVALID'
+  | 'RATE_LIMITED'
+  | 'PERMISSION_DENIED'
+  | 'NOT_FOUND'
+  | 'SESSION_ACTIVE'
+  | 'VALIDATION_ERROR'
+  | 'INTERNAL_ERROR'
+
+// ===== 认证 =====
+
+/** PIN 配对请求 */
+export interface LanBridgeAuthPairInput {
+  pin: string
+}
+
+/** PIN 配对响应 */
+export interface LanBridgeAuthPairResult {
+  token: string
+  expiresIn: number
+}
+
+/** Token 验证请求 */
+export interface LanBridgeAuthVerifyInput {
+  token: string
+}
+
+/** Token 验证响应 */
+export interface LanBridgeAuthVerifyResult {
+  valid: boolean
+}
+
+/** Token 刷新请求 */
+export interface LanBridgeAuthRefreshInput {
+  token: string
+}
+
+/** Token 刷新响应 */
+export interface LanBridgeAuthRefreshResult {
+  token: string
+  expiresIn: number
+}
+
+// ===== 数据查询 =====
+
+/** 对话列表查询结果 */
+export interface LanBridgeConversationsResult {
+  conversations: import('./chat').ConversationMeta[]
+}
+
+/** 对话消息查询 */
+export interface LanBridgeMessagesInput {
+  token: string
+  conversationId: string
+  limit?: number
+  before?: string
+}
+
+/** 对话消息查询结果 */
+export interface LanBridgeMessagesResult {
+  messages: unknown[]
+  total: number
+}
+
+/** 搜索请求 */
+export interface LanBridgeSearchInput {
+  token: string
+  query: string
+  sessionType?: 'chat' | 'agent'
+}
+
+/** 搜索结果 */
+export interface LanBridgeSearchResult {
+  results: Array<{
+    id: string
+    title: string
+    snippet: string
+    type: 'chat' | 'agent'
+    matchedAt: number
+  }>
+}
+
+/** Agent 会话列表结果 */
+export interface LanBridgeAgentSessionsResult {
+  sessions: import('./agent').AgentSessionMeta[]
+  workspaces: Array<{ id: string; name: string; slug: string }>
+}
+
+/** Agent 会话消息查询 */
+export interface LanBridgeAgentMessagesInput {
+  token: string
+  sessionId: string
+  limit?: number
+}
+
+/** Agent 消息查询结果 */
+export interface LanBridgeAgentMessagesResult {
+  messages: unknown[]
+  total: number
+}
+
+/** 工作区列表结果 */
+export interface LanBridgeWorkspacesResult {
+  workspaces: Array<{ id: string; name: string; slug: string; createdAt: number }>
+}
+
+// ===== 交互 =====
+
+/** 发送消息请求 */
+export interface LanBridgeAgentSendInput {
+  token: string
+  sessionId: string
+  userMessage: string
+  workspaceId?: string
+}
+
+/** 停止 Agent 请求 */
+export interface LanBridgeAgentStopInput {
+  token: string
+  sessionId: string
+}
+
+// ===== 订阅 =====
+
+/** 订阅请求 */
+export interface LanBridgeSubscribeInput {
+  token: string
+  sessionId: string
+}
+
+/** 取消订阅请求 */
+export interface LanBridgeUnsubscribeInput {
+  sessionId: string
+}
+
+// ===== 流式推送数据 =====
+
+/** 流式文本片段 */
+export interface LanBridgeStreamChunk {
+  sessionId: string
+  text: string
+}
+
+/** 工具调用开始 */
+export interface LanBridgeStreamToolStart {
+  sessionId: string
+  toolName: string
+  toolInput?: string
+}
+
+/** 流式完成 */
+export interface LanBridgeStreamComplete {
+  sessionId: string
+}
+
+/** 流式错误 */
+export interface LanBridgeStreamError {
+  sessionId: string
+  error: string
+}
+
+/** 会话元数据变更 */
+export interface LanBridgeSessionUpdated {
+  sessionId: string
+  title?: string
+}
+
+// ===== 配置 =====
+
+/** LAN Bridge 配置（持久化到 ~/.proma/lan-bridge.json） */
+export interface LanBridgeConfig {
+  /** 是否启用 */
+  enabled: boolean
+  /** 监听端口 */
+  port: number
+  /** 最大连接数 */
+  maxConnections: number
+}
+
+/** 默认配置 */
+export const DEFAULT_LAN_BRIDGE_CONFIG: LanBridgeConfig = {
+  enabled: false,
+  port: 29888,
+  maxConnections: 20,
+}
+
+// ===== 运行状态 =====
+
+/** LAN Bridge 运行状态 */
+export type LanBridgeStatus = 'stopped' | 'starting' | 'running' | 'error'
+
+/** 已连接客户端信息 */
+export interface LanBridgeClientInfo {
+  id: string
+  ip: string
+  authenticated: boolean
+  connectedAt: number
+  subscriptions: string[]
+}
+
+/** LAN Bridge 完整运行时状态 */
+export interface LanBridgeRuntimeState {
+  status: LanBridgeStatus
+  pin: string
+  port: number
+  localIp: string
+  connectedClients: LanBridgeClientInfo[]
+  errorMessage?: string
+}
+
+// ===== IPC 通道 =====
+
+/** LAN Bridge IPC 通道 */
+export const LAN_BRIDGE_IPC_CHANNELS = {
+  /** 获取配置 */
+  GET_CONFIG: 'lan-bridge:get-config',
+  /** 更新配置 */
+  UPDATE_CONFIG: 'lan-bridge:update-config',
+  /** 获取运行时状态 */
+  GET_STATUS: 'lan-bridge:get-status',
+  /** 启动服务 */
+  START: 'lan-bridge:start',
+  /** 停止服务 */
+  STOP: 'lan-bridge:stop',
+  /** 获取当前 PIN 码 */
+  GET_PIN: 'lan-bridge:get-pin',
+  /** 刷新 PIN 码 */
+  REFRESH_PIN: 'lan-bridge:refresh-pin',
+  /** 状态变更推送 */
+  STATUS_CHANGED: 'lan-bridge:status-changed',
+  /** 连接列表变更推送 */
+  CLIENTS_CHANGED: 'lan-bridge:clients-changed',
+} as const


### PR DESCRIPTION
## Summary

为 Proma 新增局域网远程连接能力，支持手机浏览器直接访问电脑端 Proma 进行 AI 对话。

### LAN Bridge WebSocket Server

在 Electron 主进程内嵌 WebSocket Server，作为 `BridgeRegistration` 接入统一生命周期管理。

- **认证**: 6 位 PIN 码配对 + HMAC-SHA256 Token（IP 绑定，24h 过期），`timingSafeEqual` 防时序攻击
- **安全**: 仅允许 RFC 1918 私有 IP + localhost 连接，连接数限制（默认 5），速率限制（60 条/分钟/客户端）
- **心跳**: 30s 间隔，2 次无响应断开
- **HTTP 静态服务**: 同时 serve `apps/mobile/dist/`，手机浏览器可直接访问

### Mobile Web 前端 (`apps/mobile/`)

独立 React 18 + Vite + Tailwind SPA，零耦合桌面端代码。

- **认证页**: PIN 码输入 + 自动注入免手动输入
- **抽屉导航**: Agent 按工作区分组 + Chat 平铺列表
- **聊天视图**: 消息气泡 + Markdown 渲染 + Thinking/ToolUse/ToolResult 内容块
- **流式推送**: WebSocket 实时接收 Agent/Chat 流式响应
- **对话切换**: 顶栏下拉快速切换当前工作区内的对话
- **断线重连**: 指数退避（1s → 15s）

### chat-service 扩展

`sendMessage` 新增 `onEvent` 回调参数，`webContents` 改为 nullable，支持非 Electron 渲染进程场景（LAN Bridge WS 客户端）复用聊天发送逻辑。

### 设置 UI

BotHub 新增“局域网”平台面板 (`LanBridgeSettings`)：

- 服务开关 + 端口配置
- PIN 码显示/刷新
- 访问地址（本机 + 局域网）
- 已连接设备列表

## 架构

```
手机浏览器 ──HTTP(:29888)──▶ LAN Bridge Server (Electron 主进程)
                               │
                               ├── GET /        → serve mobile/dist/index.html
                               ├── GET /assets  → serve 静态资源
                               ├── WS upgrade   → WebSocket 连接
                               └── WS 协议      → 认证 + 数据查询 + Agent 交互
```

## 新增文件（37 个）

### LAN Bridge 后端（8 个）
- `apps/electron/src/main/lib/lan-bridge/` — 主入口、认证、配置、会话管理、路由、处理器、订阅

### Mobile 前端（27 个）
- `apps/mobile/` — 完整独立 React 应用

### 共享类型 + 设置 UI（2 个）
- `packages/shared/src/types/lan-bridge.ts` — WS 协议类型、IPC 通道常量
- `apps/electron/src/renderer/components/settings/LanBridgeSettings.tsx`

## 修改文件（6 个）

| 文件 | 改动 |
|------|------|
| `main/index.ts` | 注册 LAN Bridge 到 BridgeRegistry |
| `main/ipc.ts` | 新增 LAN Bridge IPC handlers |
| `lib/chat-service.ts` | `webContents` nullable + `onEvent` 回调 |
| `preload/index.ts` | 新增 LAN Bridge API 暴露 |
| `BotHubSettings.tsx` | 新增“局域网”平台入口 |
| `shared/types/index.ts` | 导出 lan-bridge 类型 |

## 安全策略

- 仅允许 RFC 1918 私有 IP + localhost
- 6 位 PIN + HMAC-SHA256 Token（IP 绑定，24h 过期）
- `timingSafeEqual` 防时序攻击
- 默认最大 5 连接，60 条/分钟/客户端速率限制
- API Key 不暴露给客户端

## 测试计划

- [ ] 启动 Proma → 设置 → 远程连接 → 局域网 → 开启服务
- [ ] 手机浏览器访问 `http://192.168.x.x:29888` → 输入 PIN → 配对成功
- [ ] 验证对话列表加载、消息发送、流式推送
- [ ] 验证 Agent 会话创建和交互
- [ ] 停止服务 → 确认不崩溃