### PR TITLE
【已审核】feat(git-diff): 文件改动 tab 仓库选择器——按仓库聚合所有 worktree 变更与分支对比

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -138,7 +138,7 @@ import type {
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus, reinitializeRuntime } from './lib/runtime-init'
-import { getUnstagedChanges, getFileDiff, getUntrackedContent, revertFile, getDiffContents, listWorktrees, getWorktreeChanges, getMainRepoRoot } from './lib/git-diff-service'
+import { getUnstagedChanges, invalidateGitDiffCache, getFileDiff, getUntrackedContent, revertFile, getDiffContents, listWorktrees, getWorktreeChanges, getMainRepoRoot, listRepos, getRepoChanges } from './lib/git-diff-service'
 import { registerPromaFilePath } from './lib/local-file-protocol'
 import { registerUpdaterIpc } from './lib/updater/updater-ipc'
 import {
@@ -967,6 +967,15 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 使变更扫描缓存失效：agent 写文件 / git 变更完成后由渲染层调用，
+  // 保证下次 getUnstagedChanges 重新扫描并返回最新结果。可传 writtenPath 定向失效。
+  ipcMain.handle(
+    IPC_CHANNELS.INVALIDATE_GIT_DIFF_CACHE,
+    async (_, writtenPath?: string): Promise<void> => {
+      invalidateGitDiffCache(writtenPath)
+    }
+  )
+
   // 获取单个文件的 diff
   ipcMain.handle(
     IPC_CHANNELS.GET_FILE_DIFF,
@@ -1009,6 +1018,9 @@ export function registerIpcHandlers(): void {
       const access = normalizeFileAccessOptions({ sessionId })
       if (!(await ensurePathAllowedWithWorktree(dirPath, access)) || (gitRoot && !(await ensurePathAllowedWithWorktree(gitRoot, access)))) return
       await revertFile(dirPath, filePath, gitRoot)
+      // 还原会改变工作树，定向失效该文件所在仓库的变更扫描缓存。
+      // filePath 是 repo 根相对路径，必须用 gitRoot 拼绝对路径才能命中定向匹配。
+      invalidateGitDiffCache(gitRoot ? join(gitRoot, filePath) : filePath)
     }
   )
 
@@ -1030,9 +1042,9 @@ export function registerIpcHandlers(): void {
   // 列出 Git Worktree（只读取 worktree 元信息，不涉及文件内容，跳过路径安全检查）
   ipcMain.handle(
     IPC_CHANNELS.LIST_WORKTREES,
-    async (_, repoPath: string, _sessionId: string) => {
+    async (_, repoPath: string, _sessionId: string, force?: boolean) => {
       if (!repoPath || typeof repoPath !== 'string') return []
-      return await listWorktrees(repoPath)
+      return await listWorktrees(repoPath, force === true)
     }
   )
 
@@ -1047,7 +1059,53 @@ export function registerIpcHandlers(): void {
       if (!(await ensurePathAllowedWithWorktree(worktreePath, access))) {
         return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
       }
-      return getWorktreeChanges(worktreePath, baseBranch)
+      // baseBranch 为空时服务端自动探测（origin/main → origin/master → …）
+      return getWorktreeChanges(worktreePath, baseBranch || undefined)
+    }
+  )
+
+  // 列出扫描到的所有 Git 仓库（仓库选择器用）
+  ipcMain.handle(
+    IPC_CHANNELS.LIST_REPOS,
+    async (_, dirPath: string, sessionId?: string, force?: boolean) => {
+      if (!dirPath || typeof dirPath !== 'string') return []
+      const access = normalizeFileAccessOptions({ sessionId })
+      if (!(await ensurePathAllowed(dirPath, access))) return []
+      return listRepos(dirPath, { force })
+    }
+  )
+
+  // 获取仓库所有 worktree 的全量变更（仓库聚合视图用）
+  ipcMain.handle(
+    IPC_CHANNELS.GET_REPO_CHANGES,
+    async (_, repoPath: string, baseBranch: string, sessionId: string) => {
+      if (!repoPath || typeof repoPath !== 'string') {
+        return { isGitRepo: false, repoPath: '', baseBranch: '', worktrees: [] }
+      }
+      const access = normalizeFileAccessOptions({ sessionId })
+      if (!(await ensurePathAllowedWithWorktree(repoPath, access))) {
+        return { isGitRepo: false, repoPath, baseBranch: '', worktrees: [] }
+      }
+      // 防御纵深：worktree 元数据可能指向未授权目录，逐 worktree 校验后再收集；
+      // baseBranch 为空时服务端自动探测（origin/main → origin/master → …）
+      return getRepoChanges(repoPath, baseBranch || undefined, {
+        isPathAllowed: (p) => ensurePathAllowedWithWorktree(p, access),
+        sessionId,
+      })
+    }
+  )
+
+  // 打开系统目录选择对话框（手动添加仓库用；Electron 不支持 window.prompt）
+  ipcMain.handle(
+    IPC_CHANNELS.SELECT_DIRECTORY,
+    async (event): Promise<string | null> => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      const options: Electron.OpenDialogOptions = {
+        title: '选择 Git 仓库根目录',
+        properties: ['openDirectory', 'promptToCreate'],
+      }
+      const result = win ? await dialog.showOpenDialog(win, options) : await dialog.showOpenDialog(options)
+      return result.canceled || result.filePaths.length === 0 ? null : result.filePaths[0]!
     }
   )
 

--- a/apps/electron/src/main/lib/git-diff-service.test.ts
+++ b/apps/electron/src/main/lib/git-diff-service.test.ts
@@ -1,0 +1,93 @@
+/**
+ * git-diff-service 集成测试 — 用临时 git 仓库验证仓库发现 / worktree 枚举 / 聚合变更。
+ *
+ * 每个用例使用独立临时仓库，避免共享缓存与状态污染。
+ * 依赖真实 git 可执行文件（与运行时一致），测试前请确保 git 可用。
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { findAllGitRoots, getRepoChanges, getWorktreeChanges, invalidateGitDiffCache, listRepos } from './git-diff-service'
+
+let cleanupDirs: string[] = []
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'gdser-'))
+  cleanupDirs.push(root)
+  const run = (args: string[]) => execSync(`git ${args.join(' ')}`, { cwd: root, stdio: 'pipe' })
+  run(['init', '-b', 'main'])
+  run(['config', 'user.email', 'test@test.com'])
+  run(['config', 'user.name', 'test'])
+  writeFileSync(join(root, 'a.txt'), 'hello\n')
+  run(['add', '.'])
+  run(['commit', '-m', 'init'])
+  return root
+}
+
+afterEach(() => {
+  invalidateGitDiffCache()
+  for (const dir of cleanupDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+  }
+  cleanupDirs = []
+})
+
+describe('git-diff-service 仓库发现与聚合', () => {
+  it('findAllGitRoots 能发现仓库根', async () => {
+    const root = makeRepo()
+    const roots = await findAllGitRoots(root)
+    expect(roots).toContain(root.replace(/\\/g, '/'))
+  })
+
+  it('listRepos 列出仓库（含主 worktree）', async () => {
+    const root = makeRepo()
+    writeFileSync(join(root, 'a.txt'), 'hello world\n') // 未提交改动
+    const repos = await listRepos(root)
+    expect(repos.length).toBe(1)
+    expect(repos[0]!.name).toBe(root.split(/[\\/]/).pop() ?? '')
+    expect(repos[0]!.branch).toBe('main')
+    expect(repos[0]!.worktreeCount).toBe(1)
+    expect(repos[0]!.worktrees[0]!.isMain).toBe(true)
+  })
+
+  it('listRepos 枚举额外 worktree，且新 worktree 立即可见', async () => {
+    const root = makeRepo()
+    execSync('git worktree add -b dev wt-dev', { cwd: root, stdio: 'pipe' })
+    // 清缓存模拟跨扫描周期（worktree 列表 / 仓库列表均有 TTL）
+    invalidateGitDiffCache()
+    const repos = await listRepos(root)
+    expect(repos.length).toBe(1)
+    expect(repos[0]!.worktreeCount).toBe(2)
+    const branches = repos[0]!.worktrees.map((w) => w.branch)
+    expect(branches).toContain('main')
+    expect(branches).toContain('dev')
+  })
+
+  it('getRepoChanges 聚合未提交改动并探测基准分支', async () => {
+    const root = makeRepo()
+    writeFileSync(join(root, 'a.txt'), 'hello world\n') // 未提交改动
+    const repos = await listRepos(root)
+    const result = await getRepoChanges(repos[0]!.repoPath)
+    expect(result.isGitRepo).toBe(true)
+    expect(result.worktrees.length).toBe(1)
+    const files = result.worktrees[0]!.changes.files
+    expect(files.some((f) => f.filePath === 'a.txt' && f.status === 'modified')).toBe(true)
+    // 无远端时回退到本地 main 作为基准
+    expect(result.baseBranch).toBe('main')
+  })
+
+  it('getWorktreeChanges 返回自动探测的基准分支', async () => {
+    const root = makeRepo()
+    writeFileSync(join(root, 'a.txt'), 'hello world\n')
+    const result = await getWorktreeChanges(root)
+    expect(result.isGitRepo).toBe(true)
+    expect(result.baseBranch).toBe('main')
+    expect(result.files.some((f) => f.filePath === 'a.txt')).toBe(true)
+  })
+})

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -15,6 +15,315 @@ import type { ChangeSource, ChangedFileStatus } from '@proma/shared'
 /** 大文件读取上限：超过则跳过，避免 IPC 序列化撑爆内存 */
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
+/** listRepos 结果缓存 TTL：仓库列表相对稳定，避免每次打开下拉都全量扫 git */
+const LIST_REPOS_CACHE_TTL_MS = 60_000
+const listReposCache = new Map<string, { ts: number; repos: import('@proma/shared').RepoInfo[] }>()
+
+/**
+ * 全量变更扫描并发上限。
+ *
+ * 在包含大量独立 Git 仓库的项目根（如 monorepo、fork 集合目录）下，
+ * 一次 getUnstagedChanges 会为每个仓库 spawn git 进程；并发过多会让
+ * 磁盘 IO 和 CPU 同时被打满，反而比串行更慢（Windows 上尤其明显）。
+ * 限制并发可摊平峰值，又不牺牲整体吞吐。
+ */
+const MAX_CONCURRENT_GIT_ROOTS = 6
+
+/**
+ * 变更扫描结果缓存 TTL（ms）：窗口聚焦、写文件完成等高频触发在窗口内复用结果，避免重复全量 git 扫描。
+ * 5s 权衡：冷扫描约 10s+（大型目录），TTL 过短会导致频繁失效重扫；写文件/git 变更/revert 后
+ * 都会通过 invalidateGitDiffCache() 主动失效，保证最新结果立即可见，所以 TTL 可相对宽松。
+ */
+const SCAN_CACHE_TTL_MS = 5000
+
+/** 向下递归搜索 git 根时，单目录条目数上限：超过视为超大/高噪声目录，跳过深入 */
+const MAX_DIR_ENTRIES_FOR_DOWNSCAN = 5000
+
+/**
+ * 变更扫描结果缓存。key 由 dirPath/sessionPath/workspaceFilesPath/extraPaths 组合而成；
+ * TTL 内命中直接返回，避免窗口聚焦等高频率、结果通常未变的场景反复触发全量 git 命令。
+ * agent 写文件 / git 变更完成后通过 invalidateGitDiffCache() 主动失效，保证最新结果立即可见。
+ */
+interface ScanCacheEntry {
+  result: UnstagedChangesResult
+  /** 该条目覆盖的 git 仓库根（完整路径），用于定向失效 */
+  gitRoots: string[]
+  /** 写入时的缓存代际；invalidate 后递增，代际不符的写入丢弃（防 in-flight 扫描回写旧结果） */
+  generation: number
+  expiresAt: number
+}
+const scanCache = new Map<string, ScanCacheEntry>()
+
+/**
+ * 缓存代际：每次 invalidateGitDiffCache 递增。
+ * in-flight 的 getUnstagedChanges 在失效之后完成时，setCached* 会检测到
+ * 代际不符而丢弃写入，避免把失效前启动的旧扫描结果回填到缓存。
+ */
+let cacheGeneration = 0
+
+function bumpCacheGeneration(): void {
+  cacheGeneration++
+}
+
+/**
+ * 仓库级扫描结果缓存：gitRoot → 该仓库的变更结果。
+ * 与整批 scanCache 配合：写文件后定向失效只删受影响仓库的条目，
+ * 下次 getUnstagedChanges 时其他仓库命中缓存，仅重扫受影响仓库，
+ * 避免 Agent 连续写文件时每次全量重扫 31 个仓库（CPU 飙升主因）。
+ */
+interface PerRepoCacheEntry {
+  files: ChangedFileEntry[]
+  untracked: UntrackedFileEntry[]
+  /** 写入时的缓存代际；代际不符的写入丢弃 */
+  generation: number
+  expiresAt: number
+}
+const perRepoCache = new Map<string, PerRepoCacheEntry>()
+const PER_REPO_CACHE_TTL_MS = 5000
+
+/** 读取未过期的仓库级缓存（代际不符视为失效） */
+function getCachedPerRepo(gitRoot: string): { files: ChangedFileEntry[]; untracked: UntrackedFileEntry[] } | null {
+  const entry = perRepoCache.get(gitRoot)
+  if (!entry) return null
+  if (entry.generation !== cacheGeneration) {
+    perRepoCache.delete(gitRoot)
+    return null
+  }
+  if (Date.now() >= entry.expiresAt) {
+    perRepoCache.delete(gitRoot)
+    return null
+  }
+  return { files: entry.files, untracked: entry.untracked }
+}
+
+/** 写入仓库级缓存（代际不符时丢弃，防 in-flight 旧结果回填） */
+function setCachedPerRepo(
+  gitRoot: string,
+  files: ChangedFileEntry[],
+  untracked: UntrackedFileEntry[],
+): void {
+  perRepoCache.set(gitRoot, { files, untracked, generation: cacheGeneration, expiresAt: Date.now() + PER_REPO_CACHE_TTL_MS })
+  if (perRepoCache.size > 128) {
+    const oldest = perRepoCache.keys().next().value
+    if (oldest !== undefined) perRepoCache.delete(oldest)
+  }
+}
+
+/** 仓库根发现结果缓存 TTL（ms）：仓库结构比变更结果稳定，但新 clone/新建 worktree 应尽快被发现，取 10s 平衡 */
+const GIT_ROOTS_CACHE_TTL_MS = 10000
+
+interface GitRootsCacheEntry {
+  roots: string[]
+  expiresAt: number
+}
+const gitRootsCache = new Map<string, GitRootsCacheEntry>()
+
+/**
+ * 仓库根发现缓存 key：向上搜索是否跳过会影响结果（skipUpward 时不含向上命中），
+ * 故 key 需区分，避免 listRepos（skipUpward）与 getUnstagedChanges 之间串缓存。
+ */
+function gitRootsCacheKey(baseDir: string, skipUpward?: boolean): string {
+  return skipUpward ? `${baseDir}#down` : baseDir
+}
+
+/** 读取未过期的仓库根发现缓存 */
+function getCachedGitRoots(cacheKey: string): string[] | null {
+  const entry = gitRootsCache.get(cacheKey)
+  if (!entry) return null
+  if (Date.now() >= entry.expiresAt) {
+    gitRootsCache.delete(cacheKey)
+    return null
+  }
+  return entry.roots
+}
+
+/** 写入仓库根发现缓存（随变更扫描缓存一并清理） */
+function setCachedGitRoots(cacheKey: string, roots: string[]): void {
+  gitRootsCache.set(cacheKey, { roots, expiresAt: Date.now() + GIT_ROOTS_CACHE_TTL_MS })
+  if (gitRootsCache.size > 64) {
+    const oldest = gitRootsCache.keys().next().value
+    if (oldest !== undefined) gitRootsCache.delete(oldest)
+  }
+}
+
+/**
+ * 使变更扫描缓存失效。
+ *
+ * 传 writtenPath 时只失效覆盖该路径的条目（Agent 连续写文件场景下避免每次都全量失效→全量重扫）；
+ * 不传则全量失效（git 突变 / revert 等影响面不确定的操作）。
+ *
+ * 相对路径匹配策略：先做宽松匹配（repo 根相对路径，如 apps/electron/...），
+ * 若相对路径未命中任何仓库（无法确定归属），则降级为全量失效——宁可重扫也不漏。
+ */
+export function invalidateGitDiffCache(writtenPath?: string): void {
+  if (!writtenPath) {
+    bumpCacheGeneration()
+    scanCache.clear()
+    perRepoCache.clear()
+    gitRootsCache.clear()
+    worktreesCache.clear()
+    repoChangesCache.clear()
+    listReposCache.clear()
+    baseBranchCache.clear()
+    return
+  }
+
+  const raw = writtenPath.replace(/\\/g, '/')
+  const isAbsolute = raw.startsWith('/') || /^[A-Za-z]:/.test(raw)
+  const affectedGitRoots: string[] = []
+
+  // 1. 仓库级缓存：删除受影响仓库的条目（绝对路径时直接匹配；相对路径用仓库名前缀宽松匹配）
+  for (const gitRoot of perRepoCache.keys()) {
+    const rootNorm = normalizeCachePath(gitRoot)
+    let hit = false
+    if (isAbsolute) {
+      const normalized = normalizeCachePath(raw)
+      hit = normalized === rootNorm || normalized.startsWith(rootNorm + '/')
+    } else {
+      const rootBase = basename(rootNorm)
+      // 宽松匹配：raw 以仓库名开头（Proma/...）或本身就是仓库内路径片段（apps/electron/...）
+      hit = raw === rootBase || raw.startsWith(rootBase + '/')
+    }
+    if (hit) {
+      perRepoCache.delete(gitRoot)
+      affectedGitRoots.push(gitRoot)
+    }
+  }
+
+  // 2. 整批缓存：删除覆盖受影响仓库的条目。
+  //    绝对路径时直接对 scanCache 条目自身记录的 gitRoots 匹配（不依赖 perRepoCache 是否存在）；
+  //    相对路径依赖 perRepoCache 命中，未命中时降级为全量失效。
+  let clearedScan = false
+  if (isAbsolute) {
+    const normalized = normalizeCachePath(raw)
+    for (const [key, entry] of scanCache) {
+      const overlaps = entry.gitRoots.some((root) => {
+        const rootNorm = normalizeCachePath(root)
+        return normalized === rootNorm || normalized.startsWith(rootNorm + '/')
+      })
+      if (overlaps) {
+        scanCache.delete(key)
+        clearedScan = true
+      }
+    }
+    // 绝对路径未命中任何缓存条目：可能是大小写不一致 / junction 真实路径差异，
+    // 无法确定归属，降级为全量失效（宁可重扫不可漏）。
+    if (!clearedScan) {
+      scanCache.clear()
+      perRepoCache.clear()
+    }
+  } else if (affectedGitRoots.length > 0) {
+    const affectedNorms = affectedGitRoots.map(normalizeCachePath)
+    for (const [key, entry] of scanCache) {
+      const overlaps = entry.gitRoots.some((root) => affectedNorms.includes(normalizeCachePath(root)))
+      if (overlaps) scanCache.delete(key)
+    }
+  } else {
+    // 相对路径未命中任何仓库：无法确定归属，降级为全量失效（宁可重扫不可漏）
+    scanCache.clear()
+    perRepoCache.clear()
+  }
+
+  // 定向失效也清理 repoChangesCache 中受影响仓库的条目（key 前缀含仓库根），
+  // 否则 Agent 写文件后仓库聚合视图仍吃到 5s TTL 内的旧数据。
+  if (affectedGitRoots.length > 0) {
+    for (const key of repoChangesCache.keys()) {
+      const affected = affectedGitRoots.some((root) =>
+        key.includes(`repo:${normalizeGitRoot(root)}:`) || key.includes(`repo:${normalizeGitRoot(root)}|`),
+      )
+      if (affected) repoChangesCache.delete(key)
+    }
+  }
+
+  // 无论定向还是全量，都递增代际：in-flight 扫描在失效后完成的 setCached* 将被丢弃
+  bumpCacheGeneration()
+}
+
+/** 归一化路径用于缓存 key：统一分隔符（/ 与 \）并去除尾分隔符，避免同目录不同写法产生多份缓存 */
+function normalizeCachePath(p: string): string {
+  try {
+    return resolve(p).replace(/\\/g, '/').replace(/\/+$/, '')
+  } catch {
+    // 极端输入（含 NUL 等非法字符）下回退到原文，保证缓存 key 构造永不抛错
+    return p
+  }
+}
+
+/** 构建变更扫描缓存 key（规范化 extraPaths 顺序，避免同一集合不同排列造成缓存抖动） */
+function buildScanCacheKey(
+  dirPath: string,
+  sessionPath?: string,
+  workspaceFilesPath?: string,
+  extraPaths?: string[],
+): string {
+  return JSON.stringify([
+    normalizeCachePath(dirPath),
+    sessionPath ? normalizeCachePath(sessionPath) : '',
+    workspaceFilesPath ? normalizeCachePath(workspaceFilesPath) : '',
+    [...(extraPaths ?? [])].map(normalizeCachePath).sort(),
+  ])
+}
+
+/** 读取未过期缓存，命中则返回；过期或代际不符或未命中返回 null */
+function getCachedScanResult(key: string): UnstagedChangesResult | null {
+  const entry = scanCache.get(key)
+  if (!entry) return null
+  if (entry.generation !== cacheGeneration) {
+    scanCache.delete(key)
+    return null
+  }
+  if (Date.now() >= entry.expiresAt) {
+    scanCache.delete(key)
+    return null
+  }
+  return entry.result
+}
+
+/** 写入扫描结果缓存（代际不符时丢弃，防 in-flight 旧结果回填） */
+function setCachedScanResult(key: string, result: UnstagedChangesResult, allGitRoots: string[]): void {
+  // 记录该结果覆盖的 git 仓库根（完整路径），用于定向失效。
+  // 即使结果为空（clean 仓库）也必须记录 gitRoots，否则写文件后定向失效
+  // 无法命中该条目 → 整批缓存不删 → 新文件不显示。
+  const gitRoots: string[] = []
+  const pushRoot = (root?: string) => {
+    if (root && !gitRoots.includes(root)) gitRoots.push(root)
+  }
+  result.files.forEach((f) => pushRoot(f.gitRoot))
+  result.untrackedFiles.forEach((f) => pushRoot(f.gitRoot))
+  allGitRoots.forEach((root) => pushRoot(root))
+
+  scanCache.set(key, { result, gitRoots, generation: cacheGeneration, expiresAt: Date.now() + SCAN_CACHE_TTL_MS })
+  // 防止缓存无限增长：超过 64 条时清理最早的一条
+  if (scanCache.size > 64) {
+    const oldest = scanCache.keys().next().value
+    if (oldest !== undefined) scanCache.delete(oldest)
+  }
+}
+
+/**
+ * 有界并发执行器：最多同时运行 limit 个任务，结果按输入顺序返回。
+ * 用于多个 git 仓库的变更扫描，控制同时 spawn 的 git 进程数量。
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0 || limit <= 0) return []
+
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = nextIndex++
+      if (i >= items.length) break
+      results[i] = await fn(items[i]!, i)
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
 /**
  * 归一化换行符为 LF。
  *
@@ -241,6 +550,36 @@ function parseNumstat(numStat: string | null): Map<string, { additions: number; 
 }
 
 /**
+ * 按当前候选集过滤未过滤的仓库扫描结果（files/untracked），并计算 source。
+ * perRepoCache 存未过滤原始结果（避免跨候选集污染），读取后统一用本函数裁剪。
+ */
+function filterRepoResult(
+  rawFiles: ChangedFileEntry[],
+  rawUntracked: UntrackedFileEntry[],
+  gitRoot: string,
+  isUnderAnyCandidate: (absPath: string) => boolean,
+  sessionPath?: string,
+  workspaceFilesPath?: string,
+): { files: ChangedFileEntry[]; untracked: UntrackedFileEntry[] } {
+  const files: ChangedFileEntry[] = []
+  for (const f of rawFiles) {
+    const absPath = join(gitRoot, f.filePath)
+    if (!isUnderAnyCandidate(absPath)) continue
+    files.push({
+      ...f,
+      source: computeSource(f.filePath, gitRoot, sessionPath, workspaceFilesPath),
+    })
+  }
+  const untracked: UntrackedFileEntry[] = []
+  for (const u of rawUntracked) {
+    const absPath = join(gitRoot, u.filePath)
+    if (!isUnderAnyCandidate(absPath)) continue
+    untracked.push(u)
+  }
+  return { files, untracked }
+}
+
+/**
  * 获取当前工作树相对 HEAD 的文件变更列表（支持多 Git 仓库）
  *
  * 包含 staged + unstaged 改动；函数名保留为 getUnstagedChanges 以兼容现有 IPC。
@@ -251,6 +590,12 @@ export async function getUnstagedChanges(
   workspaceFilesPath?: string,
   extraPaths?: string[],
 ): Promise<UnstagedChangesResult> {
+  // 缓存：窗口聚焦、连续写文件等高频触发在 TTL 内直接复用上次结果，避免重复全量 git 扫描。
+  // agent 写文件 / git 变更完成后通过 invalidateGitDiffCache() 主动失效，保证最新结果立即可见。
+  const cacheKey = buildScanCacheKey(dirPath, sessionPath, workspaceFilesPath, extraPaths)
+  const cached = getCachedScanResult(cacheKey)
+  if (cached) return cached
+
   // 收集所有候选目录中的不重复 Git 仓库根
   const rawCandidates = [dirPath, sessionPath, workspaceFilesPath, ...(extraPaths || [])].filter(
     (p): p is string => typeof p === 'string' && p.length > 0
@@ -264,15 +609,27 @@ export async function getUnstagedChanges(
     const roots = await findAllGitRoots(cand.searchPath)
     for (const root of roots) {
       if (!gitRoots.includes(root)) gitRoots.push(root)
+      // 枚举该仓库的所有 worktree（非主 worktree 也纳入扫描），
+      // 让默认「会话改动」视图也能看到 worktree 分支里的未提交改动。
+      // worktree 列表走 10s 缓存，与 listRepos 共用，避免重复 spawn git。
+      try {
+        const wts = await listWorktreesFromRoot(root)
+        for (const wt of wts) {
+          if (wt.isMain) continue
+          const wtRoot = normalizeGitRoot(wt.path)
+          if (!gitRoots.includes(wtRoot)) gitRoots.push(wtRoot)
+        }
+      } catch {
+        // worktree 枚举失败不影响主仓库扫描
+      }
     }
   }
 
   if (gitRoots.length === 0) {
-    return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
+    const empty: UnstagedChangesResult = { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
+    setCachedScanResult(cacheKey, empty, gitRoots)
+    return empty
   }
-
-  const allFiles: ChangedFileEntry[] = []
-  const allUntracked: UntrackedFileEntry[] = []
 
   // 候选路径用于过滤：目录匹配子树，附加文件只匹配自身，避免显示同级无关改动。
   const isUnderAnyCandidate = (absPath: string): boolean => {
@@ -283,12 +640,41 @@ export async function getUnstagedChanges(
     })
   }
 
-  for (const gitRoot of gitRoots) {
-    // 获取当前工作树相对 HEAD 的变更文件列表，覆盖 staged + unstaged。
-    const nameStatus = await runGitCommand(['diff', 'HEAD', '--name-status'], gitRoot)
-    const numStat = await runGitCommand(['diff', 'HEAD', '--numstat'], gitRoot)
+  // 扫描单个仓库：先读仓库级缓存（写文件定向失效后其他仓库仍命中），未命中才跑 git。
+  // 先快速预检（git status --porcelain），工作树干净则直接跳过 3 条重命令。
+  // 在 monorepo / fork 集合等大量仓库场景下，大多数仓库在大多数时刻是干净的，
+  // 预检用 1 条轻量命令替代 3 条 diff/ls-files，可大幅降低总扫描耗时。
+  //
+  // 注意：perRepoCache 存的是**未按候选集过滤**的原始 git 结果（避免跨候选集污染），
+  // 读取后统一用当前候选集过滤（filterRepoResult）。
+  const scanGitRoot = async (gitRoot: string): Promise<{ files: ChangedFileEntry[]; untracked: UntrackedFileEntry[] }> => {
+    // 仓库级缓存命中：Agent 写文件后只重扫受影响仓库，其余仓库直接复用原始结果再过滤
+    const cachedRepo = getCachedPerRepo(gitRoot)
+    if (cachedRepo) return filterRepoResult(cachedRepo.files, cachedRepo.untracked, gitRoot, isUnderAnyCandidate, sessionPath, workspaceFilesPath)
+
+    // 快速预检：porcelain 输出为空表示无任何 staged/unstaged/untracked 变更。
+    // 显式 --untracked-files=all：规避用户 git config status.showUntrackedFiles=no
+    // 时 porcelain 不显示 untracked、与下方 ls-files --others 语义不一致的问题。
+    // porcelain === null 表示 git 命令失败（瞬态错误），不缓存为空，避免隐藏真实变更。
+    const porcelain = await runGitCommand(['status', '--porcelain', '--untracked-files=all'], gitRoot)
+    if (porcelain === '') {
+      setCachedPerRepo(gitRoot, [], [])
+      return { files: [], untracked: [] }
+    }
+    if (porcelain === null) {
+      return { files: [], untracked: [] }
+    }
+
+    // 有变更：并行执行 3 条 git 命令（name-status / numstat / ls-files）
+    const [nameStatus, numStat, untrackedOutput] = await Promise.all([
+      runGitCommand(['diff', 'HEAD', '--name-status'], gitRoot),
+      runGitCommand(['diff', 'HEAD', '--numstat'], gitRoot),
+      runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot),
+    ])
     const numStatMap = parseNumstat(numStat)
 
+    // 未过滤的原始结果（不按候选集裁剪、不计算 source），供跨候选集复用
+    const rawFiles: ChangedFileEntry[] = []
     if (nameStatus) {
       const statusLines = nameStatus.split('\n').filter(Boolean)
 
@@ -310,41 +696,49 @@ export async function getUnstagedChanges(
           continue
         }
 
-        // 过滤：只保留落在某个 candidate 内的文件
-        const absPath = join(gitRoot, filePath)
-        if (!isUnderAnyCandidate(absPath)) continue
-
         const stats = numStatMap.get(filePath) ?? { additions: 0, deletions: 0 }
 
-        allFiles.push({
+        rawFiles.push({
           filePath,
           status,
           additions: stats.additions,
           deletions: stats.deletions,
-          source: computeSource(filePath, gitRoot, sessionPath, workspaceFilesPath),
+          source: 'none',
           gitRoot,
         })
       }
     }
 
-    // 获取未追踪文件
-    const untrackedOutput = await runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot)
+    // 获取未追踪文件（未过滤）
+    const rawUntracked: UntrackedFileEntry[] = []
     if (untrackedOutput) {
       for (const rel of untrackedOutput.split('\n').filter(Boolean)) {
-        const absPath = join(gitRoot, rel)
-        if (isUnderAnyCandidate(absPath)) {
-          allUntracked.push({ filePath: rel, gitRoot })
-        }
+        rawUntracked.push({ filePath: rel, gitRoot })
       }
     }
+
+    // porcelain 非空说明有变更，但若重命令全部失败（瞬态错误），不缓存空结果，避免 5s 内隐藏真实变更
+    if (nameStatus === null && untrackedOutput === null && numStat === null) {
+      return { files: [], untracked: [] }
+    }
+
+    setCachedPerRepo(gitRoot, rawFiles, rawUntracked)
+    return filterRepoResult(rawFiles, rawUntracked, gitRoot, isUnderAnyCandidate, sessionPath, workspaceFilesPath)
   }
 
-  return {
+  // 多仓库并发扫描（有界并发，避免 git 进程风暴打满 CPU/磁盘）
+  const scanned = await mapWithConcurrency(gitRoots, MAX_CONCURRENT_GIT_ROOTS, scanGitRoot)
+  const allFiles = scanned.flatMap((r) => r.files)
+  const allUntracked = scanned.flatMap((r) => r.untracked)
+
+  const result: UnstagedChangesResult = {
     isGitRepo: true,
     files: allFiles,
     untrackedFiles: allUntracked,
     gitRootNames: gitRoots.map((r) => basename(r)),
   }
+  setCachedScanResult(cacheKey, result, gitRoots)
+  return result
 }
 
 /**
@@ -369,10 +763,20 @@ function findAllGitRootsDown(dirPath: string, maxDepth: number): string[] {
     return []
   }
 
+  // 超大/高噪声目录保护：单层条目数超过上限时不深入递归子目录，避免缓存目录、生成产物等
+  // 海量子目录拖慢扫描；但仍检查本层 .git 与直接子仓库，避免整棵子树（含兄弟仓库）被丢弃。
+  const isHugeDir = entries.length > MAX_DIR_ENTRIES_FOR_DOWNSCAN
+
   const found: string[] = []
   for (const name of entries) {
     if (name === '.git') {
-      found.push(dirPath)
+      // worktree 的 .git 是指针文件而非目录，不作为独立仓库根（由主仓库 worktree 枚举覆盖）
+      try {
+        const gitSt = statSync(join(dirPath, '.git'))
+        if (gitSt.isDirectory()) found.push(dirPath)
+      } catch {
+        // ignore
+      }
       continue
     }
     if (name.startsWith('.') || name === 'node_modules') continue
@@ -382,11 +786,20 @@ function findAllGitRootsDown(dirPath: string, maxDepth: number): string[] {
     try { st = statSync(fullPath) } catch { continue }
     if (!st.isDirectory()) continue
 
-    if (existsSync(join(fullPath, '.git'))) {
+    // 只有 .git 为目录才视为真仓库根；.git 为文件则是 worktree 指针（由主仓库枚举，跳过避免重复）
+    let gitSt
+    try { gitSt = statSync(join(fullPath, '.git')) } catch { gitSt = undefined }
+    if (gitSt?.isDirectory()) {
       found.push(fullPath)
       // 已确认是 git root，不再深入避免重复
       continue
     }
+    if (gitSt?.isFile()) {
+      // worktree 目录：跳过深层递归（其内容属于同一仓库）
+      continue
+    }
+    // 超大目录：跳过深层递归，但仍处理上面的直接子仓库检查
+    if (isHugeDir) continue
     found.push(...findAllGitRootsDown(fullPath, maxDepth - 1))
   }
 
@@ -394,15 +807,24 @@ function findAllGitRootsDown(dirPath: string, maxDepth: number): string[] {
 }
 
 /** 查找 Git 仓库根目录（支持向上搜索子目录内的 repos），返回所有找到的根 */
-export async function findAllGitRoots(baseDir: string): Promise<string[]> {
+export async function findAllGitRoots(baseDir: string, options?: { skipUpward?: boolean }): Promise<string[]> {
   if (!existsSync(baseDir)) return []
 
-  // 1. 向上搜索：git rev-parse --show-toplevel
-  const toplevel = await runGitCommand(['rev-parse', '--show-toplevel'], baseDir, { quiet: true })
+  // 仓库结构比变更结果稳定，缓存避免每次扫描重复冷启动 git rev-parse
+  const cacheKey = gitRootsCacheKey(baseDir, options?.skipUpward)
+  const cached = getCachedGitRoots(cacheKey)
+  if (cached) return cached
+
   const roots: string[] = []
-  if (toplevel && existsSync(toplevel)) {
-    const normalized = normalizeGitRoot(toplevel)
-    if (!roots.includes(normalized)) roots.push(normalized)
+
+  // 1. 向上搜索：逐级 existsSync 找最近祖先 .git（目录或 worktree 文件，~1ms），
+  //    避免 git rev-parse 冷启动（可达 3s+）；调用方已知 baseDir 非仓库时可跳过。
+  if (!options?.skipUpward) {
+    const topDir = findAncestorGitDir(baseDir)
+    if (topDir) {
+      const normalized = normalizeGitRoot(topDir)
+      if (!roots.includes(normalized)) roots.push(normalized)
+    }
   }
 
   // 2. 向下搜索所有子 .git
@@ -411,7 +833,24 @@ export async function findAllGitRoots(baseDir: string): Promise<string[]> {
     if (!roots.includes(normalized)) roots.push(normalized)
   }
 
+  setCachedGitRoots(cacheKey, roots)
   return roots
+}
+
+/** 从 dir 逐级向上查找最近的含 .git 的目录（.git 可以是目录或 worktree 文件），找不到返回 null */
+function findAncestorGitDir(dir: string): string | null {
+  let current = resolve(dir)
+  while (true) {
+    // existsSync 通常不抛错；try/catch 仅防御极端的权限/路径错误场景
+    try {
+      if (existsSync(join(current, '.git'))) return current
+    } catch {
+      // 路径无法访问时继续向上
+    }
+    const parent = dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
 }
 
 /** 查找 Git 仓库根目录，先向上后向下搜索，失败返回 null */
@@ -569,18 +1008,61 @@ export async function getMainRepoRoot(somePath: string): Promise<string | null> 
 /**
  * 列出指定仓库的所有 Git Worktree
  */
-export async function listWorktrees(repoPath: string): Promise<import('@proma/shared').WorktreeInfo[]> {
+export async function listWorktrees(repoPath: string, force = false): Promise<import('@proma/shared').WorktreeInfo[]> {
   const root = await findGitRoot(repoPath)
   if (!root) return []
+  return listWorktreesFromRoot(root, force)
+}
+
+/**
+ * 假定 root 已是仓库根，直接列出其所有 worktree。
+ *
+ * 与 listWorktrees 的区别：跳过 findGitRoot 的向上 rev-parse / 向下递归扫描
+ * （对大仓库可达数秒），供批量枚举仓库时复用已发现的根。
+ * porcelain 输出第一个 block 即主 worktree（git 保证），不再额外跑 rev-parse。
+ */
+/** worktree 列表缓存 TTL：worktree 结构相对稳定（新增/删除才变），枚举避免重复 spawn git */
+const WORKTREES_CACHE_TTL_MS = 10_000
+const worktreesCache = new Map<string, { worktrees: import('@proma/shared').WorktreeInfo[]; expiresAt: number }>()
+
+/** 读取未过期的 worktree 列表缓存 */
+function getCachedWorktrees(gitRoot: string): import('@proma/shared').WorktreeInfo[] | null {
+  const entry = worktreesCache.get(gitRoot)
+  if (!entry) return null
+  if (Date.now() >= entry.expiresAt) {
+    worktreesCache.delete(gitRoot)
+    return null
+  }
+  return entry.worktrees
+}
+
+/** 写入 worktree 列表缓存（带简单上限） */
+function setCachedWorktrees(gitRoot: string, worktrees: import('@proma/shared').WorktreeInfo[]): void {
+  worktreesCache.set(gitRoot, { worktrees, expiresAt: Date.now() + WORKTREES_CACHE_TTL_MS })
+  if (worktreesCache.size > 128) {
+    const oldest = worktreesCache.keys().next().value
+    if (oldest !== undefined) worktreesCache.delete(oldest)
+  }
+}
+
+async function listWorktreesFromRoot(root: string, force = false): Promise<import('@proma/shared').WorktreeInfo[]> {
+  const cacheKey = normalizeGitRoot(root)
+  if (!force) {
+    const cached = getCachedWorktrees(cacheKey)
+    if (cached) return cached
+  }
+
   const output = await runGitCommand(['worktree', 'list', '--porcelain'], root, { quiet: true })
-  if (!output) return []
-  const mainRepoRoot = await getMainRepoRoot(root)
-  const normalizedMainRoot = mainRepoRoot ? normalizeGitRoot(mainRepoRoot) : normalizeGitRoot(root)
+  if (!output) {
+    setCachedWorktrees(cacheKey, [])
+    return []
+  }
+  const normalizedRoot = normalizeGitRoot(root)
 
   const worktrees: import('@proma/shared').WorktreeInfo[] = []
   const blocks = output.split('\n\n').filter(Boolean)
 
-  for (const block of blocks) {
+  blocks.forEach((block, index) => {
     const lines = block.split('\n')
     let path = ''
     let head = ''
@@ -602,7 +1084,8 @@ export async function listWorktrees(repoPath: string): Promise<import('@proma/sh
     }
 
     if (path && !prunable && existsSync(path)) {
-      const isMain = normalizeGitRoot(path) === normalizedMainRoot
+      // porcelain 第一个 block 一定是主 worktree
+      const isMain = index === 0 || normalizeGitRoot(path) === normalizedRoot
       worktrees.push({
         path,
         branch: branch || 'unknown',
@@ -611,9 +1094,44 @@ export async function listWorktrees(repoPath: string): Promise<import('@proma/sh
         name: basename(path),
       })
     }
+  })
+
+  setCachedWorktrees(cacheKey, worktrees)
+  return worktrees
+}
+
+/** 基准分支探测结果缓存 TTL：分支结构相对稳定，避免每次聚焦重复跑 git */
+const BASE_BRANCH_CACHE_TTL_MS = 30_000
+const baseBranchCache = new Map<string, { base: string; expiresAt: number }>()
+
+/**
+ * 解析默认基准分支：优先远端默认分支（origin/main → origin/master），
+ * 退化本地 main/master，最后用 HEAD~1（无远端可用的相对基准）。
+ *
+ * 用单次 for-each-ref 枚举全部 refs（替代 4 次串行 rev-parse --verify，
+ * 后者对不存在的 ref 在 Windows 上单次可达 3.6s），结果按仓库缓存 30s。
+ */
+async function resolveDefaultBaseBranch(gitRoot: string): Promise<string> {
+  const key = normalizeGitRoot(gitRoot)
+  const cached = baseBranchCache.get(key)
+  if (cached && Date.now() < cached.expiresAt) return cached.base
+
+  const output = await runGitCommand(
+    ['for-each-ref', '--format=%(refname)', 'refs/remotes/origin', 'refs/heads'],
+    gitRoot,
+    { quiet: true },
+  )
+  const refs = new Set((output || '').split('\n').filter(Boolean))
+  let base = 'HEAD~1'
+  for (const ref of ['refs/remotes/origin/main', 'refs/remotes/origin/master', 'refs/heads/main', 'refs/heads/master']) {
+    if (refs.has(ref)) {
+      base = ref.replace('refs/remotes/origin/', 'origin/').replace('refs/heads/', '')
+      break
+    }
   }
 
-  return worktrees
+  baseBranchCache.set(key, { base, expiresAt: Date.now() + BASE_BRANCH_CACHE_TTL_MS })
+  return base
 }
 
 /**
@@ -621,14 +1139,12 @@ export async function listWorktrees(repoPath: string): Promise<import('@proma/sh
  */
 export async function getWorktreeChanges(
   worktreePath: string,
-  baseBranch: string = 'origin/main',
+  baseBranch?: string,
+  options?: { skipFetch?: boolean; compareMode?: boolean },
 ): Promise<import('@proma/shared').UnstagedChangesResult> {
   if (!existsSync(worktreePath)) {
     return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
   }
-
-  // 尝试 fetch 远端 main 以确保 baseBranch 最新
-  await runGitCommand(['fetch', 'origin', 'main', '--quiet'], worktreePath)
 
   // 确认是 git 仓库
   const toplevel = await runGitCommand(['rev-parse', '--show-toplevel'], worktreePath)
@@ -637,12 +1153,25 @@ export async function getWorktreeChanges(
   }
 
   const gitRoot = normalizeGitRoot(toplevel)
+
+  // 尝试 fetch 远端默认分支以确保 baseBranch 最新（聚合视图已统一 fetch，可跳过；无远端时静默降级）
+  if (!options?.skipFetch) {
+    await runGitCommand(['fetch', 'origin', '--quiet'], gitRoot, { quiet: true })
+  }
+
+  // 基准分支：显式传入优先，否则自动探测（origin/main → origin/master → …）
+  const effectiveBase = baseBranch || await resolveDefaultBaseBranch(gitRoot)
   const allFiles: import('@proma/shared').ChangedFileEntry[] = []
   const fileMap = new Map<string, import('@proma/shared').ChangedFileEntry>()
 
-  // 1. 已 commit 但未合并的改动: git diff baseBranch...HEAD
-  const committedStatus = await runGitCommand(['diff', `${baseBranch}...HEAD`, '--name-status'], gitRoot)
-  const committedNumstat = await runGitCommand(['diff', `${baseBranch}...HEAD`, '--numstat'], gitRoot)
+  // 1. 已 commit 但未合并的改动：
+  //    默认三点 diff（base...HEAD，只含共同祖先之后 HEAD 的改动）；
+  //    compareMode 用两点 diff（base HEAD，展示两分支全部差异，基准独有改动以删除呈现）
+  const committedRange = options?.compareMode
+    ? ['diff', effectiveBase, 'HEAD']
+    : ['diff', `${effectiveBase}...HEAD`]
+  const committedStatus = await runGitCommand([...committedRange, '--name-status'], gitRoot)
+  const committedNumstat = await runGitCommand([...committedRange, '--numstat'], gitRoot)
   const committedStats = parseNumstat(committedNumstat)
 
   if (committedStatus) {
@@ -737,5 +1266,221 @@ export async function getWorktreeChanges(
     files: allFiles,
     untrackedFiles,
     gitRootNames: [basename(gitRoot)],
+    baseBranch: effectiveBase,
   }
+}
+
+/**
+ * 获取 worktree 领先基准分支的 commit 摘要（git log base..HEAD --oneline）。
+ * 供仓库聚合视图展示「已提交但未合并」的 commit 概览。
+ */
+/** 解析 git log --format 输出为 CommitSummary 列表 */
+function parseCommitSummaries(output: string): import('@proma/shared').CommitSummary[] {
+  return output.split('\n').filter(Boolean).map((line) => {
+    const [hash, author, date, ...rest] = line.split('|')
+    return {
+      hash: hash || '',
+      author: author || '',
+      date: date || '',
+      subject: rest.join('|') || '',
+    }
+  })
+}
+
+/** 获取指定 commit 范围的摘要（rangeSpec 如 'base..HEAD' 或 'HEAD..base'） */
+async function getCommitRange(worktreePath: string, rangeSpec: string): Promise<import('@proma/shared').CommitSummary[]> {
+  const toplevel = await runGitCommand(['rev-parse', '--show-toplevel'], worktreePath, { quiet: true })
+  if (!toplevel) return []
+  const output = await runGitCommand(
+    ['log', rangeSpec, '--format=%h|%an|%ad|%s', '--date=short', '--max-count=50'],
+    normalizeGitRoot(toplevel),
+    { quiet: true },
+  )
+  if (!output) return []
+  return parseCommitSummaries(output)
+}
+
+/** worktree 领先基准分支的 commit 摘要（git log base..HEAD） */
+async function getLeadingCommits(worktreePath: string, baseBranch: string): Promise<import('@proma/shared').CommitSummary[]> {
+  return getCommitRange(worktreePath, `${baseBranch}..HEAD`)
+}
+
+/** 基准分支独有、worktree 没有的 commit 摘要（git log HEAD..base） */
+async function getTrailingCommits(worktreePath: string, baseBranch: string): Promise<import('@proma/shared').CommitSummary[]> {
+  return getCommitRange(worktreePath, `HEAD..${baseBranch}`)
+}
+
+/**
+ * 列出指定目录下扫描到的所有 Git 仓库（含各自的所有 worktree）。
+ *
+ * 用于文件改动 tab 的「仓库选择器」：把工作区内发现的仓库根加入可选列表，
+ * 每个仓库携带分支信息与 worktree 清单，选中后即可按仓库聚合扫描。
+ * 仓库较多时并行收集（限并发），避免串行 git worktree list 拖慢下拉。
+ */
+export async function listRepos(baseDir: string, options?: { force?: boolean }): Promise<import('@proma/shared').RepoInfo[]> {
+  if (!existsSync(baseDir)) return []
+
+  // 仓库列表相对稳定，用短 TTL 缓存避免每次打开下拉都全量扫 git（Windows 下 spawn git 较慢）
+  const cacheKey = `listRepos:${normalizeGitRoot(baseDir)}`
+  const now = Date.now()
+  const hit = listReposCache.get(cacheKey)
+  if (!options?.force && hit && now - hit.ts < LIST_REPOS_CACHE_TTL_MS) {
+    return hit.repos
+  }
+
+  // 仓库根集合：baseDir 自身若为仓库根也要纳入（skipUpward 只跳过向上 rev-parse）
+  const roots: string[] = []
+  if (existsSync(join(baseDir, '.git'))) {
+    roots.push(normalizeGitRoot(baseDir))
+  }
+  for (const r of await findAllGitRoots(baseDir, { skipUpward: true })) {
+    if (!roots.includes(r)) roots.push(r)
+  }
+  if (roots.length === 0) return []
+
+  const CONCURRENCY = 8
+  const results: (import('@proma/shared').RepoInfo | null)[] = new Array(roots.length).fill(null)
+  let cursor = 0
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = cursor++
+      if (i >= roots.length) return
+      const root = roots[i]!
+      try {
+        const worktrees = await listWorktreesFromRoot(root)
+        if (worktrees.length === 0) continue
+        const main = worktrees.find((wt) => wt.isMain) ?? worktrees[0]!
+        results[i] = {
+          repoPath: root,
+          name: basename(root),
+          branch: main.branch,
+          head: main.head,
+          worktreeCount: worktrees.length,
+          worktrees,
+        }
+      } catch {
+        // skip repos that fail
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, roots.length) }, () => worker()))
+  const repos = results
+    .filter((r): r is import('@proma/shared').RepoInfo => r !== null)
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  listReposCache.set(cacheKey, { ts: now, repos })
+  // 简单上限：超过 50 条时删除最早插入的条目（Map 迭代序即插入序）
+  if (listReposCache.size > 50) {
+    const oldestKey = listReposCache.keys().next().value as string | undefined
+    if (oldestKey) listReposCache.delete(oldestKey)
+  }
+  return repos
+}
+
+/** 仓库聚合变更结果缓存 TTL：与变更扫描缓存一致，写文件/git 变更后由 invalidateGitDiffCache 主动失效 */
+const REPO_CHANGES_CACHE_TTL_MS = 5000
+interface RepoChangesCacheEntry {
+  result: import('@proma/shared').RepoChangesResult
+  expiresAt: number
+}
+const repoChangesCache = new Map<string, RepoChangesCacheEntry>()
+
+function getCachedRepoChanges(key: string): import('@proma/shared').RepoChangesResult | null {
+  const entry = repoChangesCache.get(key)
+  if (!entry) return null
+  if (Date.now() >= entry.expiresAt) {
+    repoChangesCache.delete(key)
+    return null
+  }
+  return entry.result
+}
+
+function setCachedRepoChanges(key: string, result: import('@proma/shared').RepoChangesResult): void {
+  repoChangesCache.set(key, { result, expiresAt: Date.now() + REPO_CHANGES_CACHE_TTL_MS })
+  if (repoChangesCache.size > 64) {
+    const oldest = repoChangesCache.keys().next().value
+    if (oldest !== undefined) repoChangesCache.delete(oldest)
+  }
+}
+
+/**
+ * 获取仓库所有 worktree 相对基准分支的全量变更（聚合视图）。
+ *
+ * 每个 worktree 复用 getWorktreeChanges 逻辑；fetch 远端只执行一次，
+ * worktree 之间限并发收集，避免瞬时 spawn 过多 git 进程。
+ *
+ * @param options.isPathAllowed 逐 worktree 路径授权过滤（防御纵深：
+ *   worktree 元数据可能指向未授权目录，不通过校验的 worktree 会被跳过）
+ * @param options.sessionId 会话标识，参与缓存 key 隔离（不同会话授权范围不同）
+ */
+export async function getRepoChanges(
+  repoPath: string,
+  baseBranch?: string,
+  options?: {
+    isPathAllowed?: (p: string) => boolean | Promise<boolean>
+    sessionId?: string
+  },
+): Promise<import('@proma/shared').RepoChangesResult> {
+  // 5s 短 TTL 缓存：窗口聚焦等高频触发在窗口内复用，写文件后 invalidateGitDiffCache 主动失效；
+  // key 含 sessionId 与授权范围隔离，避免跨会话缓存泄漏
+  const cacheKey = `repo:${normalizeGitRoot(repoPath)}:${baseBranch || '*'}|${options?.sessionId || ''}`
+  const cachedResult = getCachedRepoChanges(cacheKey)
+  if (cachedResult) return cachedResult
+
+  let worktrees = await listWorktrees(repoPath)
+  if (options?.isPathAllowed) {
+    const allowed = await Promise.all(worktrees.map((wt) => Promise.resolve(options.isPathAllowed!(wt.path))))
+    worktrees = worktrees.filter((_, i) => allowed[i])
+  }
+  if (worktrees.length === 0) {
+    return { isGitRepo: false, repoPath, baseBranch: baseBranch || '', worktrees: [] }
+  }
+
+  // fetch 一次远端（以主 worktree 为 cwd），各 worktree 内部跳过 fetch；
+  // 显式指定对比基准（worktree A vs B）时无需 fetch，跳过避免无谓网络/等待；无远端时静默降级
+  const main = worktrees.find((wt) => wt.isMain) ?? worktrees[0]!
+  if (!baseBranch) {
+    await runGitCommand(['fetch', 'origin', '--quiet'], main.path, { quiet: true })
+  }
+
+  // 基准分支：显式传入优先，否则自动探测（origin/main → origin/master → …）
+  const effectiveBase = baseBranch || await resolveDefaultBaseBranch(main.path)
+  // 用户显式指定对比基准（worktree A vs B）时用两点 diff，展示两分支全部差异
+  // （基准分支独有改动以「删除」呈现，与聚合视图的祖先 diff 区分）
+  const compareMode = Boolean(baseBranch)
+
+  const CONCURRENCY = 4
+  const results: (import('@proma/shared').RepoWorktreeChanges | null)[] = new Array(worktrees.length).fill(null)
+  let cursor = 0
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = cursor++
+      if (i >= worktrees.length) return
+      const wt = worktrees[i]!
+      try {
+        const [changes, commits, trailingCommits] = await Promise.all([
+          getWorktreeChanges(wt.path, effectiveBase, { skipFetch: true, compareMode }),
+          getLeadingCommits(wt.path, effectiveBase),
+          getTrailingCommits(wt.path, effectiveBase),
+        ])
+        results[i] = { worktree: wt, changes, commits, trailingCommits }
+      } catch {
+        // skip worktrees that fail
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, worktrees.length) }, () => worker()))
+
+  const result: import('@proma/shared').RepoChangesResult = {
+    isGitRepo: true,
+    repoPath,
+    baseBranch: effectiveBase,
+    worktrees: results.filter((r): r is import('@proma/shared').RepoWorktreeChanges => r !== null),
+  }
+  setCachedRepoChanges(cacheKey, result)
+  return result
 }

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -259,7 +259,11 @@ export function watchAttachedDirectory(dirPath: string): void {
   if (attachedWatchers.has(dirPath)) return
 
   try {
-    const w = watch(dirPath, { recursive: true }, () => {
+    const w = watch(dirPath, { recursive: true }, (_eventType, filename) => {
+      // 附加目录可能是大型项目（含 node_modules/.git/dist 等高频变动目录），
+      // 不过滤会触发 IPC 事件风暴：任何一次内部写入都通知渲染层刷新，
+      // 进而反复触发 getUnstagedChanges 全量 git 扫描，CPU 被打满。
+      if (!filename || isHighNoisePath(filename.replace(/\\/g, '/'))) return
       notifyWorkspaceFilesChanged()
     })
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -189,6 +189,8 @@ export interface ElectronAPI {
 
   /** 获取未暂存的变更文件列表 */
   getUnstagedChanges: (dirPath: string, sessionPath?: string, workspaceFilesPath?: string, extraPaths?: string[], sessionId?: string) => Promise<import('@proma/shared').UnstagedChangesResult>
+  /** 使变更扫描缓存失效（可传路径做定向失效） */
+  invalidateGitDiffCache: (path?: string) => Promise<void>
   /** 获取单个文件的 diff */
   getFileDiff: (input: import('@proma/shared').GetFileDiffInput) => Promise<string>
   /** 获取未追踪文件内容 */
@@ -198,9 +200,13 @@ export interface ElectronAPI {
   /** 获取文件新旧版本内容 */
   getDiffContents: (input: import('@proma/shared').GetFileDiffInput) => Promise<{ oldContent: string; newContent: string } | null>
   /** 列出 Git Worktree */
-  listWorktrees: (repoPath: string, sessionId: string) => Promise<import('@proma/shared').WorktreeInfo[]>
+  listWorktrees: (repoPath: string, sessionId: string, force?: boolean) => Promise<import('@proma/shared').WorktreeInfo[]>
   /** 获取 Worktree 相对于基准分支的全量变更 */
   getWorktreeChanges: (worktreePath: string, baseBranch: string, sessionId: string) => Promise<import('@proma/shared').UnstagedChangesResult>
+  /** 列出扫描到的所有 Git 仓库（仓库选择器用） */
+  listRepos: (dirPath: string, sessionId?: string, force?: boolean) => Promise<import('@proma/shared').RepoInfo[]>
+  /** 获取仓库所有 worktree 的全量变更（仓库聚合视图用） */
+  getRepoChanges: (repoPath: string, baseBranch: string, sessionId: string) => Promise<import('@proma/shared').RepoChangesResult>
   /** 在独立窗口打开当前文件预览 */
   openDetachedPreview: (input: DetachedPreviewWindowInput) => Promise<string | null>
   /** 获取独立预览窗口数据 */
@@ -210,6 +216,8 @@ export interface ElectronAPI {
 
   /** 在系统默认浏览器中打开外部链接 */
   openExternal: (url: string) => Promise<void>
+  /** 打开系统目录选择对话框，返回选中路径或 null */
+  selectDirectory: () => Promise<string | null>
   /** 在系统剪贴板中写入纯文本 */
   writeClipboardText: (text: string) => Promise<void>
 
@@ -1228,6 +1236,10 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_UNSTAGED_CHANGES, dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId)
   },
 
+  invalidateGitDiffCache: (path?: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.INVALIDATE_GIT_DIFF_CACHE, path)
+  },
+
   getFileDiff: (input: import('@proma/shared').GetFileDiffInput) => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_FILE_DIFF, input)
   },
@@ -1244,12 +1256,20 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_DIFF_CONTENTS, input)
   },
 
-  listWorktrees: (repoPath: string, sessionId: string) => {
-    return ipcRenderer.invoke(IPC_CHANNELS.LIST_WORKTREES, repoPath, sessionId)
+  listWorktrees: (repoPath: string, sessionId: string, force?: boolean) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.LIST_WORKTREES, repoPath, sessionId, force)
   },
 
   getWorktreeChanges: (worktreePath: string, baseBranch: string, sessionId: string) => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_WORKTREE_CHANGES, worktreePath, baseBranch, sessionId)
