### PR TITLE
【已审核】fix(agent): 附加文件/文件夹类型选择改用 Proma 自身弹窗

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2950,11 +2950,11 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 打开支持文件与文件夹混合选择的 Composer 对话框
+  // 打开文件或文件夹选择对话框（类型由渲染层 Dialog 决定）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.OPEN_FILE_OR_FOLDER_DIALOG,
-    async (): Promise<FileOrFolderDialogResult> => {
-      return openFileOrFolderDialog()
+    async (_, type: 'file' | 'folder'): Promise<FileOrFolderDialogResult> => {
+      return openFileOrFolderDialog(type)
     }
   )
 

--- a/apps/electron/src/main/lib/attachment-service.ts
+++ b/apps/electron/src/main/lib/attachment-service.ts
@@ -340,37 +340,22 @@ export async function openFileDialog(): Promise<FileDialogResult> {
 }
 
 /**
- * 打开 Agent Composer 的混合选择对话框。
- * 文件按附件语义读取，文件夹只返回路径，交由会话目录授权流程处理。
+ * 打开 Agent Composer 的内容选择对话框。
+ * 类型选择由渲染层用 Proma 自身 Dialog 完成（见 AttachmentContentDialog），
+ * 此处按调用方指定的类型直接打开对应系统选择器：
+ * - 'file'：文件选择器，文件按附件语义读取
+ * - 'folder'：文件夹选择器，目录只返回路径，交由会话目录授权流程处理
  */
-export async function openFileOrFolderDialog(): Promise<FileOrFolderDialogResult> {
+export async function openFileOrFolderDialog(type: 'file' | 'folder'): Promise<FileOrFolderDialogResult> {
+  // 运行时守卫：非法类型直接拒绝，避免被静默当作 'folder' 处理
+  if (type !== 'file' && type !== 'folder') {
+    throw new Error(`无效的附加内容类型: ${String(type)}`)
+  }
   const parentWindow = BrowserWindow.getFocusedWindow()
-  let dialogOptions: Electron.OpenDialogOptions
-
-  if (process.platform === 'win32' || process.platform === 'linux') {
-    const choiceOptions: Electron.MessageBoxOptions = {
-      type: 'question',
-      title: '附加文件或文件夹',
-      message: '请选择要附加的内容类型',
-      buttons: ['文件', '文件夹', '取消'],
-      defaultId: 0,
-      cancelId: 2,
-      noLink: true,
-    }
-    const choice = parentWindow
-      ? await dialog.showMessageBox(parentWindow, choiceOptions)
-      : await dialog.showMessageBox(choiceOptions)
-    if (choice.response === 2) return { files: [], directories: [] }
-
-    dialogOptions = choice.response === 0
+  const dialogOptions: Electron.OpenDialogOptions =
+    type === 'file'
       ? { properties: ['openFile', 'multiSelections'], filters: FILE_FILTERS, title: '附加文件' }
       : { properties: ['openDirectory', 'multiSelections'], title: '附加文件夹' }
-  } else {
-    dialogOptions = {
-      properties: ['openFile', 'openDirectory', 'multiSelections'],
-      title: '附加文件或文件夹',
-    }
-  }
 
   const result = parentWindow
     ? await dialog.showOpenDialog(parentWindow, dialogOptions)
@@ -382,6 +367,6 @@ export async function openFileOrFolderDialog(): Promise<FileOrFolderDialogResult
 
   const directories: FileDialogDirectory[] = []
   const fileResult = readDialogFiles(result.filePaths, directories)
-  console.log(`[附件服务] 混合对话框选择了 ${fileResult.files.length} 个内存附件，${fileResult.largeFiles?.length ?? 0} 个大文件引用，${directories.length} 个目录，${fileResult.skippedFiles?.length ?? 0} 个跳过`)
+  console.log(`[附件服务] ${type === 'file' ? '文件' : '文件夹'}对话框选择了 ${fileResult.files.length} 个内存附件，${fileResult.largeFiles?.length ?? 0} 个大文件引用，${directories.length} 个目录，${fileResult.skippedFiles?.length ?? 0} 个跳过`)
   return { ...fileResult, directories }
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -750,8 +750,8 @@ export interface ElectronAPI {
   /** 打开文件夹选择对话框 */
   openFolderDialog: () => Promise<{ path: string; name: string } | null>
 
-  /** 打开支持文件与文件夹混合选择的 Composer 对话框 */
-  openFileOrFolderDialog: () => Promise<FileOrFolderDialogResult>
+  /** 打开支持文件与文件夹混合选择的 Composer 对话框（类型由渲染层 Dialog 决定） */
+  openFileOrFolderDialog: (type: 'file' | 'folder') => Promise<FileOrFolderDialogResult>
 
   /** 附加外部目录到 Agent 会话 */
   attachDirectory: (input: AgentAttachDirectoryInput) => Promise<string[]>
@@ -2031,8 +2031,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FOLDER_DIALOG)
   },
 
-  openFileOrFolderDialog: () => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FILE_OR_FOLDER_DIALOG)
+  openFileOrFolderDialog: (type: 'file' | 'folder') => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FILE_OR_FOLDER_DIALOG, type)
   },
 
   attachDirectory: (input: AgentAttachDirectoryInput) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -19,6 +19,7 @@ import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
 import { Box, CornerDownLeft, Square, Settings, X, Copy, Check, Brain, Sparkles, ChevronDown, ListTodo, Paperclip } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
