### PR TITLE
fix(security): add DOMPurify sanitization for Markdown rendering XSS

### DIFF
--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -12,7 +12,7 @@ import { TableCell } from '@tiptap/extension-table-cell'
 import { TableHeader } from '@tiptap/extension-table-header'
 import { createRoot } from 'react-dom/client'
 import type { Root } from 'react-dom/client'
-import DOMPurify from 'dompurify'
+import { sanitizeMarkdownHtml } from '../../lib/markdown-sanitize'
 import katex from 'katex'
 import { highlightCode, highlightToTokens, getDisplayName } from '@proma/core'
 import { MermaidBlock } from '@proma/ui'
@@ -352,22 +352,7 @@ function isExternalUrl(src: string): boolean {
   return /^(?:https?:|data:|blob:|file:|proma-file:)/i.test(src)
 }
 
-function sanitizeHtml(html: string): string {
-  return DOMPurify.sanitize(html, {
-    ADD_TAGS: ['video', 'source', 'summary', 'details'],
-    ADD_ATTR: [
-      'align',
-      'colspan',
-      'controls',
-      'loading',
-      'open',
-      'poster',
-      'rowspan',
-      'src',
-      'target',
-    ],
-  })
-}
+
 
 function setClass(el: HTMLElement, className: string): void {
   el.className = className
@@ -442,7 +427,7 @@ function createStaticHtmlView(
   setClass(dom, options.className)
 
   const render = (node: ProseMirrorNode) => {
-    dom.innerHTML = sanitizeHtml(options.getHtml(node))
+    dom.innerHTML = sanitizeMarkdownHtml(options.getHtml(node))
   }
 
   render(initialNode)

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -137,3 +137,52 @@ describe('linkify 合成链接防护', () => {
     expect(html).toContain('foo@bar.com')
   })
 })
