### PR TITLE
feat(electron): add agent heartbeat pulse light

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'bun:test'
+import { createStore } from 'jotai/vanilla'
+import type { AskUserRequest, ExitPlanModeRequest, PermissionRequest } from '@proma/shared'
+import {
+  agentSessionIndicatorMapAtom,
+  agentStreamErrorsAtom,
+  agentStreamingStatesAtom,
+  allPendingAskUserRequestsAtom,
+  allPendingExitPlanRequestsAtom,
+  allPendingPermissionRequestsAtom,
+  unviewedCompletedSessionIdsAtom,
+  type AgentStreamState,
+} from './agent-atoms'
+
+function runningState(overrides: Partial<AgentStreamState> = {}): AgentStreamState {
+  return {
+    running: true,
+    content: '',
+    toolActivities: [],
+    startedAt: 1_000,
+    ...overrides,
+  }
+}
+
+function permissionRequest(sessionId: string): PermissionRequest {
+  return {
+    requestId: `perm-${sessionId}`,
+    sessionId,
+    toolName: 'Bash',
+    toolInput: { command: 'bun test' },
+    description: '运行测试',
+    dangerLevel: 'normal',
+  }
+}
+
+function askUserRequest(sessionId: string): AskUserRequest {
+  return {
+    requestId: `ask-${sessionId}`,
+    sessionId,
+    questions: [{ question: '继续吗？', options: [] }],
+    toolInput: {},
+  }
+}
+
+function exitPlanRequest(sessionId: string): ExitPlanModeRequest {
+  return {
+    requestId: `plan-${sessionId}`,
+    sessionId,
+    toolInput: {},
+    allowedPrompts: [],
+  }
+}
+
+describe('agentSessionIndicatorMapAtom', () => {
+  test('given no session state when deriving indicators then idle sessions are omitted', () => {
+    const store = createStore()
+
+    expect(store.get(agentSessionIndicatorMapAtom).has('idle-session')).toBe(false)
+  })
+
+  test('given running stream state when deriving indicators then session is running', () => {
+    const store = createStore()
+    store.set(agentStreamingStatesAtom, new Map([
+      ['session-running', runningState()],
+    ]))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-running')).toBe('running')
+  })
+
+  test('given unviewed completed session when deriving indicators then session is completed', () => {
+    const store = createStore()
+    store.set(unviewedCompletedSessionIdsAtom, new Set(['session-completed']))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-completed')).toBe('completed')
+  })
+
+  test('given stream error without running state when deriving indicators then session is error', () => {
+    const store = createStore()
+    store.set(agentStreamErrorsAtom, new Map([
+      ['session-error', 'API 服务不可用'],
+    ]))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-error')).toBe('error')
+  })
+
+  test('given running stream and stream error when deriving indicators then error overrides running', () => {
+    const store = createStore()
+    store.set(agentStreamingStatesAtom, new Map([
+      ['session-error', runningState()],
+    ]))
+    store.set(agentStreamErrorsAtom, new Map([
+      ['session-error', '网络已断开'],
+    ]))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-error')).toBe('error')
+  })
+
+  test('given completed session and stream error when deriving indicators then error overrides completed', () => {
+    const store = createStore()
+    store.set(unviewedCompletedSessionIdsAtom, new Set(['session-error']))
+    store.set(agentStreamErrorsAtom, new Map([
+      ['session-error', '重试失败'],
+    ]))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-error')).toBe('error')
+  })
+
+  test('given pending permission request when deriving indicators then blocked overrides error and running', () => {
+    const store = createStore()
+    store.set(agentStreamingStatesAtom, new Map([
+      ['session-blocked', runningState()],
+    ]))
+    store.set(agentStreamErrorsAtom, new Map([
+      ['session-blocked', '旧错误不应盖过待审批'],
+    ]))
+    store.set(allPendingPermissionRequestsAtom, new Map([
+      ['session-blocked', [permissionRequest('session-blocked')]],
+    ]))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-blocked')).toBe('blocked')
+  })
+
+  test('given pending AskUser request when deriving indicators then session is blocked', () => {
+    const store = createStore()
+    store.set(agentStreamingStatesAtom, new Map([
+      ['session-ask', runningState()],
+    ]))
+    store.set(allPendingAskUserRequestsAtom, new Map([
+      ['session-ask', [askUserRequest('session-ask')]],
+    ]))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-ask')).toBe('blocked')
+  })
+
+  test('given pending ExitPlan request when deriving indicators then session is blocked', () => {
+    const store = createStore()
+    store.set(agentStreamingStatesAtom, new Map([
+      ['session-plan', runningState()],
+    ]))
+    store.set(allPendingExitPlanRequestsAtom, new Map([
+      ['session-plan', [exitPlanRequest('session-plan')]],
+    ]))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('session-plan')).toBe('blocked')
+  })
+})

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -551,7 +551,7 @@ export const agentRunningSessionIdsAtom = atom<Set<string>>((get) => {
 })
 
 /** 侧边栏会话指示点状态 */
-export type SessionIndicatorStatus = 'idle' | 'running' | 'blocked' | 'completed'
+export type SessionIndicatorStatus = 'idle' | 'running' | 'blocked' | 'completed' | 'error'
 
 /** 已完成但用户尚未查看的会话 ID 集合 */
 export const unviewedCompletedSessionIdsAtom = atom<Set<string>>(new Set<string>())
