### PR TITLE
feat(ui): 侧边栏字号放大、项目右键菜单与 Windows 灵动岛修复

### DIFF
--- a/apps/electron/src/renderer/components/agent-island/agent-island.css
+++ b/apps/electron/src/renderer/components/agent-island/agent-island.css
@@ -40,7 +40,19 @@ button {
 
 .island-root-floating .island-surface {
   border-top: 1px solid rgb(255 255 255 / 0.12);
-  border-radius: 0;
+  border-radius: 18px;
+}
+
+/* Windows 透明 BrowserWindow 中，border-radius 外侧像素仍会透出桌面。
+   给根容器与 surface 相同的背景色和圆角，把四角填实。
+   注意：根容器高度必须贴合 surface（覆盖 .island-root 的 height:100%），
+   否则透明窗口的实际高度比 surface 略大时，窗口底部会被实色背景填满，
+   看起来像“下方叠了一层 UI”（收起态下的双重 UI 重叠）。 */
+.island-root-floating {
+  height: auto;
+  background: #09090a;
+  border-radius: 18px;
+  overflow: hidden;
 }
 
 /* Windows exposes a small native drag region instead of making controls
@@ -159,7 +171,8 @@ button {
   overflow: hidden;
   font-size: 10.5px;
   font-weight: 650;
-  line-height: 1;
+  line-height: 1.2;
+  padding-top: 1px;
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -175,7 +188,7 @@ button {
   color: rgb(255 255 255 / 0.86);
   font-size: 9px;
   font-weight: 650;
-  line-height: 1;
+  line-height: 1.2;
   font-variant-numeric: tabular-nums;
 }
 
@@ -225,7 +238,7 @@ button {
   color: rgb(255 255 255 / 0.62);
   font-size: 9px;
   font-weight: 750;
-  line-height: 1;
+  line-height: 1.2;
 }
 
 .island-header-copy strong {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
+import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw, Copy, ExternalLink } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -2455,7 +2455,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         ref={sidebarRootRef}
         data-session-switch-hints={quickSwitchHintsVisible ? 'true' : undefined}
         className={cn(
-          'relative h-full flex flex-col items-center px-2',
+          'left-sidebar relative h-full flex flex-col items-center px-2',
           !noTransition && 'transition-[width] duration-300',
           isClassic
             ? 'bg-background rounded-2xl shadow-xl dark:shadow-md'
@@ -2672,7 +2672,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       ref={sidebarRootRef}
       data-session-switch-hints={quickSwitchHintsVisible ? 'true' : undefined}
       className={cn(
-        'relative h-full flex flex-col',
+        'left-sidebar relative h-full flex flex-col',
         !noTransition && 'transition-[width] duration-300',
         isClassic
           ? 'bg-background rounded-2xl shadow-xl dark:shadow-md'
@@ -4129,7 +4129,6 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   )
 
   const [renamingWorkspace, setRenamingWorkspace] = React.useState(false)
-  const [projectMenuOpen, setProjectMenuOpen] = React.useState(false)
   const [workspaceEditName, setWorkspaceEditName] = React.useState('')
   const workspaceEditRef = React.useRef<HTMLInputElement>(null)
   const justStartedRenamingRef = React.useRef(false)
@@ -4230,18 +4229,17 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         <div className="absolute -top-0.5 left-3 right-3 h-0.5 translate-x-[2px] rounded-full bg-primary z-10" />
       )}
 
-      <div className="group/project relative flex translate-x-[2px] items-center">
-        <span
-          draggable
-          onDragStart={(e) => onDragStart(e, group.workspace.id)}
-          title="拖拽排序"
-          className="absolute -left-0.5 top-1/2 z-10 flex size-[18px] -translate-y-1/2 cursor-grab items-center justify-center text-foreground/20 opacity-0 transition-opacity group-hover/project:opacity-100 active:cursor-grabbing"
-          aria-hidden="true"
-        >
-          <GripVertical size={12} />
-        </span>
-
-        {renamingWorkspace ? (
+      {renamingWorkspace ? (
+        <div className="group/project relative flex translate-x-[2px] items-center">
+          <span
+            draggable
+            onDragStart={(e) => onDragStart(e, group.workspace.id)}
+            title="拖拽排序"
+            className="absolute -left-0.5 top-1/2 z-10 flex size-[18px] -translate-y-1/2 cursor-grab items-center justify-center text-foreground/20 opacity-0 transition-opacity group-hover/project:opacity-100 active:cursor-grabbing"
+            aria-hidden="true"
+          >
+            <GripVertical size={12} />
+          </span>
           <div
             className={cn(
               'relative flex-1 min-w-0 flex items-center gap-1 pl-[9px] pr-1 py-1 rounded-md text-left titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11',
@@ -4261,7 +4259,22 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               maxLength={50}
             />
           </div>
-        ) : (
+        </div>
+      ) : (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <div
+              className="group/project relative flex translate-x-[2px] items-center titlebar-no-drag"
+            >
+              <span
+                draggable
+                onDragStart={(e) => onDragStart(e, group.workspace.id)}
+                title="拖拽排序"
+                className="absolute -left-0.5 top-1/2 z-10 flex size-[18px] -translate-y-1/2 cursor-grab items-center justify-center text-foreground/20 opacity-0 transition-opacity group-hover/project:opacity-100 active:cursor-grabbing"
+                aria-hidden="true"
+              >
+                <GripVertical size={12} />
+              </span>
           <button
             type="button"
             aria-expanded={!collapsed}
@@ -4315,108 +4328,224 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               />
             )}
           </button>
-        )}
 
-        {isCurrent && !isAutomationGroup && !projectMenuOpen && (
-          <ShortcutKeycaps
-            shortcutId="new-session"
-            className="pointer-events-none mr-6 !flex-nowrap flex-shrink-0 opacity-65 transition-opacity group-hover/project:opacity-0"
-            keycapClassName="h-4 min-w-4 rounded-[3px] border-border/60 px-0.5 text-[9px] shadow-none"
-            separatorClassName="text-[8px]"
-          />
-        )}
+          {isCurrent && !isAutomationGroup && (
+            <ShortcutKeycaps
+              shortcutId="new-session"
+              className="pointer-events-none mr-6 !flex-nowrap flex-shrink-0 opacity-65 transition-opacity group-hover/project:opacity-0"
+              keycapClassName="h-4 min-w-4 rounded-[3px] border-border/60 px-0.5 text-[9px] shadow-none"
+              separatorClassName="text-[8px]"
+            />
+          )}
 
-        {!isAutomationGroup && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={`在「${group.workspace.name}」中新建会话`}
-              onClick={(e) => {
-                e.stopPropagation()
-                void onNewSession(group.workspace.id)
-              }}
-              className="absolute right-0 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 titlebar-no-drag"
-            >
-              <Plus size={13} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            {`在此项目中新建会话${newSessionShortcutLabel ? ` (${newSessionShortcutLabel})` : ''}`}
-          </TooltipContent>
-        </Tooltip>
-        )}
+          {!isAutomationGroup && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={`在「${group.workspace.name}」中新建会话`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    void onNewSession(group.workspace.id)
+                  }}
+                  className="absolute right-0 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 titlebar-no-drag"
+                >
+                  <Plus size={13} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {`在此项目中新建会话${newSessionShortcutLabel ? ` (${newSessionShortcutLabel})` : ''}`}
+              </TooltipContent>
+            </Tooltip>
+          )}
 
-        {!isAutomationGroup && (
-        <DropdownMenu onOpenChange={setProjectMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label="项目菜单"
-              className="absolute right-5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 opacity-0 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/60 group-hover/project:opacity-100 data-[state=open]:opacity-100 titlebar-no-drag"
-            >
-              <MoreHorizontal size={13} />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-44 z-[9999] min-w-0 p-0.5">
-            <DropdownMenuItem
-              className="text-xs py-1 [&>svg]:size-3.5"
-              onSelect={() => onSelectProject(group.workspace.id)}
-            >
-              <FolderOpen size={14} />
-              设为当前项目
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-xs py-1 [&>svg]:size-3.5"
-              onSelect={handleStartWorkspaceRename}
-            >
-              <Pencil size={14} />
-              重命名
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-xs py-1 [&>svg]:size-3.5"
-              onSelect={() => onConfigureProject(group.workspace.id)}
-            >
-              <Settings size={14} />
-              配置 MCP 与 Skills
-            </DropdownMenuItem>
-            {hasUnavailableProjectRoot && (
-              <>
+          {!isAutomationGroup && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="项目菜单"
+                  className="absolute right-5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 opacity-0 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/60 group-hover/project:opacity-100 data-[state=open]:opacity-100 titlebar-no-drag"
+                >
+                  <MoreHorizontal size={13} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-44 z-[9999] min-w-0 p-0.5">
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={() => onSelectProject(group.workspace.id)}
+                >
+                  <FolderOpen size={14} />
+                  设为当前项目
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={handleStartWorkspaceRename}
+                >
+                  <Pencil size={14} />
+                  重命名
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={() => onConfigureProject(group.workspace.id)}
+                >
+                  <Settings size={14} />
+                  配置 MCP 与 Skills
+                </DropdownMenuItem>
                 <DropdownMenuSeparator className="my-0.5" />
                 <DropdownMenuItem
                   className="text-xs py-1 [&>svg]:size-3.5"
-                  onSelect={() => void onRelinkProjectRoot(group.workspace.id)}
+                  onSelect={async () => {
+                    const path = group.workspace.projectRootPath
+                      ?? await window.electronAPI.getWorkspaceFilesPath(group.workspace.slug)
+                    if (path) {
+                      await navigator.clipboard.writeText(path)
+                      toast.success('已复制项目路径')
+                    }
+                  }}
                 >
-                  <FolderInput size={14} />
-                  重新选择文件夹
+                  <Copy size={14} />
+                  复制项目路径
                 </DropdownMenuItem>
-                {group.workspace.projectRootStatus === 'missing' && (
-                  <DropdownMenuItem
-                    className="text-xs py-1 [&>svg]:size-3.5"
-                    onSelect={() => onRequestRestoreProjectRoot(group.workspace.id)}
-                  >
-                    <FolderPlus size={14} />
-                    在原路径新建空文件夹
-                  </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={async () => {
+                    const path = group.workspace.projectRootPath
+                      ?? await window.electronAPI.getWorkspaceFilesPath(group.workspace.slug)
+                    if (path) {
+                      window.electronAPI.showItemInFolder(path)
+                    }
+                  }}
+                >
+                  <ExternalLink size={14} />
+                  在文件管理器中打开
+                </DropdownMenuItem>
+                {hasUnavailableProjectRoot && (
+                  <>
+                    <DropdownMenuSeparator className="my-0.5" />
+                    <DropdownMenuItem
+                      className="text-xs py-1 [&>svg]:size-3.5"
+                      onSelect={() => void onRelinkProjectRoot(group.workspace.id)}
+                    >
+                      <FolderInput size={14} />
+                      重新选择文件夹
+                    </DropdownMenuItem>
+                    {group.workspace.projectRootStatus === 'missing' && (
+                      <DropdownMenuItem
+                        className="text-xs py-1 [&>svg]:size-3.5"
+                        onSelect={() => onRequestRestoreProjectRoot(group.workspace.id)}
+                      >
+                        <FolderPlus size={14} />
+                        在原路径新建空文件夹
+                      </DropdownMenuItem>
+                    )}
+                  </>
                 )}
-              </>
-            )}
-            <DropdownMenuSeparator className="my-0.5" />
-            <DropdownMenuItem
-              disabled={!canDeleteWorkspace}
-              className={cn(
-                'text-xs py-1 [&>svg]:size-3.5',
-                canDeleteWorkspace && 'text-destructive focus:text-destructive',
+                <DropdownMenuSeparator className="my-0.5" />
+                <DropdownMenuItem
+                  disabled={!canDeleteWorkspace}
+                  className={cn(
+                    'text-xs py-1 [&>svg]:size-3.5',
+                    canDeleteWorkspace && 'text-destructive focus:text-destructive',
+                  )}
+                  onSelect={() => onRequestDeleteWorkspace(group.workspace.id)}
+                >
+                  <Trash2 size={14} />
+                  删除项目
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+            </div>
+          </ContextMenuTrigger>
+          {!isAutomationGroup && (
+            <ContextMenuContent className="w-44 z-[9999] min-w-0 p-0.5">
+              <ContextMenuItem
+                className="text-xs py-1 [&>svg]:size-3.5"
+                onSelect={() => onSelectProject(group.workspace.id)}
+              >
+                <FolderOpen size={14} />
+                设为当前项目
+              </ContextMenuItem>
+              <ContextMenuItem
+                className="text-xs py-1 [&>svg]:size-3.5"
+                onSelect={handleStartWorkspaceRename}
+              >
+                <Pencil size={14} />
+                重命名
+              </ContextMenuItem>
+              <ContextMenuItem
+                className="text-xs py-1 [&>svg]:size-3.5"
+                onSelect={() => onConfigureProject(group.workspace.id)}
+              >
+                <Settings size={14} />
+                配置 MCP 与 Skills
+              </ContextMenuItem>
+              <ContextMenuSeparator className="my-0.5" />
+              <ContextMenuItem
+                className="text-xs py-1 [&>svg]:size-3.5"
+                onSelect={async () => {
+                  const path = group.workspace.projectRootPath
+                    ?? await window.electronAPI.getWorkspaceFilesPath(group.workspace.slug)
+                  if (path) {
+                    await navigator.clipboard.writeText(path)
+                    toast.success('已复制项目路径')
+                  }
+                }}
+              >
+                <Copy size={14} />
+                复制项目路径
+              </ContextMenuItem>
+              <ContextMenuItem
+                className="text-xs py-1 [&>svg]:size-3.5"
+                onSelect={async () => {
+                  const path = group.workspace.projectRootPath
+                    ?? await window.electronAPI.getWorkspaceFilesPath(group.workspace.slug)
+                  if (path) {
+                    window.electronAPI.showItemInFolder(path)
+                  }
+                }}
+              >
+                <ExternalLink size={14} />
+                在文件管理器中打开
+              </ContextMenuItem>
+              {hasUnavailableProjectRoot && (
+                <>
+                  <ContextMenuSeparator className="my-0.5" />
+                  <ContextMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => void onRelinkProjectRoot(group.workspace.id)}
+                  >
+                    <FolderInput size={14} />
+                    重新选择文件夹
+                  </ContextMenuItem>
+                  {group.workspace.projectRootStatus === 'missing' && (
+                    <ContextMenuItem
+                      className="text-xs py-1 [&>svg]:size-3.5"
+                      onSelect={() => onRequestRestoreProjectRoot(group.workspace.id)}
+                    >
+                      <FolderPlus size={14} />
+                      在原路径新建空文件夹
+                    </ContextMenuItem>
+                  )}
+                </>
               )}
-              onSelect={() => onRequestDeleteWorkspace(group.workspace.id)}
-            >
-              <Trash2 size={14} />
-              删除项目
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        )}
-      </div>
+              <ContextMenuSeparator className="my-0.5" />
+              <ContextMenuItem
+                disabled={!canDeleteWorkspace}
+                className={cn(
+                  'text-xs py-1 [&>svg]:size-3.5',
+                  canDeleteWorkspace && 'text-destructive focus:text-destructive',
+                )}
+                onSelect={() => onRequestDeleteWorkspace(group.workspace.id)}
+              >
+                <Trash2 size={14} />
+                删除项目
+              </ContextMenuItem>
+            </ContextMenuContent>
+          )}
+        </ContextMenu>
+      )}
 
       <div id={`project-sessions-${group.workspace.id}`} className="ml-4 mt-px">
         {!collapsed ? (

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2438,3 +2438,17 @@
 .ProseMirror-focused .ProseMirror-gapcursor {
   display: block;
 }
+
+/* ===== 左侧栏字号放大 =====
+ * 侧边栏内大量使用 text-[10px] ~ text-[13px] 等绝对像素值，
+ * 整体偏小。以下规则统一放大 +2px，提升可读性。
+ */
+.left-sidebar {
+  font-size: 14px;
+}
+.left-sidebar .text-\[10px\] { font-size: 12px !important; }
+.left-sidebar .text-\[11px\] { font-size: 13px !important; }
+.left-sidebar .text-\[12px\] { font-size: 14px !important; }
+.left-sidebar .text-\[13px\] { font-size: 15px !important; }
+.left-sidebar .text-xs { font-size: 13px !important; }
+.left-sidebar .text-sm { font-size: 15px !important; }


### PR DESCRIPTION
## Summary

Two commits made today (2026-08-05), relative to upstream `main`:

### 1. Sidebar UI customization (LeftSidebar.tsx + globals.css)
- **Project context menu (right-click)**: right-click on a project/workspace in the sidebar now opens a context menu with: Set as current project, Rename, Configure MCP & Skills, Copy project path, Open in file manager, Re-select folder, and Delete project (mirrors the existing "..." dropdown menu).
- **Copy project path** and **Open in file manager** actions added to both the dropdown and context menus.
- **Sidebar font scaling**: `.left-sidebar` scoped CSS rules enlarge text sizes by +2px (e.g. `text-[10px]` → 12px, `text-xs` → 13px, `text-sm` → 15px) to improve readability on the left sidebar.

### 2. Windows agent-island fixes (agent-island.css)
- Floating island now uses `border-radius: 18px`.
- Fixes a Windows-specific issue where, in a transparent BrowserWindow, pixels outside the border-radius still showed the desktop through the corners — the root container now matches the surface's background and radius with `overflow: hidden`.
- Root container height is set to `auto` to prevent the collapsed-state "double UI overlap" bug (the transparent window being taller than the surface, filling the bottom with a solid background).
- Small-text clipping fix: bumped `line-height` to `1.2` and added `padding-top: 1px` for header text elements.

## Files changed
- `apps/electron/src/renderer/components/agent-island/agent-island.css`
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
- `apps/electron/src/renderer/styles/globals.css`

---

### 中文摘要
今天对桌面端做的两处改动：
1. 侧边栏 UI 定制——项目右键菜单（设为当前项目/重命名/配置 MCP 与 Skills/复制路径/在文件管理器中打开/删除项目）、侧边栏字号放大 +2px；
2. Windows 灵动岛修复——圆角、透明窗口四角透出桌面、收起态双重 UI 重叠、小字号裁剪等问题的修复。