+  },
+
+  listRepos: (dirPath: string, sessionId?: string, force?: boolean) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.LIST_REPOS, dirPath, sessionId, force)
+  },
+
+  getRepoChanges: (repoPath: string, baseBranch: string, sessionId: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.GET_REPO_CHANGES, repoPath, baseBranch, sessionId)
   },
 
   openDetachedPreview: (input: DetachedPreviewWindowInput) => {
@@ -1263,6 +1283,10 @@ const electronAPI: ElectronAPI = {
   // 通用工具
   openExternal: (url: string) => {
     return ipcRenderer.invoke(IPC_CHANNELS.OPEN_EXTERNAL, url)
+  },
+
+  selectDirectory: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.SELECT_DIRECTORY) as Promise<string | null>
   },
 
   writeClipboardText: (text: string) => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -414,6 +414,18 @@ export const agentDiffRefreshVersionAtom = atom(new Map<string, number>())
 /** 当前会话选中的 worktree 路径，null = 默认行为（显示 session 改动） */
 export const agentSelectedWorktreeAtom = atom(new Map<string, string | null>())
 
+/** 当前会话 worktree 对比基准分支（如 "origin/main" 或另一分支名），空 = 自动探测 */
+export const agentDiffBaseBranchAtom = atom(new Map<string, string>())
+
+/** 当前会话选中的仓库根路径，null = 默认（扫描整个工作区的所有仓库） */
+export const agentSelectedRepoAtom = atom(new Map<string, string | null>())
+
+/**
+ * Repo 聚合视图数据缓存 — 按 session 隔离，存放上一次 IPC 拉取的仓库聚合变更结果。
+ * 与 agentDiffDataAtom（UnstagedChangesResult）类型不同，单独缓存避免类型混用。
+ */
+export const agentDiffRepoDataAtom = atom(new Map<string, import('@proma/shared').RepoChangesResult>())
+
 /** 是否有未查看的代码改动 — 按 session 隔离 */
 export const agentDiffUnseenChangesAtom = atom(new Map<string, boolean>())
 

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -37,7 +37,6 @@ import {
   agentNonGitFileChangesAtom,
   agentFileChangesCurrentRunAtom,
   fileBrowserAutoRevealAtom,
-  agentSelectedWorktreeAtom,
 } from '@/atoms/agent-atoms'
 import type { AgentSidePanelTab, AgentFileSourceFilter } from '@/atoms/agent-atoms'
 import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
