### PR TITLE
Fix Windows Proma CLI recovery command

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.17",
+  "version": "0.14.18",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-session-context-prompt.ts
+++ b/apps/electron/src/main/lib/agent-session-context-prompt.ts
@@ -26,12 +26,8 @@ function getSessionCleanerSkillName(workspaceSlug?: string): string {
     : 'session-cleaner'
 }
 
-function getSessionCliCommandPrefix(): string {
-  return getBundledCliPath() ? '"$PROMA_CLI"' : 'proma'
-}
-
 function buildSessionCliAccessGuide(sessionId: string, historyPath: string, workspaceSlug?: string): string {
-  const cli = getSessionCliCommandPrefix()
+  const cli = 'proma'
   const skillName = getSessionCleanerSkillName(workspaceSlug)
   return [
     `优先使用 session-cleaner skill（${skillName}）读取当前会话历史；它是 Proma CLI 的薄封装，会把 Agent JSONL 清洗为干净对话。`,


### PR DESCRIPTION
## Summary
This PR changes Agent session recovery prompts to call `proma` via PATH instead of `"$PROMA_CLI"`, avoiding POSIX-only env var syntax that Windows shells do not execute.
It also bumps `@proma/electron` to `0.14.18` for the Electron package change.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:main`
- `git diff --check`
