### PR TITLE
feat(agent): add workspace collaboration board

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -56,6 +56,7 @@ import type {
   GetTaskOutputResult,
   StopTaskInput,
   WorkspaceMcpConfig,
+  WorkspaceBoard,
   SkillMeta,
   SkillFileContent,
   WorkspaceCapabilities,
@@ -225,6 +226,8 @@ import {
   listWorkspaceAutoMemoryFiles,
   readWorkspaceAutoMemoryFile,
   writeWorkspaceAutoMemoryFile,
+  readWorkspaceBoard,
+  writeWorkspaceBoard,
   getWorkspaceAttachedDirectories,
   getWorkspaceAttachedFiles,
   attachWorkspaceDirectory,
@@ -2200,6 +2203,20 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.WRITE_WORKSPACE_AUTO_MEMORY_FILE,
     async (_, workspaceSlug: string, relativePath: string, content: string): Promise<void> => {
       writeWorkspaceAutoMemoryFile(workspaceSlug, relativePath, content)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.READ_WORKSPACE_BOARD,
+    async (_, workspaceSlug: string): Promise<WorkspaceBoard> => {
+      return readWorkspaceBoard(workspaceSlug)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.WRITE_WORKSPACE_BOARD,
+    async (_, workspaceSlug: string, board: WorkspaceBoard): Promise<WorkspaceBoard> => {
+      return writeWorkspaceBoard(workspaceSlug, board)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -192,6 +192,7 @@ Proma 提供内置 \`collaboration\` 工具，可以创建真实可见的协作�
 存在两个 \`.context/\` 目录，用途不同：
 - **会话级** \`.context/\`（当前 cwd 下）：当前会话的临时工作台，存放本次任务的 todo.md、plan/、临时笔记等
 - **工作区级** \`~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/workspace-files/.context/\`：跨会话共享的持久文档，存放长期 note.md、项目级知识等
+- **工作区协作台** \`~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/workspace-files/.context/workspace-board.json\`：跨会话共享的结构化状态，记录当前目标、Todo、阻塞、决策草案、Proma 建议、自动任务/Skill 引用和待沉淀候选
 
 选择写入哪个目录时：
 - 只与当前任务相关的内容 → 会话级 \`.context/\`
@@ -263,6 +264,7 @@ Context 用来承载正在进行的任务状态、长期工作区资料和可搜
 
 - **会话级 Context**：当前 cwd 下的 \`.context/\`，服务于本次任务，存放临时 todo、plan、研究笔记、handoff 和中间产物。任务结束后通常不需要长期维护。
 - **工作区级 Context**：工作区 \`workspace-files/.context/\` 及其他工作区本地文档，跨会话共享，存放长期 note、调研、架构分析、决策记录、索引和大型证据材料。
+- **工作区协作台**：\`workspace-files/.context/workspace-board.json\` 记录当前工作区仍在推进的目标、Todo、阻塞、待确认事项和 Proma 建议。新会话开始时应优先检查；任务推进后可以小幅更新，但不要把它当长期记忆或 Skill。它是结构化 JSON，顶层 schema 固定为 \`schemaVersion/title/summary/automationLevel/updatedAt/goals/todos/blockers/decisions/recommendations/automationRefs/skillRefs/knowledgeCandidates/notes\`；可在条目中使用 \`sourceRefs\` 关联 session、file、skill、automation、memory 或 board。主动维护规则由 \`automationLevel\` 决定：\`manual\` 只读取不主动新增条目；\`suggest\` 可写建议和候选项；\`assistive\` 可维护 Todo、阻塞和建议。任务结束后若仍有明确下一步，写入 1-3 条 \`todos\`；遇到需要用户决策或外部条件时写入 \`blockers\`；发现重复流程写 \`recommendations.kind=create_automation\`；发现可复用 SOP 写 \`recommendations.kind=create_skill\`；发现稳定经验但未经用户确认时写 \`knowledgeCandidates\` 或 \`recommendations.kind=promote_memory\`，不要直接改 Memory。
 - **选择原则**：只对当前任务有用 → 会话级；未来多个会话会引用 → 工作区级；稳定规则摘要 → CLAUDE.md；经验/偏好/纠错 → Memory；重复流程 → Skill。
 
 ### .context/ 文档类型

--- a/apps/electron/src/main/lib/agent-workspace-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test'
-import { normalizeWorkspaceMcpConfig } from './agent-workspace-manager'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  normalizeWorkspaceMcpConfig,
+  readWorkspaceBoard,
+  writeWorkspaceBoard,
+} from './agent-workspace-manager'
+import { getAgentWorkspacePath } from './config-paths'
 
 describe('Agent 工作区 MCP 配置', () => {
   test('Given 工作区 MCP 包含内置保留名 When 归一化配置 Then 剔除冲突项并保留普通服务器', () => {
@@ -25,5 +32,100 @@ describe('Agent 工作区 MCP 配置', () => {
 
     expect(Object.keys(normalized.servers).sort()).toEqual(['github'])
     expect(normalized.servers.github?.command).toBe('github-mcp')
+  })
+
+  test('Given 工作区已有旧 Markdown 协作台 When 读取协作台 Then 转为结构化 JSON schema', () => {
+    const workspaceSlug = `legacy-board-workspace-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+    try {
+      const contextDir = join(getAgentWorkspacePath(workspaceSlug), 'workspace-files', '.context')
+      mkdirSync(contextDir, { recursive: true })
+      writeFileSync(join(contextDir, 'workspace-board.md'), '# 协作台\n\n- [ ] 迁移旧 Todo\n', 'utf-8')
+
+      const board = readWorkspaceBoard(workspaceSlug)
+      expect(board.schemaVersion).toBe(1)
+      expect(board.todos[0]?.title).toBe('迁移旧 Todo')
+      expect(board.recommendations[0]?.kind).toBe('follow_up')
+      expect(board.recommendations[0]?.sourceRefs?.[0]?.path).toBe('.context/workspace-board.md')
+      expect(board.notes[0]?.source).toBe('.context/workspace-board.md')
+    } finally {
+      rmSync(getAgentWorkspacePath(workspaceSlug), { recursive: true, force: true })
+    }
+  })
+})
+
+describe('Agent 工作区协作台', () => {
+  test('Given 工作区没有协作台文件 When 保存协作台内容 Then 写入 workspace-files/.context 并可再次读取', () => {
+    const workspaceSlug = `board-workspace-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+    try {
+      const empty = readWorkspaceBoard(workspaceSlug)
+      expect(empty.schemaVersion).toBe(1)
+      expect(empty.todos).toEqual([])
+      expect(empty.recommendations).toEqual([])
+      expect(empty.automationRefs).toEqual([])
+      expect(empty.skillRefs).toEqual([])
+      expect(empty.automationLevel).toBe('suggest')
+
+      writeWorkspaceBoard(workspaceSlug, {
+        ...empty,
+        automationLevel: 'assistive',
+        recommendations: [{
+          id: 'recommendation-1',
+          title: '创建自动任务跟进阻塞',
+          kind: 'create_automation',
+          status: 'suggested',
+          confidence: 1.2,
+          safetyLevel: 'creates_automation',
+          sourceRefs: [{ type: 'board', id: 'blocker-1', title: '阻塞记录' }],
+          createdAt: '2026-07-05T00:00:00.000Z',
+          updatedAt: '2026-07-05T00:00:00.000Z',
+        }],
+        automationRefs: [{
+          id: 'automation-ref-1',
+          title: '每日状态扫描',
+          status: 'linked',
+          automationId: 'automation-1',
+          trigger: 'daily',
+          createdAt: '2026-07-05T00:00:00.000Z',
+          updatedAt: '2026-07-05T00:00:00.000Z',
+        }],
+        skillRefs: [{
+          id: 'skill-ref-1',
+          title: '缺陷扫描流程',
+          status: 'enabled',
+          skillSlug: 'proma-daily-defect-scan',
+          createdAt: '2026-07-05T00:00:00.000Z',
+          updatedAt: '2026-07-05T00:00:00.000Z',
+        }],
+        todos: [{
+          id: 'todo-1',
+          title: '跟进状态',
+          status: 'in_progress',
+          owner: 'agent',
+          createdAt: '2026-07-05T00:00:00.000Z',
+          updatedAt: '2026-07-05T00:00:00.000Z',
+        }],
+      })
+
+      const saved = readWorkspaceBoard(workspaceSlug)
+      expect(saved.schemaVersion).toBe(1)
+      expect(saved.automationLevel).toBe('assistive')
+      expect(saved.todos[0]?.title).toBe('跟进状态')
+      expect(saved.todos[0]?.status).toBe('in_progress')
+      expect(saved.recommendations[0]?.confidence).toBe(1)
+      expect(saved.recommendations[0]?.sourceRefs?.[0]?.type).toBe('board')
+      expect(saved.automationRefs[0]?.trigger).toBe('daily')
+      expect(saved.skillRefs[0]?.skillSlug).toBe('proma-daily-defect-scan')
+
+      expect(existsSync(join(
+        getAgentWorkspacePath(workspaceSlug),
+        'workspace-files',
+        '.context',
+        'workspace-board.json',
+      ))).toBe(true)
+    } finally {
+      rmSync(getAgentWorkspacePath(workspaceSlug), { recursive: true, force: true })
+    }
   })
 })

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -19,12 +19,13 @@ import {
   getInactiveSkillsDir,
   getDefaultSkillsDir,
   parseSkillVersion,
+  getWorkspaceFilesDir,
 } from './config-paths'
 import { findAllGitRoots, normalizeGitRoot } from './git-diff-service'
 import { listBuiltinMcpServers } from './builtin-mcp/catalog'
 import { RESERVED_BUILTIN_KEYS } from './builtin-mcp/baseline'
 import { inferMcpTransportType, normalizeMcpTransportType } from '@proma/shared'
-import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent, WorkspaceMemorySummary } from '@proma/shared'
+import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent, WorkspaceMemorySummary, WorkspaceBoard, WorkspaceBoardAutomationRef, WorkspaceBoardBlocker, WorkspaceBoardDecision, WorkspaceBoardGoal, WorkspaceBoardKnowledgeCandidate, WorkspaceBoardNote, WorkspaceBoardRecommendation, WorkspaceBoardSkillRef, WorkspaceBoardSourceRef, WorkspaceBoardTodo } from '@proma/shared'
 
 interface AgentWorkspacesIndex {
   version: number
@@ -906,6 +907,8 @@ const SKILL_TREE_MAX_DEPTH = 8
 const WORKSPACE_CLAUDE_MD = 'CLAUDE.md'
 const AUTO_MEMORY_DIR = '.claude/memory'
 const AUTO_MEMORY_INDEX = 'MEMORY.md'
+const WORKSPACE_BOARD_RELATIVE_PATH = '.context/workspace-board.json'
+const LEGACY_WORKSPACE_BOARD_RELATIVE_PATH = '.context/workspace-board.md'
 
 function fileSummary(absPath: string): WorkspaceMemorySummary['claudeMd'] {
   if (!existsSync(absPath)) {
@@ -926,6 +929,14 @@ export function getWorkspaceClaudeMdPath(workspaceSlug: string): string {
 
 function getWorkspaceAutoMemoryPath(workspaceSlug: string): string {
   return join(getAgentWorkspacePath(workspaceSlug), AUTO_MEMORY_DIR)
+}
+
+export function getWorkspaceBoardPath(workspaceSlug: string): string {
+  return join(getWorkspaceFilesDir(workspaceSlug), WORKSPACE_BOARD_RELATIVE_PATH)
+}
+
+function getLegacyWorkspaceBoardPath(workspaceSlug: string): string {
+  return join(getWorkspaceFilesDir(workspaceSlug), LEGACY_WORKSPACE_BOARD_RELATIVE_PATH)
 }
 
 export function getWorkspaceAutoMemoryDir(workspaceSlug: string): string {
@@ -1131,6 +1142,275 @@ export function writeWorkspaceAutoMemoryFile(workspaceSlug: string, relativePath
   }
   writeFileSync(abs, content, 'utf-8')
   console.log(`[Agent 工作区] 已更新 auto memory 文件: ${workspaceSlug}/${relativePath}`)
+}
+
+function createWorkspaceBoardId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${randomUUID().slice(0, 8)}`
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function normalizeBoardSourceRefs(value: unknown): WorkspaceBoardSourceRef[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const refs = value
+    .map((entry): WorkspaceBoardSourceRef | null => {
+      const ref = asRecord(entry)
+      const type = ref.type === 'session' ||
+        ref.type === 'file' ||
+        ref.type === 'skill' ||
+        ref.type === 'automation' ||
+        ref.type === 'memory' ||
+        ref.type === 'board'
+        ? ref.type
+        : null
+      if (!type) return null
+      return {
+        type,
+        title: asString(ref.title) || undefined,
+        id: asString(ref.id) || undefined,
+        path: asString(ref.path) || undefined,
+      }
+    })
+    .filter((ref): ref is WorkspaceBoardSourceRef => ref !== null)
+  return refs.length > 0 ? refs : undefined
+}
+
+function normalizeBoardBaseItem<TStatus extends string>(
+  value: unknown,
+  fallbackPrefix: string,
+  allowedStatuses: readonly TStatus[],
+  fallbackStatus: TStatus,
+): { id: string; title: string; details?: string; source?: string; sourceRefs?: WorkspaceBoardSourceRef[]; status: TStatus; createdAt: string; updatedAt: string } | null {
+  const item = asRecord(value)
+  const title = asString(item.title).trim()
+  if (!title) return null
+  const status = allowedStatuses.includes(item.status as TStatus) ? item.status as TStatus : fallbackStatus
+  const createdAt = asString(item.createdAt, nowIso())
+  return {
+    id: asString(item.id, createWorkspaceBoardId(fallbackPrefix)),
+    title,
+    details: asString(item.details) || undefined,
+    source: asString(item.source) || undefined,
+    sourceRefs: normalizeBoardSourceRefs(item.sourceRefs),
+    status,
+    createdAt,
+    updatedAt: asString(item.updatedAt, createdAt),
+  }
+}
+
+function normalizeBoardArray<T>(value: unknown, mapper: (entry: unknown) => T | null): T[] {
+  if (!Array.isArray(value)) return []
+  return value.map(mapper).filter((entry): entry is T => entry !== null)
+}
+
+function normalizeWorkspaceBoard(input: unknown): WorkspaceBoard {
+  const board = asRecord(input)
+  const updatedAt = asString(board.updatedAt, nowIso())
+  const automationLevel = board.automationLevel === 'manual' ||
+    board.automationLevel === 'assistive'
+    ? board.automationLevel
+    : 'suggest'
+  const goals = normalizeBoardArray<WorkspaceBoardGoal>(board.goals, (entry) =>
+    normalizeBoardBaseItem(entry, 'goal', ['active', 'blocked', 'done', 'archived'] as const, 'active')
+  )
+  const todos = normalizeBoardArray<WorkspaceBoardTodo>(board.todos, (entry) => {
+    const item = normalizeBoardBaseItem(entry, 'todo', ['pending', 'in_progress', 'blocked', 'done', 'cancelled'] as const, 'pending')
+    if (!item) return null
+    const raw = asRecord(entry)
+    const owner = raw.owner === 'user' || raw.owner === 'agent' || raw.owner === 'shared' ? raw.owner : undefined
+    return { ...item, owner }
+  })
+  const blockers = normalizeBoardArray<WorkspaceBoardBlocker>(board.blockers, (entry) =>
+    normalizeBoardBaseItem(entry, 'blocker', ['open', 'resolved'] as const, 'open')
+  )
+  const decisions = normalizeBoardArray<WorkspaceBoardDecision>(board.decisions, (entry) =>
+    normalizeBoardBaseItem(entry, 'decision', ['proposed', 'accepted', 'rejected'] as const, 'proposed')
+  )
+  const recommendations = normalizeBoardArray<WorkspaceBoardRecommendation>(board.recommendations, (entry) => {
+    const item = normalizeBoardBaseItem(entry, 'recommendation', ['suggested', 'accepted', 'dismissed'] as const, 'suggested')
+    if (!item) return null
+    const raw = asRecord(entry)
+    const kind = raw.kind === 'create_automation' ||
+      raw.kind === 'create_skill' ||
+      raw.kind === 'promote_memory' ||
+      raw.kind === 'open_agent_session' ||
+      raw.kind === 'review_blocker'
+      ? raw.kind
+      : 'follow_up'
+    const confidence = typeof raw.confidence === 'number' && Number.isFinite(raw.confidence)
+      ? Math.min(1, Math.max(0, raw.confidence))
+      : undefined
+    const safetyLevel = raw.safetyLevel === 'read_only' ||
+      raw.safetyLevel === 'writes_board' ||
+      raw.safetyLevel === 'writes_memory' ||
+      raw.safetyLevel === 'runs_agent' ||
+      raw.safetyLevel === 'creates_automation'
+      ? raw.safetyLevel
+      : undefined
+    return {
+      ...item,
+      kind,
+      confidence,
+      actionLabel: asString(raw.actionLabel) || undefined,
+      safetyLevel,
+    }
+  })
+  const automationRefs = normalizeBoardArray<WorkspaceBoardAutomationRef>(board.automationRefs, (entry) => {
+    const item = normalizeBoardBaseItem(entry, 'automation-ref', ['linked', 'suggested', 'archived'] as const, 'linked')
+    if (!item) return null
+    const raw = asRecord(entry)
+    return {
+      ...item,
+      automationId: asString(raw.automationId) || undefined,
+      trigger: asString(raw.trigger) || undefined,
+    }
+  })
+  const skillRefs = normalizeBoardArray<WorkspaceBoardSkillRef>(board.skillRefs, (entry) => {
+    const item = normalizeBoardBaseItem(entry, 'skill-ref', ['enabled', 'disabled', 'suggested', 'archived'] as const, 'enabled')
+    if (!item) return null
+    const raw = asRecord(entry)
+    return {
+      ...item,
+      skillSlug: asString(raw.skillSlug) || undefined,
+    }
+  })
+  const knowledgeCandidates = normalizeBoardArray<WorkspaceBoardKnowledgeCandidate>(board.knowledgeCandidates, (entry) => {
+    const item = normalizeBoardBaseItem(entry, 'candidate', ['candidate', 'promoted', 'dismissed'] as const, 'candidate')
+    if (!item) return null
+    const raw = asRecord(entry)
+    const kind = raw.kind === 'skill' || raw.kind === 'doc' || raw.kind === 'memory' ? raw.kind : 'memory'
+    return { ...item, kind }
+  })
+  const notes = normalizeBoardArray<WorkspaceBoardNote>(board.notes, (entry) => {
+    const item = normalizeBoardBaseItem(entry, 'note', ['active'] as const, 'active')
+    if (!item) return null
+    const raw = asRecord(entry)
+    const kind = raw.kind === 'legacy_scratch_pad' || raw.kind === 'handoff' || raw.kind === 'note' ? raw.kind : 'note'
+    const { status: _status, ...base } = item
+    return { ...base, kind }
+  })
+
+  return {
+    schemaVersion: 1,
+    title: asString(board.title, '协作台'),
+    summary: asString(board.summary) || undefined,
+    automationLevel,
+    updatedAt,
+    goals,
+    todos,
+    blockers,
+    decisions,
+    recommendations,
+    automationRefs,
+    skillRefs,
+    knowledgeCandidates,
+    notes,
+  }
+}
+
+function createEmptyWorkspaceBoard(): WorkspaceBoard {
+  return normalizeWorkspaceBoard({
+    title: '协作台',
+    summary: '维护当前工作区正在推进的目标、Todo、阻塞、决策草案和待沉淀候选。',
+    updatedAt: nowIso(),
+  })
+}
+
+function createWorkspaceBoardFromLegacyMarkdown(markdown: string): WorkspaceBoard {
+  const timestamp = nowIso()
+  const todos = markdown
+    .split(/\r?\n/)
+    .map((line) => line.match(/^\s*[-*]\s+\[([ xX])]\s+(.+?)\s*$/))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match): WorkspaceBoardTodo => ({
+      id: createWorkspaceBoardId('legacy-todo'),
+      title: match[2] ?? '旧协作台 Todo',
+      status: match[1]?.toLowerCase() === 'x' ? 'done' : 'pending',
+      owner: 'shared',
+      source: LEGACY_WORKSPACE_BOARD_RELATIVE_PATH,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }))
+
+  return normalizeWorkspaceBoard({
+    title: '协作台',
+    summary: '已从旧 Markdown 协作台迁移内容，请按结构化字段继续整理。',
+    updatedAt: timestamp,
+    todos,
+    recommendations: markdown.trim().length > 0 ? [{
+      id: createWorkspaceBoardId('legacy-recommendation'),
+      kind: 'follow_up',
+      title: '检查旧协作台迁移内容',
+      details: '旧 Markdown 内容已迁移到工作笔记；建议确认 Todo、目标和决策是否需要拆分到对应区域。',
+      status: 'suggested',
+      confidence: 0.8,
+      actionLabel: '整理迁移内容',
+      safetyLevel: 'writes_board',
+      sourceRefs: [{ type: 'file', path: LEGACY_WORKSPACE_BOARD_RELATIVE_PATH, title: '旧协作台' }],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }] : [],
+    notes: markdown.trim().length > 0 ? [{
+      id: createWorkspaceBoardId('legacy-note'),
+      kind: 'note',
+      title: '旧 Markdown 协作台迁移',
+      details: markdown.trim(),
+      source: LEGACY_WORKSPACE_BOARD_RELATIVE_PATH,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }] : [],
+  })
+}
+
+export function readWorkspaceBoard(workspaceSlug: string): WorkspaceBoard {
+  const abs = getWorkspaceBoardPath(workspaceSlug)
+  if (!existsSync(abs)) {
+    const legacyAbs = getLegacyWorkspaceBoardPath(workspaceSlug)
+    if (existsSync(legacyAbs)) {
+      const st = statSync(legacyAbs)
+      if (st.isFile() && st.size <= SKILL_FILE_SIZE_LIMIT) {
+        return createWorkspaceBoardFromLegacyMarkdown(readFileSync(legacyAbs, 'utf-8'))
+      }
+    }
+    return createEmptyWorkspaceBoard()
+  }
+
+  const st = statSync(abs)
+  if (!st.isFile()) throw new Error(`${WORKSPACE_BOARD_RELATIVE_PATH} 不是文件`)
+  if (st.size > SKILL_FILE_SIZE_LIMIT) {
+    throw new Error(`文件过大（${(st.size / 1024 / 1024).toFixed(2)} MB），超过 10 MB 限制`)
+  }
+
+  const raw = readFileSync(abs, 'utf-8')
+  return normalizeWorkspaceBoard(JSON.parse(raw))
+}
+
+export function writeWorkspaceBoard(workspaceSlug: string, board: WorkspaceBoard): WorkspaceBoard {
+  const normalized = normalizeWorkspaceBoard({ ...board, updatedAt: nowIso() })
+  const content = `${JSON.stringify(normalized, null, 2)}\n`
+  const byteLen = Buffer.byteLength(content, 'utf-8')
+  if (byteLen > SKILL_FILE_SIZE_LIMIT) {
+    throw new Error(`内容过大（${(byteLen / 1024 / 1024).toFixed(2)} MB），超过 10 MB 限制`)
+  }
+
+  const abs = getWorkspaceBoardPath(workspaceSlug)
+  const parent = dirname(abs)
+  if (!existsSync(parent)) {
+    mkdirSync(parent, { recursive: true })
+  }
+  writeFileSync(abs, content, 'utf-8')
+  console.log(`[Agent 工作区] 已更新协作台: ${workspaceSlug}/${WORKSPACE_BOARD_RELATIVE_PATH}`)
+  return normalized
 }
 
 /** 把相对路径限制在 Skill 根目录内，并拒绝直接覆盖 SKILL.md */

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -49,6 +49,7 @@ import type {
   GetTaskOutputResult,
   StopTaskInput,
   WorkspaceMcpConfig,
+  WorkspaceBoard,
   SkillMeta,
   OtherWorkspaceSkillsGroup,
   WorkspaceCapabilities,
@@ -572,6 +573,12 @@ export interface ElectronAPI {
 
   /** 写入工作区 auto memory 文件 */
   writeWorkspaceAutoMemoryFile: (workspaceSlug: string, relativePath: string, content: string) => Promise<void>
+
+  /** 读取工作区协作台文件 */
+  readWorkspaceBoard: (workspaceSlug: string) => Promise<WorkspaceBoard>
+
+  /** 写入工作区协作台文件 */
+  writeWorkspaceBoard: (workspaceSlug: string, board: WorkspaceBoard) => Promise<WorkspaceBoard>
 
   /** 订阅 Agent 流式事件（返回清理函数） */
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => () => void
@@ -1638,6 +1645,14 @@ const electronAPI: ElectronAPI = {
 
   writeWorkspaceAutoMemoryFile: (workspaceSlug: string, relativePath: string, content: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.WRITE_WORKSPACE_AUTO_MEMORY_FILE, workspaceSlug, relativePath, content)
+  },
+
+  readWorkspaceBoard: (workspaceSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.READ_WORKSPACE_BOARD, workspaceSlug)
+  },
+
+  writeWorkspaceBoard: (workspaceSlug: string, board: WorkspaceBoard) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.WRITE_WORKSPACE_BOARD, workspaceSlug, board)
   },
 
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => {

--- a/apps/electron/src/renderer/atoms/active-view.ts
+++ b/apps/electron/src/renderer/atoms/active-view.ts
@@ -3,17 +3,22 @@
  *
  * 控制 MainArea 显示的内容：
  * - conversations: 对话视图（Chat/Agent 模式内容）
+ * - workspace-board: 协作台中控视图
  * - automations: 定时任务列表视图
  * - agent-skills: Agent 技能（Skills/MCP）全屏管理视图
  */
 
 import { atom } from 'jotai'
 
-export type ActiveView = 'conversations' | 'automations' | 'agent-skills'
+export type ActiveView = 'conversations' | 'workspace-board' | 'automations' | 'agent-skills'
+export type WorkspaceBoardTab = 'overview' | 'automations' | 'skills' | 'notes'
 export type AgentSkillsCapabilityTab = 'skills' | 'mcp' | 'memory'
 
 /** 当前活跃视图（不持久化，每次启动默认显示对话） */
 export const activeViewAtom = atom<ActiveView>('conversations')
+
+/** 协作台当前子页 */
+export const workspaceBoardTabAtom = atom<WorkspaceBoardTab>('overview')
 
 /** Agent 技能视图当前子页，用于外部入口直达 MCP 管理 */
 export const agentSkillsTabAtom = atom<AgentSkillsCapabilityTab>('skills')

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -1,7 +1,7 @@
 /**
  * Tab Atoms — 当前工作区入口状态管理
  *
- * 顶部只保留 Scratch Pad 与当前会话两个入口；会话恢复与导航交给左侧列表。
+ * 顶部只保留协作台与当前会话两个入口；会话恢复与导航交给左侧列表。
  * 通过桥接 atom 与现有 currentConversationIdAtom / currentAgentSessionIdAtom 同步，
  * 确保所有现有派生 atoms 无需修改。
  */
@@ -24,7 +24,7 @@ import type { PreviewFile } from './preview-atoms'
 /** 标签页类型（Settings 不作为 Tab，保留独立视图） */
 export type TabType = 'chat' | 'agent' | 'scratch' | 'preview' | 'tutorial'
 
-/** Scratch Pad 专用的固定 sessionId */
+/** 协作台专用的固定 sessionId（沿用旧 ID，兼容已持久化的 Tab 状态） */
 export const SCRATCH_PAD_ID = '__scratch-pad__'
 
 /** 教程 Tab 固定 ID */
@@ -34,8 +34,8 @@ export const TUTORIAL_TAB_TITLE = 'Proma 使用教程'
 /** 会话预览 Tab 的 ID 前缀：运行时临时入口，不参与持久化 */
 const PREVIEW_TAB_PREFIX = '__preview__:'
 
-/** Scratch Pad 标签默认标题 */
-export const SCRATCH_PAD_TITLE = 'Scratch Pad'
+/** 协作台标签默认标题 */
+export const SCRATCH_PAD_TITLE = '协作台'
 
 /** 标签页数据 */
 export interface TabItem {
@@ -81,7 +81,7 @@ export interface OpenTabRestore {
 
 // ===== 核心 Atoms =====
 
-/** 顶部入口列表：Scratch Pad + 当前会话 */
+/** 顶部入口列表：协作台 + 当前会话 */
 export const tabsAtom = atom<TabItem[]>([])
 
 /** 当前激活的标签 ID */
@@ -113,9 +113,9 @@ export interface TabMinimapItem {
 }
 export const tabMinimapCacheAtom = atom<Map<string, TabMinimapItem[]>>(new Map())
 
-/** Scratch Pad 编辑内容（HTML 字符串，供 TipTap 编辑器使用） */
+/** 旧 Scratch Pad 编辑内容（HTML 字符串，仅用于迁移到协作台） */
 export const scratchPadContentAtom = atom<string>('')
-/** Scratch Pad 内容是否已从磁盘加载 */
+/** 旧 Scratch Pad 内容是否已从磁盘加载 */
 export const scratchPadLoadedAtom = atom<boolean>(false)
 
 // ===== 派生 Atoms =====

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -58,7 +58,7 @@ import { agentProcessGroupsKeepExpandedAtom, agentSessionPendingFilesAtom } from
 import { agentSessionsAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
 import { automationsAtom, automationFormAtom, automationToDraft } from '@/atoms/automation-atoms'
-import { activeViewAtom } from '@/atoms/active-view'
+import { activeViewAtom, workspaceBoardTabAtom } from '@/atoms/active-view'
 import { environmentCheckDialogOpenAtom } from '@/atoms/environment'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenPreview } from '@/components/diff/preview-opener'
@@ -887,6 +887,7 @@ function ScheduledRunBadge(): React.ReactElement {
   const automations = useAtomValue(automationsAtom)
   const setForm = useSetAtom(automationFormAtom)
   const setActiveView = useSetAtom(activeViewAtom)
+  const setWorkspaceBoardTab = useSetAtom(workspaceBoardTabAtom)
 
   const session = sessions.find((s) => s.id === activeSessionId)
   const automation = session?.sourceAutomationId && !session.sourceDelegationId
@@ -895,7 +896,8 @@ function ScheduledRunBadge(): React.ReactElement {
 
   const handleClick = (): void => {
     if (!automation) return
-    setActiveView('automations')
+    setWorkspaceBoardTab('automations')
+    setActiveView('workspace-board')
     setForm({
       open: true,
       draft: automationToDraft(automation),

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -42,7 +42,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
   const isClassic = interfaceVariant === 'classic'
   // 定时任务表单打开时隐藏右侧文件面板，让中间区域扩展到全宽（表单内含自己的右栏配置）
   const activeView = useAtomValue(activeViewAtom)
-  const showRightPanel = appMode === 'agent' && !!currentSessionId && !automationForm.open && activeView !== 'automations' && activeView !== 'agent-skills'
+  const showRightPanel = appMode === 'agent' && !!currentSessionId && !automationForm.open && activeView !== 'workspace-board' && activeView !== 'automations' && activeView !== 'agent-skills'
   const isWindows = React.useMemo(() => detectIsWindows(), [])
 
   // 右侧面板可拖拽宽度

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,13 +11,13 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw, LayoutDashboard } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
 import { SearchDialog } from './SearchDialog'
 import { UserAvatar } from '@/components/chat/UserAvatar'
-import { activeViewAtom, agentSkillsTabAtom } from '@/atoms/active-view'
+import { activeViewAtom, agentSkillsTabAtom, workspaceBoardTabAtom } from '@/atoms/active-view'
 import { automationFormAtom, automationsAtom } from '@/atoms/automation-atoms'
 import { appModeAtom, type AppMode } from '@/atoms/app-mode'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
@@ -204,6 +204,55 @@ function SidebarUpdateButton({
       </TooltipTrigger>
       <TooltipContent side={tooltipSide}>{label}</TooltipContent>
     </Tooltip>
+  )
+}
+
+interface WorkspaceBoardSidebarEntryProps {
+  automationCount: number
+  skillUpdateCount: number
+  active: boolean
+  onClick: () => void
+}
+
+function WorkspaceBoardSidebarEntry({
+  automationCount,
+  skillUpdateCount,
+  active,
+  onClick,
+}: WorkspaceBoardSidebarEntryProps): React.ReactElement {
+  const badgeCount = automationCount + skillUpdateCount
+
+  return (
+    <button
+      type="button"
+      aria-label={`协作台，${automationCount} 个自动任务${skillUpdateCount > 0 ? `，${skillUpdateCount} 个技能可更新` : ''}`}
+      onClick={onClick}
+      className={cn(
+        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
+        active
+          ? 'bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
+      )}
+    >
+      <span className="flex min-w-0 items-center gap-3">
+        <span className={cn('flex-shrink-0 w-[18px] h-[18px]', active ? 'text-accent-foreground' : 'text-foreground/45')}>
+          <LayoutDashboard size={16} className="block" />
+        </span>
+        <span className="truncate">协作台</span>
+      </span>
+      {badgeCount > 0 && (
+        <span
+          className={cn(
+            'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums',
+            active
+              ? 'bg-accent-foreground/[0.26] text-primary-foreground'
+              : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',
+          )}
+        >
+          {formatAutomationCount(badgeCount)}
+        </span>
+      )}
+    </button>
   )
 }
 
@@ -603,6 +652,7 @@ function deleteSetEntry<T>(prev: Set<T>, value: T): Set<T> {
 export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [activeView, setActiveView] = useAtom(activeViewAtom)
   const setAgentSkillsTab = useSetAtom(agentSkillsTabAtom)
+  const setWorkspaceBoardTab = useSetAtom(workspaceBoardTabAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
   const automations = useAtomValue(automationsAtom)
   const setAutomations = useSetAtom(automationsAtom)
@@ -899,10 +949,24 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     return () => window.removeEventListener('focus', handleFocus)
   }, [setConversations, setAgentSessions])
 
-  /** 打开/关闭自动任务列表 */
+  /** 打开/关闭协作台 */
+  const handleOpenWorkspaceBoard = React.useCallback((): void => {
+    if (activeView === 'workspace-board') {
+      if (store.get(automationFormAtom).open) {
+        setAutomationForm({ open: false, draft: null })
+        return
+      }
+      setActiveView('conversations')
+      return
+    }
+    setWorkspaceBoardTab('overview')
+    setAutomationForm({ open: false, draft: null })
+    setActiveView('workspace-board')
+  }, [activeView, setAutomationForm, setActiveView, setWorkspaceBoardTab, store])
+
+  /** 打开/关闭自动任务列表，保留旧入口行为 */
   const handleOpenAutomations = React.useCallback((): void => {
     if (activeView === 'automations') {
-      // 编辑页 → 关表单回列表；列表页 → 退出到对话
       if (store.get(automationFormAtom).open) {
         setAutomationForm({ open: false, draft: null })
         return
@@ -914,7 +978,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setActiveView('automations')
   }, [activeView, setAutomationForm, setActiveView, store])
 
-  /** 打开/关闭 Agent 技能视图 */
+  /** 打开/关闭 Agent 技能视图，保留旧入口行为 */
   const handleOpenSkills = React.useCallback((): void => {
     if (activeView === 'agent-skills') {
       setActiveView('conversations')
@@ -926,8 +990,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 打开当前工作区的 MCP 管理页 */
   const handleOpenMcpManagement = React.useCallback((): void => {
     setAgentSkillsTab('mcp')
-    setActiveView('agent-skills')
-  }, [setAgentSkillsTab, setActiveView])
+    setWorkspaceBoardTab('skills')
+    setActiveView('workspace-board')
+  }, [setAgentSkillsTab, setActiveView, setWorkspaceBoardTab])
 
   // 切换模式时重置归档视图
   React.useEffect(() => {
@@ -2070,6 +2135,39 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 type="button"
+                aria-label="协作台"
+                onClick={handleOpenWorkspaceBoard}
+                className={cn(
+                  'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
+                  activeView === 'workspace-board'
+                    ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
+                    : 'border-border/45 bg-foreground/[0.025] text-foreground/45 hover:border-border/70 hover:bg-foreground/[0.045] hover:text-primary',
+                )}
+              >
+                <LayoutDashboard size={16} />
+                {(automationCount + (capabilities?.skills.filter((s) => s.hasUpdate).length ?? 0)) > 0 && (
+                  <span
+                    className={cn(
+                      'absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
+                      activeView === 'workspace-board'
+                        ? 'bg-primary-foreground text-primary'
+                        : 'bg-primary text-primary-foreground',
+                    )}
+                  >
+                    {formatAutomationCount(automationCount + (capabilities?.skills.filter((s) => s.hasUpdate).length ?? 0))}
+                  </span>
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              协作台
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
                 aria-label={`自动任务，${automationCount} 个任务已创建`}
                 onClick={handleOpenAutomations}
                 className={cn(
@@ -2242,8 +2340,18 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </Tooltip>
       </div>
 
-      {/* 自动任务入口：作为任务中心入口放在置顶区上方，不参与置顶列表层级。 */}
+      {/* 协作台入口：聚合工作区状态、自动任务和 Agent 技能。 */}
       <div className="px-3 pt-2 pb-0.5">
+        <WorkspaceBoardSidebarEntry
+          automationCount={automationCount}
+          skillUpdateCount={capabilities?.skills.filter((s) => s.hasUpdate).length ?? 0}
+          active={activeView === 'workspace-board'}
+          onClick={handleOpenWorkspaceBoard}
+        />
+      </div>
+
+      {/* 自动任务入口：保留旧入口，避免习惯用户找不到。 */}
+      <div className="px-3 pb-0.5">
         <AutomationSidebarEntry
           count={automationCount}
           active={activeView === 'automations'}
@@ -2251,7 +2359,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         />
       </div>
 
-      {/* Agent 技能入口：Skills / MCP 能力中心，仅 Agent 模式可见 */}
+      {/* Agent 技能入口：Skills / MCP 能力中心，保留旧入口。 */}
       {mode === 'agent' && (
         <div className="px-3 pb-0.5">
           <SkillsSidebarEntry

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/atoms/automation-atoms'
 import { agentWorkspacesAtom, agentSessionsAtom, agentChannelIdsAtom, currentAgentWorkspaceIdAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
-import { activeViewAtom, agentSkillsTabAtom } from '@/atoms/active-view'
+import { activeViewAtom, agentSkillsTabAtom, workspaceBoardTabAtom } from '@/atoms/active-view'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { MarkdownRichEditor } from '@/components/diff/MarkdownRichEditor'
@@ -271,6 +271,7 @@ export function AutomationFormView(): React.ReactElement | null {
   const currentAgentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const setActiveView = useSetAtom(activeViewAtom)
   const setAgentSkillsTab = useSetAtom(agentSkillsTabAtom)
+  const setWorkspaceBoardTab = useSetAtom(workspaceBoardTabAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
   const openSession = useOpenSession()
@@ -950,7 +951,8 @@ export function AutomationFormView(): React.ReactElement | null {
                   className="ml-auto text-xs underline underline-offset-2 hover:text-foreground transition-colors"
                   onClick={() => {
                     setAgentSkillsTab('mcp')
-                    setActiveView('agent-skills')
+                    setWorkspaceBoardTab('skills')
+                    setActiveView('workspace-board')
                   }}
                 >
                   前往 MCP 管理

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -1,336 +1,1236 @@
 /**
- * ScratchPadView — 草稿本编辑器
+ * WorkspaceBoardView — 工作区协作台
  *
- * 基于 TipTap 的轻量 Markdown 编辑器，内容持久化到 ~/.proma/scratch-pad.md。
- * 自动保存由 ScratchPadPersistence 组件通过监听 scratchPadContentAtom 统一管理。
- *
- * 支持：Markdown 快捷输入、图片粘贴、Todo 列表（- [ ] 触发）、代码高亮（lowlight）、数学公式（$..$ / $$..$$ 触发）、导出为 Markdown
+ * 协作台使用结构化 JSON 存储在 workspace-files/.context/workspace-board.json。
+ * 旧 Scratch Pad 内容仅作为迁移来源，避免用户已有草稿丢失。
  */
 
 import * as React from 'react'
-import { useEditor, EditorContent } from '@tiptap/react'
-import StarterKit from '@tiptap/starter-kit'
-import Placeholder from '@tiptap/extension-placeholder'
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import { useAtom, useAtomValue } from 'jotai'
-import { FileDown } from 'lucide-react'
-import { scratchPadContentAtom, scratchPadLoadedAtom, tabsAtom, activeTabIdAtom } from '@/atoms/tab-atoms'
-import { currentAgentWorkspaceIdAtom, agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import { useAtomValue } from 'jotai'
 import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuPortal,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-} from '@/components/ui/dropdown-menu'
-import { lowlight } from '@/lib/lowlight'
-import { htmlToMarkdown, markdownToHtml } from '@/lib/markdown-rich-text'
-import {
-  MathBlock,
-  MathInline,
-  RawHtmlBlock,
-  RawHtmlInline,
-  TaskItem,
-  TaskList,
-  tableExtensions,
-  createMarkdownImage,
-  createMarkdownVideo,
-} from '@/components/diff/markdown-preview-extensions'
-import { SpeechButton } from '@/components/ai-elements/speech-button'
-import {
-  SCRATCH_PAD_VOICE_INPUT_ID,
-  VOICE_DICTATION_INSERT_EVENT,
-  getLastFocusedVoiceInputId,
-  setLastFocusedVoiceInputId,
-} from '@/lib/voice-input-focus'
+  AlertCircle,
+  AlarmClock,
+  Archive,
+  ArrowRight,
+  Blocks,
+  BookOpen,
+  Brain,
+  CheckCircle2,
+  Circle,
+  Clock3,
+  FileText,
+  GitPullRequestDraft,
+  LayoutDashboard,
+  ListTodo,
+  Pencil,
+  ShieldAlert,
+  Sparkles,
+  Target,
+} from 'lucide-react'
+import type {
+  WorkspaceBoard,
+  WorkspaceBoardAutomationLevel,
+  WorkspaceBoardBaseItem,
+  WorkspaceBoardCandidateKind,
+  WorkspaceBoardRecommendation,
+  WorkspaceBoardRecommendationKind,
+  WorkspaceBoardRecommendationSafetyLevel,
+  WorkspaceBoardRecommendationStatus,
+  WorkspaceBoardNote,
+  WorkspaceBoardSourceRef,
+  WorkspaceBoardTodo,
+  WorkspaceBoardTodoStatus,
+} from '@proma/shared'
+import { scratchPadContentAtom, scratchPadLoadedAtom } from '@/atoms/tab-atoms'
+import { agentWorkspacesAtom, currentAgentWorkspaceIdAtom } from '@/atoms/agent-atoms'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { htmlToMarkdown } from '@/lib/markdown-rich-text'
+import { cn } from '@/lib/utils'
 
-export function ScratchPadView(): React.ReactElement {
-  const [content, setContent] = useAtom(scratchPadContentAtom)
-  const loaded = useAtomValue(scratchPadLoadedAtom)
-  const containerRef = React.useRef<HTMLDivElement>(null)
+const TODO_STATUS_LABEL: Record<WorkspaceBoardTodoStatus, string> = {
+  pending: '待处理',
+  in_progress: '进行中',
+  blocked: '阻塞',
+  done: '完成',
+  cancelled: '取消',
+}
 
-  // 用 ref 追踪最新内容，避免在 useEffect deps 里包含 content 导致循环
-  const contentRef = React.useRef(content)
-  contentRef.current = content
+const TODO_STATUS_ORDER: WorkspaceBoardTodoStatus[] = ['pending', 'in_progress', 'blocked', 'done', 'cancelled']
 
-  const extensions = React.useMemo(() => [
-    StarterKit.configure({
-      heading: { levels: [1, 2, 3] },
-      codeBlock: false, // 用 CodeBlockLowlight 替代：支持 ``` 触发、可编辑、可删除
-    }),
-    Placeholder.configure({
-      placeholder: '在此随意书写… 支持 Markdown 快捷输入',
-    }),
-    CodeBlockLowlight.configure({ lowlight }),
-    // ScratchPad 无会话/文件上下文，传 null 跳过路径解析（仅支持 data-URL / 外链 / file: 协议）
-    createMarkdownImage(null),
-    createMarkdownVideo(null),
-    RawHtmlBlock,
-    RawHtmlInline,
-    MathBlock,
-    MathInline,
-    TaskList,
-    TaskItem,
-    ...tableExtensions,
-  ], [])
+const AUTOMATION_LEVEL_LABEL: Record<WorkspaceBoardAutomationLevel, string> = {
+  manual: '手动',
+  suggest: '建议',
+  assistive: '协助',
+}
 
-  const editor = useEditor({
-    extensions,
-    content: content || '',
-    onUpdate: ({ editor }) => {
-      setContent(editor.getHTML())
-    },
-    immediatelyRender: false,
-  })
+const AUTOMATION_LEVEL_DESCRIPTION: Record<WorkspaceBoardAutomationLevel, string> = {
+  manual: 'Agent 只读取协作台，不主动新增条目。',
+  suggest: 'Agent 可以写建议和候选项，用户决定是否采纳。',
+  assistive: 'Agent 可以维护 Todo、阻塞和建议，但不直接写 Memory 或创建自动任务。',
+}
 
-  // ===== 导出 =====
+const AUTOMATION_LEVEL_ORDER: WorkspaceBoardAutomationLevel[] = ['manual', 'suggest', 'assistive']
 
-  // 导出目标上下文
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function createBoardId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function createEmptyBoard(): WorkspaceBoard {
+  return {
+    schemaVersion: 1,
+    title: '协作台',
+    summary: '维护当前工作区正在推进的目标、Todo、阻塞、决策草案和待沉淀候选。',
+    automationLevel: 'suggest',
+    updatedAt: nowIso(),
+    goals: [],
+    todos: [],
+    blockers: [],
+    decisions: [],
+    recommendations: [],
+    automationRefs: [],
+    skillRefs: [],
+    knowledgeCandidates: [],
+    notes: [],
+  }
+}
+
+function boardSignature(board: WorkspaceBoard): string {
+  return JSON.stringify(board)
+}
+
+function isBoardEmpty(board: WorkspaceBoard): boolean {
+  return (
+    board.goals.length === 0 &&
+    board.todos.length === 0 &&
+    board.blockers.length === 0 &&
+    board.decisions.length === 0 &&
+    board.recommendations.length === 0 &&
+    board.automationRefs.length === 0 &&
+    board.skillRefs.length === 0 &&
+    board.knowledgeCandidates.length === 0 &&
+    board.notes.length === 0
+  )
+}
+
+function extractLegacyTodos(markdown: string): WorkspaceBoardTodo[] {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => line.match(/^\s*[-*]\s+\[([ xX])]\s+(.+?)\s*$/))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match) => {
+      const status: WorkspaceBoardTodoStatus = match[1]?.toLowerCase() === 'x' ? 'done' : 'pending'
+      const timestamp = nowIso()
+      return {
+        id: createBoardId('legacy-todo'),
+        title: match[2] ?? '旧草稿 Todo',
+        status,
+        owner: 'shared',
+        source: 'legacy_scratch_pad',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }
+    })
+}
+
+function migrateLegacyScratch(board: WorkspaceBoard, legacyHtml: string): WorkspaceBoard {
+  const markdown = htmlToMarkdown(legacyHtml).trim()
+  if (!markdown) return board
+  const timestamp = nowIso()
+  return {
+    ...board,
+    summary: board.summary ?? '已从旧草稿页迁移内容，请按当前目标和 Todo 继续整理。',
+    updatedAt: timestamp,
+    todos: [...board.todos, ...extractLegacyTodos(markdown)],
+    recommendations: [
+      ...board.recommendations,
+      {
+        id: createBoardId('legacy-recommendation'),
+        kind: 'follow_up',
+        title: '检查旧草稿迁移内容',
+        details: '旧草稿已迁移为工作笔记；建议确认哪些内容需要拆成 Todo、目标或决策。',
+        status: 'suggested',
+        confidence: 0.8,
+        actionLabel: '整理迁移内容',
+        safetyLevel: 'writes_board',
+        source: 'scratch-pad.md',
+        sourceRefs: [{ type: 'file', path: 'scratch-pad.md', title: '旧草稿' }],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    notes: [
+      ...board.notes,
+      {
+        id: createBoardId('legacy-note'),
+        kind: 'legacy_scratch_pad',
+        title: '旧草稿迁移',
+        details: markdown,
+        source: 'scratch-pad.md',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+  }
+}
+
+function normalizeBoardFromJson(raw: string, fallback: WorkspaceBoard): WorkspaceBoard | null {
+  try {
+    const parsed = JSON.parse(raw) as WorkspaceBoard
+    return {
+      ...fallback,
+      ...parsed,
+      schemaVersion: 1,
+      automationLevel: parsed.automationLevel === 'manual' || parsed.automationLevel === 'assistive'
+        ? parsed.automationLevel
+        : 'suggest',
+      updatedAt: nowIso(),
+      goals: Array.isArray(parsed.goals) ? parsed.goals : [],
+      todos: Array.isArray(parsed.todos) ? parsed.todos : [],
+      blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+      decisions: Array.isArray(parsed.decisions) ? parsed.decisions : [],
+      recommendations: Array.isArray(parsed.recommendations) ? parsed.recommendations : [],
+      automationRefs: Array.isArray(parsed.automationRefs) ? parsed.automationRefs : [],
+      skillRefs: Array.isArray(parsed.skillRefs) ? parsed.skillRefs : [],
+      knowledgeCandidates: Array.isArray(parsed.knowledgeCandidates) ? parsed.knowledgeCandidates : [],
+      notes: Array.isArray(parsed.notes) ? parsed.notes : [],
+    }
+  } catch {
+    return null
+  }
+}
+
+function nextTodoStatus(status: WorkspaceBoardTodoStatus): WorkspaceBoardTodoStatus {
+  if (status === 'pending') return 'in_progress'
+  if (status === 'in_progress') return 'done'
+  if (status === 'blocked') return 'in_progress'
+  if (status === 'done') return 'pending'
+  return 'pending'
+}
+
+function candidateKindLabel(kind: WorkspaceBoardCandidateKind): string {
+  if (kind === 'skill') return 'Skill'
+  if (kind === 'doc') return '本地文档'
+  return 'Memory'
+}
+
+function recommendationKindLabel(kind: WorkspaceBoardRecommendationKind): string {
+  if (kind === 'create_automation') return '自动任务'
+  if (kind === 'create_skill') return 'Skill'
+  if (kind === 'promote_memory') return 'Memory'
+  if (kind === 'open_agent_session') return 'Agent 会话'
+  if (kind === 'review_blocker') return '检查阻塞'
+  return '跟进'
+}
+
+function recommendationStatusLabel(status: WorkspaceBoardRecommendationStatus): string {
+  if (status === 'accepted') return '已采纳'
+  if (status === 'dismissed') return '已忽略'
+  return '建议'
+}
+
+function safetyLevelLabel(level?: WorkspaceBoardRecommendationSafetyLevel): string {
+  if (level === 'writes_board') return '更新协作台'
+  if (level === 'writes_memory') return '写入 Memory'
+  if (level === 'runs_agent') return '启动 Agent'
+  if (level === 'creates_automation') return '创建自动任务'
+  return '只读'
+}
+
+function formatRelativeTime(iso: string): string {
+  const time = new Date(iso).getTime()
+  if (!Number.isFinite(time)) return ''
+  const diffMinutes = Math.max(0, Math.floor((Date.now() - time) / 60000))
+  if (diffMinutes < 1) return '刚刚'
+  if (diffMinutes < 60) return `${diffMinutes} 分钟前`
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) return `${diffHours} 小时前`
+  return `${Math.floor(diffHours / 24)} 天前`
+}
+
+type FocusQueueItemKind = 'blocker' | 'recommendation' | 'todo' | 'goal'
+
+interface FocusQueueItem {
+  kind: FocusQueueItemKind
+  id: string
+  title: string
+  details?: string
+  badge: string
+  tone: 'default' | 'warning' | 'accent'
+}
+
+function buildFocusQueue(board: WorkspaceBoard): FocusQueueItem[] {
+  const openBlockers = board.blockers
+    .filter((blocker) => blocker.status === 'open')
+    .map((blocker): FocusQueueItem => ({
+      kind: 'blocker',
+      id: blocker.id,
+      title: blocker.title,
+      details: blocker.details,
+      badge: '阻塞',
+      tone: 'warning',
+    }))
+
+  const suggestedRecommendations = board.recommendations
+    .filter((recommendation) => recommendation.status === 'suggested')
+    .map((recommendation): FocusQueueItem => ({
+      kind: 'recommendation',
+      id: recommendation.id,
+      title: recommendation.title,
+      details: recommendation.details,
+      badge: recommendationKindLabel(recommendation.kind),
+      tone: 'accent',
+    }))
+
+  const urgentTodos = board.todos
+    .filter((todo) => todo.status === 'in_progress' || todo.status === 'blocked')
+    .map((todo): FocusQueueItem => ({
+      kind: 'todo',
+      id: todo.id,
+      title: todo.title,
+      details: todo.details,
+      badge: TODO_STATUS_LABEL[todo.status],
+      tone: todo.status === 'blocked' ? 'warning' : 'default',
+    }))
+
+  const pendingTodos = board.todos
+    .filter((todo) => todo.status === 'pending')
+    .map((todo): FocusQueueItem => ({
+      kind: 'todo',
+      id: todo.id,
+      title: todo.title,
+      details: todo.details,
+      badge: TODO_STATUS_LABEL[todo.status],
+      tone: 'default',
+    }))
+
+  const activeGoals = board.goals
+    .filter((goal) => goal.status === 'active' || goal.status === 'blocked')
+    .map((goal): FocusQueueItem => ({
+      kind: 'goal',
+      id: goal.id,
+      title: goal.title,
+      details: goal.details,
+      badge: goal.status === 'blocked' ? '目标阻塞' : '当前目标',
+      tone: goal.status === 'blocked' ? 'warning' : 'default',
+    }))
+
+  return [...openBlockers, ...suggestedRecommendations, ...urgentTodos, ...pendingTodos, ...activeGoals].slice(0, 3)
+}
+
+function recommendationPrimaryActionLabel(recommendation: WorkspaceBoardRecommendation): string {
+  if (recommendation.kind === 'create_automation') return '加入自动任务候选'
+  if (recommendation.kind === 'create_skill') return '加入 Skill 候选'
+  if (recommendation.kind === 'promote_memory') return '加入沉淀候选'
+  return recommendation.actionLabel || '转成 Todo'
+}
+
+function recommendationSourceRefs(recommendation: WorkspaceBoardRecommendation): WorkspaceBoardSourceRef[] {
+  return [
+    { type: 'board', id: recommendation.id, title: recommendation.title },
+    ...(recommendation.sourceRefs ?? []),
+  ]
+}
+
+function candidateKindFromRecommendation(recommendation: WorkspaceBoardRecommendation): WorkspaceBoardCandidateKind {
+  if (recommendation.kind === 'create_skill') return 'skill'
+  if (recommendation.kind === 'promote_memory') return 'memory'
+  return 'doc'
+}
+
+export interface ScratchPadViewProps {
+  mode?: 'full' | 'notes'
+}
+
+export function ScratchPadView({ mode = 'full' }: ScratchPadViewProps): React.ReactElement {
+  const legacyScratchHtml = useAtomValue(scratchPadContentAtom)
+  const legacyScratchLoaded = useAtomValue(scratchPadLoadedAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
-  const tabs = useAtomValue(tabsAtom)
-  const activeTabId = useAtomValue(activeTabIdAtom)
-
   const currentWorkspace = React.useMemo(
-    () => workspaces.find((w) => w.id === currentWorkspaceId) ?? null,
+    () => workspaces.find((workspace) => workspace.id === currentWorkspaceId) ?? null,
     [workspaces, currentWorkspaceId],
   )
 
-  const activeSessionId = React.useMemo(() => {
-    const activeTab = tabs.find((t) => t.id === activeTabId)
-    if (activeTab?.type === 'agent' || activeTab?.type === 'preview') return activeTab.sessionId
-    const agentTab = [...tabs].reverse().find((t) => t.type === 'agent')
-    return agentTab?.sessionId ?? null
-  }, [tabs, activeTabId])
+  const [board, setBoard] = React.useState<WorkspaceBoard>(() => createEmptyBoard())
+  const [loaded, setLoaded] = React.useState(false)
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [rawOpen, setRawOpen] = React.useState(false)
+  const [rawDraft, setRawDraft] = React.useState('')
+  const [rawError, setRawError] = React.useState<string | null>(null)
+  const lastSavedRef = React.useRef<string>('')
+  const saveTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
 
-  const activeSessionTitle = React.useMemo(() => {
-    const agentTab = tabs.find((t) => t.sessionId === activeSessionId && t.type === 'agent')
-    return agentTab?.title ?? null
-  }, [tabs, activeSessionId])
+  React.useEffect(() => {
+    const workspaceSlug = currentWorkspace?.slug
+    if (!workspaceSlug) {
+      setBoard(createEmptyBoard())
+      setLoaded(true)
+      setError(null)
+      lastSavedRef.current = ''
+      return
+    }
 
-  const makeFilename = () => {
-    const now = new Date()
-    const pad = (n: number) => String(n).padStart(2, '0')
-    return `scratch-pad-${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}.md`
+    let cancelled = false
+    setLoaded(false)
+    setError(null)
+    window.electronAPI.readWorkspaceBoard(workspaceSlug)
+      .then((loadedBoard) => {
+        if (cancelled) return
+        let nextBoard = loadedBoard
+        lastSavedRef.current = boardSignature(loadedBoard)
+        if (legacyScratchLoaded && isBoardEmpty(loadedBoard) && legacyScratchHtml.trim().length > 0) {
+          nextBoard = migrateLegacyScratch(loadedBoard, legacyScratchHtml)
+        }
+        setBoard(nextBoard)
+        setRawDraft(JSON.stringify(nextBoard, null, 2))
+        setLoaded(true)
+      })
+      .catch((loadError) => {
+        if (cancelled) return
+        console.error('[协作台] 加载失败:', loadError)
+        setError('协作台加载失败')
+        setLoaded(true)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [currentWorkspace?.slug, legacyScratchLoaded, legacyScratchHtml])
+
+  React.useEffect(() => {
+    if (!loaded || !currentWorkspace?.slug || error) return
+    const signature = boardSignature(board)
+    if (signature === lastSavedRef.current) return
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+
+    const workspaceSlug = currentWorkspace.slug
+    saveTimerRef.current = setTimeout(() => {
+      setSaving(true)
+      window.electronAPI.writeWorkspaceBoard(workspaceSlug, board)
+        .then((savedBoard) => {
+          setBoard(savedBoard)
+          setRawDraft(JSON.stringify(savedBoard, null, 2))
+          lastSavedRef.current = boardSignature(savedBoard)
+        })
+        .catch((saveError) => {
+          console.error('[协作台] 保存失败:', saveError)
+          setError('协作台保存失败')
+        })
+        .finally(() => setSaving(false))
+    }, 600)
+
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    }
+  }, [board, loaded, currentWorkspace?.slug, error])
+
+  const activeTodos = React.useMemo(
+    () => TODO_STATUS_ORDER.flatMap((status) => board.todos.filter((todo) => todo.status === status)),
+    [board.todos],
+  )
+  const activeGoalCount = board.goals.filter((goal) => goal.status === 'active' || goal.status === 'blocked').length
+  const openBlockerCount = board.blockers.filter((blocker) => blocker.status === 'open').length
+  const suggestedRecommendationCount = board.recommendations.filter((recommendation) => recommendation.status === 'suggested').length
+  const focusQueue = React.useMemo(() => buildFocusQueue(board), [board])
+
+  const updateTodoStatus = React.useCallback((todoId: string, status: WorkspaceBoardTodoStatus) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      todos: prev.todos.map((todo) =>
+        todo.id === todoId ? { ...todo, status, updatedAt: timestamp } : todo
+      ),
+    }))
+  }, [])
+
+  const updateRecommendationStatus = React.useCallback((recommendationId: string, status: WorkspaceBoardRecommendationStatus) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      recommendations: prev.recommendations.map((recommendation) =>
+        recommendation.id === recommendationId ? { ...recommendation, status, updatedAt: timestamp } : recommendation
+      ),
+    }))
+  }, [])
+
+  const resolveBlocker = React.useCallback((blockerId: string) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      blockers: prev.blockers.map((blocker) =>
+        blocker.id === blockerId ? { ...blocker, status: 'resolved', updatedAt: timestamp } : blocker
+      ),
+    }))
+  }, [])
+
+  const convertRecommendationToTodo = React.useCallback((recommendation: WorkspaceBoardRecommendation) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      todos: [
+        {
+          id: createBoardId('todo'),
+          title: recommendation.actionLabel || recommendation.title,
+          details: recommendation.details,
+          status: 'pending',
+          owner: 'shared',
+          source: recommendation.source ?? 'Proma 建议',
+          sourceRefs: recommendationSourceRefs(recommendation),
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        ...prev.todos,
+      ],
+      recommendations: prev.recommendations.map((item) =>
+        item.id === recommendation.id ? { ...item, status: 'accepted', updatedAt: timestamp } : item
+      ),
+    }))
+  }, [])
+
+  const createAutomationRefFromRecommendation = React.useCallback((recommendation: WorkspaceBoardRecommendation) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      automationRefs: [
+        {
+          id: createBoardId('automation-ref'),
+          title: recommendation.actionLabel || recommendation.title,
+          details: recommendation.details,
+          status: 'suggested',
+          trigger: '待设置触发条件',
+          source: recommendation.source ?? 'Proma 建议',
+          sourceRefs: recommendationSourceRefs(recommendation),
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        ...prev.automationRefs,
+      ],
+      recommendations: prev.recommendations.map((item) =>
+        item.id === recommendation.id ? { ...item, status: 'accepted', updatedAt: timestamp } : item
+      ),
+    }))
+  }, [])
+
+  const createSkillRefFromRecommendation = React.useCallback((recommendation: WorkspaceBoardRecommendation) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      skillRefs: [
+        {
+          id: createBoardId('skill-ref'),
+          title: recommendation.actionLabel || recommendation.title,
+          details: recommendation.details,
+          status: 'suggested',
+          source: recommendation.source ?? 'Proma 建议',
+          sourceRefs: recommendationSourceRefs(recommendation),
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        ...prev.skillRefs,
+      ],
+      recommendations: prev.recommendations.map((item) =>
+        item.id === recommendation.id ? { ...item, status: 'accepted', updatedAt: timestamp } : item
+      ),
+    }))
+  }, [])
+
+  const createKnowledgeCandidateFromRecommendation = React.useCallback((recommendation: WorkspaceBoardRecommendation) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      knowledgeCandidates: [
+        {
+          id: createBoardId('knowledge-candidate'),
+          kind: candidateKindFromRecommendation(recommendation),
+          title: recommendation.actionLabel || recommendation.title,
+          details: recommendation.details,
+          status: 'candidate',
+          source: recommendation.source ?? 'Proma 建议',
+          sourceRefs: recommendationSourceRefs(recommendation),
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        ...prev.knowledgeCandidates,
+      ],
+      recommendations: prev.recommendations.map((item) =>
+        item.id === recommendation.id ? { ...item, status: 'accepted', updatedAt: timestamp } : item
+      ),
+    }))
+  }, [])
+
+  const runRecommendationAction = React.useCallback((recommendation: WorkspaceBoardRecommendation) => {
+    if (recommendation.kind === 'create_automation') {
+      createAutomationRefFromRecommendation(recommendation)
+      return
+    }
+    if (recommendation.kind === 'create_skill') {
+      createSkillRefFromRecommendation(recommendation)
+      return
+    }
+    if (recommendation.kind === 'promote_memory') {
+      createKnowledgeCandidateFromRecommendation(recommendation)
+      return
+    }
+    convertRecommendationToTodo(recommendation)
+  }, [
+    convertRecommendationToTodo,
+    createAutomationRefFromRecommendation,
+    createKnowledgeCandidateFromRecommendation,
+    createSkillRefFromRecommendation,
+  ])
+
+  const runRecommendationActionById = React.useCallback((recommendationId: string) => {
+    const recommendation = board.recommendations.find((item) => item.id === recommendationId)
+    if (!recommendation) return
+    runRecommendationAction(recommendation)
+  }, [board.recommendations, runRecommendationAction])
+
+  const updateAutomationLevel = React.useCallback((automationLevel: WorkspaceBoardAutomationLevel) => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      automationLevel,
+      updatedAt: timestamp,
+    }))
+  }, [])
+
+  const addTodo = React.useCallback(() => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      todos: [
+        {
+          id: createBoardId('todo'),
+          title: '新的待办事项',
+          status: 'pending',
+          owner: 'shared',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        ...prev.todos,
+      ],
+    }))
+  }, [])
+
+  const addNote = React.useCallback(() => {
+    const timestamp = nowIso()
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: timestamp,
+      notes: [
+        {
+          id: createBoardId('note'),
+          kind: 'note',
+          title: '新的工作笔记',
+          details: '',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        ...prev.notes,
+      ],
+    }))
+  }, [])
+
+  const updateNote = React.useCallback((noteId: string, patch: Partial<Pick<WorkspaceBoardNote, 'title' | 'details'>>) => {
+    setBoard((prev) => ({
+      ...prev,
+      updatedAt: nowIso(),
+      notes: prev.notes.map((note) =>
+        note.id === noteId ? { ...note, ...patch, updatedAt: nowIso() } : note
+      ),
+    }))
+  }, [])
+
+  const applyRawDraft = React.useCallback(() => {
+    const parsed = normalizeBoardFromJson(rawDraft, board)
+    if (!parsed) {
+      setRawError('JSON 格式无效')
+      return
+    }
+    setRawError(null)
+    setBoard(parsed)
+  }, [rawDraft, board])
+
+  const notesOnly = mode === 'notes'
+
+  if (!currentWorkspace) {
+    return (
+      <div className="flex h-full items-center justify-center bg-muted/20 px-6">
+        <div className="max-w-md rounded-lg bg-background p-6 text-center shadow-sm">
+          <LayoutDashboard className="mx-auto mb-3 size-8 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">协作台</h1>
+          <p className="mt-2 text-sm text-muted-foreground">请选择 Agent 工作区后使用协作台。</p>
+        </div>
+      </div>
+    )
   }
 