@@ -580,7 +580,7 @@ export const dockBadgeCountAtom = atom<number>((get) => {
 
 /**
  * 每个会话的指示点状态（只包含非 idle 的会话）
- * 优先级：blocked > running > completed > idle
+ * 优先级：blocked > error > running > completed > idle
  */
 export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorStatus>>((get) => {
   const streamStates = get(agentStreamingStatesAtom)
@@ -588,6 +588,7 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
   const pendingAskUser = get(allPendingAskUserRequestsAtom)
   const pendingExitPlan = get(allPendingExitPlanRequestsAtom)
   const unviewedCompleted = get(unviewedCompletedSessionIdsAtom)
+  const streamErrors = get(agentStreamErrorsAtom)
 
   const map = new Map<string, SessionIndicatorStatus>()
 
@@ -597,6 +598,12 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
       || (pendingAskUser.get(id)?.length ?? 0) > 0
       || (pendingExitPlan.get(id)?.length ?? 0) > 0
     map.set(id, hasBlock ? 'blocked' : 'running')
+  }
+
+  for (const id of streamErrors.keys()) {
+    if (map.get(id) !== 'blocked') {
+      map.set(id, 'error')
+    }
   }
 
   for (const id of unviewedCompleted) {

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -8,8 +8,10 @@
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { Pencil, Check, X } from 'lucide-react'
-import { agentSessionsAtom } from '@/atoms/agent-atoms'
+import { agentSessionsAtom, agentSessionIndicatorMapAtom, agentSessionStreamingStateAtomFamily, agentStreamErrorsAtom, type SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
+import type { AgentSessionMeta } from '@proma/shared'
+import { AgentStatusPulseLight, buildAgentDelegationProgressSummary } from './AgentStatusPulseLight'
 import { replaceAgentSessionInFreshnessOrder } from '@/lib/agent-session-list'
 import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
@@ -19,10 +21,45 @@ interface AgentHeaderProps {
   sessionId: string
 }
 
+function getDirectDelegatedChildren(sessions: AgentSessionMeta[], parentSessionId: string): AgentSessionMeta[] {
+  return sessions.filter((session) => session.parentSessionId === parentSessionId && session.sourceDelegationId)
+}
+
+function aggregateHeaderStatus(
+  sessionId: string,
+  sessions: AgentSessionMeta[],
+  indicatorMap: Map<string, SessionIndicatorStatus>,
+): SessionIndicatorStatus {
+  const childSessions = getDirectDelegatedChildren(sessions, sessionId)
+  const statuses = [
+    indicatorMap.get(sessionId) ?? 'idle',
+    ...childSessions.map((session) => {
+      const status = indicatorMap.get(session.id)
+      if (status) return status
+      return session.delegationStatus === 'running' ? 'running' : 'idle'
+    }),
+  ]
+
+  if (statuses.includes('blocked')) return 'blocked'
+  if (statuses.includes('error')) return 'error'
+  if (statuses.includes('running')) return 'running'
+  if (statuses.includes('completed')) return 'completed'
+  return 'idle'
+}
+
 export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement | null {
   const isWindows = React.useMemo(() => detectIsWindows(), [])
   const sessions = useAtomValue(agentSessionsAtom)
+  const indicatorMap = useAtomValue(agentSessionIndicatorMapAtom)
+  const streamState = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))
+  const streamErrors = useAtomValue(agentStreamErrorsAtom)
   const session = sessions.find((s) => s.id === sessionId) ?? null
+  const status = aggregateHeaderStatus(sessionId, sessions, indicatorMap)
+  const errorMessage = streamErrors.get(sessionId) ?? null
+  const delegationSummary = buildAgentDelegationProgressSummary(
+    getDirectDelegatedChildren(sessions, sessionId),
+    streamState?.running ? streamState.startedAt : undefined,
+  )
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const setTabs = useSetAtom(tabsAtom)
   const [editing, setEditing] = React.useState(false)
@@ -102,9 +139,15 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
         </div>
       ) : (
         <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          <span className="truncate text-sm font-medium text-foreground">
+          <span className="min-w-0 truncate text-sm font-medium text-foreground">
             {session.title}
           </span>
+          <AgentStatusPulseLight
+            status={status}
+            streamState={streamState}
+            errorMessage={errorMessage}
+            delegationSummary={delegationSummary}
+          />
           <button
             type="button"
             onMouseDown={(e) => e.preventDefault()}

--- a/apps/electron/src/renderer/components/agent/AgentStatusPulseLight.test.ts
+++ b/apps/electron/src/renderer/components/agent/AgentStatusPulseLight.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from 'bun:test'
+import type { AgentStreamState, ToolActivity } from '@/atoms/agent-atoms'
+import { buildAgentDelegationProgressSummary, buildAgentStatusTooltipModel, formatAgentStatusDuration } from './AgentStatusPulseLight'
+
+function toolActivity(overrides: Partial<ToolActivity>): ToolActivity {
+  return {
+    toolUseId: overrides.toolUseId ?? 'tool-1',
+    toolName: overrides.toolName ?? 'Read',
+    input: overrides.input ?? {},
+    done: overrides.done ?? false,
+    ...overrides,
+  }
+}
+
+function streamState(overrides: Partial<AgentStreamState> = {}): AgentStreamState {
+  return {
+    running: true,
+    content: '',
+    toolActivities: [],
+    startedAt: 1_000,
+    ...overrides,
+  }
+}
+
+describe('AgentStatusPulseLight tooltip model', () => {
+  test('given running tool activity without higher-level progress when building tooltip then includes tool progress', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState({
+        startedAt: 1_000,
+        toolActivities: [
+          toolActivity({ toolName: 'Bash', done: false }),
+        ],
+      }),
+      now: 13_000,
+    })
+
+    expect(model.headline).toBe('执行中 · 12秒')
+    expect(model.rows).toContainEqual({ label: '当前', value: '执行 Bash · 已完成 0/1 · 运行中 1' })
+    expect(model.rows.some((row) => row.label === '工具')).toBe(false)
+  })
+
+  test('given mixed tool activities without higher-level progress when building tooltip then summarizes completed, running, and error counts', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState({
+        toolActivities: [
+          toolActivity({ toolUseId: 'tool-1', toolName: 'Read', done: true }),
+          toolActivity({ toolUseId: 'tool-2', toolName: 'Bash', done: false }),
+          toolActivity({ toolUseId: 'tool-3', toolName: 'Edit', done: true, isError: true }),
+        ],
+      }),
+      now: 2_000,
+    })
+
+    expect(model.rows).toContainEqual({ label: '当前', value: '执行 Bash · 已完成 1/3 · 运行中 1 · 出错 1' })
+    expect(model.rows.some((row) => row.label === '工具')).toBe(false)
+  })
+
+  test('given historical and current-run delegations when building summary then only current run is counted', () => {
+    const summary = buildAgentDelegationProgressSummary([
+      { createdAt: 1_000, delegationStatus: 'completed' },
+      { createdAt: 2_000, delegationStatus: 'completed' },
+      { createdAt: 3_000, delegationStatus: 'completed' },
+      { createdAt: 20_000, delegationStatus: 'running' },
+      { createdAt: 21_000, delegationStatus: 'running' },
+    ], 19_000)
+
+    expect(summary).toEqual({
+      total: 2,
+      completed: 0,
+      running: 2,
+      failed: 0,
+      cancelled: 0,
+      interrupted: 0,
+    })
+  })
+
+  test('given delegation dispatch tool before child sessions exist when building tooltip then shows dispatching state', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState({
+        toolActivities: [
+          toolActivity({ toolName: 'mcp__collaboration__delegate_agents', done: false }),
+        ],
+      }),
+      now: 2_000,
+    })
+
+    expect(model.rows).toContainEqual({ label: '当前', value: '正在派发子任务' })
+    expect(model.rows.some((row) => row.label === '子会话')).toBe(false)
+  })
+
+  test('given completed delegations while parent is running when building tooltip then shows result aggregation', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState(),
+      delegationSummary: {
+        total: 3,
+        completed: 3,
+        running: 0,
+      },
+      now: 2_000,
+    })
+
+    expect(model.rows).toContainEqual({ label: '当前', value: '正在汇总子任务结果' })
+    expect(model.rows).toContainEqual({ label: '子会话', value: '已完成 3/3' })
+  })
+
+  test('given running delegations when building tooltip then shows child session progress', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState(),
+      delegationSummary: {
+        total: 3,
+        completed: 1,
+        running: 2,
+      },
+      now: 2_000,
+    })
+
+    expect(model.rows).toContainEqual({ label: '当前', value: '等待子任务结果' })
+    expect(model.rows).toContainEqual({ label: '子会话', value: '已完成 1/3 · 运行中 2' })
+  })
+
+  test('given task progress when building tooltip then prioritizes current step over tool name', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState({
+        toolActivities: [
+          toolActivity({
+            toolUseId: 'create-1',
+            toolName: 'TaskCreate',
+            done: true,
+            input: { subject: '读取设计文档' },
+            result: JSON.stringify({ task: { id: 'task-1', subject: '读取设计文档' } }),
+          }),
+          toolActivity({
+            toolUseId: 'update-1',
+            toolName: 'TaskUpdate',
+            done: true,
+            input: { taskId: 'task-1', status: 'completed' },
+          }),
+          toolActivity({
+            toolUseId: 'create-2',
+            toolName: 'TaskCreate',
+            done: true,
+            input: { subject: '重做 Hover 信息' },
+            result: JSON.stringify({ task: { id: 'task-2', subject: '重做 Hover 信息' } }),
+          }),
+          toolActivity({
+            toolUseId: 'update-2',
+            toolName: 'TaskUpdate',
+            done: true,
+            input: { taskId: 'task-2', status: 'in_progress', activeForm: '设计 tooltip' },
+          }),
+          toolActivity({
+            toolUseId: 'create-3',
+            toolName: 'TaskCreate',
+            done: true,
+            input: { subject: '验证测试' },
+            result: JSON.stringify({ task: { id: 'task-3', subject: '验证测试' } }),
+          }),
+        ],
+      }),
+      now: 2_000,
+    })
+
+    expect(model.rows).toContainEqual({ label: '当前', value: '设计 tooltip' })
+    expect(model.rows).toContainEqual({ label: '进度', value: '已完成 1/3 · 当前第 2 步' })
+    expect(model.rows.some((row) => row.label === '工具')).toBe(false)
+  })
+
+  test('given stream model when building tooltip then omits model because it is not progress information', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState({ model: 'deepseek-v4-pro' }),
+      now: 2_000,
+    })
+
+    expect(model.rows.some((row) => row.label === '模型')).toBe(false)
+    expect(model.ariaLabel).not.toContain('deepseek-v4-pro')
+  })
+
+  test('given retrying stream when building tooltip then includes retry attempt details', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'running',
+      streamState: streamState({
+        retrying: {
+          currentAttempt: 6,
+          maxAttempts: 25,
+          history: [],
+          failed: false,
+        },
+      }),
+      now: 2_000,
+    })
+
+    expect(model.rows).toContainEqual({ label: '当前', value: '网络波动，自动恢复中' })
+    expect(model.rows).toContainEqual({ label: '重试', value: '第 6/25 次' })
+  })
+
+  test('given error status when building tooltip then exposes error message as first row', () => {
+    const model = buildAgentStatusTooltipModel({
+      status: 'error',
+      errorMessage: 'API 服务不可用',
+      now: 2_000,
+    })
+
+    expect(model.headline).toBe('异常')
+    expect(model.rows[0]).toEqual({ label: '错误', value: 'API 服务不可用' })
+    expect(model.ariaLabel).toContain('错误：API 服务不可用')
+  })
+
+  test('formats duration for seconds, minutes, and hours', () => {
+    expect(formatAgentStatusDuration(12_000)).toBe('12秒')
+    expect(formatAgentStatusDuration(72_000)).toBe('1分12秒')
+    expect(formatAgentStatusDuration(3_900_000)).toBe('1小时5分')
+  })
+})

