### PR TITLE
【已审核】feat(tabs): Tab 预览展示完整迷你会话流

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -313,6 +313,16 @@ export const agentSessionStreamingStateAtomFamily = atomFamily((sessionId: strin
  */
 export const liveMessagesMapAtom = atom<Map<string, SDKMessage[]>>(new Map())
 
+/**
+ * 单个 session 的 live SDKMessage 派生 atomFamily — 按 sessionId 切片订阅。
+ *
+ * 用于 Tab 预览等轻量订阅点：只在本 session 的实时消息变化时重渲染，
+ * 避免直接订阅全局 Map 被任意会话的流式更新触发整树重渲染。
+ */
+export const agentSessionLiveMessagesAtomFamily = atomFamily((sessionId: string) =>
+  atom((get) => get(liveMessagesMapAtom).get(sessionId)),
+)
+
 export const agentPendingPromptAtom = atom<AgentPendingPrompt | null>(null)
 
 /**

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -6,7 +6,7 @@
  */
 
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
+import { atomFamily, atomWithStorage } from 'jotai/utils'
 import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
 
 /** 全局渠道列表缓存（启动时加载一次，设置变更时刷新） */
@@ -60,6 +60,16 @@ export interface ConversationStreamState {
  * 流式结束后：从 Map 中删除该 key
  */
 export const streamingStatesAtom = atom<Map<string, ConversationStreamState>>(new Map())
+
+/**
+ * 单个 conversation 的 streaming state 派生 atomFamily — 按 conversationId 切片订阅。
+ *
+ * 直接订阅 streamingStatesAtom 会让任意对话的流式更新都触发订阅者整树重渲染。
+ * 本 family 让订阅者只在本 conversation 的 state 引用变化时重渲染。
+ */
+export const conversationStreamingStateAtomFamily = atomFamily((conversationId: string) =>
+  atom((get) => get(streamingStatesAtom).get(conversationId)),
+)
 
 /**
  * 当前正在流式输出的对话 ID 集合（派生只读原子）

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -8,6 +8,7 @@
 
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
+import type { SDKMessage } from '@proma/shared'
 import {
   streamingConversationIdsAtom,
 } from './chat-atoms'
@@ -112,6 +113,34 @@ export interface TabMinimapItem {
   model?: string
 }
 export const tabMinimapCacheAtom = atom<Map<string, TabMinimapItem[]>>(new Map())
+
+/** Tab 预览中的单条工具活动（统一 agent/chat 两种来源） */
+export interface TabStreamActivity {
+  /** 工具调用 ID（chat 合并后取首个 toolCallId） */
+  id: string
+  toolName: string
+  input: Record<string, unknown>
+  done: boolean
+  isError?: boolean
+}
+
+/** Tab 预览中的会话流运行数据（流式运行时由 TabBarItem 组装） */
+export interface TabStreamRunData {
+  kind: 'agent' | 'chat'
+  /** 恒为 true（非运行状态由 streamRun 为 null 表达），保留字段以便未来扩展 */
+  running: boolean
+  /** 实时生成的文本内容 */
+  content: string
+  /** Chat 会话的实时推理内容（thinking），Agent 会话由 liveMessages 承载 */
+  reasoning?: string
+  /** 流式绑定的模型 ID */
+  model?: string
+  /** 流式开始时间戳 */
+  startedAt?: number
+  activities: TabStreamActivity[]
+  /** Agent 会话的实时 SDKMessage 流（thinking / tool_use / text 按时间顺序），Chat 会话无此字段 */
+  liveMessages?: SDKMessage[]
+}
 
 /** Scratch Pad 编辑内容（HTML 字符串，供 TipTap 编辑器使用） */
 export const scratchPadContentAtom = atom<string>('')

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -30,6 +30,7 @@ import {
   conversationThinkingEnabledAtom,
   conversationParallelModeAtom,
   agentSideChatMapAtom,
+  conversationStreamingStateAtomFamily,
 } from '@/atoms/chat-atoms'
 import {
   agentSessionsAtom,
@@ -53,6 +54,7 @@ import {
   agentFileChangesCurrentRunAtom,
   agentDiffDataAtom,
   agentStreamingStatesAtom,
+  agentSessionLiveMessagesAtomFamily,
   liveMessagesMapAtom,
   agentSessionPendingFilesAtom,
   agentSessionStreamingStateAtomFamily,
@@ -914,6 +916,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     // atomFamily 内部缓存（Jotai 对 string key 强引用 Map，不显式 remove 永不释放）。
     // 删除/归档是会话的终态，连同草稿一起清理，无需像关闭 Tab 那样保留可恢复输入。
     agentSessionStreamingStateAtomFamily.remove(id)
+    agentSessionLiveMessagesAtomFamily.remove(id)
     agentSessionDraftAtomFamily.remove(id)
     agentSessionDraftHtmlAtomFamily.remove(id)
     agentPendingFilesAtomFamily.remove(id)
@@ -1256,6 +1259,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       // 即使后端报错，也从本地列表移除（可能是对话已不存在）
       setConversations((prev) => prev.filter((c) => c.id !== pendingDeleteId))
     } finally {
+      // atomFamily 内部缓存（Jotai 对 string key 强引用 Map，不显式 remove 永不释放）。
+      // 删除是对话的终态，清理流式状态派生缓存条目。
+      conversationStreamingStateAtomFamily.remove(pendingDeleteId)
       setPendingDeleteId(null)
     }
   }

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -406,6 +406,7 @@ function TabBarInner({
             key={tab.id}
             id={tab.id}
             type={tab.type}
+            sessionId={tab.sessionId}
             title={tab.title}
             workspaceName={tab.type === 'agent' ? workspaceNameBySessionId.get(tab.sessionId) : undefined}
             isAutomation={tab.type === 'agent' && automationSessionIds.has(tab.sessionId)}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -11,16 +11,21 @@ import { createPortal } from 'react-dom'
 import { useAtomValue } from 'jotai'
 import { FileText, StickyNote, X, Clock, GitBranch } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
+import type { TabType, TabMinimapItem, TabStreamRunData } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
+import { agentSessionStreamingStateAtomFamily, agentSessionLiveMessagesAtomFamily } from '@/atoms/agent-atoms'
+import { conversationStreamingStateAtomFamily } from '@/atoms/chat-atoms'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { Spinner } from '@/components/ui/spinner'
 import { TabPreviewPanel } from './TabPreviewPanel'
+import type { ChatToolActivity } from '@proma/shared'
 
 export interface TabBarItemProps {
   id: string
   type: TabType
+  /** 该 Tab 所属会话 ID（preview Tab 为 owner agent sessionId） */
+  sessionId: string
   title: string
   workspaceName?: string
   isActive: boolean
@@ -52,6 +57,7 @@ export interface TabBarItemProps {
 export function TabBarItem({
   id,
   type,
+  sessionId,
   title,
   workspaceName,
   isActive,
@@ -75,6 +81,47 @@ export function TabBarItem({
   const minimapCache = useAtomValue(tabMinimapCacheAtom)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const isClassic = interfaceVariant === 'classic'
+
+  // 订阅该 Tab 所属会话的实时流式状态（按 sessionId 切片，避免整树重渲染）
+  const agentStream = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))
+  const chatStream = useAtomValue(conversationStreamingStateAtomFamily(sessionId))
+  // Agent 会话的实时 SDKMessage 流（完整会话流数据源）
+  const liveAgentMessages = useAtomValue(agentSessionLiveMessagesAtomFamily(sessionId))
+
+  // 组装 Tab 预览面板用的会话流运行数据（仅运行中返回，否则保持 null）
+  const streamRun = React.useMemo<TabStreamRunData | null>(() => {
+    if (type === 'agent' || type === 'preview') {
+      if (!agentStream?.running) return null
+      return {
+        kind: 'agent',
+        running: true,
+        content: agentStream.content ?? '',
+        model: agentStream.model,
+        startedAt: agentStream.startedAt,
+        liveMessages: liveAgentMessages,
+        activities: agentStream.toolActivities.map((ta) => ({
+          id: ta.toolUseId,
+          toolName: ta.toolName,
+          input: ta.input,
+          done: ta.done,
+          isError: ta.isError,
+        })),
+      }
+    }
+    if (type === 'chat') {
+      if (!chatStream?.streaming) return null
+      return {
+        kind: 'chat',
+        running: true,
+        content: chatStream.content ?? '',
+        reasoning: chatStream.reasoning ?? '',
+        model: chatStream.model,
+        startedAt: chatStream.startedAt,
+        activities: mergeChatActivities(chatStream.toolActivities),
+      }
+    }
+    return null
+  }, [type, agentStream, chatStream, liveAgentMessages])
 
   React.useEffect(() => {
     const el = buttonRef.current
@@ -218,6 +265,7 @@ export function TabBarItem({
           buttonRef={buttonRef}
           title={title}
           items={previewItems}
+          streamRun={streamRun}
           isLeaving={isLeaving}
           onMouseEnter={onPanelHoverEnter}
           onMouseLeave={onPanelHoverLeave}
@@ -232,6 +280,7 @@ function TabPreviewDropdown({
   buttonRef,
   title,
   items,
+  streamRun,
   isLeaving,
   onMouseEnter,
   onMouseLeave,
@@ -239,6 +288,7 @@ function TabPreviewDropdown({
   buttonRef: React.RefObject<HTMLButtonElement | null>
   title: string
   items: TabMinimapItem[]
+  streamRun: TabStreamRunData | null
   isLeaving: boolean
   onMouseEnter: () => void
   onMouseLeave: () => void
@@ -271,8 +321,36 @@ function TabPreviewDropdown({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <TabPreviewPanel title={title} items={items} isLeaving={isLeaving} />
+      <TabPreviewPanel title={title} items={items} streamRun={streamRun} isLeaving={isLeaving} />
     </div>,
     document.body
   )
+}
+
+/**
+ * 合并 Chat 模式的 start/result 工具活动事件为统一的活动列表
+ * （与 ChatToolActivityIndicator 合并逻辑一致）
+ */
+function mergeChatActivities(activities: ChatToolActivity[]): TabStreamRunData['activities'] {
+  const map = new Map<string, TabStreamRunData['activities'][number]>()
+  for (const a of activities) {
+    const existing = map.get(a.toolCallId)
+    if (a.type === 'start') {
+      map.set(a.toolCallId, {
+        id: a.toolCallId,
+        toolName: a.toolName,
+        input: a.input ?? existing?.input ?? {},
+        done: false,
+      })
+    } else if (a.type === 'result') {
+      map.set(a.toolCallId, {
+        id: a.toolCallId,
+        toolName: existing?.toolName ?? a.toolName,
+        input: a.input ?? existing?.input ?? {},
+        done: true,
+        isError: a.isError,
+      })
+    }
+  }
+  return Array.from(map.values())
 }

--- a/apps/electron/src/renderer/components/tabs/TabPreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabPreviewPanel.tsx
@@ -3,7 +3,9 @@
  *
  * 在 Tab hover 时向下弹出，显示：
  * 1. 对话标题
- * 2. 消息列表（复用 minimap 风格）
+ * 2. 会话流实时运行状态（会话正在流式运行时）：迷你会话流——thinking / 工具调用 / 文本输出
+ *    按时间顺序滚动展示，末尾是正在生成的实时内容
+ * 3. 消息列表（复用 minimap 风格）
  * 无搜索、无最小条目限制。
  */
 
@@ -11,16 +13,30 @@ import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, AlertCircle, Brain, CheckCircle2, Loader2 } from 'lucide-react'
 import { UserAvatar } from '@/components/chat/UserAvatar'
-import { getModelLogo, resolveModelProvider } from '@/lib/model-logo'
+import { getModelLogo, resolveModelDisplayName, resolveModelProvider } from '@/lib/model-logo'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { cn } from '@/lib/utils'
-import type { TabMinimapItem } from '@/atoms/tab-atoms'
+import { Spinner } from '@/components/ui/spinner'
+import { getToolPhrase } from '@/components/agent/tool-phrase'
+import { getSDKCompactStatus } from '@proma/shared'
+import type {
+  SDKMessage,
+  SDKAssistantMessage,
+  SDKUserMessage,
+  SDKSystemMessage,
+  SDKContentBlock,
+  SDKToolUseBlock,
+  SDKUserContentBlock,
+} from '@proma/shared'
+import type { TabMinimapItem, TabStreamRunData, TabStreamActivity } from '@/atoms/tab-atoms'
 
 interface TabPreviewPanelProps {
   title: string
   items: TabMinimapItem[]
+  /** 会话流实时运行数据（流式运行时传入，否则为 null） */
+  streamRun?: TabStreamRunData | null
   isLeaving: boolean
 }
 
@@ -36,6 +52,21 @@ const PREVIEW_MD_COMPONENTS = {
   a: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
 } as const
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+// ── 迷你会话流条目 ──
+
+/** 迷你会话流中的单条渲染条目（由 liveMessages + 实时流式状态转换而来） */
+interface TabFlowEntry {
+  id: string
+  type: 'text' | 'thinking' | 'tool' | 'user' | 'status'
+  text?: string
+  toolName?: string
+  input?: Record<string, unknown>
+  done?: boolean
+  isError?: boolean
+  /** 是否属于当前正在生成的实时内容 */
+  streaming?: boolean
+}
 
 // ── 子组件 ──
 
@@ -59,7 +90,7 @@ function ItemIcon({ item }: { item: TabMinimapItem }): React.ReactElement {
   return <div className="size-4 shrink-0 mt-0.5 rounded-[20%] bg-muted" />
 }
 
-function Preview({ text }: { text: string }): React.ReactElement {
+function PreviewInner({ text }: { text: string }): React.ReactElement {
   if (!text) {
     return <span className="text-xs opacity-40">(空消息)</span>
   }
@@ -73,9 +104,305 @@ function Preview({ text }: { text: string }): React.ReactElement {
   )
 }
 
+/** memo 化：流式 content 不变时跳过 Markdown 重解析（高频重渲染下收益明显） */
+const Preview = React.memo(PreviewInner)
+
+/** 运行耗时计时器 — 从 startedAt 起实时刷新（250ms 节流，足够秒级可读且省资源） */
+function StreamRunTimer({ startedAt }: { startedAt?: number }): React.ReactElement {
+  const [elapsed, setElapsed] = React.useState(0)
+
+  React.useEffect(() => {
+    const start = startedAt ?? Date.now()
+    const update = (): void => setElapsed((Date.now() - start) / 1000)
+    update()
+    const timer = setInterval(update, 250)
+    return () => clearInterval(timer)
+  }, [startedAt])
+
+  const formatTime = (seconds: number): string => {
+    if (seconds < 60) return `${seconds.toFixed(1)}s`
+    const m = Math.floor(seconds / 60)
+    const s = seconds % 60
+    return `${m}m ${s.toFixed(0)}s`
+  }
+
+  return <span className="tabular-nums">{formatTime(elapsed)}</span>
+}
+
+/** 单条工具活动行 — 运行中/完成/出错三种状态 */
+function StreamActivityRow({ activity }: { activity: TabStreamActivity }): React.ReactElement {
+  const phrase = getToolPhrase(activity.toolName, activity.input)
+  const label = activity.done ? phrase.label : (phrase.loadingLabel || `正在${phrase.label}...`)
+
+  return (
+    <div className="flex items-center gap-1.5 min-w-0">
+      {activity.done ? (
+        activity.isError
+          ? <AlertCircle className="size-3 shrink-0 text-destructive" />
+          : <CheckCircle2 className="size-3 shrink-0 text-emerald-500/80" />
+      ) : (
+        <Loader2 className="size-3 shrink-0 animate-spin text-primary/70" />
+      )}
+      <span className="truncate text-[11px] text-popover-foreground/75">{label}</span>
+    </div>
+  )
+}
+
+/** 迷你会话流单条渲染 */
+function FlowEntry({ entry }: { entry: TabFlowEntry }): React.ReactElement {
+  if (entry.type === 'tool') {
+    return (
+      <StreamActivityRow
+        activity={{
+          id: entry.id,
+          toolName: entry.toolName ?? 'tool',
+          input: entry.input ?? {},
+          done: entry.done ?? false,
+          isError: entry.isError,
+        }}
+      />
+    )
+  }
+
+  if (entry.type === 'thinking') {
+    return (
+      <div className="rounded-md border border-border/40 bg-muted/20 px-2 py-1">
+        <div className="flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground/60 mb-0.5">
+          <Brain className="size-2.5" />
+          Thinking
+        </div>
+        <div className="text-[11px] leading-4 text-popover-foreground/60 line-clamp-2 overflow-hidden whitespace-pre-wrap break-words">
+          {entry.text}
+        </div>
+      </div>
+    )
+  }
+
+  if (entry.type === 'user') {
+    return (
+      <div className="rounded-md bg-primary/[0.06] px-2 py-1">
+        <div className="text-[11px] leading-4 text-popover-foreground/85 line-clamp-2 overflow-hidden whitespace-pre-wrap break-words">
+          {entry.text}
+        </div>
+      </div>
+    )
+  }
+
+  if (entry.type === 'status') {
+    return (
+      <div className="flex items-center gap-1.5 text-[11px] text-amber-600/80 dark:text-amber-400/80">
+        <AlertTriangle className="size-3 shrink-0" />
+        {entry.text}
+      </div>
+    )
+  }
+
+  // text
+  return (
+    <div className={cn(
+      'rounded-md',
+      entry.streaming ? 'bg-background/60 border border-border/40 px-1.5 py-1' : 'px-1 py-0.5',
+    )}>
+      <Preview text={entry.text ?? ''} />
+    </div>
+  )
+}
+
+// ── 迷你会话流数据转换 ──
+
+/** 从 SDKMessage 块中提取文本（与 SessionMiniMapPopover 语义一致） */
+function blockText(block: SDKContentBlock | SDKUserContentBlock): string {
+  if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
+    return block.text
+  }
+  if (block.type === 'thinking' && 'thinking' in block && typeof block.thinking === 'string') {
+    return block.thinking
+  }
+  return ''
+}
+
+/** Agent：把实时 SDKMessage 流转换为按时间顺序的流条目 */
+function buildAgentFlowEntries(
+  liveMessages: SDKMessage[] | undefined,
+  content: string,
+  activities: TabStreamActivity[],
+): TabFlowEntry[] {
+  const entries: TabFlowEntry[] = []
+
+  for (const message of liveMessages ?? []) {
+    if (message.type === 'assistant') {
+      const assistant = message as SDKAssistantMessage
+      const blocks = Array.isArray(assistant.message?.content) ? assistant.message.content : []
+      const baseId = assistant.uuid ?? `assistant-${entries.length}`
+      blocks.forEach((block, blockIndex) => {
+        if (block.type === 'tool_use') {
+          const tb = block as SDKToolUseBlock
+          entries.push({
+            id: tb.id,
+            type: 'tool',
+            toolName: tb.name,
+            input: (tb.input ?? {}) as Record<string, unknown>,
+            done: false,
+          })
+          return
+        }
+        const text = blockText(block).trim()
+        if (!text) return
+        entries.push({
+          id: `${baseId}-${blockIndex}`,
+          type: block.type === 'thinking' ? 'thinking' : 'text',
+          text,
+        })
+      })
+      continue
+    }
+
+    if (message.type === 'user') {
+      const user = message as SDKUserMessage
+      const blocks = Array.isArray(user.message?.content) ? user.message.content : []
+      // tool_result 块是工具调用的回执（工具行已表达），过滤后提取同一消息里的用户文本
+      const text = blocks
+        .filter((b) => b.type !== 'tool_result')
+        .map(blockText)
+        .filter(Boolean)
+        .join('\n')
+        .trim()
+      if (!text) continue
+      entries.push({
+        id: user.uuid ?? `user-${entries.length}`,
+        type: 'user',
+        text,
+      })
+      continue
+    }
+
+    if (message.type === 'system') {
+      const system = message as SDKSystemMessage
+      const compactStatus = getSDKCompactStatus(system)
+      const statusText = compactStatus === 'success' ? '上下文已压缩'
+        : compactStatus === 'compacting' ? '正在压缩上下文...'
+        : compactStatus === 'failed' ? '上下文压缩失败'
+        : compactStatus === 'noop' ? '当前上下文无需压缩'
+        : system.subtype === 'permission_denied' ? '权限检查已拒绝操作'
+        : ''
+      if (statusText) {
+        // SDKSystemMessage 无 uuid，用索引作稳定 id
+        entries.push({ id: `system-${entries.length}`, type: 'status', text: statusText })
+      }
+    }
+  }
+
+  // 用 streamState 活动回填/补充工具条目：
+  // - 已出现在 liveMessages 的 tool_use 条目用活动状态回填完成/错误态（tool_result 消息不进入流条目）
+  // - 尚未出现（tool_start 先于 SDKMessage 到达）且进行中的活动才追加
+  for (const activity of activities) {
+    const idx = entries.findIndex((e) => e.id === activity.id && e.type === 'tool')
+    if (idx >= 0) {
+      if (activity.done) {
+        entries[idx] = { ...entries[idx]!, done: true, isError: activity.isError }
+      }
+    } else if (!activity.done) {
+      entries.push({ ...activity, type: 'tool', streaming: true })
+    }
+  }
+
+  // 实时文本：固定 id 的 live 条目追加在流末尾（绝不覆盖已完成的历史 text 块）。
+  // 若 SDK 已把最后一条 text 块 partial 更新到与 content 相同则跳过，避免重复。
+  const trimmedContent = content.trim()
+  if (trimmedContent) {
+    const liveIdx = entries.findIndex((e) => e.id === 'live-text')
+    if (liveIdx >= 0) {
+      entries[liveIdx] = { ...entries[liveIdx]!, text: content, streaming: true }
+    } else {
+      const lastEntry = entries[entries.length - 1]
+      const alreadyLive = lastEntry?.type === 'text' && lastEntry.text === content
+      if (!alreadyLive) {
+        entries.push({ id: 'live-text', type: 'text', text: content, streaming: true })
+      }
+    }
+  }
+
+  return entries
+}
+
+/** Chat：由 reasoning / toolActivities / content 组成同类流 */
+function buildChatFlowEntries(data: TabStreamRunData): TabFlowEntry[] {
+  const entries: TabFlowEntry[] = []
+
+  if (data.reasoning && data.reasoning.trim()) {
+    entries.push({ id: 'chat-reasoning', type: 'thinking', text: data.reasoning.trim() })
+  }
+
+  for (const activity of data.activities) {
+    entries.push({ ...activity, type: 'tool' })
+  }
+
+  if (data.content && data.content.trim()) {
+    entries.push({ id: 'chat-content', type: 'text', text: data.content, streaming: true })
+  }
+
+  return entries
+}
+
+/** 统一的流条目构建入口 */
+function buildFlowEntries(data: TabStreamRunData): TabFlowEntry[] {
+  if (data.kind === 'agent') {
+    return buildAgentFlowEntries(data.liveMessages, data.content, data.activities)
+  }
+  return buildChatFlowEntries(data)
+}
+
 // ── 主组件 ──
 
-export function TabPreviewPanel({ title, items, isLeaving }: TabPreviewPanelProps): React.ReactElement {
+/** 会话流实时运行区域 — 运行指示 + 迷你会话流（自动滚动） */
+function StreamRunSection({ streamRun }: { streamRun: TabStreamRunData }): React.ReactElement {
+  const channels = useAtomValue(channelsAtom)
+  const modelName = streamRun.model
+    ? resolveModelDisplayName(streamRun.model, channels)
+    : undefined
+  const flowEntries = React.useMemo(() => buildFlowEntries(streamRun), [streamRun])
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+
+  // 实时流自动滚动：仅当用户接近底部时才贴底，避免劫持 hover 阅读
+  React.useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40
+    if (nearBottom) el.scrollTop = el.scrollHeight
+  }, [flowEntries])
+
+  return (
+    <div className="shrink-0 border-b border-border/60 bg-muted/20 flex flex-col">
+      {/* 运行指示条 */}
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Spinner size="sm" className="text-primary/70 shrink-0" />
+        <span className="text-[11px] font-medium text-popover-foreground/85 truncate">
+          {streamRun.kind === 'agent' ? 'Agent 运行中' : 'Chat 生成中'}
+        </span>
+        <StreamRunTimer startedAt={streamRun.startedAt} />
+        {modelName && (
+          <span className="shrink-0 ml-auto text-[10px] text-muted-foreground/80 truncate max-w-[96px]">
+            {modelName}
+          </span>
+        )}
+      </div>
+
+      {/* 迷你会话流 */}
+      {flowEntries.length > 0 && (
+        <div
+          ref={scrollRef}
+          className="max-h-[220px] overflow-y-auto px-2 pb-2 space-y-1 scrollbar-thin"
+        >
+          {flowEntries.map((entry) => (
+            <FlowEntry key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function TabPreviewPanel({ title, items, streamRun, isLeaving }: TabPreviewPanelProps): React.ReactElement {
   return (
     <div
       className={cn(
@@ -92,30 +419,35 @@ export function TabPreviewPanel({ title, items, isLeaving }: TabPreviewPanelProp
           {title}
         </span>
         <span className="text-[11px] text-muted-foreground tabular-nums ml-2 shrink-0">
-          {items.length}
+          {streamRun ? '● 实时' : items.length}
         </span>
       </div>
 
-      {/* 消息列表 */}
-      <div className="overflow-y-auto flex-1 p-1.5 space-y-0.5 scrollbar-thin">
-        {items.length === 0 ? (
-          <div className="py-6 text-center text-xs text-muted-foreground">
-            暂无消息
-          </div>
-        ) : (
-          items.map((item) => (
-            <div
-              key={item.id}
-              className="flex items-start gap-2 w-full rounded-md px-2 py-1.5 text-left"
-            >
-              <ItemIcon item={item} />
-              <div className="flex-1 min-w-0">
-                <Preview text={item.preview} />
-              </div>
+      {/* 会话流实时运行区域（流式运行时显示；此时不渲染下方消息列表，避免两段重复） */}
+      {streamRun && <StreamRunSection streamRun={streamRun} />}
+
+      {/* 消息列表（仅非流式运行时显示） */}
+      {!streamRun && (
+        <div className="overflow-y-auto flex-1 p-1.5 space-y-0.5 scrollbar-thin">
+          {items.length === 0 ? (
+            <div className="py-6 text-center text-xs text-muted-foreground">
+              暂无消息
             </div>
-          ))
-        )}
-      </div>
+          ) : (
+            items.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-start gap-2 w-full rounded-md px-2 py-1.5 text-left"
+              >
+                <ItemIcon item={item} />
+                <div className="flex-1 min-w-0">
+                  <Preview text={item.preview} />
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 概述

Tab hover 预览面板新增会话流实时运行展示：当会话正在流式运行时，悬停 Tab 弹出的小窗展示完整迷你会话流——thinking、工具调用、文本输出按时间顺序滚动，顶部带运行指示条（耗时 + 模型名），并自动滚动贴底（用户上滚时暂停跟随）。运行中预览窗只保留流式区域一段（不再同时显示历史消息摘要），会话结束后恢复原有消息摘要预览，行为与改动前一致。

## 改动

- `apps/electron/src/renderer/atoms/agent-atoms.ts`：新增 `agentSessionLiveMessagesAtomFamily`（按 sessionId 切片订阅实时 SDK 消息，避免整树重渲染）
- `apps/electron/src/renderer/atoms/chat-atoms.ts`：新增 `conversationStreamingStateAtomFamily`（Chat 流式状态切片订阅）
- `apps/electron/src/renderer/atoms/tab-atoms.ts`：新增 `TabStreamRunData` / `TabStreamActivity` 类型（含 liveMessages / reasoning 字段）
- `apps/electron/src/renderer/components/tabs/TabBar.tsx`：向 `TabBarItem` 传入 `sessionId`
- `apps/electron/src/renderer/components/tabs/TabBarItem.tsx`：订阅 agent/chat 流式状态，组装 `streamRun` 数据（Chat 工具事件 start/result 合并）
- `apps/electron/src/renderer/components/tabs/TabPreviewPanel.tsx`：新增 `StreamRunSection` + 迷你会话流渲染器（`buildAgentFlowEntries` / `buildChatFlowEntries` / `FlowEntry`）；工具完成/出错态由 streamState 回填；实时文本用固定 id 追加不覆盖已完成块；Preview memo 化、计时器 250ms 节流
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`：删除会话/对话时清理 streaming / liveMessages atomFamily 缓存

## 测试

`bun run typecheck` 通过。已通过 BDD 自审查（独立子会话审查两轮，修复工具完成态回填、实时文本合并误判、自动滚动劫持等 4 个问题）。dev 模式实测：Agent 会话运行时 hover Tab，可看到 thinking / 工具活动（进行中旋转 → 完成绿勾 → 出错红叉）/ 文本输出按序实时滚动，仅显示单段；会话结束后恢复原消息摘要预览。

## 紧急度

常规

## 备注

无关联 upstream issue。