-  const handleExport = React.useCallback(
-    async (target: 'session' | 'workspace') => {
-      if (!editor || editor.isEmpty) return
-      // htmlToMarkdown 能正确处理本编辑器的所有自定义节点（math/task/markdownImage/table 等），
-      // 而通用 turndown 不认识这些 data-type 节点，会丢内容。
-      const markdownContent = htmlToMarkdown(editor.getHTML())
-      const filename = makeFilename()
-
-      try {
-        let dirPath: string | null = null
-        if (target === 'session' && activeSessionId && currentWorkspaceId) {
-          dirPath = await window.electronAPI.getAgentSessionPath(currentWorkspaceId, activeSessionId)
-        } else if (target === 'workspace' && currentWorkspace?.slug) {
-          dirPath = await window.electronAPI.getWorkspaceFilesPath(currentWorkspace.slug)
-        }
-        if (!dirPath) return
-        await window.electronAPI.exportScratchPad(markdownContent, dirPath, filename)
-      } catch (err) {
-        console.error('[ScratchPad] 导出失败:', err)
-      }
-    },
-    [editor, activeSessionId, currentWorkspaceId, currentWorkspace],
-  )
-
-  const handleBrowseExport = React.useCallback(async () => {
-    if (!editor || editor.isEmpty) return
-
-    const filename = makeFilename()
-    const filePath = await window.electronAPI.chooseExportPath(filename)
-    if (!filePath) return
-
-    try {
-      const markdownContent = htmlToMarkdown(editor.getHTML())
-      // 传空 filename 触发 IPC 的完整路径模式，由 Node.js path.dirname 安全处理
-      await window.electronAPI.exportScratchPad(markdownContent, filePath, '')
-    } catch (err) {
-      console.error('[ScratchPad] 导出失败:', err)
-    }
-  }, [editor])
-
-  // ===== 内容同步 =====
-
-  // 仅在初始加载或编辑器重新挂载时同步内容到编辑器。
-  // content 不加入 deps：用户每次输入都会更新 atom，若加入 deps 会导致
-  // setContent → onUpdate → atom 变化 → setContent 死循环，
-  // HTML 规范化解析会吞掉尾部空格和空段落，并重置光标位置。
-  React.useEffect(() => {
-    if (!loaded || !editor) return
-    const latestContent = contentRef.current
-    if (latestContent && editor.getHTML() !== latestContent) {
-      editor.commands.setContent(latestContent)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loaded, editor])
-
-  // ===== 语音输入路由 =====
-
-  // 编辑器获得焦点时，把"语音输入目标"标记为 Scratch Pad；点击语音按钮 / 触发快捷键时编辑器会失焦，
-  // 但 ID 保持不变，从而确保识别完成回填的文本会路由到这里而不是被 RichTextInput / agent draft 抢走。
-  React.useEffect(() => {
-    if (!editor) return
-    const dom = editor.view.dom
-    const handleFocus = (): void => {
-      setLastFocusedVoiceInputId(SCRATCH_PAD_VOICE_INPUT_ID)
-    }
-    dom.addEventListener('focus', handleFocus, true)
-    return () => dom.removeEventListener('focus', handleFocus, true)
-  }, [editor])
-
-  // 监听语音输入回填事件：仅在"上次聚焦目标"是 Scratch Pad 时消费，插入到当前光标位置
-  React.useEffect(() => {
-    if (!editor) return
-    const handler = (event: Event): void => {
-      if (getLastFocusedVoiceInputId() !== SCRATCH_PAD_VOICE_INPUT_ID) return
-      const customEvent = event as CustomEvent<{ text?: string }>
-      const text = customEvent.detail?.text?.trim()
-      if (!text) return
-      editor.chain().focus().insertContent({ type: 'text', text }).run()
-      event.preventDefault()
-    }
-    window.addEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
-    return () => window.removeEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
-  }, [editor])
-
-  // ===== 粘贴处理 =====
-
-  // 粘贴时：图片转 data URL 插入；含 markdown 标记的文本走 markdownToHtml 转 HTML 注入
-  React.useEffect(() => {
-    const el = containerRef.current
-    if (!el || !editor) return
-
-    const handlePaste = (e: ClipboardEvent): void => {
-      // 检测剪贴板中的图片
-      const items = e.clipboardData?.items
-      if (items) {
-        for (const item of items) {
-          if (item.type.startsWith('image/')) {
-            e.preventDefault()
-            e.stopPropagation()
-            const file = item.getAsFile()
-            if (!file) return
-            const reader = new FileReader()
-            reader.onload = () => {
-              editor.chain().focus().insertContent({
-                type: 'markdownImage',
-                attrs: { src: reader.result as string, alt: '', title: '' },
-              }).run()
-            }
-            reader.readAsDataURL(file)
-            return
-          }
-        }
-      }
-
-      const text = e.clipboardData?.getData('text/plain')
-      if (!text) return
-      // markdown 触发字符：#标题 *强调 >引用 -列表 `代码 [链接 ~删除 |表格 $公式
-      if (!/[#*>\-`[\]~|$]/.test(text)) return
-
-      e.preventDefault()
-      e.stopPropagation()
-      try {
-        const html = markdownToHtml(text)
-        editor.chain().focus().insertContent(html).run()
-      } catch {
-        // 转换失败，回退到纯文本插入
-        editor.chain().focus().insertContent(text).run()
-      }
-    }
-
-    el.addEventListener('paste', handlePaste, true)
-    return () => el.removeEventListener('paste', handlePaste, true)
-  }, [editor])
-
   return (
-    <div ref={containerRef} className="relative flex flex-col h-full">
-      <div className="flex-1 overflow-auto scrollbar-thin px-8 pt-6 pb-20">
-        <div className="max-w-3xl mx-auto h-full">
-          <div className="mb-5 flex flex-col gap-2">
-            <div>
-              <h1 className="text-xl font-semibold tracking-normal text-foreground">草稿页</h1>
-              <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
-                临时记录内容、整理 Todo、暂存剪贴板文本，稍后再导出到会话或工作区。
+    <div className="flex h-full min-h-0 flex-col bg-muted/20">
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="mx-auto flex min-h-full max-w-7xl flex-col gap-4">
+          {!notesOnly && (
+          <header className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-background px-4 py-3 shadow-sm">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <LayoutDashboard className="size-5 text-primary" />
+                <h1 className="truncate text-base font-semibold tracking-normal">{board.title || '协作台'}</h1>
+              </div>
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                {board.summary || '工作区级结构化状态，供人和 Agent 跨会话协作。'}
               </p>
             </div>
-            <div className="flex flex-wrap gap-1.5 text-[11px] text-muted-foreground/80">
-              <span className="rounded-md bg-muted px-2 py-1">临时笔记</span>
-              <span className="rounded-md bg-muted px-2 py-1">Todo 草稿</span>
-              <span className="rounded-md bg-muted px-2 py-1">剪贴板暂存</span>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <AutomationLevelControl
+                value={board.automationLevel ?? 'suggest'}
+                onChange={updateAutomationLevel}
+              />
+              <span className="text-xs text-muted-foreground">
+                {saving ? '保存中' : loaded ? `已保存 · ${formatRelativeTime(board.updatedAt)}` : '加载中'}
+              </span>
+              <Button variant="outline" size="sm" onClick={() => setRawOpen((open) => !open)}>
+                <Pencil className="size-3.5" />
+                Schema
+              </Button>
             </div>
+          </header>
+          )}
+
+          {!notesOnly && (
+          <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+            <MetricCard icon={<Sparkles className="size-4" />} label="活跃目标" value={activeGoalCount} />
+            <MetricCard icon={<ListTodo className="size-4" />} label="待办队列" value={activeTodos.length} />
+            <MetricCard icon={<ShieldAlert className="size-4" />} label="开放阻塞" value={openBlockerCount} tone={openBlockerCount > 0 ? 'warning' : 'default'} />
+            <MetricCard icon={<Brain className="size-4" />} label="主动建议" value={suggestedRecommendationCount} tone={suggestedRecommendationCount > 0 ? 'accent' : 'default'} />
           </div>
-          {loaded ? (
-            <EditorContent
-              editor={editor}
-              className="prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
-            />
-          ) : (
-            <div className="min-h-[200px] flex items-center justify-center">
-              <span className="text-sm text-muted-foreground/40">加载中…</span>
+          )}
+
+          {!notesOnly && (
+          <FocusQueueSection
+            items={focusQueue}
+            onResolveBlocker={resolveBlocker}
+            onCycleTodoStatus={(todoId) => {
+              const todo = board.todos.find((item) => item.id === todoId)
+              if (!todo) return
+              updateTodoStatus(todo.id, nextTodoStatus(todo.status))
+            }}
+            onRunRecommendation={runRecommendationActionById}
+            onAddTodo={addTodo}
+          />
+          )}
+
+          {!notesOnly && (
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_420px]">
+            <main className="grid min-w-0 auto-rows-min gap-4">
+              <BoardSection
+                title="Todo 队列"
+                icon={<ListTodo className="size-4" />}
+                emptyText="还没有 Todo"
+                empty={activeTodos.length === 0}
+                action={<Button variant="secondary" size="sm" onClick={addTodo}>新增 Todo</Button>}
+              >
+                <div className="grid gap-2">
+                  {activeTodos.map((todo) => (
+                    <TodoRow
+                      key={todo.id}
+                      todo={todo}
+                      onCycleStatus={() => updateTodoStatus(todo.id, nextTodoStatus(todo.status))}
+                      onStatusChange={(status) => updateTodoStatus(todo.id, status)}
+                    />
+                  ))}
+                </div>
+              </BoardSection>
+
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <BoardSection title="当前目标" icon={<Target className="size-4" />} emptyText="还没有当前目标" empty={board.goals.length === 0}>
+                  <div className="grid gap-2">
+                    {board.goals.map((goal) => (
+                      <BoardItemCard key={goal.id} item={goal} badge={goal.status} />
+                    ))}
+                  </div>
+                </BoardSection>
+
+                <BoardSection title="阻塞与待确认" icon={<AlertCircle className="size-4" />} emptyText="暂无阻塞" empty={board.blockers.length === 0}>
+                  <div className="grid gap-2">
+                    {board.blockers.map((blocker) => (
+                      <BoardItemCard key={blocker.id} item={blocker} badge={blocker.status === 'open' ? '待处理' : '已解决'} />
+                    ))}
+                  </div>
+                </BoardSection>
+              </div>
+
+              <BoardSection title="决策记录" icon={<GitPullRequestDraft className="size-4" />} emptyText="暂无决策记录" empty={board.decisions.length === 0}>
+                <div className="grid gap-2">
+                  {board.decisions.map((decision) => (
+                    <BoardItemCard key={decision.id} item={decision} badge={decision.status} />
+                  ))}
+                </div>
+              </BoardSection>
+            </main>
+
+            <aside className="grid auto-rows-min gap-4">
+              <BoardSection title="Proma 建议" icon={<Brain className="size-4" />} emptyText="暂无主动建议" empty={board.recommendations.length === 0}>
+                <div className="grid gap-2">
+                  {board.recommendations.map((recommendation) => (
+                    <RecommendationCard
+                      key={recommendation.id}
+                      recommendation={recommendation}
+                      onPrimaryAction={() => runRecommendationAction(recommendation)}
+                      onDismiss={() => updateRecommendationStatus(recommendation.id, 'dismissed')}
+                    />
+                  ))}
+                </div>
+              </BoardSection>
+
+              <BoardSection title="可沉淀候选" icon={<Archive className="size-4" />} emptyText="暂无候选" empty={board.knowledgeCandidates.length === 0}>
+                <div className="grid gap-2">
+                  {board.knowledgeCandidates.map((candidate) => (
+                    <BoardItemCard
+                      key={candidate.id}
+                      item={candidate}
+                      badge={`${candidateKindLabel(candidate.kind)} · ${candidate.status}`}
+                    />
+                  ))}
+                </div>
+              </BoardSection>
+
+              <BoardSection title="自动任务引用" icon={<AlarmClock className="size-4" />} emptyText="暂无引用" empty={board.automationRefs.length === 0}>
+                <div className="grid gap-2">
+                  {board.automationRefs.map((automationRef) => (
+                    <BoardItemCard
+                      key={automationRef.id}
+                      item={automationRef}
+                      badge={automationRef.trigger ? `${automationRef.status} · ${automationRef.trigger}` : automationRef.status}
+                    />
+                  ))}
+                </div>
+              </BoardSection>
+
+              <BoardSection title="Agent 技能引用" icon={<Blocks className="size-4" />} emptyText="暂无引用" empty={board.skillRefs.length === 0}>
+                <div className="grid gap-2">
+                  {board.skillRefs.map((skillRef) => (
+                    <BoardItemCard
+                      key={skillRef.id}
+                      item={skillRef}
+                      badge={skillRef.skillSlug ? `${skillRef.status} · ${skillRef.skillSlug}` : skillRef.status}
+                    />
+                  ))}
+                </div>
+              </BoardSection>
+
+            </aside>
+          </div>
+          )}
+
+          <BoardSection
+            title="工作笔记"
+            icon={<BookOpen className="size-4" />}
+            emptyText="暂无笔记"
+            empty={board.notes.length === 0}
+            action={<Button variant="secondary" size="sm" onClick={addNote}>新增笔记</Button>}
+            className="min-h-[360px] flex-1"
+            contentClassName="min-h-[280px]"
+          >
+            <div className="grid min-h-[280px] gap-3">
+              {board.notes.map((note) => (
+                <WorkNoteCard
+                  key={note.id}
+                  note={note}
+                  onTitleChange={(title) => updateNote(note.id, { title })}
+                  onDetailsChange={(details) => updateNote(note.id, { details })}
+                />
+              ))}
             </div>
+          </BoardSection>
+        </div>
+      </div>
+
+      {rawOpen && (
+        <div className="border-t border-border/50 bg-background p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <div>
+              <h2 className="text-sm font-medium">协作台 Schema</h2>
+              <p className="text-xs text-muted-foreground">Agent 可直接维护这个 JSON；保存时主进程会归一化 schema。</p>
+            </div>
+            <Button variant="default" size="sm" onClick={applyRawDraft}>应用 JSON</Button>
+          </div>
+          {rawError && <p className="mb-2 text-xs text-destructive">{rawError}</p>}
+          <Textarea
+            value={rawDraft}
+            onChange={(event) => setRawDraft(event.target.value)}
+            className="h-64 resize-none font-mono text-xs"
+            spellCheck={false}
+          />
+        </div>
+      )}
+
+      {error && (
+        <div className="border-t border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AutomationLevelControl({
+  value,
+  onChange,
+}: {
+  value: WorkspaceBoardAutomationLevel
+  onChange: (value: WorkspaceBoardAutomationLevel) => void
+}): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2 rounded-md bg-muted/50 p-1" title={AUTOMATION_LEVEL_DESCRIPTION[value]}>
+      <span className="px-1 text-[10px] text-muted-foreground">自动化</span>
+      {AUTOMATION_LEVEL_ORDER.map((level) => (
+        <button
+          key={level}
+          type="button"
+          onClick={() => onChange(level)}
+          className={cn(
+            'h-7 rounded px-2 text-xs text-muted-foreground transition-colors',
+            value === level && 'bg-background text-foreground shadow-sm',
+          )}
+          title={AUTOMATION_LEVEL_DESCRIPTION[level]}
+        >
+          {AUTOMATION_LEVEL_LABEL[level]}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function FocusQueueSection({
+  items,
+  onResolveBlocker,
+  onCycleTodoStatus,
+  onRunRecommendation,
+  onAddTodo,
+}: {
+  items: FocusQueueItem[]
+  onResolveBlocker: (blockerId: string) => void
+  onCycleTodoStatus: (todoId: string) => void
+  onRunRecommendation: (recommendationId: string) => void
+  onAddTodo: () => void
+}): React.ReactElement {
+  return (
+    <section className="rounded-lg bg-background p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <span className="text-primary"><Sparkles className="size-4" /></span>
+          当前焦点
+        </div>
+        <Button variant="secondary" size="sm" onClick={onAddTodo}>
+          新增 Todo
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-md bg-muted/50 px-4 py-6">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <CheckCircle2 className="size-4 text-primary" />
+            现在没有必须立刻处理的焦点
+          </div>
+          <p className="mt-2 max-w-3xl text-xs leading-5 text-muted-foreground">
+            你可以直接写工作笔记；Agent 在会话结束、遇到阻塞、发现重复流程或需要沉淀经验时，会把下一步建议写到这里，由你决定是否采纳。
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-2 lg:grid-cols-3">
+          {items.map((item) => (
+            <article
+              key={`${item.kind}-${item.id}`}
+              className={cn(
+                'grid min-h-[128px] grid-rows-[auto_1fr_auto] rounded-md bg-muted/35 p-3',
+                item.tone === 'warning' && 'bg-amber-500/10',
+                item.tone === 'accent' && 'bg-primary/10',
+              )}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="rounded-md bg-background px-2 py-1 text-[10px] text-muted-foreground shadow-sm">
+                  {item.badge}
+                </span>
+                {item.kind === 'blocker' && <AlertCircle className="size-4 text-amber-600 dark:text-amber-300" />}
+                {item.kind === 'recommendation' && <Brain className="size-4 text-primary" />}
+                {item.kind === 'todo' && <ListTodo className="size-4 text-muted-foreground" />}
+                {item.kind === 'goal' && <Target className="size-4 text-muted-foreground" />}
+              </div>
+
+              <div className="mt-3 min-w-0">
+                <h3 className="line-clamp-2 text-sm font-medium leading-5">{item.title}</h3>
+                {item.details && (
+                  <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                    {item.details}
+                  </p>
+                )}
+              </div>
+
+              <div className="mt-3">
+                {item.kind === 'blocker' && (
+                  <Button variant="secondary" size="sm" className="h-7 px-2 text-xs" onClick={() => onResolveBlocker(item.id)}>
+                    标记解决
+                  </Button>
+                )}
+                {item.kind === 'recommendation' && (
+                  <Button variant="secondary" size="sm" className="h-7 px-2 text-xs" onClick={() => onRunRecommendation(item.id)}>
+                    处理建议
+                    <ArrowRight className="size-3" />
+                  </Button>
+                )}
+                {item.kind === 'todo' && (
+                  <Button variant="secondary" size="sm" className="h-7 px-2 text-xs" onClick={() => onCycleTodoStatus(item.id)}>
+                    推进状态
+                  </Button>
+                )}
+                {item.kind === 'goal' && (
+                  <span className="text-[10px] text-muted-foreground">
+                    目标会由 Todo、阻塞和建议继续拆解
+                  </span>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function MetricCard({
+  icon,
+  label,
+  value,
+  tone = 'default',
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+  tone?: 'default' | 'warning' | 'accent'
+}): React.ReactElement {
+  return (
+    <div className={cn(
+      'rounded-lg bg-background p-4 shadow-sm',
+      tone === 'warning' && 'bg-amber-500/10 text-amber-700 dark:text-amber-300',
+      tone === 'accent' && 'bg-primary/10 text-primary',
+    )}>
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">{label}</span>
+        <span className="text-muted-foreground">{icon}</span>
+      </div>
+      <div className="mt-2 text-2xl font-semibold tabular-nums">{value}</div>
+    </div>
+  )
+}
+
+function BoardSection({
+  title,
+  icon,
+  emptyText,
+  empty,
+  action,
+  className,
+  contentClassName,
+  children,
+}: {
+  title: string
+  icon: React.ReactNode
+  emptyText: string
+  empty: boolean
+  action?: React.ReactNode
+  className?: string
+  contentClassName?: string
+  children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <section className={cn('rounded-lg bg-background p-4 shadow-sm', className)}>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <span className="text-muted-foreground">{icon}</span>
+          {title}
+        </div>
+        {action}
+      </div>
+      {empty ? (
+        <div className={cn('rounded-md bg-muted/50 px-3 py-6 text-center text-xs text-muted-foreground', contentClassName)}>{emptyText}</div>
+      ) : (
+        <div className={contentClassName}>{children}</div>
+      )}
+    </section>
+  )
+}
+
+function RecommendationCard({
+  recommendation,
+  onPrimaryAction,
+  onDismiss,
+}: {
+  recommendation: WorkspaceBoardRecommendation
+  onPrimaryAction: () => void
+  onDismiss: () => void
+}): React.ReactElement {
+  const inactive = recommendation.status !== 'suggested'
+  const confidence = typeof recommendation.confidence === 'number'
+    ? `${Math.round(recommendation.confidence * 100)}%`
+    : null
+
+  return (
+    <article className={cn('rounded-md bg-muted/35 p-3', inactive && 'opacity-70')}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="rounded-md bg-background px-2 py-1 text-[10px] text-primary shadow-sm">
+              {recommendationKindLabel(recommendation.kind)}
+            </span>
+            <span className="rounded-md bg-background px-2 py-1 text-[10px] text-muted-foreground shadow-sm">
+              {recommendationStatusLabel(recommendation.status)}
+            </span>
+          </div>
+          <h3 className="mt-2 text-sm font-medium leading-5">{recommendation.title}</h3>
+          {recommendation.details && (
+            <p className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap text-xs leading-5 text-muted-foreground">
+              {recommendation.details}
+            </p>
           )}
         </div>
       </div>
-      {/* 底部居中悬浮：圆形语音输入按钮 */}
-      <div className="absolute left-1/2 -translate-x-1/2 bottom-10 z-20">
-        <SpeechButton className="size-11 rounded-full bg-background/95 border border-border/60 shadow-md backdrop-blur hover:bg-accent text-foreground/80" />
+
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground/80">
+        <span>{safetyLevelLabel(recommendation.safetyLevel)}</span>
+        {confidence && <span>置信度 {confidence}</span>}
+        {recommendation.sourceRefs?.slice(0, 2).map((ref) => (
+          <span key={`${ref.type}-${ref.id ?? ref.path ?? ref.title}`} className="truncate">
+            {ref.title ?? ref.path ?? ref.id ?? ref.type}
+          </span>
+        ))}
       </div>
-      <div className="h-[28px] border-t border-border/40 px-4 flex items-center justify-between">
-        <span className="text-[11px] text-muted-foreground/60">
-          Scratch Pad — 内容自动保存到本地
-        </span>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="text-[11px] text-muted-foreground/60 hover:text-foreground flex items-center gap-1 transition-colors"
-              title="导出为 Markdown"
-            >
-              <FileDown className="w-3 h-3" />
-              导出
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuPortal>
-          <DropdownMenuContent align="end" side="top" className="min-w-[240px] z-[9999]">
-            <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
-              导出为 Markdown
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={() => handleExport('session')}
-              disabled={!activeSessionId}
-              className="flex flex-col items-start"
-            >
-              <span className="text-xs">保存到会话目录</span>
-              <span className="text-[10px] text-muted-foreground">
-                {activeSessionTitle ?? '无活跃会话'}
-              </span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onSelect={() => handleExport('workspace')}
-              disabled={!currentWorkspace}
-              className="flex flex-col items-start"
-            >
-              <span className="text-xs">保存到工作区目录</span>
-              <span className="text-[10px] text-muted-foreground">
-                {currentWorkspace?.name ?? '无当前工作区'}
-              </span>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={handleBrowseExport}>
-              浏览选择位置...
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-          </DropdownMenuPortal>
-        </DropdownMenu>
+
+      {recommendation.status === 'suggested' && (
+        <div className="mt-3 flex items-center gap-2">
+          <Button variant="secondary" size="sm" className="h-7 px-2 text-xs" onClick={onPrimaryAction}>
+            {recommendationPrimaryActionLabel(recommendation)}
+          </Button>
+          <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={onDismiss}>
+            忽略
+          </Button>
+        </div>
+      )}
+    </article>
+  )
+}
+
+function BoardItemCard({ item, badge }: { item: WorkspaceBoardBaseItem; badge: string }): React.ReactElement {
+  return (
+    <article className="rounded-md bg-muted/35 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium">{item.title}</h3>
+          {item.details && <p className="mt-1 max-h-44 overflow-auto whitespace-pre-wrap text-xs leading-5 text-muted-foreground">{item.details}</p>}
+        </div>
+        <span className="shrink-0 rounded-md bg-background px-2 py-1 text-[10px] text-muted-foreground shadow-sm">{badge}</span>
       </div>
-    </div>
+      <div className="mt-2 flex items-center gap-2 text-[10px] text-muted-foreground/70">
+        <Clock3 className="size-3" />
+        {formatRelativeTime(item.updatedAt)}
+        {item.source && (
+          <>
+            <FileText className="size-3" />
+            {item.source}
+          </>
+        )}
+      </div>
+    </article>
+  )
+}
+
+function WorkNoteCard({
+  note,
+  onTitleChange,
+  onDetailsChange,
+}: {
+  note: WorkspaceBoardNote
+  onTitleChange: (title: string) => void
+  onDetailsChange: (details: string) => void
+}): React.ReactElement {
+  const badge = note.kind === 'legacy_scratch_pad' ? '旧草稿' : note.kind
+
+  return (
+    <article className="grid min-h-[220px] grid-rows-[auto_minmax(160px,1fr)_auto] rounded-md bg-muted/35 p-3">
+      <div className="flex items-center gap-2">
+        <input
+          value={note.title}
+          onChange={(event) => onTitleChange(event.target.value)}
+          className="min-w-0 flex-1 rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-medium outline-none hover:border-border/60 focus:border-primary/60 focus:bg-background"
+        />
+        <span className="shrink-0 rounded-md bg-background px-2 py-1 text-[10px] text-muted-foreground shadow-sm">{badge}</span>
+      </div>
+      <Textarea
+        value={note.details ?? ''}
+        onChange={(event) => onDetailsChange(event.target.value)}
+        placeholder="记录给人看的上下文、草稿、复盘或临时想法。Agent 可以读取，但这里不自动沉淀为 Memory 或 Skill。"
+        className="mt-2 min-h-[160px] resize-y border-border/40 bg-background/70 text-sm leading-6"
+      />
+      <div className="mt-2 flex items-center gap-2 text-[10px] text-muted-foreground/70">
+        <Clock3 className="size-3" />
+        {formatRelativeTime(note.updatedAt)}
+        {note.source && (
+          <>
+            <FileText className="size-3" />
+            {note.source}
+          </>
+        )}
+      </div>
+    </article>
+  )
+}
+
+function TodoRow({
+  todo,
+  onCycleStatus,
+  onStatusChange,
+}: {
+  todo: WorkspaceBoardTodo
+  onCycleStatus: () => void
+  onStatusChange: (status: WorkspaceBoardTodoStatus) => void
+}): React.ReactElement {
+  const done = todo.status === 'done'
+  return (
+    <article className="grid grid-cols-[auto_minmax(0,1fr)_128px] items-center gap-3 rounded-md bg-muted/35 p-3">
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={onCycleStatus}
+        title="切换状态"
+      >
+        {done ? <CheckCircle2 className="size-4 text-primary" /> : <Circle className="size-4" />}
+      </button>
+      <div className="min-w-0">
+        <h3 className={cn('truncate text-sm font-medium', done && 'text-muted-foreground line-through')}>{todo.title}</h3>
+        {todo.details && <p className="mt-1 truncate text-xs text-muted-foreground">{todo.details}</p>}
+      </div>
+      <select
+        value={todo.status}
+        onChange={(event) => onStatusChange(event.target.value as WorkspaceBoardTodoStatus)}
+        className="h-8 rounded-md border border-border/60 bg-background px-2 text-xs"
+      >
+        {TODO_STATUS_ORDER.map((status) => (
+          <option key={status} value={status}>{TODO_STATUS_LABEL[status]}</option>
+        ))}
+      </select>
+    </article>
   )
 }

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -19,6 +19,7 @@ import { TabContent } from './TabContent'
 import { AutomationFormView } from '@/components/automation/AutomationFormView'
 import { AutomationsListView } from '@/components/automation/AutomationsListView'
 import { AgentSkillsView } from '@/components/agent-skills/AgentSkillsView'
+import { WorkspaceBoardHubView } from '@/components/workspace-board/WorkspaceBoardHubView'
 import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
@@ -157,7 +158,9 @@ export function MainArea(): React.ReactElement {
             className="flex flex-col min-w-0 h-full relative"
             style={leftFlexStyle}
           >
-            {activeView === 'automations' ? (
+            {activeView === 'workspace-board' ? (
+              <WorkspaceBoardHubView />
+            ) : activeView === 'automations' ? (
               automationFormOpen ? (
                 // 定时任务设置页：与列表同层级替换中间区，不经过 TabBar，避免切换时闪出会话 Tab。
                 <AutomationFormView />

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAtomValue } from 'jotai'
-import { FileText, StickyNote, X, Clock, GitBranch } from 'lucide-react'
+import { FileText, LayoutDashboard, X, Clock, GitBranch } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -88,7 +88,7 @@ export function TabBarItem({
   }, [])
 
   const handleMouseDown = (e: React.MouseEvent): void => {
-    // Scratch Pad 不可中键关闭
+    // 协作台不可中键关闭
     if (type === 'scratch') return
     if (e.button === 1) {
       e.preventDefault()
@@ -107,7 +107,7 @@ export function TabBarItem({
   // 当前 active Tab 不显示预览面板
   const showPreview = isHovered && !isActive
 
-  // Scratch Pad 是固定草稿入口
+  // 协作台是固定入口
   if (isScratch) {
     return (
       <div
@@ -135,8 +135,8 @@ export function TabBarItem({
           onMouseDown={handleMouseDown}
           onPointerDown={onDragStart}
         >
-          <StickyNote className="size-3.5" />
-          <span className="truncate">草稿</span>
+          <LayoutDashboard className="size-3.5" />
+          <span className="truncate">协作台</span>
         </button>
       </div>
     )

--- a/apps/electron/src/renderer/components/tabs/TabContent.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabContent.tsx
@@ -14,7 +14,7 @@ import { AgentView } from '@/components/agent'
 import { PreviewTabContent } from '@/components/diff/PreviewTabContent'
 import { MarkdownRichEditor } from '@/components/diff/MarkdownRichEditor'
 import { MarkdownToc } from '@/components/diff/MarkdownToc'
-import { ScratchPadView } from '@/components/scratch-pad/ScratchPadView'
+import { WorkspaceBoardHubView } from '@/components/workspace-board/WorkspaceBoardHubView'
 import { TabErrorBoundary } from './TabErrorBoundary'
 
 export interface TabContentProps {
@@ -41,7 +41,7 @@ export function TabContent({ tabId }: TabContentProps): React.ReactElement {
   }
 
   if (tab.type === 'scratch') {
-    return <ScratchPadView />
+    return <WorkspaceBoardHubView />
   }
 
   if (tab.type === 'tutorial') {

--- a/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
@@ -9,7 +9,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useAtom } from 'jotai'
-import { Lightbulb, MessageSquare, Bot, StickyNote } from 'lucide-react'
+import { LayoutDashboard, Lightbulb, MessageSquare, Bot } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { appModeAtom, type AppMode } from '@/atoms/app-mode'
@@ -28,7 +28,7 @@ function getGreeting(hour: number): string {
 const MODE_CONFIG: Record<AppMode, { icon: React.ReactNode; label: string }> = {
   chat: { icon: <MessageSquare size={15} />, label: 'Chat' },
   agent: { icon: <Bot size={15} />, label: 'Agent' },
-  scratch: { icon: <StickyNote size={15} />, label: 'Scratch Pad' },
+  scratch: { icon: <LayoutDashboard size={15} />, label: '协作台' },
 }
 
 export function WelcomeEmptyState(): React.ReactElement {

--- a/apps/electron/src/renderer/components/workspace-board/WorkspaceBoardHubView.tsx
+++ b/apps/electron/src/renderer/components/workspace-board/WorkspaceBoardHubView.tsx
@@ -1,0 +1,79 @@
+/**
+ * WorkspaceBoardHubView — 协作台中控入口
+ *
+ * 协作台是工作区运行状态入口，内部承载总览、自动任务、Agent 技能和工作笔记。
+ */
+
+import * as React from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import { AlarmClock, Blocks, BookOpen, LayoutDashboard } from 'lucide-react'
+import { workspaceBoardTabAtom, type WorkspaceBoardTab } from '@/atoms/active-view'
+import { automationFormAtom } from '@/atoms/automation-atoms'
+import { AgentSkillsView } from '@/components/agent-skills/AgentSkillsView'
+import { AutomationFormView } from '@/components/automation/AutomationFormView'
+import { AutomationsListView } from '@/components/automation/AutomationsListView'
+import { ScratchPadView } from '@/components/scratch-pad/ScratchPadView'
+import { cn } from '@/lib/utils'
+
+const WORKSPACE_BOARD_TABS: Array<{
+  value: WorkspaceBoardTab
+  label: string
+  icon: React.ReactNode
+}> = [
+  { value: 'overview', label: '总览', icon: <LayoutDashboard className="size-4" /> },
+  { value: 'automations', label: '自动任务', icon: <AlarmClock className="size-4" /> },
+  { value: 'skills', label: 'Agent 技能', icon: <Blocks className="size-4" /> },
+  { value: 'notes', label: '工作笔记', icon: <BookOpen className="size-4" /> },
+]
+
+export function WorkspaceBoardHubView(): React.ReactElement {
+  const [tab, setTab] = useAtom(workspaceBoardTabAtom)
+  const automationFormOpen = useAtomValue(automationFormAtom).open
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-muted/20">
+      <div className="flex flex-shrink-0 items-center justify-between border-b border-border/50 bg-background px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <LayoutDashboard className="size-5 text-primary" />
+            <h1 className="truncate text-base font-semibold">协作台</h1>
+          </div>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            工作区状态、自动化、Agent 能力和人类笔记的中控入口
+          </p>
+        </div>
+
+        <div className="flex items-center rounded-lg bg-muted p-1">
+          {WORKSPACE_BOARD_TABS.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => setTab(item.value)}
+              className={cn(
+                'flex h-8 items-center gap-1.5 rounded-md px-3 text-xs transition-colors',
+                tab === item.value
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {tab === 'overview' ? (
+          <ScratchPadView />
+        ) : tab === 'automations' ? (
+          automationFormOpen ? <AutomationFormView /> : <AutomationsListView />
+        ) : tab === 'skills' ? (
+          <AgentSkillsView />
+        ) : (
+          <ScratchPadView mode="notes" />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.197",
         "@anthropic-ai/sdk": "^0.93.0",
@@ -182,7 +182,7 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.35",
+      "version": "0.1.38",
       "devDependencies": {
         "typescript": "^5.0.0",
       },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -883,6 +883,94 @@ export interface WorkspaceMemorySummary {
   }
 }
 
+export type WorkspaceBoardItemStatus = 'active' | 'blocked' | 'done' | 'archived'
+export type WorkspaceBoardTodoStatus = 'pending' | 'in_progress' | 'blocked' | 'done' | 'cancelled'
+export type WorkspaceBoardCandidateKind = 'memory' | 'skill' | 'doc'
+export type WorkspaceBoardSourceKind = 'session' | 'file' | 'skill' | 'automation' | 'memory' | 'board'
+export type WorkspaceBoardRecommendationKind = 'follow_up' | 'create_automation' | 'create_skill' | 'promote_memory' | 'open_agent_session' | 'review_blocker'
+export type WorkspaceBoardRecommendationStatus = 'suggested' | 'accepted' | 'dismissed'
+export type WorkspaceBoardRecommendationSafetyLevel = 'read_only' | 'writes_board' | 'writes_memory' | 'runs_agent' | 'creates_automation'
+export type WorkspaceBoardAutomationLevel = 'manual' | 'suggest' | 'assistive'
+
+export interface WorkspaceBoardSourceRef {
+  type: WorkspaceBoardSourceKind
+  title?: string
+  id?: string
+  path?: string
+}
+
+export interface WorkspaceBoardBaseItem {
+  id: string
+  title: string
+  details?: string
+  source?: string
+  sourceRefs?: WorkspaceBoardSourceRef[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WorkspaceBoardGoal extends WorkspaceBoardBaseItem {
+  status: WorkspaceBoardItemStatus
+}
+
+export interface WorkspaceBoardTodo extends WorkspaceBoardBaseItem {
+  status: WorkspaceBoardTodoStatus
+  owner?: 'user' | 'agent' | 'shared'
+}
+
+export interface WorkspaceBoardBlocker extends WorkspaceBoardBaseItem {
+  status: 'open' | 'resolved'
+}
+
+export interface WorkspaceBoardDecision extends WorkspaceBoardBaseItem {
+  status: 'proposed' | 'accepted' | 'rejected'
+}
+
+export interface WorkspaceBoardKnowledgeCandidate extends WorkspaceBoardBaseItem {
+  kind: WorkspaceBoardCandidateKind
+  status: 'candidate' | 'promoted' | 'dismissed'
+}
+
+export interface WorkspaceBoardRecommendation extends WorkspaceBoardBaseItem {
+  kind: WorkspaceBoardRecommendationKind
+  status: WorkspaceBoardRecommendationStatus
+  confidence?: number
+  actionLabel?: string
+  safetyLevel?: WorkspaceBoardRecommendationSafetyLevel
+}
+
+export interface WorkspaceBoardAutomationRef extends WorkspaceBoardBaseItem {
+  automationId?: string
+  status: 'linked' | 'suggested' | 'archived'
+  trigger?: string
+}
+
+export interface WorkspaceBoardSkillRef extends WorkspaceBoardBaseItem {
+  skillSlug?: string
+  status: 'enabled' | 'disabled' | 'suggested' | 'archived'
+}
+
+export interface WorkspaceBoardNote extends WorkspaceBoardBaseItem {
+  kind: 'note' | 'legacy_scratch_pad' | 'handoff'
+}
+
+export interface WorkspaceBoard {
+  schemaVersion: 1
+  title: string
+  summary?: string
+  automationLevel?: WorkspaceBoardAutomationLevel
+  updatedAt: string
+  goals: WorkspaceBoardGoal[]
+  todos: WorkspaceBoardTodo[]
+  blockers: WorkspaceBoardBlocker[]
+  decisions: WorkspaceBoardDecision[]
+  recommendations: WorkspaceBoardRecommendation[]
+  automationRefs: WorkspaceBoardAutomationRef[]
+  skillRefs: WorkspaceBoardSkillRef[]
+  knowledgeCandidates: WorkspaceBoardKnowledgeCandidate[]
+  notes: WorkspaceBoardNote[]
+}
+
 /** 工作区能力摘要（MCP + Skill 计数） */
 export interface WorkspaceCapabilities {
   mcpServers: Array<{ name: string; enabled: boolean; type: McpTransportType }>
@@ -1468,6 +1556,10 @@ export const AGENT_IPC_CHANNELS = {
   READ_WORKSPACE_AUTO_MEMORY_FILE: 'agent:read-workspace-auto-memory-file',
   /** 写入工作区 auto memory 文件 */
   WRITE_WORKSPACE_AUTO_MEMORY_FILE: 'agent:write-workspace-auto-memory-file',
+  /** 读取工作区协作台文件 */
+  READ_WORKSPACE_BOARD: 'agent:read-workspace-board',
+  /** 写入工作区协作台文件 */
+  WRITE_WORKSPACE_BOARD: 'agent:write-workspace-board',
 
   // 流式事件（主进程 → 渲染进程推送）
   /** Agent 流式事件 */


### PR DESCRIPTION
Adds a workspace-level collaboration board backed by a structured JSON schema for goals, todos, blockers, decisions, recommendations, automation refs, skill refs, knowledge candidates, and human work notes.
Replaces the old scratch-pad surface with a collaboration hub that also embeds automation and Agent skill entry points while keeping the legacy standalone entries available.
Adds board IPC persistence, legacy scratch migration, proactive focus/recommendation actions, and an automation-level preference that guides how actively Agent sessions may maintain the board.
Validated with Electron/shared typechecks, the workspace-board manager test, renderer/main/preload builds, and git diff checks.