--- a/apps/electron/src/renderer/components/agent/AgentStatusPulseLight.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentStatusPulseLight.tsx
@@ -1,0 +1,331 @@
+import * as React from 'react'
+import type { AgentStreamState, SessionIndicatorStatus, ToolActivity } from '@/atoms/agent-atoms'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { aggregateTaskItems, type TaskItem } from './task-progress'
+
+export interface AgentDelegationProgressSummary {
+  total: number
+  completed: number
+  running?: number
+  failed?: number
+  cancelled?: number
+  interrupted?: number
+}
+
+export interface AgentDelegationProgressSource {
+  createdAt: number
+  delegationStatus?: 'running' | 'completed' | 'failed' | 'cancelled' | 'interrupted'
+}
+
+export function buildAgentDelegationProgressSummary(
+  sessions: AgentDelegationProgressSource[],
+  currentRunStartedAt?: number,
+): AgentDelegationProgressSummary | undefined {
+  const cutoff = currentRunStartedAt == null ? null : currentRunStartedAt - 1000
+  const scopedSessions = cutoff == null
+    ? sessions
+    : sessions.filter((session) => session.createdAt >= cutoff)
+
+  if (scopedSessions.length === 0) return undefined
+
+  return {
+    total: scopedSessions.length,
+    completed: scopedSessions.filter((session) => session.delegationStatus === 'completed').length,
+    running: scopedSessions.filter((session) => session.delegationStatus === 'running').length,
+    failed: scopedSessions.filter((session) => session.delegationStatus === 'failed').length,
+    cancelled: scopedSessions.filter((session) => session.delegationStatus === 'cancelled').length,
+    interrupted: scopedSessions.filter((session) => session.delegationStatus === 'interrupted').length,
+  }
+}
+
+interface AgentStatusPulseLightProps {
+  status: SessionIndicatorStatus | undefined
+  streamState?: AgentStreamState
+  errorMessage?: string | null
+  delegationSummary?: AgentDelegationProgressSummary
+  className?: string
+  tooltipSide?: 'top' | 'right' | 'bottom' | 'left'
+}
+
+interface AgentStatusTooltipRow {
+  label: string
+  value: string
+}
+
+export interface AgentStatusTooltipModel {
+  headline: string
+  rows: AgentStatusTooltipRow[]
+  ariaLabel: string
+}
+
+interface BuildAgentStatusTooltipModelInput {
+  status: Exclude<SessionIndicatorStatus, 'idle'>
+  streamState?: AgentStreamState
+  errorMessage?: string | null
+  delegationSummary?: AgentDelegationProgressSummary
+  now: number
+}
+
+const STATUS_LABEL: Record<Exclude<SessionIndicatorStatus, 'idle'>, string> = {
+  running: '执行中',
+  blocked: '需要介入',
+  completed: '已完成',
+  error: '异常',
+}
+
+const STATUS_COLOR_CLASS: Record<Exclude<SessionIndicatorStatus, 'idle'>, string> = {
+  running: 'text-blue-500',
+  blocked: 'text-orange-500',
+  completed: 'text-emerald-500',
+  error: 'text-red-500',
+}
+
+function useTicker(enabled: boolean): number {
+  const [now, setNow] = React.useState(() => Date.now())
+
+  React.useEffect(() => {
+    if (!enabled) return undefined
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [enabled])
+
+  return now
+}
+
+export function formatAgentStatusDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 1) return `${seconds}秒`
+  if (minutes < 60) return `${minutes}分${seconds.toString().padStart(2, '0')}秒`
+  const hours = Math.floor(minutes / 60)
+  const remainMinutes = minutes % 60
+  return `${hours}小时${remainMinutes}分`
+}
+
+function truncateText(value: string, maxLength = 96): string {
+  const trimmed = value.trim()
+  if (trimmed.length <= maxLength) return trimmed
+  return `${trimmed.slice(0, maxLength - 1)}...`
+}
+
+function getToolAction(activity: ToolActivity): string {
+  return activity.displayName || activity.intent || activity.toolName
+}
+
+function getLatestToolActivity(activities: ToolActivity[]): ToolActivity | undefined {
+  for (let i = activities.length - 1; i >= 0; i -= 1) {
+    const activity = activities[i]
+    if (activity && !activity.done) return activity
+  }
+  return activities[activities.length - 1]
+}
+
+function getTaskProgress(items: TaskItem[]): {
+  summary: string | null
+  current: string | null
+} {
+  if (items.length === 0) return { summary: null, current: null }
+
+  const completedCount = items.filter((item) => item.status === 'completed').length
+  const currentIndex = items.findIndex((item) => item.status === 'in_progress')
+  const pendingIndex = items.findIndex((item) => item.status === 'pending')
+  const activeIndex = currentIndex >= 0 ? currentIndex : pendingIndex
+  const activeItem = activeIndex >= 0 ? items[activeIndex] : null
+  const parts = [`已完成 ${completedCount}/${items.length}`]
+
+  if (activeIndex >= 0) parts.push(`当前第 ${activeIndex + 1} 步`)
+
+  return {
+    summary: parts.join(' · '),
+    current: activeItem ? truncateText(activeItem.activeForm || activeItem.subject, 64) : null,
+  }
+}
+
+function getDelegationProgress(summary: AgentDelegationProgressSummary | undefined): string | null {
+  if (!summary || summary.total <= 0) return null
+
+  const running = summary.running ?? 0
+  const failed = summary.failed ?? 0
+  const cancelled = summary.cancelled ?? 0
+  const interrupted = summary.interrupted ?? 0
+  const parts = [`已完成 ${summary.completed}/${summary.total}`]
+
+  if (running > 0) parts.push(`运行中 ${running}`)
+  if (failed > 0) parts.push(`失败 ${failed}`)
+  if (cancelled > 0) parts.push(`已取消 ${cancelled}`)
+  if (interrupted > 0) parts.push(`已中断 ${interrupted}`)
+
+  return parts.join(' · ')
+}
+
+function getDelegationCurrent(summary: AgentDelegationProgressSummary | undefined): string | null {
+  if (!summary || summary.total <= 0) return null
+  const running = summary.running ?? 0
+  const failed = summary.failed ?? 0
+  const cancelled = summary.cancelled ?? 0
+  const interrupted = summary.interrupted ?? 0
+
+  if (running > 0) return '等待子任务结果'
+  if (failed > 0 || cancelled > 0 || interrupted > 0) return '检查子任务结果'
+  if (summary.completed >= summary.total) return '正在汇总子任务结果'
+  return '等待子任务结果'
+}
+
+function getToolProgressSummary(activities: ToolActivity[]): string | null {
+  if (activities.length === 0) return null
+
+  const completedCount = activities.filter((activity) => activity.done && !activity.isError).length
+  const runningCount = activities.filter((activity) => !activity.done).length
+  const errorCount = activities.filter((activity) => activity.isError).length
+  const parts = [`已完成 ${completedCount}/${activities.length}`]
+
+  if (runningCount > 0) parts.push(`运行中 ${runningCount}`)
+  if (errorCount > 0) parts.push(`出错 ${errorCount}`)
+
+  return parts.join(' · ')
+}
+
+function getToolProgressRow(activities: ToolActivity[]): string | null {
+  const summary = getToolProgressSummary(activities)
+  if (!summary) return null
+
+  const latestTool = getLatestToolActivity(activities)
+  if (!latestTool) return summary
+
+  return `${truncateText(getToolAction(latestTool), 48)} · ${summary}`
+}
+
+function hasActiveDelegationDispatch(activities: ToolActivity[]): boolean {
+  return activities.some((activity) => {
+    if (activity.done) return false
+    const action = `${activity.toolName} ${activity.displayName ?? ''} ${activity.intent ?? ''}`.toLowerCase()
+    return action.includes('delegate_agent') || action.includes('delegate_agents')
+  })
+}
+
+export function buildAgentStatusTooltipModel({
+  status,
+  streamState,
+  errorMessage,
+  delegationSummary,
+  now,
+}: BuildAgentStatusTooltipModelInput): AgentStatusTooltipModel {
+  const duration = streamState?.startedAt ? formatAgentStatusDuration(now - streamState.startedAt) : null
+  const headline = duration ? `${STATUS_LABEL[status]} · ${duration}` : STATUS_LABEL[status]
+  const activities = streamState?.toolActivities ?? []
+  const taskItems = aggregateTaskItems(activities, status !== 'running')
+  const taskProgress = getTaskProgress(taskItems)
+  const delegationCurrent = getDelegationCurrent(delegationSummary)
+  const delegationProgress = getDelegationProgress(delegationSummary)
+  const toolProgress = getToolProgressRow(activities)
+  const delegationDispatching = hasActiveDelegationDispatch(activities)
+
+  let currentAction: string
+  if (status === 'error') {
+    currentAction = errorMessage ? truncateText(errorMessage) : '需要检查当前会话'
+  } else if (status === 'blocked') {
+    currentAction = '等待你的操作或确认'
+  } else if (status === 'completed') {
+    currentAction = '任务已完成'
+  } else if (streamState?.isCompacting) {
+    currentAction = '正在压缩上下文'
+  } else if (streamState?.retrying) {
+    currentAction = '网络波动，自动恢复中'
+  } else if (delegationDispatching && !delegationCurrent) {
+    currentAction = '正在派发子任务'
+  } else if (delegationCurrent) {
+    currentAction = delegationCurrent
+  } else if (taskProgress.current) {
+    currentAction = taskProgress.current
+  } else if (streamState?.content.trim()) {
+    currentAction = '正在生成回复'
+  } else if (toolProgress) {
+    currentAction = `执行 ${toolProgress}`
+  } else {
+    currentAction = '正在思考'
+  }
+
+  const rows: AgentStatusTooltipRow[] = [
+    {
+      label: status === 'error' ? '错误' : '当前',
+      value: currentAction,
+    },
+  ]
+
+  if (taskProgress.summary) {
+    rows.push({ label: '进度', value: taskProgress.summary })
+  }
+
+  if (delegationProgress) {
+    rows.push({ label: '子会话', value: delegationProgress })
+  }
+
+  if (streamState?.retrying) {
+    rows.push({
+      label: '重试',
+      value: `第 ${streamState.retrying.currentAttempt}/${streamState.retrying.maxAttempts} 次${streamState.retrying.failed ? ' · 已失败' : ''}`,
+    })
+  }
+
+  return {
+    headline,
+    rows: rows.slice(0, 4),
+    ariaLabel: [headline, ...rows.map((row) => `${row.label}：${row.value}`)].join('，'),
+  }
+}
+
+export function AgentStatusPulseLight({
+  status,
+  streamState,
+  errorMessage,
+  delegationSummary,
+  className,
+  tooltipSide = 'top',
+}: AgentStatusPulseLightProps): React.ReactElement | null {
+  const activeStatus = status && status !== 'idle' ? status : null
+  const now = useTicker(activeStatus === 'running' && !!streamState?.startedAt)
+
+  if (!activeStatus) return null
+
+  const tooltip = buildAgentStatusTooltipModel({
+    status: activeStatus,
+    streamState,
+    errorMessage,
+    delegationSummary,
+    now,
+  })
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            'agent-status-pulse-light titlebar-no-drag inline-flex size-3 shrink-0 items-center justify-center rounded-full align-middle',
+            STATUS_COLOR_CLASS[activeStatus],
+            activeStatus === 'running' && 'agent-status-pulse-light-running',
+            className,
+          )}
+          aria-label={tooltip.ariaLabel}
+        >
+          <span className="size-2 rounded-full bg-current" aria-hidden="true" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side={tooltipSide} className="w-[320px] max-w-[calc(100vw-24px)] space-y-2">
+        <div className={cn('flex items-center gap-2 font-medium', STATUS_COLOR_CLASS[activeStatus])}>
+          <span className="size-2 rounded-full bg-current shadow-[0_0_6px_currentColor]" aria-hidden="true" />
+          <span className="text-tooltip-foreground">{tooltip.headline}</span>
+        </div>
+        <div className="grid gap-1.5 text-[12px] leading-relaxed">
+          {tooltip.rows.map((row) => (
+            <div key={row.label} className="grid grid-cols-[2.75rem_minmax(0,1fr)] gap-x-2">
+              <span className="text-tooltip-muted">{row.label}</span>
+              <span className="min-w-0 break-words text-tooltip-foreground/90">{row.value}</span>
+            </div>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -52,6 +52,7 @@ import {
   agentDiffUnseenFilesAtom,
   agentDiffDataAtom,
   agentStreamingStatesAtom,
+  agentStreamErrorsAtom,
   liveMessagesMapAtom,
   agentSessionPendingFilesAtom,
   agentSessionStreamingStateAtomFamily,
@@ -86,6 +87,7 @@ import { interfaceVariantAtom } from '@/atoms/theme'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
+import { AgentStatusPulseLight, buildAgentDelegationProgressSummary, type AgentDelegationProgressSummary } from '@/components/agent/AgentStatusPulseLight'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
 import {
   SessionMiniMapPopover,
@@ -331,15 +333,17 @@ const SESSION_QUICK_SWITCH_KEYUP_EVENT = 'proma:session-quick-switch-keyup'
 
 const ACTIVE_SESSION_STATUSES: ReadonlySet<SessionIndicatorStatus> = new Set([
   'blocked',
+  'error',
   'running',
   'completed',
 ])
 
 const ACTIVE_SESSION_STATUS_PRIORITY: Record<SessionIndicatorStatus, number> = {
   blocked: 0,
-  running: 1,
-  completed: 2,
-  idle: 3,
+  error: 1,
+  running: 2,
+  completed: 3,
+  idle: 4,
 }
 
 function formatRelativeUpdatedAt(updatedAt: number, now: number): string {
@@ -390,6 +394,7 @@ const RAIL_STATUS_CLASS: Record<SessionIndicatorStatus, string> = {
   running: 'border-blue-500 animate-pulse',
   blocked: 'border-orange-500',
   completed: 'border-emerald-500',
+  error: 'border-red-500',
 }
 
 const SIDEBAR_DRAG_STRIP_HEIGHT = {
@@ -521,6 +526,7 @@ function getSessionTreeStatus(
   ]
 
   if (statuses.includes('blocked')) return 'blocked'
+  if (statuses.includes('error')) return 'error'
   if (statuses.includes('running')) return 'running'
   if (statuses.includes('completed')) return 'completed'
   return 'idle'
@@ -528,6 +534,13 @@ function getSessionTreeStatus(
 
 function countCompletedDelegatedChildren(childSessions: AgentSessionMeta[]): number {
   return childSessions.filter((session) => session.delegationStatus === 'completed').length
+}
+
+function countDelegatedChildrenByStatus(
+  childSessions: AgentSessionMeta[],
+  status: AgentSessionMeta['delegationStatus'],
+): number {
+  return childSessions.filter((session) => session.delegationStatus === status).length
 }
 
 function treeContainsSessionId(item: AgentSessionTreeItem, sessionId: string | null): boolean {
@@ -763,6 +776,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
   const [currentAgentSessionId, setCurrentAgentSessionId] = useAtom(currentAgentSessionIdAtom)
   const agentIndicatorMap = useAtomValue(agentSessionIndicatorMapAtom)
+  const agentStreamErrors = useAtomValue(agentStreamErrorsAtom)
   const unviewedCompletedSessionIds = useAtomValue(unviewedCompletedSessionIdsAtom)
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
   const agentChannelId = useAtomValue(agentChannelIdAtom)
@@ -2219,10 +2233,11 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         const priority = (session: AgentSessionMeta, status: SessionIndicatorStatus): number => {
           if (session.id === activeSessionId) return 0
           if (status === 'blocked') return 1
-          if (status === 'running') return 2
-          if (session.pinned) return 3
-          if (status === 'completed') return 4
-          return 5
+          if (status === 'error') return 2
+          if (status === 'running') return 3
+          if (session.pinned) return 4
+          if (status === 'completed') return 5
+          return 6
         }
         const priorityDelta = priority(a, statusA) - priority(b, statusB)
         if (priorityDelta !== 0) return priorityDelta
@@ -2764,15 +2779,21 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             session={item.session}
                             active={treeActive}
                             indicatorStatus={rowStatus}
+                            errorMessage={agentStreamErrors.get(item.session.id)}
                             showPinIcon={false}
                             delegationSummary={childCount > 0
                               ? {
                                 total: childCount,
                                 completed: countCompletedDelegatedChildren(item.childSessions),
+                                running: countDelegatedChildrenByStatus(item.childSessions, 'running'),
+                                failed: countDelegatedChildrenByStatus(item.childSessions, 'failed'),
+                                cancelled: countDelegatedChildrenByStatus(item.childSessions, 'cancelled'),
+                                interrupted: countDelegatedChildrenByStatus(item.childSessions, 'interrupted'),
                                 expanded: expandedChildren,
                                 onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
                               }
                               : undefined}
+                            delegationChildSessions={item.childSessions}
                             leftAccent={getSessionLeftAccent(rowStatus)}
                             workspaceName={item.session.workspaceId ? workspaceNameMap.get(item.session.workspaceId) : undefined}
                             relativeTimeNow={relativeTimeNow}
@@ -2792,6 +2813,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                                   session={childSession}
                                   activeSessionId={activeSessionId}
                                   agentIndicatorMap={agentIndicatorMap}
+                                  agentStreamErrors={agentStreamErrors}
                                   relativeTimeNow={relativeTimeNow}
                                   workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
                                   onSelect={handleSelectAgentSession}
@@ -2867,6 +2889,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                     collapsed={collapsedWorkspaceIds.has(group.workspace.id)}
                     activeSessionId={activeSessionId}
                     agentIndicatorMap={agentIndicatorMap}
+                    agentStreamErrors={agentStreamErrors}
                     expandedDelegationParentIds={expandedDelegationParentIds}
                     collapsedDelegationParentIds={collapsedDelegationParentIds}
                     relativeTimeNow={relativeTimeNow}
@@ -2962,15 +2985,21 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             session={item.session}
                             active={treeActive}
                             indicatorStatus={rowStatus}
+                            errorMessage={agentStreamErrors.get(item.session.id)}
                             showPinIcon={!!item.session.pinned}
                             delegationSummary={childCount > 0
                               ? {
                                 total: childCount,
                                 completed: countCompletedDelegatedChildren(item.childSessions),
+                                running: countDelegatedChildrenByStatus(item.childSessions, 'running'),
+                                failed: countDelegatedChildrenByStatus(item.childSessions, 'failed'),
+                                cancelled: countDelegatedChildrenByStatus(item.childSessions, 'cancelled'),
+                                interrupted: countDelegatedChildrenByStatus(item.childSessions, 'interrupted'),
                                 expanded: expandedChildren,
                                 onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
                               }
                               : undefined}
+                            delegationChildSessions={item.childSessions}
                             leftAccent={getSessionLeftAccent(rowStatus)}
                             workspaceName={item.session.workspaceId ? workspaceNameMap.get(item.session.workspaceId) : undefined}
                             relativeTimeNow={relativeTimeNow}
@@ -2990,6 +3019,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                                   session={childSession}
                                   activeSessionId={activeSessionId}
                                   agentIndicatorMap={agentIndicatorMap}
+                                  agentStreamErrors={agentStreamErrors}
                                   relativeTimeNow={relativeTimeNow}
                                   workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
                                   onSelect={handleSelectAgentSession}
@@ -3520,17 +3550,19 @@ const ConversationItem = React.memo(function ConversationItem({
 // ===== Agent 会话列表项 =====
 
 /** 会话行左侧状态条的颜色 — 与 SessionIndicatorStatus 呼应 */
-type SessionLeftAccent = 'orange' | 'blue' | 'green'
+type SessionLeftAccent = 'orange' | 'blue' | 'green' | 'red'
 const SESSION_ACCENT_ROW_CLASS: Record<SessionLeftAccent, string> = {
   orange: 'bg-orange-500/[0.08] text-foreground font-medium',
   blue: 'text-foreground font-medium hover:bg-foreground/[0.03]',
   green: 'text-foreground font-medium hover:bg-foreground/[0.03]',
+  red: 'text-foreground font-medium hover:bg-foreground/[0.03]',
 }
 
 const SESSION_ACCENT_INDICATOR_CLASS: Record<SessionLeftAccent, string> = {
   orange: 'bg-orange-500',
   blue: 'bg-blue-500',
   green: 'bg-green-500',
+  red: 'bg-red-500',
 }
 
 const DELEGATION_STATUS_ICON_CLASS: Record<SessionIndicatorStatus, string> = {
@@ -3538,12 +3570,14 @@ const DELEGATION_STATUS_ICON_CLASS: Record<SessionIndicatorStatus, string> = {
   running: 'text-blue-500',
   blocked: 'text-orange-500',
   completed: 'text-green-500',
+  error: 'text-red-500',
 }
 
 function getSessionLeftAccent(status: SessionIndicatorStatus): SessionLeftAccent | undefined {
   if (status === 'blocked') return 'orange'
   if (status === 'running') return 'blue'
   if (status === 'completed') return 'green'
+  if (status === 'error') return 'red'
   return undefined
 }
 
@@ -3551,13 +3585,13 @@ interface AgentSessionItemProps {
   session: AgentSessionMeta
   active: boolean
   indicatorStatus: SessionIndicatorStatus
+  errorMessage?: string | null
   showPinIcon?: boolean
-  delegationSummary?: {
-    total: number
-    completed: number
+  delegationSummary?: AgentDelegationProgressSummary & {
     expanded: boolean
     onToggle: () => void
   }
+  delegationChildSessions?: AgentSessionMeta[]
   /** 行左侧状态色块；未传则不显示 */
   leftAccent?: SessionLeftAccent
   /** 是否禁用悬浮 Mini 地图 */
@@ -3578,8 +3612,10 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   session,
   active,
   indicatorStatus,
+  errorMessage,
   showPinIcon,
   delegationSummary,
+  delegationChildSessions,
   leftAccent,
   disableMiniMap,
   workspaceName,
@@ -3599,6 +3635,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
   const preview = useSessionMiniMapHover(600, disableMiniMap || menuOpen)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const streamState = useAtomValue(agentSessionStreamingStateAtomFamily(session.id))
   const isClassic = interfaceVariant === 'classic'
 
   const startEdit = (): void => {
@@ -3636,6 +3673,10 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 
   const childCount = delegationSummary?.total ?? 0
   const hasChildren = childCount > 0
+  const pulseDelegationSummary = buildAgentDelegationProgressSummary(
+    delegationChildSessions ?? [],
+    streamState?.running ? streamState.startedAt : undefined,
+  )
   const pinLabel = session.pinned ? '取消置顶' : '置顶会话'
   const cascadePinLabel = session.pinned
     ? `取消置顶(含 ${childCount} 个子会话)`
@@ -3744,7 +3785,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                   <GitBranch size={11} className={cn('flex-shrink-0', DELEGATION_STATUS_ICON_CLASS[indicatorStatus])} />
                 )}
                 <span
-                  className="truncate"
+                  className="min-w-0 truncate"
                   onDoubleClick={(event) => {
                     event.stopPropagation()
                     startEdit()
@@ -3752,6 +3793,14 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                 >
                   {session.title}
                 </span>
+                <AgentStatusPulseLight
+                  status={indicatorStatus}
+                  streamState={streamState}
+                  errorMessage={errorMessage}
+                  delegationSummary={pulseDelegationSummary}
+                  tooltipSide="right"
+                  className="-ml-0.5"
+                />
                 {workspaceName && (
                   <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-primary/10 text-[10px] leading-4 workspace-badge font-medium truncate max-w-[80px]">
                     {workspaceName}
@@ -3841,6 +3890,7 @@ interface DelegatedChildSessionItemProps {
   session: AgentSessionMeta
   activeSessionId: string | null
   agentIndicatorMap: Map<string, SessionIndicatorStatus>
+  agentStreamErrors: Map<string, string>
   relativeTimeNow: number
   workspaceName?: string
   onSelect: (id: string, title: string) => void
@@ -3855,6 +3905,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
   session,
   activeSessionId,
   agentIndicatorMap,
+  agentStreamErrors,
   relativeTimeNow,
   workspaceName,
   onSelect,
@@ -3871,6 +3922,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
       session={session}
       active={session.id === activeSessionId}
       indicatorStatus={status}
+      errorMessage={agentStreamErrors.get(session.id)}
       relativeTimeNow={relativeTimeNow}
       workspaceName={workspaceName}
       onSelect={onSelect}
@@ -3898,6 +3950,7 @@ interface AgentProjectGroupItemProps {
   extraCount: number
   activeSessionId: string | null
   agentIndicatorMap: Map<string, SessionIndicatorStatus>
+  agentStreamErrors: Map<string, string>
   expandedDelegationParentIds: Set<string>
   collapsedDelegationParentIds: Set<string>
   relativeTimeNow: number
@@ -3935,6 +3988,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   extraCount,
   activeSessionId,
   agentIndicatorMap,
+  agentStreamErrors,
   expandedDelegationParentIds,
   collapsedDelegationParentIds,
   relativeTimeNow,
@@ -4221,15 +4275,21 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                       session={item.session}
                       active={treeActive}
                       indicatorStatus={rowStatus}
+                      errorMessage={agentStreamErrors.get(item.session.id)}
                       showPinIcon={!!item.session.pinned}
                       delegationSummary={childCount > 0
                         ? {
                           total: childCount,
                           completed: countCompletedDelegatedChildren(item.childSessions),
+                          running: countDelegatedChildrenByStatus(item.childSessions, 'running'),
+                          failed: countDelegatedChildrenByStatus(item.childSessions, 'failed'),
+                          cancelled: countDelegatedChildrenByStatus(item.childSessions, 'cancelled'),
+                          interrupted: countDelegatedChildrenByStatus(item.childSessions, 'interrupted'),
                           expanded: expandedChildren,
                           onToggle: () => onToggleDelegationParent(item.session.id, expandedChildren),
                         }
                         : undefined}
+                      delegationChildSessions={item.childSessions}
                       leftAccent={getSessionLeftAccent(rowStatus)}
                       relativeTimeNow={relativeTimeNow}
                       workspaceName={isAutomationGroup && item.session.workspaceId ? workspaceNameMap?.get(item.session.workspaceId) : undefined}
@@ -4249,6 +4309,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                             session={childSession}
                             activeSessionId={activeSessionId}
                             agentIndicatorMap={agentIndicatorMap}
+                            agentStreamErrors={agentStreamErrors}
                             relativeTimeNow={relativeTimeNow}
                             workspaceName={isAutomationGroup && childSession.workspaceId ? workspaceNameMap?.get(childSession.workspaceId) : undefined}
                             onSelect={onSelectSession}

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -487,7 +487,7 @@ function SwitcherCandidateRow({
   onClick: () => void
 }): ReactElement {
   const indicatorColor = getIndicatorColor(candidate.status)
-  const indicatorPulse = candidate.status === 'running' || candidate.status === 'blocked'
+  const indicatorPulse = candidate.status === 'running'
 
   return (
     <button
@@ -553,5 +553,6 @@ function getIndicatorColor(status: SessionIndicatorStatus): string | undefined {
   if (status === 'idle') return undefined
   if (status === 'completed') return 'bg-green-500'
   if (status === 'blocked') return 'bg-orange-500'
+  if (status === 'error') return 'bg-red-500'
   return 'bg-blue-500'
 }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -832,6 +832,33 @@
   }
 }
 
+.agent-status-pulse-light {
+  filter: drop-shadow(0 0 3px currentColor);
+}
+
+.agent-status-pulse-light-running {
+  animation: agent-status-pulse-light-breathe 1.5s ease-in-out infinite;
+}
+
+@keyframes agent-status-pulse-light-breathe {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+    filter: drop-shadow(0 0 3px currentColor);
+  }
+  50% {
+    opacity: 0.72;
+    transform: scale(1.18);
+    filter: drop-shadow(0 0 7px currentColor);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-status-pulse-light-running {
+    animation: none;
+  }
+}
+
 .theme-terminal-dark .mode-btn-selected {
   color: #000000 !important;
 }


### PR DESCRIPTION
## Summary
- add an Agent heartbeat pulse light for header and expanded sidebar rows
- extend shared session indicator status with `error` and red error rendering in sidebar/tab indicators
- show compact hover progress for current phase, Task progress, delegated child-session progress, retry/error/blocked states, and tool fallback
- scope delegated child progress to the current running turn to avoid historical child sessions polluting hover progress

## Validation
- `bun install`
- `bun test apps/electron/src/renderer/atoms/agent-atoms.test.ts`
- `bun test apps/electron/src/renderer/components/agent/AgentStatusPulseLight.test.ts`
- `bun test apps/electron/src/renderer/components/agent/task-progress.test.ts`
- `bun test apps/electron/src/renderer`
- `bun run typecheck`
- `bun run --filter='@proma/electron' build:renderer`
- `git diff --check`
