### PR TITLE
fix(diff): 首次打开 diff 预览自动定位到第一个变更行

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.20",
+  "version": "0.14.21",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -841,6 +841,55 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   // SAVE scroll position on scroll (throttled via rAF)
   const scrollRafRef = React.useRef(0)
+
+  // 首次打开 diff（无缓存滚动位置）时自动定位到第一个变更行。
+  // 有缓存位置时由上方 restoreScroll 恢复用户上次位置，本 effect 不介入。
+  const autoScrollChangeFiredRef = React.useRef(false)
+  const autoScrollChangeRafRef = React.useRef(0)
+  React.useEffect(() => {
+    autoScrollChangeFiredRef.current = false
+  }, [filePath, sessionId])
+  React.useEffect(() => {
+    if (previewOnly || loading) return
+    if (restoreScrollRef.current) return // 有缓存位置，交给 restoreScroll
+    if (autoScrollChangeFiredRef.current) return
+    if (scrollPositionCache.has(scrollKey)) return
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    autoScrollChangeFiredRef.current = true
+    // 等待 Shiki tokenize 等异步渲染完成（连续 3 帧 scrollHeight 稳定），
+    // 再定位第一个变更行，避免变更行尚未渲染到位时定位失败。
+    let prevHeight = container.scrollHeight
+    let stableFrames = 0
+    const tryScroll = () => {
+      const curHeight = container.scrollHeight
+      if (curHeight === prevHeight) {
+        stableFrames++
+      } else {
+        stableFrames = 0
+        prevHeight = curHeight
+      }
+      if (stableFrames >= 3) {
+        autoScrollChangeRafRef.current = 0
+        const target = container.querySelector<HTMLElement>(
+          '[data-line-type=change-addition], [data-line-type=change-deletion]',
+        )
+        if (target) target.scrollIntoView({ block: 'center' })
+        return
+      }
+      autoScrollChangeRafRef.current = requestAnimationFrame(tryScroll)
+    }
+    autoScrollChangeRafRef.current = requestAnimationFrame(tryScroll)
+
+    return () => {
+      if (autoScrollChangeRafRef.current) {
+        cancelAnimationFrame(autoScrollChangeRafRef.current)
+        autoScrollChangeRafRef.current = 0
+      }
+    }
+  }, [previewOnly, loading, scrollKey])
+
   const handleScroll = React.useCallback(() => {
     if (scrollRafRef.current) return
     scrollRafRef.current = requestAnimationFrame(() => {
@@ -857,6 +906,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     return () => {
       if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
       if (restoreRafRef.current) cancelAnimationFrame(restoreRafRef.current)
+      if (autoScrollChangeRafRef.current) cancelAnimationFrame(autoScrollChangeRafRef.current)
     }
   }, [])
 


### PR DESCRIPTION
## 关联 Issue
Closes #1017

## 根因
`DiffView.tsx:144-148` 的滚动容器无 ref、无"首次打开自动定位"effect。`DiffTabContent.tsx:801-840` 的 `restoreScroll` 只在有缓存滚动位置（`restoreScrollRef.current === true`）时触发；首次打开（无缓存）时在 `:802` 直接 return，视图停在 `scrollTop=0`（文件顶部），离实际变更可能隔着好几屏。

## 修复
在 `DiffTabContent` 新增独立的"首次打开自动定位"effect（`:845-891`）：
- **触发条件**：`!previewOnly && !loading && !restoreScrollRef.current && !scrollPositionCache.has(scrollKey) && 未触发过`
- **等待异步渲染**：复用现有 rAF 3 帧稳定模式（等 Shiki tokenize/ProseMirror mount 完成，与 `restoreScroll` 同模式）
- **定位**：`querySelector('[data-line-type=change-addition], [data-line-type=change-deletion]')` + `scrollIntoView({ block: 'center' })`
- **不破坏 restoreScroll**：显式检查 `restoreScrollRef.current` 与 `scrollPositionCache.has(scrollKey)`，有缓存位置时完全不介入
- **防重复**：触发后置标志位，`[filePath, sessionId]` 变化时重置
- **多文件 diff**：`querySelector` 命中第一个有变更的文件的第一个变更行
- **cleanup**：unmount 时取消 rAF

采用 `scrollIntoView` 而非手动算 `offsetTop`，因为滚动容器嵌套（`scrollContainerRef` 的 overflow-auto div 与 `@pierre/diffs` 内部 `[data-code]` 滚动元素），浏览器自动滚动所有可滚动祖先，对单文件与多文件均生效。

## 验证
- `bun run typecheck`：通过
- `bun test`：通过（1 个 pre-existing flake 同 #1134 说明）
- `bun run build:renderer`：通过

## 改动范围
- `apps/electron/src/renderer/components/diff/DiffTabContent.tsx`：+50 行（auto-scroll effect + cleanup）
- `apps/electron/package.json`：patch 版本递增