+import { AttachmentContentDialog } from './AttachmentContentDialog'
 import { AgentHeader } from './AgentHeader'
 import { AgentMessageQueue } from './AgentMessageQueue'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -1706,10 +1707,23 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [addLargeDialogFilesAsReferences, setPendingFiles])
 
-  /** 打开混合选择器：文件作为附件，文件夹仅授权给当前会话。 */
-  const handleAttachContent = React.useCallback(async (): Promise<void> => {
+  /** Composer 附加内容类型选择弹窗（替代系统原生 MessageBox）是否打开 */
+  const [attachContentDialogOpen, setAttachContentDialogOpen] = React.useState(false)
+  /** 重入锁：防止退出动画期间双击“文件/文件夹”重复打开系统选择器 */
+  const attachContentBusyRef = React.useRef(false)
+
+  /** 打开混合选择器：先弹 Proma 自身类型选择弹窗，文件作为附件，文件夹仅授权给当前会话。 */
+  const handleAttachContent = React.useCallback((): void => {
+    setAttachContentDialogOpen(true)
+  }, [])
+
+  /** 按用户选择的类型打开系统选择器，并复用原有附件/目录处理逻辑。 */
+  const handleAttachContentType = React.useCallback(async (type: 'file' | 'folder'): Promise<void> => {
+    if (attachContentBusyRef.current) return
+    attachContentBusyRef.current = true
+    setAttachContentDialogOpen(false)
     try {
-      const result = await window.electronAPI.openFileOrFolderDialog()
+      const result = await window.electronAPI.openFileOrFolderDialog(type)
       const largeFiles = result.largeFiles ?? []
       const skippedFiles = result.skippedFiles ?? []
       if (result.files.length === 0 && largeFiles.length === 0 && skippedFiles.length === 0 && result.directories.length === 0) return
@@ -1745,6 +1759,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     } catch (error) {
       console.error('[AgentView] 附加内容选择失败:', error)
       toast.error('附加文件或文件夹失败')
+    } finally {
+      attachContentBusyRef.current = false
     }
   }, [addDialogFilesAsAttachments, sessionId, setAttachedDirsMap])
 
@@ -2964,7 +2980,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               variant="ghost"
               size="icon"
               className={inputToolbarButtonClass}
-              onClick={() => void handleAttachContent()}
+              onClick={handleAttachContent}
               aria-label="附加文件或文件夹"
             >
               <Paperclip className="size-[17px]" />
@@ -3264,6 +3280,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         )}
       </div>
     </AgentSessionProvider>
+
+    <AttachmentContentDialog
+      open={attachContentDialogOpen}
+      onOpenChange={setAttachContentDialogOpen}
+      onSelect={(type) => void handleAttachContentType(type)}
+    />
 
     <Dialog open={todoDialogOpen} onOpenChange={setTodoDialogOpen}>
       <DialogContent className="max-w-lg">

