### PR TITLE
【已审核】style(ui): 统一全代码库滚动条架构

### DIFF
--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/pierre-styles.ts
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/pierre-styles.ts
@@ -5,9 +5,36 @@
  * 供 edit-result / write-result / read-result 等工具渲染器复用。
  */
 
+/**
+ * 滚动条共享样式 — 尺寸/圆角/轨道/透明度引用全局 --scrollbar-* 变量（globals.css :root）。
+ * 颜色在使用处写 hsl(var(--muted-foreground) / var(--opacity))：--muted-foreground 经 host
+ * 继承链传入 shadow root，随主题（.dark/.theme-*）正确变化；不能预先算成 --scrollbar-thumb 变量。
+ */
+export const PIERRE_SCROLLBAR_CSS = `
+  [data-code]::-webkit-scrollbar {
+    width: var(--scrollbar-size, 6px);
+    height: var(--scrollbar-size, 6px);
+  }
+  [data-code]::-webkit-scrollbar-track {
+    background: var(--scrollbar-track, transparent);
+  }
+  [data-code]::-webkit-scrollbar-thumb {
+    background: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity, 0.3));
+    border-radius: var(--scrollbar-radius, 3px);
+  }
+  [data-code]::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / var(--scrollbar-thumb-hover-opacity, 0.5));
+  }
+  [data-code]::-webkit-scrollbar-corner {
+    background: var(--scrollbar-track, transparent);
+  }
+`
+
 /** Pierre diffs 主题颜色 CSS — 注入到 unsafeCSS */
 export const PIERRE_DIFF_CSS = `
   :root, :host {
+    /* 覆盖 pierre 库默认 color-scheme: light dark，让 light-dark() 跟随应用主题 class 而非系统偏好 */
+    color-scheme: inherit;
     --diffs-bg: transparent;
     --diffs-addition-base: rgb(67,167,71);
     --diffs-deletion-base: rgb(206,66,52);
@@ -15,26 +42,8 @@ export const PIERRE_DIFF_CSS = `
     --diffs-deletion-bg: light-dark(rgb(248,231,230), rgb(39,22,20));
     --diffs-separator-bg: hsl(var(--background));
     --diffs-gap-style: 3px solid hsl(var(--content-area));
-    --diffs-scrollbar-thumb: light-dark(hsl(var(--muted-foreground) / 0.6), hsl(var(--muted-foreground) / 0.2));
-    --diffs-scrollbar-thumb-hover: light-dark(hsl(var(--muted-foreground) / 0.8), hsl(var(--muted-foreground) / 0.35));
   }
-  [data-code]::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  [data-code]::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  [data-code]::-webkit-scrollbar-thumb {
-    background: var(--diffs-scrollbar-thumb);
-    border-radius: 3px;
-  }
-  [data-code]::-webkit-scrollbar-thumb:hover {
-    background: var(--diffs-scrollbar-thumb-hover);
-  }
-  [data-code]::-webkit-scrollbar-corner {
-    background: transparent;
-  }
+  ${PIERRE_SCROLLBAR_CSS}
   [data-separator=line-info],
   [data-separator=line-info] [data-separator-wrapper],
   [data-separator=line-info] [data-separator-content],
@@ -71,27 +80,10 @@ export const PIERRE_DIFF_CSS = `
 /** Pierre File 组件的 CSS — 纯代码预览（无 diff 行类型） */
 export const PIERRE_FILE_CSS = `
   :root, :host {
+    color-scheme: inherit;
     --diffs-bg: transparent;
-    --diffs-scrollbar-thumb: light-dark(hsl(var(--muted-foreground) / 0.6), hsl(var(--muted-foreground) / 0.2));
-    --diffs-scrollbar-thumb-hover: light-dark(hsl(var(--muted-foreground) / 0.8), hsl(var(--muted-foreground) / 0.35));
   }