@@ -94,18 +93,18 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     })
   }, [sessionId, openPreview])
 
-  // Worktree 选择状态（仅用于 diff 文件点击时传递 baseRef，选取逻辑已下沉至 DiffChangesList）
-  const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
-  const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
+  // Worktree / 仓库选择状态已下沉至 DiffChangesList，这里仅透传文件点击时的基准分支
 
-  const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {
+  const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string, baseRef?: string) => {
+    // 仓库聚合视图 / worktree 视图展示的是相对基准分支的差异，
+    // baseRef 由 DiffChangesList 透传（服务端自动探测结果），未透传时保持默认 HEAD 对比
     openPreview(sessionId, {
       filePath,
       dirPath: sessionPath || undefined,
       gitRoot,
-      baseRef: selectedWorktreePath ? 'origin/main' : undefined,
+      baseRef,
     })
-  }, [openPreview, sessionId, sessionPath, selectedWorktreePath])
+  }, [openPreview, sessionId, sessionPath])
 
   // 动画标志：isOpen 变化时启用过渡动画，切换会话时即时显示
   const prevIsOpenRef = React.useRef(isOpen)

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -52,6 +52,10 @@ import {
   agentNonGitFileChangesAtom,
   agentFileChangesCurrentRunAtom,
   agentDiffDataAtom,
+  agentDiffRepoDataAtom,
+  agentSelectedWorktreeAtom,
+  agentSelectedRepoAtom,
+  agentDiffBaseBranchAtom,
   agentStreamingStatesAtom,
   liveMessagesMapAtom,
   agentSessionPendingFilesAtom,
@@ -850,6 +854,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setNonGitFileChanges = useSetAtom(agentNonGitFileChangesAtom)
   const setFileChangesCurrentRun = useSetAtom(agentFileChangesCurrentRunAtom)
   const setDiffData = useSetAtom(agentDiffDataAtom)
+  const setSelectedWorktree = useSetAtom(agentSelectedWorktreeAtom)
+  const setSelectedRepo = useSetAtom(agentSelectedRepoAtom)
+  const setDiffRepoData = useSetAtom(agentDiffRepoDataAtom)
+  const setDiffBaseBranch = useSetAtom(agentDiffBaseBranchAtom)
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
   const setSessionPendingFiles = useSetAtom(agentSessionPendingFilesAtom)
@@ -888,7 +896,23 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setDiffUnseenFiles(deleteKey)
     setNonGitFileChanges(deleteKey)
     setFileChangesCurrentRun(deleteKey)
-    setDiffData(deleteKey)
+    // 前缀键（sessionId:repo:*/sessionId:worktree:*）也需清理，避免孤立缓存条目
+    const deletePrefixed = <T,>(prev: Map<string, T>): Map<string, T> => {
+      let changed = false
+      const map = new Map(prev)
+      for (const key of map.keys()) {
+        if (key === id || key.startsWith(`${id}:`)) {
+          map.delete(key)
+          changed = true
+        }
+      }
+      return changed ? map : prev
+    }
+    setDiffData(deletePrefixed)
+    setDiffRepoData(deletePrefixed)
+    setSelectedWorktree(deleteKey)
+    setSelectedRepo(deleteKey)
+    setDiffBaseBranch(deleteKey)
     setSessionChannelMap(deleteKey)
     setSessionModelMap(deleteKey)
     // 会话工作目录路径：不清理会导致右侧文件面板继续用已删除目录请求 list-directory
@@ -922,7 +946,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     sessionExistsAtom.remove(id)
 
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setSelectedWorktree, setSelectedRepo, setDiffRepoData, setDiffBaseBranch, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -2,17 +2,20 @@
  * DiffChangesList — 代码改动文件列表
  *
  * 显示当前工作树相对 HEAD 的代码改动，按目录分组，支持 hover 操作按钮。
+ * 同时支持「仓库选择器」：选中仓库后聚合展示该仓库所有 worktree 的变更与分支对比。
+ * 非 Git 目录下的会话文件变更（non-git）也在此展示。
  */
 
 import * as React from 'react'
-import { Box, ChevronRight, FolderSearch, Search, Undo2, X } from 'lucide-react'
+import { Box, ChevronRight, FolderSearch, GitBranch, Search, Undo2, X } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
-import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom } from '@/atoms/agent-atoms'
-import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
+import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentDiffRepoDataAtom, agentSelectedWorktreeAtom, agentSelectedRepoAtom, agentDiffBaseBranchAtom } from '@/atoms/agent-atoms'
+import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo, RepoChangesResult, RepoWorktreeChanges } from '@proma/shared'
 import { WorktreeSelector } from './WorktreeSelector'