--- a/apps/electron/src/renderer/components/agent/AttachmentContentDialog.tsx
+++ b/apps/electron/src/renderer/components/agent/AttachmentContentDialog.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { FileText, Folder } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface AttachmentContentDialogProps {
+  /** 是否显示弹窗（受控） */
+  open: boolean
+  /** 打开状态变化回调（取消/关闭时传 false） */
+  onOpenChange: (open: boolean) => void
+  /** 用户选择附加类型后回调 */
+  onSelect: (type: 'file' | 'folder') => void
+}
+
+/**
+ * Composer 附加内容类型选择弹窗。
+ * 替代原先主进程的系统原生 MessageBox，保持 Proma 自身 UI 风格。
+ */
+export function AttachmentContentDialog({
+  open,
+  onOpenChange,
+  onSelect,
+}: AttachmentContentDialogProps): React.ReactElement {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>附加文件或文件夹</DialogTitle>
+          <DialogDescription>请选择要附加的内容类型</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            取消
+          </Button>
+          {/* 文件为默认操作：焦点（autoFocus）、Enter 默认触发、视觉主按钮三者统一 */}
+          <Button type="button" variant="default" autoFocus onClick={() => onSelect('file')}>
+            <FileText className="size-4" />
+            文件
+          </Button>
+          <Button type="button" variant="outline" onClick={() => onSelect('folder')}>
+            <Folder className="size-4" />
+            文件夹
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1652,7 +1652,7 @@ export const AGENT_IPC_CHANNELS = {
   GET_WORKSPACE_FILES_PATH: 'agent:get-workspace-files-path',
   /** 打开文件夹选择对话框 */
   OPEN_FOLDER_DIALOG: 'agent:open-folder-dialog',
-  /** 打开支持文件与文件夹混合选择的 Composer 对话框 */
+  /** 打开文件或文件夹选择对话框（类型由渲染层 Dialog 决定） */
   OPEN_FILE_OR_FOLDER_DIALOG: 'agent:open-file-or-folder-dialog',
   /** 附加外部目录到 Agent 会话 */
   ATTACH_DIRECTORY: 'agent:attach-directory',


### PR DESCRIPTION
## 概述

Composer 输入工具栏的「附加文件或文件夹」按钮在 Windows/Linux 上会先弹出 Electron 系统原生 MessageBox（dialog.showMessageBox）选择"文件/文件夹"类型，再打开系统文件选择器——系统弹窗与 Proma 自身 UI 风格割裂（Windows 原生对话框外观）。本 PR 将类型选择移到渲染层，用 Proma 自己的 Dialog（新增 AttachmentContentDialog）完成，主进程按类型直接打开对应系统选择器，体验统一。

## 改动

- `apps/electron/src/main/lib/attachment-service.ts`：`openFileOrFolderDialog(type: 'file' | 'folder')` 改为必传类型，删除系统 MessageBox 分支，按类型直接打开多选选择器（file：openFile+multiSelections+FILE_FILTERS；folder：openDirectory+multiSelections）；新增运行时 type 守卫，防止非法值被静默当作 folder
- `apps/electron/src/main/ipc.ts`：handler 透传 type
- `apps/electron/src/preload/index.ts`：API 签名加 type 参数并透传
- `apps/electron/src/renderer/components/agent/AgentView.tsx`：`handleAttachContent` 改为打开 Proma 类型弹窗；新增 `handleAttachContentType`（含双击重入锁，防止退出动画期间连点重复打开选择器）；附件/目录处理逻辑逐字复用原实现
- `apps/electron/src/renderer/components/agent/AttachmentContentDialog.tsx`（新增）：Proma 风格类型选择弹窗——标题「附加文件或文件夹」、DialogDescription「请选择要附加的内容类型」、三个按钮（取消 ghost / 文件 default+autoFocus / 文件夹 outline），文件为默认操作（与原系统 MessageBox defaultId=0 语义一致）
- `packages/shared/src/types/agent.ts`：通道注释同步为"类型由渲染层 Dialog 决定"

## 测试

- `bun run typecheck`：全部 6 包 exit 0
- BDD 自审（4 个独立角度子会话并行）：正确性/安全/边界、UX/a11y/主题、平台布局/回归、代码质量/一致性，均通过；审查发现项已修复（双击重入锁、焦点与视觉主按钮统一、组件惯例 named export、注释同步）
- Playwright 模拟验证：Proma 亮/暗主题弹窗与系统 MessageBox 视觉对比，风格统一协调
- 未做 Windows 实时 UI 验证（需人工 `bun run dev` 确认弹窗外观与交互链路）

## 紧急度

常规

## 备注

- **macOS 行为变化（有意取舍）**：原先 macOS 一步混合选择文件+文件夹（openFile+openDirectory），现统一为先选类型再打开对应选择器；附带收益是 macOS 文件模式现在也带 FILE_FILTERS 过滤
- 文件多选、文件夹多选、大文件引用、跳过提示等原有行为全部保留
- 无关联 upstream issue