-  [data-code]::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  [data-code]::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  [data-code]::-webkit-scrollbar-thumb {
-    background: var(--diffs-scrollbar-thumb);
-    border-radius: 3px;
-  }
-  [data-code]::-webkit-scrollbar-thumb:hover {
-    background: var(--diffs-scrollbar-thumb-hover);
-  }
-  [data-code]::-webkit-scrollbar-corner {
-    background: transparent;
-  }
+  ${PIERRE_SCROLLBAR_CSS}
   [data-column-number],
   [data-gutter] {
     background-color: hsl(var(--content-area)) !important;

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -930,7 +930,18 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
           font-style: ${suggestionActive ? 'italic' : 'normal'};
         }
         .ProseMirror::-webkit-scrollbar {
-          width: 3px;
+          /* 输入框超细特例，引用全局 --scrollbar-size-sm */
+          width: var(--scrollbar-size-sm, 3px);
+        }
+        .ProseMirror::-webkit-scrollbar-thumb {
+          background: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity));
+          border-radius: var(--scrollbar-radius, 3px);
+        }
+        .ProseMirror::-webkit-scrollbar-thumb:hover {
+          background: hsl(var(--muted-foreground) / var(--scrollbar-thumb-hover-opacity));
+        }
+        .ProseMirror::-webkit-scrollbar-track {
+          background: var(--scrollbar-track);
         }
         .mention-chip {
           background-color: hsl(var(--primary) / 0.1);

--- a/apps/electron/src/renderer/components/diff/DiffView.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffView.tsx
@@ -13,6 +13,7 @@ import { useAtomValue } from 'jotai'
 import { MultiFileDiff } from '@pierre/diffs/react'
 import type { FileContents } from '@pierre/diffs'
 import { resolvedThemeAtom } from '@/atoms/theme'
+import { PIERRE_DIFF_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
 import './diff-scroll.css'
 
 /** 单侧超过此行数的文件不计算 diff，避免 Myers O(N*D) + shiki 阻塞主线程 */
@@ -60,67 +61,7 @@ export const DiffView = React.memo(function DiffView({ oldContent, newContent, f
     lineDiffType: 'none' as const,
     overflow: 'scroll' as const,
     themeType: theme as 'light' | 'dark' | 'system',
-    unsafeCSS: `
-      :root, :host {
-        --diffs-bg: transparent;
-        --diffs-addition-base: rgb(67,167,71);
-        --diffs-deletion-base: rgb(206,66,52);
-        --diffs-addition-bg: light-dark(rgb(228,244,233), rgb(19,34,23));
-        --diffs-deletion-bg: light-dark(rgb(248,231,230), rgb(39,22,20));
-        --diffs-separator-bg: hsl(var(--background));
-        --diffs-gap-style: 3px solid hsl(var(--content-area));
-        --diffs-scrollbar-thumb: light-dark(hsl(var(--muted-foreground) / 0.6), hsl(var(--muted-foreground) / 0.2));
-        --diffs-scrollbar-thumb-hover: light-dark(hsl(var(--muted-foreground) / 0.8), hsl(var(--muted-foreground) / 0.35));
-      }
-      .diff-scroll [data-code]::-webkit-scrollbar {
-        width: 6px;
-        height: 6px;
-      }
-      .diff-scroll [data-code]::-webkit-scrollbar-track {
-        background: transparent;
-      }
-      .diff-scroll [data-code]::-webkit-scrollbar-thumb {
-        background: var(--diffs-scrollbar-thumb);
-        border-radius: 3px;
-      }
-      .diff-scroll [data-code]::-webkit-scrollbar-thumb:hover {
-        background: var(--diffs-scrollbar-thumb-hover);
-      }
-      .diff-scroll [data-code]::-webkit-scrollbar-corner {
-        background: transparent;
-      }
-      [data-separator=line-info],
-      [data-separator=line-info] [data-separator-wrapper],
-      [data-separator=line-info] [data-separator-content],
-      [data-separator=line-info] [data-expand-button] {
-        background-color: var(--diffs-separator-bg) !important;
-      }
-      [data-line-type=change-addition] {
-        background-color: var(--diffs-addition-bg) !important;
-      }
-      [data-line-type=change-deletion] {
-        background-color: var(--diffs-deletion-bg) !important;
-      }
-      [data-line-type=change-addition] [data-column-number],
-      [data-line-type=change-addition] [data-gutter-buffer]:not([data-gutter-buffer=buffer]) {
-        color: rgb(67,167,71) !important;
-        background-color: var(--diffs-addition-bg) !important;
-      }
-      [data-line-type=change-deletion] [data-column-number],
-      [data-line-type=change-deletion] [data-gutter-buffer]:not([data-gutter-buffer=buffer]) {
-        color: rgb(206,66,52) !important;
-        background-color: var(--diffs-deletion-bg) !important;
-      }
-      [data-gutter-buffer=buffer] {
-        background: none !important;
-      }
-      [data-line-type=context] [data-column-number],
-      [data-line-type=metadata] [data-column-number],
-      [data-line-type=expanded] [data-column-number],
-      [data-gutter] {
-        background-color: hsl(var(--content-area)) !important;
-      }
-    `,
+    unsafeCSS: PIERRE_DIFF_CSS,
   }), [viewMode, theme])
 
   if (tooLarge) {

--- a/apps/electron/src/renderer/components/diff/diff-scroll.css
+++ b/apps/electron/src/renderer/components/diff/diff-scroll.css
@@ -1,22 +1,24 @@
-/* Diff 滚动条 — overlay 在代码上方，不占布局空间 */
+/* Diff 滚动条 — overlay 在代码上方，不占布局空间。
+ * 尺寸/圆角/轨道引用全局 --scrollbar-* 变量（globals.css :root），颜色在使用处
+ * 写 hsl(var(--muted-foreground) / var(--opacity)) 以正确跟随主题。 */
 .diff-scroll::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: var(--scrollbar-size, 6px);
+  height: var(--scrollbar-size, 6px);
 }
 
 .diff-scroll::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track, transparent);
 }
 
 .diff-scroll::-webkit-scrollbar-thumb {
-  background: hsl(var(--muted-foreground) / 0.2);
-  border-radius: 3px;
+  background: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity, 0.3));
+  border-radius: var(--scrollbar-radius, 3px);
 }
 
 .diff-scroll::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.35);
