### PR TITLE
fix(agent): 同步委派子会话进度状态【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -96,6 +96,8 @@ import { detectIsMac } from '@/lib/platform'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
   collectAgentSessionTreeIds,
+  countSettledDelegatedChildren,
+  getDelegatedChildSessionStatus,
   isAgentSessionVisibleInTrees,
   replaceAgentSessionInFreshnessOrder,
   sortAgentSessionsByUpdatedAtDesc,
@@ -506,9 +508,7 @@ function getDelegatedChildStatus(
   session: AgentSessionMeta,
   agentIndicatorMap: Map<string, SessionIndicatorStatus>,
 ): SessionIndicatorStatus {
-  const status = agentIndicatorMap.get(session.id)
-  if (status) return status
-  return session.delegationStatus === 'running' ? 'running' : 'idle'
+  return getDelegatedChildSessionStatus(session, agentIndicatorMap)
 }
 
 function getSessionTreeStatus(
@@ -524,10 +524,6 @@ function getSessionTreeStatus(
   if (statuses.includes('running')) return 'running'
   if (statuses.includes('completed')) return 'completed'
   return 'idle'
-}
-
-function countCompletedDelegatedChildren(childSessions: AgentSessionMeta[]): number {
-  return childSessions.filter((session) => session.delegationStatus === 'completed').length
 }
 
 function treeContainsSessionId(item: AgentSessionTreeItem, sessionId: string | null): boolean {
@@ -2744,7 +2740,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             delegationSummary={childCount > 0
                               ? {
                                 total: childCount,
-                                completed: countCompletedDelegatedChildren(item.childSessions),
+                                settled: countSettledDelegatedChildren(item.childSessions, agentIndicatorMap),
                                 expanded: expandedChildren,
                                 onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
                               }
@@ -2945,7 +2941,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             delegationSummary={childCount > 0
                               ? {
                                 total: childCount,
-                                completed: countCompletedDelegatedChildren(item.childSessions),
+                                settled: countSettledDelegatedChildren(item.childSessions, agentIndicatorMap),
                                 expanded: expandedChildren,
                                 onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
                               }
@@ -3535,7 +3531,7 @@ interface AgentSessionItemProps {
   showPinIcon?: boolean
   delegationSummary?: {
     total: number
-    completed: number
+    settled: number
     expanded: boolean
     onToggle: () => void
   }
@@ -3774,7 +3770,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                 )}
                 {delegationSummary && (
                   <span className="flex-shrink-0 text-[11px] leading-4 text-foreground/45">
-                    {delegationSummary.completed}/{delegationSummary.total}
+                    {delegationSummary.settled}/{delegationSummary.total}
                   </span>
                 )}
               </div>
@@ -4270,7 +4266,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                       delegationSummary={childCount > 0
                         ? {
                           total: childCount,
-                          completed: countCompletedDelegatedChildren(item.childSessions),
+                          settled: countSettledDelegatedChildren(item.childSessions, agentIndicatorMap),
                           expanded: expandedChildren,
                           onToggle: () => onToggleDelegationParent(item.session.id, expandedChildren),
                         }

--- a/apps/electron/src/renderer/lib/agent-session-list.test.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.test.ts
@@ -5,6 +5,7 @@ import {
   replaceAgentSessionInFreshnessOrder,
   upsertAgentSession,
   mergeFetchedAgentSessions,
+  countSettledDelegatedChildren,
 } from './agent-session-list'
 
 function makeSession(
@@ -122,5 +123,38 @@ describe('mergeFetchedAgentSessions', () => {
     const result = mergeFetchedAgentSessions(sessions, sessions)
     expect(result.map((s) => s.id)).toEqual(['a', 'b'])
     expect(result).toHaveLength(2)
+  })
+})
+
+describe('countSettledDelegatedChildren', () => {
+  test('取消后的子会话被直接重跑时，实时 running 状态优先于历史 cancelled', () => {
+    const child = makeSession('child', 1, {
+      parentSessionId: 'parent',
+      sourceDelegationId: 'delegation',
+      delegationStatus: 'cancelled',
+    })
+
+    expect(countSettledDelegatedChildren([child], new Map([['child', 'running' as const]]))).toBe(0)
+    expect(countSettledDelegatedChildren([child], new Map())).toBe(1)
+  })
+
+  test('运行中或阻塞中的子会话不计入已停止数量', () => {
+    const running = makeSession('running', 1, { delegationStatus: 'running' })
+    const blocked = makeSession('blocked', 1, { delegationStatus: 'completed' })
+    const finished = makeSession('finished', 1, { delegationStatus: 'cancelled' })
+
+    const statusMap = new Map([
+      ['running', 'running' as const],
+      ['blocked', 'blocked' as const],
+      ['finished', 'completed' as const],
+    ])
+
+    expect(countSettledDelegatedChildren([running, blocked, finished], statusMap)).toBe(1)
+  })
+
+  test('应用重启后没有实时流状态时，持久化 running 仍不计入已停止数量', () => {
+    const child = makeSession('child', 1, { delegationStatus: 'running' })
+
+    expect(countSettledDelegatedChildren([child], new Map())).toBe(0)
   })
 })

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -1,4 +1,5 @@
 import type { AgentSessionMeta } from '@proma/shared'
+import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 
 interface AgentSessionTreeLike {
   session: Pick<AgentSessionMeta, 'id'>
@@ -99,4 +100,36 @@ export function isAgentSessionVisibleInTrees(
 ): boolean {
   if (!sessionId) return false
   return collectAgentSessionTreeIds(items).has(sessionId)
+}
+
+/**
+ * 以侧栏指示器为准解析协作子会话的当前状态。
+ *
+ * 实时流状态优先于持久化的 delegationStatus。后者只在应用重启后、流式
+ * 状态尚未恢复时保留“原委派仍在运行”的信息；历史 cancelled 不应覆盖子会话
+ * 后续被直接重跑时的真实运行状态。
+ */
+export function getDelegatedChildSessionStatus(
+  session: AgentSessionMeta,
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>,
+): SessionIndicatorStatus {
+  const status = agentIndicatorMap.get(session.id)
+  if (status) return status
+  return session.delegationStatus === 'running' ? 'running' : 'idle'
+}
+
+/**
+ * 父会话进度的分子：当前已停止的直属子会话数量。
+ *
+ * 这里刻意不读取历史 delegationStatus 是否为 completed。用户可在原委派
+ * 被取消后直接重跑子会话，父行进度应与该子会话在左侧栏的实时状态保持一致。
+ */
+export function countSettledDelegatedChildren(
+  childSessions: readonly AgentSessionMeta[],
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>,
+): number {
+  return childSessions.filter((session) => {
+    const status = getDelegatedChildSessionStatus(session, agentIndicatorMap)
+    return status !== 'running' && status !== 'blocked'
+  }).length
 }


### PR DESCRIPTION
## 概述

父会话左侧栏原先仅按持久化 `delegationStatus === 'completed'` 统计子会话，导致原委派已取消、但子会话随后直接重跑时，父会话摘要仍显示过期进度。本 PR 将摘要与子会话的实时状态统一，使运行、停止与完成能立即反映到父会话。

## 改动

- `apps/electron/src/renderer/lib/agent-session-list.ts` — 提取委派子会话状态解析与已停止计数函数；实时 indicator 优先，应用重启时才以持久化 `running` 作为兜底。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 三个父会话列表入口统一改用实时 settled 计数，并让树状态与摘要复用同一状态解析规则。
- `apps/electron/src/renderer/lib/agent-session-list.test.ts` — 覆盖取消后重跑、运行/阻塞状态以及重启后持久化 running 的回归场景。

## 测试方法

1. 执行 `bun test apps/electron/src/renderer/lib/agent-session-list.test.ts`，确认 12 项测试通过。
2. 执行 `bun run typecheck`，确认全部 workspace package 类型检查通过。
3. 在 `apps/electron` 执行 `bun run build:renderer`，确认 renderer production build 通过。
4. 手动验证：取消子会话后直接在该子会话中重跑，父会话 `x/y` 在运行时递减、结束后恢复；打开已完成会话后计数不回退。

## 备注

- 摘要分子现在表示当前已停止的直属子会话数，不再是原始委派生命周期中成功完成的数量。
- 已完成代码审查及 Windows 静态兼容性扫描，未发现平台相关问题。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)