+import { RepoSelector } from './RepoSelector'
 import { groupSessionFileChanges } from '@/lib/session-file-changes'
 import type { SessionFileChange } from '@/lib/session-file-changes'
 
@@ -47,7 +50,7 @@ interface DiffChangesListProps {
   /** 工作区共享文件目录（用于 badge 计算） */
   workspaceFilesPath?: string
   /** 点击文件回调 */
-  onFileClick: (filePath: string, isUntracked: boolean, gitRoot?: string) => void
+  onFileClick: (filePath: string, isUntracked: boolean, gitRoot?: string, baseRef?: string) => void
   /** 自动刷新信号（版本号递增触发） */
   refreshVersion?: number
   /** 当前选中的文件路径（高亮显示） */
@@ -58,11 +61,11 @@ interface DiffChangesListProps {
   workspaceSlug?: string
   /** 用于自动发现 worktree 的仓库候选路径 */
   worktreeRepoPaths?: string[]
-  /** 本会话在非 Git 目录中成功写入的文件 */
+  /** 本会话的 non-git 文件变更（非 Git 目录下的会话文件） */
   nonGitFileChanges?: SessionFileChange[]
-  /** 当前 Agent run ID，用于将文件变更划分为本轮和更早 */
+  /** 当前文件变更 run id（区分本轮/更早） */
   currentFileChangeRunId?: string
-  /** 点击非 Git 文件时打开纯文件预览 */
+  /** non-git 文件点击回调 */
   onPlainFileClick?: (filePath: string) => void
 }
 
@@ -93,28 +96,62 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
   const setSelectedWorktreeMap = useSetAtom(agentSelectedWorktreeAtom)
   const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
-  const diffCacheKey = selectedWorktreePath ? `${sessionId}:worktree:${selectedWorktreePath}` : `${sessionId}:session`
-  const worktreeMode = React.useMemo(
-    () => selectedWorktreePath ? { path: selectedWorktreePath, baseBranch: 'origin/main' } : undefined,
-    [selectedWorktreePath],
-  )
+  // 仓库选择状态（内联 RepoSelector，优先级高于 worktree）
+  const selectedRepoMap = useAtomValue(agentSelectedRepoAtom)
+  const setSelectedRepoMap = useSetAtom(agentSelectedRepoAtom)
+  const selectedRepoPath = selectedRepoMap.get(sessionId) ?? null
+  const repoMode = Boolean(selectedRepoPath)
+  // 对比基准分支（worktree A vs B）：用户显式选择，空 = 服务端自动探测
+  const baseBranchMap = useAtomValue(agentDiffBaseBranchAtom)
+  const setBaseBranchMap = useSetAtom(agentDiffBaseBranchAtom)
+  const diffBaseBranch = baseBranchMap.get(sessionId) ?? ''
+  const handleRepoSelect = React.useCallback((repo: import('@proma/shared').RepoInfo | null) => {
+    setSelectedRepoMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, repo?.repoPath ?? null)
+      return m
+    })
+  }, [sessionId, setSelectedRepoMap])
+
   const handleWorktreeSelect = React.useCallback((worktree: WorktreeInfo | null) => {
     setSelectedWorktreeMap((prev) => {
       const m = new Map(prev)
       m.set(sessionId, worktree?.path ?? null)
       return m
     })
-  }, [sessionId, setSelectedWorktreeMap])
+    // 切换 worktree 时清除对比基准，避免旧基准串到新 worktree
+    setBaseBranchMap((prev) => {
+      if (!prev.has(sessionId)) return prev
+      const m = new Map(prev)
+      m.delete(sessionId)
+      return m
+    })
+  }, [sessionId, setSelectedWorktreeMap, setBaseBranchMap])
 
   // Diff 数据缓存：mount 时若已有上次结果，立即用作初值，避免空数组闪 1s "没有代码改动"
   const diffDataMap = useAtomValue(agentDiffDataAtom)
   const setDiffDataMap = useSetAtom(agentDiffDataAtom)