+  background: hsl(var(--muted-foreground) / var(--scrollbar-thumb-hover-opacity, 0.5));
 }
 
 .diff-scroll::-webkit-scrollbar-corner {
-  background: transparent;
+  background: var(--scrollbar-track, transparent);
 }

--- a/apps/electron/src/renderer/components/ui/scroll-area.tsx
+++ b/apps/electron/src/renderer/components/ui/scroll-area.tsx
@@ -31,14 +31,14 @@ const ScrollBar = React.forwardRef<
     className={cn(
       "flex touch-none select-none transition-colors",
       orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+        "h-full w-[var(--scrollbar-size)] border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+        "h-[var(--scrollbar-size)] flex-col border-t border-t-transparent p-[1px]",
       className
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 scroll-area-thumb" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ))
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName

--- a/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
+++ b/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
@@ -614,7 +614,7 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
             <div className="h-px bg-border/70" />
             <div
               ref={transcriptBoxRef}
-              className="box-border min-h-[34px] px-3 pt-2.5 pb-2.5 text-[15px] leading-7 text-foreground [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+              className="box-border min-h-[34px] px-3 pt-2.5 pb-2.5 text-[15px] leading-7 text-foreground scrollbar-none"
               style={{
                 maxHeight: transcriptMaxHeight ?? undefined,
                 overflowY: 'auto',

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -85,9 +85,28 @@
     --shadow-md: 0 4px 8px -2px rgb(0 0 0 / 0.08), 0 2px 4px -1px rgb(0 0 0 / 0.05), 0 0 0 1px rgb(0 0 0 / 0.04);
     --shadow-lg: 0 12px 24px -6px rgb(0 0 0 / 0.12), 0 4px 8px -2px rgb(0 0 0 / 0.06), 0 0 0 1px rgb(0 0 0 / 0.04);
     --shadow-xl: 0 24px 48px -12px rgb(0 0 0 / 0.18), 0 12px 24px -6px rgb(0 0 0 / 0.08), 0 0 0 1px rgb(0 0 0 / 0.05);
+
+    /* ===== 滚动条统一 token（单一事实来源）=====
+     * 全代码库滚动条架构：尺寸/圆角/轨道/透明度统一引用这组变量，
+     * 禁止在组件内硬编码滚动条值。
+     * ⚠️ 颜色必须在使用处写 hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity))，
+     *    不能预先算成 --scrollbar-thumb 变量——CSS 自定义属性在声明元素(:root)上替换 var()，
+     *    深色/彩色主题继承的是已计算值，主题色相会丢失。
+     * 6px 宽 + 3px radius = 完美胶囊形，与 999px 视觉一致。
+     * color-scheme：跟随应用主题 class，让系统默认滚动条/表单控件在深色下自动显深色，
+     * 并让 light-dark() 按应用主题（而非系统偏好）取分支。
+     */
+    --scrollbar-size: 6px;
+    --scrollbar-size-sm: 3px; /* 输入框等超细场景 */
+    --scrollbar-radius: 3px;
+    --scrollbar-track: transparent;
+    --scrollbar-thumb-opacity: 0.3;
+    --scrollbar-thumb-hover-opacity: 0.5;
+    color-scheme: light;
   }
 
   .dark {
+    color-scheme: dark;
     --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.4);
     --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.5), inset 0 1px 0 0 hsl(0 0% 100% / 0.06);
     --shadow-md: 0 6px 16px -4px rgb(0 0 0 / 0.55), 0 2px 4px 0 rgb(0 0 0 / 0.35), inset 0 1px 0 0 hsl(0 0% 100% / 0.08);
@@ -1168,33 +1187,81 @@
   display: none;
 }
 
-/* 纤细滚动条 */
+/* 纤细滚动条 — 引用全局 --scrollbar-* 变量 */
 .scrollbar-thin,
 .scrollbar-thin > * {
   scrollbar-width: thin;
-  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+  scrollbar-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity)) var(--scrollbar-track);
 }
 .scrollbar-thin::-webkit-scrollbar,
 .scrollbar-thin > *::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
 }
 .scrollbar-thin::-webkit-scrollbar-track,
 .scrollbar-thin > *::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track);
 }
 .scrollbar-thin::-webkit-scrollbar-thumb,
 .scrollbar-thin > *::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--muted-foreground) / 0.3);