+
+describe('XSS 防护（markdown-it 转义层）', () => {
+  // bun 测试环境无 DOM，DOMPurify 净化不执行。
+  // 以下测试验证 markdown-it 自定义渲染器将原始 HTML 转义为 data 属性，
+  // 不生成实际的可执行 HTML 元素。
+  // DOMPurify 净化（enhanceMarkdownHtml + NodeView 渲染层）在 Electron 渲染进程中生效。
+
+  test('原始 <script> 标签被转义，不生成实际 script 元素', () => {
+    const html = markdownToHtml('hello <script>alert(1)</script> world')
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).toContain('hello')
+    expect(html).toContain('world')
+  })
+
+  test('原始 <img onerror> 被转义，不生成实际 img 元素', () => {
+    const html = markdownToHtml('<img src=x onerror="alert(1)">')
+    expect(html).not.toContain('<img')
+    expect(html).toContain('data-type="raw-html-block"')
+  })
+
+  test('原始 <a href="javascript:"> 被转义，不生成实际链接元素', () => {
+    const html = markdownToHtml('<a href="javascript:alert(1)">click</a>')
+    expect(html).not.toContain('<a ')
+    expect(html).toContain('data-type="raw-html-inline"')
+  })
+
+  test('原始 <iframe> 被转义，不生成实际 iframe 元素（Obsidian 本地文件泄露教训）', () => {
+    const html = markdownToHtml('<iframe src="app://local/C:/Users/secret.txt"></iframe>')
+    expect(html).not.toContain('<iframe')
+  })
+
+  test('原始 <object> 和 <embed> 被转义', () => {
+    const html = markdownToHtml('<object data="evil.swf"></object><embed src="evil.swf">')
+    expect(html).not.toContain('<object')
+    expect(html).not.toContain('<embed')
+  })
+
+  test('保留 math block 的 data 属性', () => {
+    const html = markdownToHtml('$$\nE=mc^2\n$$')
+    expect(html).toContain('data-type="math-block"')
+    expect(html).toContain('data-latex')
+  })
+
+  test('保留 details/summary 块', () => {
+    const html = markdownToHtml('<details><summary>Click</summary>\ncontent\n</details>')
+    expect(html).toContain('data-type="raw-html-block"')
+  })
+})

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from 'markdown-it'
+import { sanitizeMarkdownHtml } from './markdown-sanitize'
 
 const VIDEO_EXT_RE = /\.(mp4|webm|ogg|ogv|mov|m4v)(?:[?#].*)?$/i
 const PREVIEW_BLOCK_RE = /^<div\s+[^>]*data-type=(["'])(?:raw-html-block|math-block)\1/i
@@ -334,7 +335,7 @@ function enhanceMarkdownHtml(html: string): string {
   if (typeof document === 'undefined') return html
 
   const root = document.createElement('div')
-  root.innerHTML = html
+  root.innerHTML = sanitizeMarkdownHtml(html)
 
   for (const li of Array.from(root.querySelectorAll('li'))) {
     const first = li.firstChild
@@ -366,7 +367,7 @@ export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: bo
   if (!html || html === '<p></p>') return ''
 
   const div = document.createElement('div')
-  div.innerHTML = html
+  div.innerHTML = sanitizeMarkdownHtml(html)
 
   function processNode(node: Node, context: 'normal' | 'code' = 'normal'): string {
     if (node.nodeType === Node.TEXT_NODE) {

--- a/apps/electron/src/renderer/lib/markdown-sanitize.ts
+++ b/apps/electron/src/renderer/lib/markdown-sanitize.ts
@@ -1,0 +1,59 @@
+/**
+ * Markdown HTML 净化模块
+ *
+ * 基于 DOMPurify 对 Markdown 渲染产出的 HTML 进行 XSS 净化。
+ * 参考业界最佳实践（Obsidian DOMPurify 方案 + VS Code CSP 纵深防御），
+ * 采用严格白名单配置：禁止 iframe/object/embed 等危险标签，
+ * 禁止任意 data-* 属性（仅允许显式列出的），防止 DOM clobbering。
+ *
+ * 使用场景：
+ * - markdown-rich-text.ts 的 enhanceMarkdownHtml / htmlToMarkdown
+ * - markdown-preview-extensions.tsx 的 NodeView 渲染
+ *
+ * @see HITCON 2023 "Pwning Electron-based Markdown Note-taking Apps"
+ */
+
+import DOMPurify from 'dompurify'
+import type { Config } from 'dompurify'
+
+/**
+ * Markdown 渲染 HTML 净化配置
+ *
+ * 安全策略：
+ * 1. FORBID_TAGS：显式禁止 iframe/object/embed/form 等高危标签
+ *    （Obsidian 曾因允许 iframe 导致本地文件泄露）
+ * 2. ALLOW_DATA_ATTR: false：禁止任意 data-* 属性，防止 DOM clobbering
+ * 3. ADD_ATTR 白名单：只允许明确需要的属性
+ */
+const MARKDOWN_SANITIZE_CONFIG: Config = {
+  // 禁止高危标签（DOMPurify 默认禁止 script/style，此处补充其他危险标签）
+  FORBID_TAGS: ['iframe', 'object', 'embed', 'form', 'input', 'textarea', 'button', 'select', 'option'],
+  // 禁止事件处理器属性（DOMPurify 默认处理 on* 属性，此处显式确认）
+  FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur', 'oninput', 'onchange'],
+  // 关键：不允许任意 data-* 属性（防止 DOM clobbering 和属性注入）
+  ALLOW_DATA_ATTR: false,
+  // 允许 Markdown 富内容所需的额外标签
+  ADD_TAGS: ['video', 'source', 'summary', 'details'],
+  // 白名单属性：标准 HTML 属性 + Proma 自定义 data 属性
+  ADD_ATTR: [
+    // 媒体和交互
+    'controls', 'poster', 'open', 'loading', 'autoplay', 'muted', 'loop',
+    // 表格
+    'align', 'colspan', 'rowspan',
+    // 链接
+    'target', 'rel',
+    // Proma 自定义属性（markdown 渲染管线依赖）
+    'data-type', 'data-html', 'data-markdown', 'data-latex',
+    'data-checked', 'data-id', 'data-mention-suggestion-char',
+  ],
+}
+
+/**
+ * 净化 Markdown 渲染产出的 HTML
+ *
+ * 在 innerHTML 赋值前调用，剥离所有危险标签和属性。
+ * 保留 math block、task list、details、video 等合法富内容。
+ */
+export function sanitizeMarkdownHtml(html: string): string {
+  return DOMPurify.sanitize(html, MARKDOWN_SANITIZE_CONFIG) as string
+}


### PR DESCRIPTION
## 问题

`markdown-rich-text.ts` 使用 `markdown-it`（`html: true`）渲染 Markdown，输出通过 `innerHTML` 赋值给 DOM，缺少 DOMPurify 净化。这是 6 月 23 日深度 Bug 审计中标记的最后一个 P0 安全问题。

## 修复方案

基于业界调研（Obsidian DOMPurify 方案 + VS Code CSP 纵深防御 + Open WebUI 模式），在 HTML 进入 DOM 前用 DOMPurify 严格配置净化。

### 改动

1. **新建 `markdown-sanitize.ts`** — 共享 DOMPurify 净化模块
   - `FORBID_TAGS`: iframe/object/embed/form 等高危标签（Obsidian 曾因允许 iframe 导致本地文件泄露，HITCON 2023）
   - `ALLOW_DATA_ATTR: false`: 禁止任意 data-* 属性，防止 DOM clobbering
   - `ADD_ATTR` 白名单: 只允许 Proma 渲染管线依赖的 data-type/data-html/data-markdown/data-latex 等
2. **修改 `markdown-rich-text.ts`** — `enhanceMarkdownHtml` 和 `htmlToMarkdown` 的 `innerHTML` 前加 `sanitizeMarkdownHtml()`
3. **修改 `markdown-preview-extensions.tsx`** — 删除本地 `sanitizeHtml` 函数，改用共享模块（配置统一，避免漂移）
4. **新增 7 个 XSS 测试** — script/onerror/javascript:/iframe/object 剥离 + math block/details 保留回归

### 防御层级

```
Markdown 输入
  → markdown-it 自定义渲染器（原始 HTML 转义为 data 属性）  ← 第一层
  → DOMPurify.sanitize()（enhanceMarkdownHtml 入口）        ← 第二层（本 PR 新增）
  → TipTap insertContent → NodeView sanitizeMarkdownHtml   ← 第三层（已有，统一配置）
```

### 调研依据

| 产品 | 策略 |
|------|------|
| ChatGPT/Claude.ai | 不允许原始 HTML（react-markdown 默认） |
| VS Code | html:true + Webview CSP 沙箱 |
| Obsidian | html:true + DOMPurify（曾因允许 iframe 被攻破） |
| GitHub | 服务端默认剥离原始 HTML |
| Open WebUI | DOMPurify.sanitize(marked.parse(content)) |

Proma 采用 Obsidian 同路线（DOMPurify），配置比 Obsidian 更严格（禁止 iframe + ALLOW_DATA_ATTR: false）。