+  // 仓库模式专用缓存（类型不同，独立 atom 避免与 UnstagedChangesResult 混用）
+  const repoDataMap = useAtomValue(agentDiffRepoDataAtom)
+  const setRepoDataMap = useSetAtom(agentDiffRepoDataAtom)
+  const diffCacheKey = repoMode
+    ? (selectedWorktreePath ? `${sessionId}:repo-wt:${selectedWorktreePath}` : `${sessionId}:repo:${selectedRepoPath}`)
+    : selectedWorktreePath ? `${sessionId}:worktree:${selectedWorktreePath}` : `${sessionId}:session`
   const cached = diffDataMap.get(diffCacheKey)
   const [files, setFiles] = React.useState<ChangedFileEntry[]>(() => cached?.files ?? [])
   const [untrackedFiles, setUntrackedFiles] = React.useState<UntrackedFileEntry[]>(() => cached?.untrackedFiles ?? [])
   const [isGitRepo, setIsGitRepo] = React.useState(() => cached?.isGitRepo ?? true)
+  // 仓库聚合模式（repoMode && 未选单 worktree）：数据在 agentDiffRepoDataAtom，与 worktree 视图分离
+  const isRepoAggregate = repoMode && !selectedWorktreePath
+  // 仓库模式：所有 worktree 的聚合变更
+  const [repoChanges, setRepoChanges] = React.useState<RepoChangesResult | null>(() => {
+    if (!isRepoAggregate) return null
+    return repoDataMap.get(diffCacheKey) ?? null
+  })
+  // 实际使用的基准分支（服务端自动探测后返回），用于文件 diff 预览对齐
+  const [worktreeBaseBranch, setWorktreeBaseBranch] = React.useState<string>('')
   /** 首次 fetch 是否已返回——区分 loading 与真·空，避免 "没有代码改动" 误闪 */
-  const [hasFetched, setHasFetched] = React.useState<boolean>(() => cached !== undefined)
+  const [hasFetched, setHasFetched] = React.useState<boolean>(() => isRepoAggregate ? repoDataMap.has(diffCacheKey) : cached !== undefined)
   const [collapsedDirs, setCollapsedDirs] = React.useState<Set<string>>(new Set())
   const [searchQuery, setSearchQuery] = React.useState('')
   /** 单调递增的 fetch 序号，用于丢弃乱序到达的旧响应 */
@@ -127,8 +164,11 @@ export const DiffChangesList = React.memo(function DiffChangesList({
     setFiles(nextCached?.files ?? [])
     setUntrackedFiles(nextCached?.untrackedFiles ?? [])
     setIsGitRepo(nextCached?.isGitRepo ?? true)
-    setHasFetched(nextCached !== undefined)
-  }, [diffCacheKey])
+    setHasFetched(isRepoAggregate ? repoDataMap.has(diffCacheKey) : nextCached !== undefined)
+    if (isRepoAggregate) {
+      setRepoChanges(repoDataMap.get(diffCacheKey) ?? null)
+    }
+  }, [diffCacheKey, repoMode, isRepoAggregate])
 
   // Agent 本轮刚修改但尚未查看的文件
   const unseenFilesMap = useAtomValue(agentDiffUnseenFilesAtom)