-  border-radius: 3px;
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity));
+  border-radius: var(--scrollbar-radius);
 }
 .scrollbar-thin::-webkit-scrollbar-thumb:hover,
 .scrollbar-thin > *::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--muted-foreground) / 0.5);
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-hover-opacity));
 }
 .scrollbar-thin::-webkit-scrollbar-corner,
 .scrollbar-thin > *::-webkit-scrollbar-corner {
-  background: transparent;
+  background: var(--scrollbar-track);
+}
+
+/* ===== 全局滚动条兜底 =====
+ * 未显式套 .scrollbar-thin / .scrollbar-none 的滚动容器，统一使用同一套视觉：
+ * 6px 胶囊、随主题配色。
+ * 注意：此兜底定义在工具类之后，但工具类（.scrollbar-none 的 display:none、
+ * .scrollbar-thin 的细化样式）优先级更高（更具体匹配目标元素），不会被覆盖。
+ * 横向纯滚动条（overflow-x）同样生效。
+ */
+*::-webkit-scrollbar {
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
+}
+*::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+*::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity));
+  border-radius: var(--scrollbar-radius);
+}
+*::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-hover-opacity));
+}
+*::-webkit-scrollbar-corner {
+  background: var(--scrollbar-track);
+}
+@media (pointer: fine) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity)) var(--scrollbar-track);
+  }
+}
+
+/* ===== Radix ScrollArea 滚动条统一 =====
+ * ScrollArea 用 div 模拟滚动条（不走原生 ::-webkit-scrollbar），
+ * 这里把轨道/thumb 视觉与全局滚动条架构对齐：6px 胶囊、随主题配色、hover 变深。
+ */
+.scroll-area-thumb {
+  border-radius: var(--scrollbar-radius);
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity));
+  transition: background-color 0.15s ease;
+}
+.scroll-area-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-hover-opacity));
+}
+[data-radix-scroll-area-viewport] {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity)) var(--scrollbar-track);
 }
 
 /* 滚动区域上下渐隐遮罩 */
@@ -1230,29 +1297,29 @@
 .code-block-wrapper pre.shiki,
 .mermaid-block-scroll {
   scrollbar-width: thin;
-  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+  scrollbar-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity)) var(--scrollbar-track);
 }
 
 :is(.code-block-wrapper pre.shiki, .mermaid-block-scroll)::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
 }
 
 :is(.code-block-wrapper pre.shiki, .mermaid-block-scroll)::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track);
 }
 
 :is(.code-block-wrapper pre.shiki, .mermaid-block-scroll)::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--muted-foreground) / 0.3);
-  border-radius: 999px;
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity));
+  border-radius: var(--scrollbar-radius);
 }
 
 :is(.code-block-wrapper pre.shiki, .mermaid-block-scroll)::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--muted-foreground) / 0.5);