@@ -148,12 +188,40 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   }, [sessionId, setUnseenFilesMap])
 
   const fetchChanges = React.useCallback(async () => {
-    if (!dirPath && !worktreeMode) return
+    if (!dirPath && !repoMode) return
     const requestId = ++fetchSeqRef.current
     try {
-      const result = worktreeMode
-        ? await window.electronAPI.getWorktreeChanges(worktreeMode.path, worktreeMode.baseBranch, sessionId)
-        : await window.electronAPI.getUnstagedChanges(dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId)
+      if (repoMode && selectedRepoPath) {
+        // 聚合视图自动探测基准；worktree 细化传用户选择的对比基准（A vs B）
+        const result = await window.electronAPI.getRepoChanges(selectedRepoPath, isRepoAggregate ? '' : diffBaseBranch, sessionId)
+        if (requestId !== fetchSeqRef.current) return
+        setIsGitRepo(result.isGitRepo)
+        if (isRepoAggregate) {
+          setRepoChanges(result)
+          setFiles([])
+          setUntrackedFiles([])
+          setRepoDataMap((prev) => {
+            const next = new Map(prev)
+            next.set(diffCacheKey, result)
+            return next
+          })
+        } else {
+          // 仓库内选中单个 worktree：从聚合结果中取出对应 worktree 的变更，放入 diffDataMap
+          const target = result.worktrees.find((w) => w.worktree.path === selectedWorktreePath)
+          const changes = target?.changes ?? { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
+          setFiles(changes.files || [])
+          setUntrackedFiles(changes.untrackedFiles || [])
+          setWorktreeBaseBranch(target?.worktree.path ? (result.baseBranch || '') : '')
+          setDiffDataMap((prev) => {
+            const next = new Map(prev)
+            next.set(diffCacheKey, changes)
+            return next
+          })
+        }
+        setHasFetched(true)
+        return
+      }
+      const result = await window.electronAPI.getUnstagedChanges(dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId)
       if (requestId !== fetchSeqRef.current) return
       setIsGitRepo(result.isGitRepo)
       setFiles(result.files || [])
@@ -169,7 +237,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       setIsGitRepo(true)
       setHasFetched(true)
     }
-  }, [dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId, setDiffDataMap, worktreeMode, diffCacheKey])
+  }, [dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId, setDiffDataMap, setRepoDataMap, diffCacheKey, repoMode, selectedRepoPath, isRepoAggregate, diffBaseBranch])
 
   React.useEffect(() => {
     fetchChanges()
@@ -240,19 +308,44 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   const hasGitChanges = isGitRepo && hasAnyChanges
   const hasNonGitFileChanges = nonGitFileChanges.length > 0
   const hasAnyVisibleChanges = hasGitChanges || hasNonGitFileChanges
-  const shouldShowSearch = isGitRepo && (hasAnyChanges || searchQuery.length > 0)
-  const shouldShowWorktreeSelector = isGitRepo && Boolean(workspaceSlug || (worktreeRepoPaths?.length ?? 0) > 0)
+  // 仓库聚合模式：搜索框基于聚合结果判断；worktree 细化/默认视图基于 files
+  const repoTotalChanges = repoChanges
+    ? repoChanges.worktrees.reduce((s, w) => s + w.changes.files.length + w.changes.untrackedFiles.length, 0)
+    : 0
+  const shouldShowSearch = isGitRepo && (isRepoAggregate
+    ? (repoTotalChanges > 0 || searchQuery.length > 0)
+    : (hasAnyChanges || searchQuery.length > 0))
+  const shouldShowWorktreeSelector = repoMode && Boolean(selectedRepoPath)
+  const shouldShowRepoSelector = (worktreeRepoPaths?.length ?? 0) > 0
 
   return (
     <div className="flex flex-col h-full overflow-y-auto">
-      {/* Worktree 分支选择器仅作用于 Git 改动。 */}
-      {shouldShowWorktreeSelector && (
+      {/* 仓库选择器 — 选择后该会话只扫描此仓库的所有 worktree */}
+      {shouldShowRepoSelector && (
+        <RepoSelector
+          sessionId={sessionId}
+          repoPaths={worktreeRepoPaths}
+          workspaceSlug={workspaceSlug || undefined}
+          selectedPath={selectedRepoPath}
+          onSelect={handleRepoSelect}
+        />
+      )}
+      {/* Worktree 过滤条 — 选中仓库后可在聚合视图与单个 worktree 之间切换 */}
+      {shouldShowWorktreeSelector && selectedRepoPath && (
         <WorktreeSelector
           sessionId={sessionId}
-          workspaceSlug={workspaceSlug}
-          repoPaths={worktreeRepoPaths}
+          repoPath={selectedRepoPath}
           selectedPath={selectedWorktreePath}
           onSelect={handleWorktreeSelect}
+          baseBranch={diffBaseBranch || undefined}
+          onBaseBranchChange={(base) => {
+            setBaseBranchMap((prev) => {
+              const m = new Map(prev)
+              if (base) m.set(sessionId, base)
+              else m.delete(sessionId)
+              return m
+            })
+          }}
         />
       )}
 
@@ -288,7 +381,8 @@ export const DiffChangesList = React.memo(function DiffChangesList({
         </div>
       )}
 
-      {hasNonGitFileChanges && (
+      {/* non-git 会话文件变更 — 仅在非仓库聚合视图显示 */}
+      {!isRepoAggregate && hasNonGitFileChanges && (
         <NonGitChangesList
           changes={nonGitFileChanges}
           currentRunId={currentFileChangeRunId}
@@ -297,71 +391,87 @@ export const DiffChangesList = React.memo(function DiffChangesList({
         />
       )}
 
-      {!hasAnyVisibleChanges && (
-        <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-          <p className="text-[12px] text-center">
-            {isGitRepo ? (hasFetched ? '没有文件改动' : '加载中…') : '当前目录不是 Git 仓库'}
-          </p>
-        </div>
-      )}
-      {hasGitChanges && isEmpty && (
-        <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-          <p className="text-[12px] text-center">没有匹配的代码改动</p>
-        </div>
-      )}
-      {hasGitChanges && !isEmpty && (
+      {isRepoAggregate ? (
+        <RepoChangesView
+          result={repoChanges}
+          hasFetched={hasFetched}
+          isGitRepo={isGitRepo}
+          searchQuery={searchQuery}
+          selectedFilePath={selectedFilePath}
+          unseenFiles={unseenFiles}
+          markFileAsSeen={markFileAsSeen}
+          onFileClick={onFileClick}
+          onRevert={handleRevert}
+        />
+      ) : (
         <>
-          {fileGroups.map((group) => {
-            const isCollapsed = collapsedDirs.has(group.gitRoot)
-            return (
-              <div key={group.gitRoot}>
-                {/* 文件夹 bar */}
-                <button
-                  type="button"
-                  onClick={() => toggleDir(group.gitRoot)}
-                  className="flex items-center gap-1.5 w-full px-3 py-2 text-[13px] font-medium text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
-                >
-                  <ChevronRight
-                    className={cn('size-3.5 transition-transform', !isCollapsed && 'rotate-90')}
-                  />
-                  <span className="truncate">{group.dirName}</span>
-                  {/* 文件夹层级的来源 badges */}
-                  {group.sources.map((src) => {
-                    const cfg = SOURCE_CONFIG[src] ?? SOURCE_CONFIG.none!
-                    return (
-                      <span key={src} className={cn('rounded px-1 py-0.5 text-[12px] leading-none shrink-0', cfg.color)}>
-                        {cfg.label}
+          {!hasAnyVisibleChanges && (
+            <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+              <p className="text-[12px] text-center">
+                {isGitRepo ? (hasFetched ? '没有文件改动' : '加载中…') : '当前目录不是 Git 仓库'}
+              </p>
+            </div>
+          )}
+          {hasGitChanges && isEmpty && (
+            <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+              <p className="text-[12px] text-center">没有匹配的代码改动</p>
+            </div>
+          )}
+          {hasGitChanges && !isEmpty && (
+            <>
+              {fileGroups.map((group) => {
+                const isCollapsed = collapsedDirs.has(group.gitRoot)
+                return (
+                  <div key={group.gitRoot}>
+                    {/* 文件夹 bar */}
+                    <button
+                      type="button"
+                      onClick={() => toggleDir(group.gitRoot)}
+                      className="flex items-center gap-1.5 w-full px-3 py-2 text-[13px] font-medium text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
+                    >
+                      <ChevronRight
+                        className={cn('size-3.5 transition-transform', !isCollapsed && 'rotate-90')}
+                      />
+                      <span className="truncate">{group.dirName}</span>
+                      {/* 文件夹层级的来源 badges */}
+                      {group.sources.map((src) => {
+                        const cfg = SOURCE_CONFIG[src] ?? SOURCE_CONFIG.none!
+                        return (
+                          <span key={src} className={cn('rounded px-1 py-0.5 text-[12px] leading-none shrink-0', cfg.color)}>
+                            {cfg.label}
+                          </span>
+                        )
+                      })}
+                      <span className="ml-auto shrink-0 flex items-center gap-1.5">
+                        <span className="text-foreground/30">{group.files.length} files</span>
+                        {group.totalAdditions > 0 && <span className="text-foreground/30">+{group.totalAdditions}</span>}
+                        {group.totalDeletions > 0 && <span className="text-foreground/30">-{group.totalDeletions}</span>}
                       </span>
-                    )
-                  })}
-                  <span className="ml-auto shrink-0 flex items-center gap-1.5">
-                    <span className="text-foreground/30">{group.files.length} files</span>
-                    {group.totalAdditions > 0 && <span className="text-foreground/30">+{group.totalAdditions}</span>}
-                    {group.totalDeletions > 0 && <span className="text-foreground/30">-{group.totalDeletions}</span>}
-                  </span>
-                </button>
+                    </button>
 
-                {/* 文件列表 */}
-                {!isCollapsed && group.files.map((file) => {
-                  const absPath = `${file.gitRoot || dirPath}/${file.filePath}`.replace(/\/+/g, '/')
-                  return (
-                    <FileRow
-                      key={`${file.gitRoot}:${file.filePath}`}
-                      file={file}
-                      isSelected={absPath === selectedFilePath || file.filePath === selectedFilePath}
-                      isUnseen={unseenFiles.has(absPath)}
-                      onClick={() => {
-                        markFileAsSeen(absPath)
-                        onFileClick(file.filePath, file.status === 'untracked', file.gitRoot)
-                      }}
-                      onRevert={file.status === 'untracked' ? undefined : () => handleRevert(file.filePath, file.gitRoot)}
-                      dirPath={dirPath}
-                    />
-                  )
-                })}
-              </div>
-            )
-          })}
+                    {/* 文件列表 */}
+                    {!isCollapsed && group.files.map((file) => {
+                      const absPath = `${file.gitRoot || dirPath}/${file.filePath}`.replace(/\/+/g, '/')
+                      return (
+                        <FileRow
+                          key={`${file.gitRoot}:${file.filePath}`}
+                          file={file}
+                          isSelected={absPath === selectedFilePath || file.filePath === selectedFilePath}
+                          isUnseen={unseenFiles.has(absPath)}
+                          onClick={() => {
+                            markFileAsSeen(absPath)
+                            onFileClick(file.filePath, file.status === 'untracked', file.gitRoot, worktreeBaseBranch || undefined)
+                          }}
+                          onRevert={file.status === 'untracked' ? undefined : () => handleRevert(file.filePath, file.gitRoot)}
+                          dirPath={dirPath}
+                        />
+                      )
+                    })}
+                  </div>
+                )
+              })}
+            </>
+          )}
         </>
       )}
     </div>
@@ -585,5 +695,201 @@ function GitStatusMarker({
       </TooltipTrigger>
       <TooltipContent side="bottom">{description}</TooltipContent>
     </Tooltip>
+  )
+}
+
+interface RepoChangesViewProps {
+  result: RepoChangesResult | null
+  hasFetched: boolean
+  isGitRepo: boolean
+  searchQuery: string
+  selectedFilePath?: string
+  unseenFiles: Set<string>
+  markFileAsSeen: (filePath: string) => void
+  onFileClick: (filePath: string, isUntracked: boolean, gitRoot?: string, baseRef?: string) => void
+  onRevert: (filePath: string, gitRoot: string) => void
+}
+
+/**
+ * 仓库聚合视图 — 展示所选仓库所有 worktree 的变更（含领先分支的 commit 概览）。
+ *
+ * 每个 worktree 是一个可折叠分组：标题为分支名 + head + 统计，
+ * 展开后依次是领先 commit 列表、基准独有 commit、已追踪文件、未追踪文件。
+ */
+function RepoChangesView({
+  result,
+  hasFetched,
+  isGitRepo,
+  searchQuery,
+  selectedFilePath,
+  unseenFiles,
+  markFileAsSeen,
+  onFileClick,
+  onRevert,
+}: RepoChangesViewProps): React.ReactElement {
+  const [collapsedWorktrees, setCollapsedWorktrees] = React.useState<Set<string>>(new Set())
+  const toggleWorktree = React.useCallback((key: string) => {
+    setCollapsedWorktrees((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }, [])
+
+  const q = searchQuery.toLowerCase().trim()
+
+  if (!isGitRepo) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+        <p className="text-[12px] text-center">当前目录不是 Git 仓库</p>
+      </div>
+    )
+  }
+
+  if (!result || result.worktrees.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+        <p className="text-[12px] text-center">{hasFetched ? '没有代码改动' : '加载中…'}</p>
+      </div>
+    )
+  }
+
+  const totalChanges = result.worktrees.reduce(
+    (sum, w) => sum + w.changes.files.length + w.changes.untrackedFiles.length,
+    0,
+  )
+  const totalCommits = result.worktrees.reduce((sum, w) => sum + w.commits.length + w.trailingCommits.length, 0)
+  if (totalChanges === 0 && totalCommits === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+        <p className="text-[12px] text-center">{hasFetched ? '没有代码改动' : '加载中…'}</p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {result.worktrees.map((w: RepoWorktreeChanges) => {
+        const changes = w.changes
+        const key = w.worktree.path
+        const isCollapsed = collapsedWorktrees.has(key)
+        const files = changes.files.filter((f) => !q || f.filePath.toLowerCase().includes(q))
+        const untracked = changes.untrackedFiles.filter((f) => !q || f.filePath.toLowerCase().includes(q))
+        const totalAdd = files.reduce((s, f) => s + f.additions, 0)
+        const totalDel = files.reduce((s, f) => s + f.deletions, 0)
+        const hasContent = files.length > 0 || untracked.length > 0 || w.commits.length > 0 || w.trailingCommits.length > 0
+        if (!hasContent) return null
+        return (
+          <div key={key}>
+            {/* worktree 标题 bar */}
+            <button
+              type="button"
+              onClick={() => toggleWorktree(key)}
+              aria-expanded={!isCollapsed}
+              className="flex items-center gap-1.5 w-full px-2 py-2 text-[13px] font-medium text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
+            >
+              <ChevronRight
+                className={cn('size-3 shrink-0 transition-transform', !isCollapsed && 'rotate-90')}
+              />
+              <GitBranch className="size-3 shrink-0" />
+              <span className="truncate">{w.worktree.branch}</span>
+              {w.worktree.isMain && (
+                <span className="text-[10px] px-1 rounded bg-muted text-muted-foreground shrink-0">main</span>
+              )}
+              <span className="text-[10px] text-muted-foreground/50 shrink-0">{w.worktree.head}</span>
+              {w.commits.length > 0 && (
+                <span className="text-[10px] px-1 rounded bg-blue-500/10 text-blue-500 shrink-0">
+                  +{w.commits.length}
+                </span>
+              )}
+              {w.trailingCommits.length > 0 && (
+                <span className="text-[10px] px-1 rounded bg-amber-500/10 text-amber-500 shrink-0" title={`${result?.baseBranch || '基准'} 独有 ${w.trailingCommits.length} commits`}>
+                  -{w.trailingCommits.length}
+                </span>
+              )}
+              <span className="ml-auto shrink-0 flex items-center gap-1.5 text-foreground/30">
+                <span>{files.length + untracked.length} 文件</span>
+                {totalAdd > 0 && <span>+{totalAdd}</span>}
+                {totalDel > 0 && <span>-{totalDel}</span>}
+              </span>
+            </button>
+
+            {!isCollapsed && (
+              <>
+                {/* 领先基准分支的 commit 概览（graph 摘要） */}
+                {w.commits.length > 0 && (
+                  <div className="px-3 py-1 border-l-2 border-border/40 ml-3 flex flex-col gap-1 bg-muted/20">
+                    <div className="text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+                      领先 {result?.baseBranch || '基准'} · {w.commits.length} commits
+                    </div>
+                    {w.commits.map((c) => (
+                      <div key={c.hash} className="flex items-center gap-1.5 text-[11px] text-muted-foreground min-w-0">
+                        <span className="text-foreground/40 font-mono tabular-nums shrink-0">{c.hash}</span>
+                        <span className="truncate">{c.subject}</span>
+                        <span className="text-foreground/25 shrink-0 hidden min-[360px]:inline">
+                          {c.author} · {c.date}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* 基准分支独有、该 worktree 没有的 commit（对比基准时区分选择效果） */}
+                {w.trailingCommits.length > 0 && (
+                  <div className="px-3 py-1 border-l-2 border-amber-500/30 ml-3 flex flex-col gap-1 bg-amber-500/[0.04]">
+                    <div className="text-[10px] font-medium text-amber-600/70 dark:text-amber-500/70 uppercase tracking-wider">
+                      {result?.baseBranch || '基准'} 独有 · {w.trailingCommits.length} commits
+                    </div>
+                    {w.trailingCommits.map((c) => (
+                      <div key={c.hash} className="flex items-center gap-1.5 text-[11px] text-muted-foreground min-w-0">
+                        <span className="text-foreground/40 font-mono tabular-nums shrink-0">{c.hash}</span>
+                        <span className="truncate">{c.subject}</span>
+                        <span className="text-foreground/25 shrink-0 hidden min-[360px]:inline">
+                          {c.author} · {c.date}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* 已追踪文件 */}
+                {files.map((file) => {
+                  const absPath = `${file.gitRoot || w.worktree.path}/${file.filePath}`.replace(/\/+/g, '/')
+                  return (
+                    <FileRow
+                      key={`${file.gitRoot}:${file.filePath}`}
+                      file={file}
+                      isSelected={absPath === selectedFilePath || file.filePath === selectedFilePath}
+                      isUnseen={unseenFiles.has(absPath)}
+                      onClick={() => { markFileAsSeen(absPath); onFileClick(file.filePath, false, file.gitRoot, result?.baseBranch || undefined) }}
+                      onRevert={() => onRevert(file.filePath, file.gitRoot)}
+                      dirPath={w.worktree.path}
+                    />
+                  )
+                })}
+
+                {/* 未追踪文件 */}
+                {untracked.length > 0 && (
+                  <div>
+                    <div className="flex items-center px-3 py-1.5 text-[12px] font-medium text-muted-foreground border-t border-border/30">
+                      未追踪文件
+                    </div>
+                    {untracked.map((file) => (
+                      <FileRow
+                        key={`${file.gitRoot}:${file.filePath}`}
+                        file={{ ...file, status: 'untracked', additions: 0, deletions: 0 }}
+                        onClick={() => onFileClick(file.filePath, true, file.gitRoot, result?.baseBranch || undefined)}
+                        dirPath={w.worktree.path}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )
+      })}
+    </>
   )
 }

--- a/apps/electron/src/renderer/components/diff/RepoSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/RepoSelector.tsx
@@ -1,0 +1,221 @@
+import * as React from 'react'
+import { GitBranch, GitFork, Plus, ChevronDown, RefreshCw } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { RepoInfo } from '@proma/shared'
+import { normalizePathForCompare } from '@proma/shared'
+
+interface RepoSelectorProps {
+  sessionId: string
+  /** 扫描根路径（通常是项目根 + 会话路径 + 附加目录） */
+  repoPaths?: string[]
+  /** 工作区 slug，用于合并手动配置的 worktree 仓库 + 添加入口 */
+  workspaceSlug?: string
+  /** 当前选中的仓库根路径，null = 全部仓库 */
+  selectedPath: string | null
+  onSelect: (repo: RepoInfo | null) => void
+}
+
+function normalizePathKey(filePath: string): string {
+  return normalizePathForCompare(filePath)
+}
+
+/**
+ * 仓库选择器 — 文件改动 tab 顶部的仓库下拉。
+ *
+ * 把扫描到的 Git 仓库加入可选列表并绑定会话；选中某个仓库后，
+ * 该会话的 diff 列表只扫描这个仓库的所有 worktree。
+ */
+export function RepoSelector({
+  sessionId,
+  repoPaths,
+  workspaceSlug,
+  selectedPath,
+  onSelect,
+}: RepoSelectorProps): React.ReactElement {
+  const [repos, setRepos] = React.useState<RepoInfo[]>([])
+  const [isOpen, setIsOpen] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(false)
+  const dropdownRef = React.useRef<HTMLDivElement>(null)
+
+  const fetchRepos = React.useCallback(async (force = false) => {
+    setIsLoading(true)
+    try {
+      const repoMap = new Map<string, RepoInfo>()
+      // 1. 手动配置的 worktree 仓库（可能不在扫描范围内）
+      if (workspaceSlug) {
+        try {
+          const configured = await window.electronAPI.getWorktreeRepos(workspaceSlug)
+          for (const repo of configured) {
+            if (!repoMap.has(normalizePathKey(repo.repoPath))) {
+              repoMap.set(normalizePathKey(repo.repoPath), {
+                repoPath: repo.repoPath,
+                name: repo.name,
+                branch: '',
+                head: '',
+                worktreeCount: 0,
+                worktrees: [],
+              })
+            }
+          }
+        } catch {
+          // skip
+        }
+      }
+      // 2. 扫描到的仓库（覆盖配置项，补充完整信息）
+      for (const p of repoPaths ?? []) {
+        if (!p) continue
+        try {
+          const list = await window.electronAPI.listRepos(p, sessionId, force)
+          for (const repo of list) {
+            repoMap.set(normalizePathKey(repo.repoPath), repo)
+          }
+        } catch {
+          // skip paths that fail
+        }
+      }
+      const sorted = Array.from(repoMap.values()).sort((a, b) => {
+        // 有多个 worktree 的仓库优先（用户更可能在多分支并行工作），再按名称
+        if (b.worktreeCount !== a.worktreeCount) return b.worktreeCount - a.worktreeCount
+        return a.name.localeCompare(b.name)
+      })
+      setRepos(sorted)
+    } catch {
+      setRepos([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [repoPaths, sessionId, workspaceSlug])
+
+  React.useEffect(() => {
+    fetchRepos()
+  }, [fetchRepos])
+
+  // 已选仓库被移除/路径失效时自动回退到「全部仓库」，避免聚合视图卡在无效路径
+  React.useEffect(() => {
+    if (selectedPath && repos.length > 0 && !repos.some((r) => normalizePathKey(r.repoPath) === normalizePathKey(selectedPath))) {
+      onSelect(null)
+    }
+  }, [repos, selectedPath, onSelect])
+
+  React.useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen])
+
+  // 无可用仓库时不渲染选择器（但有手动添加入口的工作区除外，保留「添加仓库」可达）
+  if (repos.length === 0 && !isLoading && !workspaceSlug) return <></>
+
+  const selectedRepo = repos.find((r) => normalizePathKey(r.repoPath) === normalizePathKey(selectedPath ?? '')) ?? null
+  const displayLabel = selectedRepo
+    ? `${selectedRepo.name} · ${selectedRepo.branch} · ${selectedRepo.worktreeCount} 工作树`
+    : '全部仓库'
+
+  return (
+    <div ref={dropdownRef} className="relative px-3 py-1.5 border-b border-border/50">
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-label="选择仓库"
+          className={cn(
+            'flex items-center gap-1.5 px-2 py-1 rounded-md text-xs',
+            'hover:bg-accent/50 transition-colors',
+            'text-muted-foreground hover:text-foreground',
+            selectedRepo && 'text-foreground font-medium',
+          )}
+        >
+          <GitFork className="w-3.5 h-3.5 shrink-0" />
+          <span className="truncate max-w-[200px]">{displayLabel}</span>
+          <ChevronDown className={cn('w-3 h-3 shrink-0 transition-transform', isOpen && 'rotate-180')} />
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            fetchRepos(true)
+          }}
+          aria-label="刷新仓库列表"
+          className="p-1 rounded hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors"
+          title="刷新仓库列表"
+        >
+          <RefreshCw className={cn('w-3 h-3', isLoading && 'animate-spin')} />
+        </button>
+      </div>
+
+      {isOpen && (
+        <div className="absolute left-2 right-2 top-full mt-0.5 z-50 bg-popover border border-border rounded-md shadow-md py-1 max-h-[280px] overflow-y-auto">
+          <button
+            onClick={() => {
+              onSelect(null)
+              setIsOpen(false)
+            }}
+            className={cn(
+              'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors',
+              !selectedRepo && 'bg-accent/30 font-medium',
+            )}
+          >
+            全部仓库（扫描整个工作区）
+          </button>
+          {repos.map((repo) => {
+            const isSelected = normalizePathKey(repo.repoPath) === normalizePathKey(selectedPath ?? '')
+            return (
+              <button
+                key={repo.repoPath}
+                onClick={() => {
+                  onSelect(repo)
+                  setIsOpen(false)
+                }}
+                className={cn(
+                  'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors flex items-center gap-2',
+                  isSelected && 'bg-accent/30 font-medium',
+                )}
+              >
+                <GitBranch className="w-3 h-3 shrink-0 text-muted-foreground" />
+                <span className="truncate font-medium">{repo.name}</span>
+                <span className="text-muted-foreground truncate max-w-[100px]">{repo.branch}</span>
+                <span className="text-muted-foreground ml-auto shrink-0 tabular-nums">
+                  {repo.worktreeCount} 工作树
+                </span>
+              </button>
+            )
+          })}
+          {workspaceSlug && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                void handleAddRepo()
+              }}
+              className="w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors flex items-center gap-2 text-muted-foreground border-t border-border/40 mt-0.5"
+            >
+              <Plus className="w-3 h-3 shrink-0" />
+              <span>添加仓库…（不在扫描范围内时手动加入）</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  async function handleAddRepo(): Promise<void> {
+    if (!workspaceSlug) return
+    const repoPath = await window.electronAPI.selectDirectory()
+    if (!repoPath) return
+    try {
+      await window.electronAPI.addWorktreeRepo(workspaceSlug, {
+        name: repoPath.split(/[\\/]/).filter(Boolean).pop() || repoPath,
+        repoPath,
+        worktreesPath: '',
+        priority: 0,
+      })
+      await fetchRepos(true)
+    } catch {
+      window.alert('添加仓库失败，请确认路径可访问')
+    }
+  }
+}

--- a/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
@@ -1,91 +1,50 @@
 import * as React from 'react'
 import { GitBranch, ChevronDown, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import type { WorktreeInfo, WorkspaceWorktreeRepo } from '@proma/shared'
-import { normalizePathForCompare } from '@proma/shared'
+import type { WorktreeInfo } from '@proma/shared'
 
 interface WorktreeSelectorProps {
   sessionId: string
-  workspaceSlug?: string
-  repoPaths?: string[]
+  /** 当前选中的仓库根路径（仅列出该仓库的 worktree） */
+  repoPath: string
+  /** 当前选中的 worktree 路径，null = 聚合视图（全部工作树） */
   selectedPath: string | null
   onSelect: (worktree: WorktreeInfo | null) => void
+  /** 当前对比基准分支（空 = 自动探测） */
+  baseBranch?: string
+  onBaseBranchChange?: (base: string | null) => void
 }
 
-interface RepoWorktrees {
-  repo: WorkspaceWorktreeRepo
-  worktrees: WorktreeInfo[]
-}
-
-function normalizePathKey(filePath: string): string {
-  return normalizePathForCompare(filePath)
-}
-
-function getPathBasename(filePath: string): string {
-  return normalizePathKey(filePath).split('/').filter(Boolean).pop() || filePath
-}
-
+/**
+ * Worktree 过滤条 — 在仓库聚合视图内细看单个 worktree。
+ *
+ * 仅当选中某个仓库后显示；「全部工作树」回到聚合视图，
+ * 选中某个 worktree 则只展示该 worktree 相对基准分支的变更。
+ */
 export function WorktreeSelector({
   sessionId,
-  workspaceSlug,
-  repoPaths,
+  repoPath,
   selectedPath,
   onSelect,
+  baseBranch,
+  onBaseBranchChange,
 }: WorktreeSelectorProps): React.ReactElement {
-  const [repoWorktrees, setRepoWorktrees] = React.useState<RepoWorktrees[]>([])
+  const [worktrees, setWorktrees] = React.useState<WorktreeInfo[]>([])
   const [isOpen, setIsOpen] = React.useState(false)
   const [isLoading, setIsLoading] = React.useState(false)
   const dropdownRef = React.useRef<HTMLDivElement>(null)
 
-  const fetchWorktrees = React.useCallback(async () => {
+  const fetchWorktrees = React.useCallback(async (force = false) => {
     setIsLoading(true)
     try {
-      const repoMap = new Map<string, WorkspaceWorktreeRepo>()
-
-      if (workspaceSlug) {
-        const repos = await window.electronAPI.getWorktreeRepos(workspaceSlug)
-        for (const repo of repos) {
-          repoMap.set(normalizePathKey(repo.repoPath), repo)
-        }
-      }
-
-      for (const repoPath of repoPaths ?? []) {
-        if (!repoPath) continue
-        const key = normalizePathKey(repoPath)
-        if (repoMap.has(key)) continue
-        repoMap.set(key, {
-          name: getPathBasename(repoPath),
-          repoPath,
-          worktreesPath: '',
-          priority: 0,
-        })
-      }
-
-      const repos = Array.from(repoMap.values())
-      if (repos.length === 0) {
-        setRepoWorktrees([])
-        return
-      }
-
-      const results: RepoWorktrees[] = []
-      for (const repo of repos) {
-        try {
-          const list = await window.electronAPI.listWorktrees(repo.repoPath, sessionId)
-          const nonMain = list.filter((wt) => !wt.isMain)
-          if (nonMain.length > 0) {
-            results.push({ repo, worktrees: nonMain })
-          }
-        } catch {
-          // skip repos that fail
-        }
-      }
-      setRepoWorktrees(results)
+      const list = await window.electronAPI.listWorktrees(repoPath, sessionId, force)
+      setWorktrees(list)
     } catch {
-      setRepoWorktrees([])
+      setWorktrees([])
     } finally {
       setIsLoading(false)
     }
-  }, [workspaceSlug, repoPaths, sessionId])
+  }, [repoPath, sessionId])
 
   React.useEffect(() => {
     fetchWorktrees()
@@ -103,36 +62,43 @@ export function WorktreeSelector({
     }
   }, [isOpen])
 
-  const allWorktrees = repoWorktrees.flatMap((rw) => rw.worktrees)
-  const selectedWorktree = allWorktrees.find((wt) => wt.path === selectedPath)
-  const displayLabel = selectedWorktree ? selectedWorktree.branch : 'Worktrees'
-  const hasMultipleRepos = repoWorktrees.length > 1
+  if (worktrees.length === 0 && !isLoading) return <></>
 
-  if (allWorktrees.length === 0) return <></>
+  const selectedWorktree = worktrees.find((wt) => wt.path === selectedPath) ?? null
+  const displayLabel = selectedWorktree
+    ? (baseBranch ? `${selectedWorktree.branch} vs ${baseBranch}` : selectedWorktree.branch)
+    : '全部工作树'
+  // 对比基准候选：本仓库其他 worktree 的分支
+  const baseCandidates = selectedWorktree
+    ? worktrees.filter((wt) => wt.path !== selectedWorktree.path && wt.branch !== 'unknown')
+    : []
 
   return (
-    <div ref={dropdownRef} className="relative px-3 py-1.5 border-b border-border/50">
+    <div ref={dropdownRef} className="relative px-3 py-1 border-b border-border/50 bg-muted/10">
       <div className="flex items-center gap-1.5">
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-label="选择工作树"
           className={cn(
-            'flex items-center gap-1.5 px-2 py-1 rounded-md text-xs',
+            'flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px]',
             'hover:bg-accent/50 transition-colors',
             'text-muted-foreground hover:text-foreground',
             selectedWorktree && 'text-foreground font-medium',
           )}
         >
-          <GitBranch className="w-3.5 h-3.5 shrink-0" />
+          <GitBranch className="w-3 h-3 shrink-0" />
           <span className="truncate max-w-[160px]">{displayLabel}</span>
           <ChevronDown className={cn('w-3 h-3 shrink-0 transition-transform', isOpen && 'rotate-180')} />
         </button>
         <button
           onClick={(e) => {
             e.stopPropagation()
-            fetchWorktrees()
+            fetchWorktrees(true)
           }}
-          className="p-1 rounded hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors"
-          title="刷新 worktree 列表"
+          aria-label="刷新工作树列表"
+          className="p-0.5 rounded hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors"
+          title="刷新工作树列表"
         >
           <RefreshCw className={cn('w-3 h-3', isLoading && 'animate-spin')} />
         </button>
@@ -147,37 +113,65 @@ export function WorktreeSelector({
             }}
             className={cn(
               'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors',
-              !selectedPath && 'bg-accent/30 font-medium',
+              !selectedWorktree && 'bg-accent/30 font-medium',
             )}
           >
-            会话改动
+            全部工作树（聚合视图）
           </button>
-          {repoWorktrees.map((rw) => (
-            <React.Fragment key={rw.repo.repoPath}>
-              {hasMultipleRepos && (
-                <div className="px-3 pt-2 pb-0.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
-                  {rw.repo.name}
-                </div>
+          {worktrees.map((wt) => (
+            <button
+              key={wt.path}
+              onClick={() => {
+                onSelect(wt)
+                setIsOpen(false)
+              }}
+              className={cn(
+                'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors flex items-center gap-2',
+                selectedPath === wt.path && 'bg-accent/30 font-medium',
               )}
-              {rw.worktrees.map((wt) => (
+            >
+              <GitBranch className="w-3 h-3 shrink-0 text-muted-foreground" />
+              <span className="truncate">{wt.branch}</span>
+              {wt.isMain && <span className="text-[10px] px-1 rounded bg-muted text-muted-foreground shrink-0">main</span>}
+              <span className="text-muted-foreground ml-auto shrink-0">{wt.head}</span>
+            </button>
+          ))}
+          {/* 对比基准：选中单个 worktree 后可选对比目标（worktree A vs B） */}
+          {selectedWorktree && baseCandidates.length > 0 && (
+            <>
+              <div className="px-3 pt-2 pb-0.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+                对比基准
+              </div>
+              <button
+                onClick={() => {
+                  onBaseBranchChange?.(null)
+                  setIsOpen(false)
+                }}
+                className={cn(
+                  'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors',
+                  !baseBranch && 'bg-accent/30 font-medium',
+                )}
+              >
+                默认（自动探测主分支）
+              </button>
+              {baseCandidates.map((wt) => (
                 <button
-                  key={wt.path}
+                  key={`base:${wt.path}`}
                   onClick={() => {
-                    onSelect(wt)
+                    onBaseBranchChange?.(wt.branch)
                     setIsOpen(false)
                   }}
                   className={cn(
                     'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors flex items-center gap-2',
-                    selectedPath === wt.path && 'bg-accent/30 font-medium',
+                    baseBranch === wt.branch && 'bg-accent/30 font-medium',
                   )}
                 >
-                  <GitBranch className="w-3 h-3 shrink-0 text-muted-foreground" />
                   <span className="truncate">{wt.branch}</span>
-                  <span className="text-muted-foreground ml-auto shrink-0">{wt.head}</span>
+                  <span className="text-muted-foreground ml-auto shrink-0">对比此分支</span>
                 </button>
               ))}
-            </React.Fragment>
-          ))}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -962,6 +962,11 @@ export function useGlobalAgentListeners(): void {
               const writtenPath = entry.path
               pendingWriteTools.delete(event.toolUseId)
               if (event.isError) continue
+              // 定向失效主进程变更扫描缓存：只失效该文件所在仓库的缓存，
+              // 避免 Agent 连续写文件时每次都全量失效→全量重扫（CPU 飙升主因）。
+              window.electronAPI.invalidateGitDiffCache(writtenPath || undefined).catch((err) => {
+                console.warn('[GlobalAgentListeners] 失效变更扫描缓存失败:', err)
+              })
               store.set(agentDiffRefreshVersionAtom, (prev) => {
                 const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
               })
@@ -1013,6 +1018,10 @@ export function useGlobalAgentListeners(): void {
             // Bash git 突变命令完成时，仅刷新 diff 列表（不标记 unseen，避免红点）
             if (pendingGitMutateTools.has(event.toolUseId)) {
               pendingGitMutateTools.delete(event.toolUseId)
+              // 失效主进程变更扫描缓存（commit/checkout/reset 等会改变变更集）
+              window.electronAPI.invalidateGitDiffCache().catch((err) => {
+                console.warn('[GlobalAgentListeners] 失效变更扫描缓存失败:', err)
+              })
               store.set(agentDiffRefreshVersionAtom, (prev) => {
                 const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
               })
@@ -1458,6 +1467,17 @@ export function useGlobalAgentListeners(): void {
 
         if (prevHash === undefined || prevHash !== hash) {
           // 首次建立 hash 基准时也刷新一次，避免用户离开窗口后首次外部修改被吞掉。
+          // 内容确实变化时定向失效该文件所在仓库的变更扫描缓存，避免聚焦刷新命中 TTL 内旧缓存显示过期变更集。
+          // filePath 可能是 repo 根相对路径（如 apps/electron/src/x.ts），用 gitRoot 拼绝对路径
+          // 才能命中主进程的定向匹配，否则会退化到全量失效（正确但性能打折）。
+          const filePathRaw = previewFile.filePath
+          const invalidatePath =
+            previewFile.gitRoot && filePathRaw && !isAbsolutePath(filePathRaw)
+              ? previewFile.gitRoot.replace(/\\/g, '/').replace(/\/+$/, '') + '/' + filePathRaw.replace(/\\/g, '/')
+              : filePathRaw
+          window.electronAPI.invalidateGitDiffCache(invalidatePath).catch((err) => {
+            console.warn('[GlobalAgentListeners] 失效变更扫描缓存失败:', err)
+          })
           bumpDiffRefresh(activeSessionId)
         }
         fileContentHashMap.set(hashKey, hash)

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -136,6 +136,8 @@ export interface UnstagedChangesResult {
   untrackedFiles: UntrackedFileEntry[]
   /** Git 仓库根目录名数组（多仓库场景用于分组显示） */
   gitRootNames: string[]
+  /** 实际使用的基准分支（自动探测后返回给前端，用于 diff 预览对齐） */
+  baseBranch?: string
 }
 
 /** Git Worktree 信息 */
@@ -150,6 +152,58 @@ export interface WorktreeInfo {
   isMain: boolean
   /** 显示名（路径最后一段） */
   name: string
+}
+
+/** Git 仓库概览信息（仓库选择器用） */
+export interface RepoInfo {
+  /** 仓库根绝对路径（主 worktree 路径） */
+  repoPath: string
+  /** 显示名（路径最后一段） */
+  name: string
+  /** 当前分支名（主 worktree） */
+  branch: string
+  /** HEAD commit hash (short) */
+  head: string
+  /** 该仓库所有 worktree 数量（含主 worktree） */
+  worktreeCount: number
+  /** 该仓库所有 worktree（含主 worktree） */
+  worktrees: WorktreeInfo[]
+}
+
+/** commit 摘要（graph 概览用） */
+export interface CommitSummary {
+  /** 短 hash */
+  hash: string
+  /** commit 主题 */
+  subject: string
+  /** 作者名 */
+  author: string
+  /** 日期（YYYY-MM-DD） */
+  date: string
+}
+
+/** 单个 worktree 的变更汇总（仓库聚合视图用） */
+export interface RepoWorktreeChanges {
+  /** worktree 信息 */
+  worktree: WorktreeInfo
+  /** 该 worktree 相对基准分支的全量变更 */
+  changes: UnstagedChangesResult
+  /** 领先基准分支的 commit 摘要（git log base..HEAD） */
+  commits: CommitSummary[]
+  /** 基准分支独有、该 worktree 没有的 commit 摘要（git log HEAD..base） */
+  trailingCommits: CommitSummary[]
+}
+
+/** 仓库全量变更结果：该仓库所有 worktree 的变更 */
+export interface RepoChangesResult {
+  /** 是否为 Git 仓库 */
+  isGitRepo: boolean
+  /** 仓库根绝对路径 */
+  repoPath: string
+  /** 基准分支（默认 origin/main） */
+  baseBranch: string
+  /** 按 worktree 分组的变更列表（含主 worktree） */
+  worktrees: RepoWorktreeChanges[]
 }
 
 /** 获取文件 Diff 的输入 */
@@ -346,6 +400,8 @@ export const IPC_CHANNELS = {
   GET_GIT_REPO_STATUS: 'git:get-repo-status',
   /** 获取未暂存的变更文件列表 */
   GET_UNSTAGED_CHANGES: 'git:get-unstaged-changes',
+  /** 使变更扫描缓存失效（agent 写文件 / git 变更完成后调用，保证下次读取拿到最新结果） */
+  INVALIDATE_GIT_DIFF_CACHE: 'git:invalidate-diff-cache',
   /** 获取单个文件的 diff */
   GET_FILE_DIFF: 'git:get-file-diff',
   /** 获取未追踪文件内容 */
@@ -357,6 +413,12 @@ export const IPC_CHANNELS = {
   LIST_WORKTREES: 'git:list-worktrees',
   /** 获取 Worktree 相对于基准分支的全量变更 */
   GET_WORKTREE_CHANGES: 'git:get-worktree-changes',
+  /** 列出扫描到的所有 Git 仓库（仓库选择器用） */
+  LIST_REPOS: 'git:list-repos',
+  /** 获取仓库所有 worktree 的全量变更（仓库聚合视图用） */
+  GET_REPO_CHANGES: 'git:get-repo-changes',
+  /** 打开系统目录选择对话框（手动添加仓库用） */
+  SELECT_DIRECTORY: 'shell:select-directory',
   /** 在系统默认浏览器中打开外部链接 */
   OPEN_EXTERNAL: 'shell:open-external',
   /** 用系统默认应用打开任意文件 */


### PR DESCRIPTION
## 概述

右侧边栏「文件改动」tab 在包含大量 Git 仓库的项目根（monorepo / fork 集合）下存在两个痛点：所有仓库的改动混杂显示无法聚焦；主仓库的 git worktree 分支改动（`.worktrees/` 下）默认扫描不到。

本 PR 引入**仓库选择器**：把工作区扫描到的 Git 仓库加入下拉并绑定会话，选中后该会话只扫描此仓库的**所有 worktree**（含 main 与各分支 worktree），以聚合视图展示未提交改动 + 领先/落后 commit 概览；支持仓库内单 worktree 细化、分支间对比（A vs B）、手动添加仓库、基准分支自动探测。同时以 merge 形式包含 `perf/git-diff-parallel-cache`（PR #1424）的扫描性能优化作为基础设施。

## 改动

- `apps/electron/src/main/lib/git-diff-service.ts`（+831）：新增 `listRepos` / `getRepoChanges` / `listWorktreesFromRoot` / `resolveDefaultBaseBranch`（单次 for-each-ref + 30s 缓存）；`findAllGitRootsDown` 区分 .git 目录与 worktree 指针文件；默认 `getUnstagedChanges` 枚举 worktree；多级缓存 + 定向失效
- `apps/electron/src/main/ipc.ts`：新增 `git:list-repos` / `git:get-repo-changes` / `shell:select-directory`，逐 worktree 路径授权、缓存 key 会话隔离
- `apps/electron/src/preload/index.ts`：electronAPI 新增 `listRepos` / `getRepoChanges` / `selectDirectory`
- `packages/shared/src/types/runtime.ts`：新增 `RepoInfo` / `RepoChangesResult` / `RepoWorktreeChanges` / `CommitSummary` 类型与 3 个 IPC 通道
- `apps/electron/src/renderer/components/diff/RepoSelector.tsx`（新增）：仓库下拉选择器，绑定会话，支持手动添加仓库
- `apps/electron/src/renderer/components/diff/WorktreeSelector.tsx`：改造为仓库内工作树过滤条，支持对比基准选择（A vs B 双向 commit 概览）
- `apps/electron/src/renderer/components/diff/DiffChangesList.tsx`：聚合视图（worktree 分组 + 领先/落后 commit + 折叠/搜索）+ 单 worktree 细化视图切换；兼容上游 #1429 的 non-git 文件变更展示
- `apps/electron/src/renderer/atoms/agent-atoms.ts` / `SidePanel.tsx` / `LeftSidebar.tsx` / `useGlobalAgentListeners.ts` / `workspace-watcher.ts`：per-session 选择状态、缓存清理、预览基准透传、写文件失效
- `apps/electron/src/main/lib/git-diff-service.test.ts`（新增）：临时仓库集成测试（发现/枚举/聚合/基准探测）

## 与 PR #1424 的关系（重要）

- 本 PR **包含** `perf/git-diff-parallel-cache`（PR #1424）的扫描性能优化（并发预检 + scanCache/perRepoCache/gitRootsCache 三层缓存 + 定向失效 + watcher 过滤），作为仓库选择器功能的基础设施（`findAllGitRoots` 缓存、`invalidateGitDiffCache` 定向失效被 `listRepos`/`getRepoChanges` 依赖）。
- **建议合并顺序：先合并 #1424，再合并本 PR**。如此本 PR rebase 后 perf 相关代码自动消去，仅剩仓库选择器功能；反向顺序则 #1424 需要 rebase 去重。
- 若维护者希望本 PR 独立、不含 perf 代码，请告知，可另行拆分（需重做缓存依赖，工作量较大）。

## 测试

- `bun run --filter=@proma/electron typecheck` ✅
- `build:main / build:preload / build:renderer` ✅
- `bun test` 5 个集成用例全过（临时 git 仓库验证 findAllGitRoots / listRepos / worktree 枚举 / getRepoChanges 聚合 / 基准自动探测）
- dev 实测：选中 Proma 仓库显示 5 个 worktree 聚合（分支/head/commits/文件统计）、单 worktree 细化、对比基准切换显示「基准独有 commits」、添加仓库对话框均正常

## 紧急度

常规

## 备注

- Closes #290（open 功能请求：增加 git 组件与代码 diff 差异查看组件——本 PR 提供仓库选择器 + worktree 聚合 + 分支对比，实质满足该诉求）
- Related: #649 #650（既有 Changes tab worktree 支持基础，本 PR 在其上增强为按仓库聚合）
- 基准分支自动探测：origin/main → origin/master → 本地 main → HEAD~1；显式对比基准时用两点 diff 展示两分支全部差异
- worktree 枚举走 10s 短 TTL 缓存，`listRepos` 60s TTL + 强制刷新
- rebase 至最新 main（`d7f76914`），已兼容上游 #1429（non-git file changes）的 DiffChangesList 改动