+  background-color: hsl(var(--muted-foreground) / var(--scrollbar-thumb-hover-opacity));
 }
 
 :is(.code-block-wrapper pre.shiki, .mermaid-block-scroll)::-webkit-scrollbar-corner {
-  background: transparent;
+  background: var(--scrollbar-track);
 }
 
 .code-block-wrapper pre.shiki code {


### PR DESCRIPTION
## 概述

统一 Proma 全代码库滚动条架构。此前滚动条样式散落在 7 处（工具类、Shiki/mermaid 代码块、diff 组件、@pierre/diffs 渲染器、ProseMirror 输入框、Radix ScrollArea、系统默认兜底），尺寸/颜色/圆角互相不一致，且全局缺少 `color-scheme` 导致深色/彩色主题下滚动条显色异常。

本次在 `globals.css :root` 建立 `--scrollbar-*` 变量作为单一事实来源（SSOT），所有滚动条统一引用；同时补齐 `color-scheme` 主题跟随，并加全局 `*::-webkit-scrollbar` 兜底让未套工具类的滚动容器也统一。

## 改动

- `styles/globals.css`（+101/-…）
  - 新增 `--scrollbar-size / --scrollbar-size-sm / --scrollbar-radius / --scrollbar-track / --scrollbar-thumb-opacity / --scrollbar-thumb-hover-opacity` 变量
  - `:root` / `.dark` 分别设 `color-scheme: light / dark`，让系统滚动条与 light-dark() 跟随应用主题
  - `.scrollbar-thin` 工具类引用变量（颜色在使用处写 `hsl(var(--muted-foreground) / var(--opacity))`，保证主题跟随）
  - Shiki/mermaid 滚动条引用变量
  - 新增全局兜底 `*::-webkit-scrollbar`（未套类容器统一 6px 胶囊）
  - 新增 `.scroll-area-thumb`（Radix ScrollArea 统一）
- `pierre-styles.ts`（-30）：抽取共享 `PIERRE_SCROLLBAR_CSS` 常量，`PIERRE_DIFF_CSS` / `PIERRE_FILE_CSS` 复用；`:host` 加 `color-scheme: inherit` 覆盖库默认，让 diff 内 light-dark() 跟随应用主题
- `DiffView.tsx`（-60）：删除内联重复的 unsafeCSS，复用 `PIERRE_DIFF_CSS`；顺带修复原 `.diff-scroll [data-code]` 前缀在 shadow DOM 内不生效的隐藏 bug
- `diff-scroll.css`：引用全局变量
- `rich-text-input.tsx`（ProseMirror）：宽度引用 `--scrollbar-size-sm`，补全 thumb/track/radius（原仅有宽度、深色下用系统默认 thumb）
- `scroll-area.tsx`：轨道宽度 10px→6px（`--scrollbar-size`），thumb 引用 `.scroll-area-thumb`
- `VoiceDictationApp.tsx`：隐藏滚动条改用 `.scrollbar-none` 工具类

## 关键设计点

- **颜色必须在使用处计算**：`hsl(var(--muted-foreground) / var(--scrollbar-thumb-opacity))`。不能预先算成 `--scrollbar-thumb` 变量——CSS 自定义属性在声明元素(:root)上替换 var()，深色/彩色主题继承的是已计算值，主题色相会丢失（经浏览器实测确认）。
- **全局兜底优先级**：`.scrollbar-none`（display:none，0,1,0）与 `.scrollbar-thin` 细化样式高于 `*`（0,0,0），隐藏保留滚动与细化覆盖不受影响。
- **shadow DOM**：`--scrollbar-*` 经 host 继承链穿透 shadow root；pierre 的 `color-scheme: inherit` 覆盖库自带 `light dark`。

## 测试

- `bun run typecheck`：6 包全部 0 错误
- `bun run --filter='@proma/electron' build`：通过（含 proma CLI 编译）
- 浏览器实测：浅色 thumb `rgba(115,115,115,.3)` / 深色 `rgba(163,163,163,.3)` 主题跟随正确；`.scrollbar-none` 隐藏优先；shadow DOM + `@layer unsafe` 的 `color-scheme: inherit` 覆盖语义正确
- 两轮独立子会话 BDD 自审通过（第一轮发现并修复 P1 主题跟随 bug；第二轮 approve）

## 紧急度

常规

## 备注

- 本 PR 仅做滚动条视觉与架构统一，不改变任何滚动行为/布局逻辑；全局兜底使此前显示系统默认滚动条的容器（文件浏览器、设置面板、自动任务列表、Radix 弹层等）变为 6px 胶囊统一样式，内容区宽度会相应变化约 6px，属预期
- 特殊主题（ocean/forest/slate/terminal 的 `-light/-dark` 后缀）均定义 `--muted-foreground`，`color-scheme` 跟随 `.dark` class 逻辑与 theme.ts 完全同步；CRT 终端（旧屏微光）的 ScrollMinimap 特制滚动指示器为自定义 div + `!important`，不受全局兜底影响，已确认保留
