### PR TITLE
【已审核】fix(tabs): Windows 上 FAQ/快捷键按钮不再悬浮遮挡预览页面

### DIFF
--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -28,6 +28,7 @@ import {
   unviewedCompletedSessionIdsAtom,
 } from '@/atoms/agent-atoms'
 import { appModeAtom } from '@/atoms/app-mode'
+import { activeViewAtom } from '@/atoms/active-view'
 import { automationFormAtom } from '@/atoms/automation-atoms'
 import { tearOffPreviewToSplit } from '@/components/diff/preview-opener'
 import { tearOffScratchToSplit } from '@/components/scratch-pad/scratch-pad-opener'
@@ -232,6 +233,20 @@ function TabBarInner({
   // 该按钮的 absolute 定位与 DiffPanelTabBar.PanelRightClose 的 mr-1 mb-[3px] 坐标耦合，
   // 若右侧关闭按钮样式变化，这里需同步调整。
   const [isPanelOpen, setSidePanelOpen] = useAtom(agentSidePanelOpenAtom)
+
+  // 右侧 Agent 文件面板是否实际渲染并展开（= 是否让 TabBar 右缘缩进到面板左缘）。
+  // 与 AppShell 的 showRightPanel 判断保持一致，且需面板展开（isPanelOpen）才真正缩进。
+  const appMode = useAtomValue(appModeAtom)
+  const automationForm = useAtomValue(automationFormAtom)
+  const activeView = useAtomValue(activeViewAtom)
+  const currentAgentSessionId = useAtomValue(currentAgentSessionIdAtom)
+  const tabbarRightCollapsed =
+    appMode === 'agent'
+    && !!currentAgentSessionId
+    && !automationForm.open
+    && activeView !== 'planning'
+    && activeView !== 'agent-skills'
+    && isPanelOpen
   const setShortcutGuideOpen = useSetAtom(shortcutGuideOpenAtom)
   const setFaqDialogOpen = useSetAtom(faqDialogOpenAtom)
   const activeTab = React.useMemo(() => tabs.find((t) => t.id === activeTabId), [tabs, activeTabId])
@@ -430,6 +445,7 @@ function TabBarInner({
       <ShortcutGuideButton
         isWindows={isWindows}
         hasPanelButton={showOpenPanelButton}
+        tabbarRightCollapsed={tabbarRightCollapsed}
         onOpen={openShortcutGuide}
         onOpenFaq={openFaqDialog}
       />
@@ -446,21 +462,26 @@ function TabBarInner({
 function ShortcutGuideButton({
   isWindows,
   hasPanelButton,
+  tabbarRightCollapsed,
   onOpen,
   onOpenFaq,
 }: {
   isWindows: boolean
   hasPanelButton: boolean
+  /** TabBar 右缘是否被右侧 Agent 文件面板缩进（面板实际渲染且展开） */
+  tabbarRightCollapsed: boolean
   onOpen: () => void
   onOpenFaq: () => void
 }): React.ReactElement {
   return (
     <div
       className={cn(
-        "absolute flex items-center gap-1 titlebar-no-drag",
+        "absolute flex items-center gap-1 titlebar-no-drag inset-y-0 items-end pb-[3px] z-10 transition-[right] duration-200 ease-in-out",
+        // Windows：TabBar 右缘缩进时贴右缘（right-1，右侧就是面板，无空带）；否则避开 WindowControls（right-[126px]）。
+        // 不能用 fixed：面板（z-[60]）与 MainArea（z-[60]）同级且 DOM 靠后，fixed 子元素无法越过父容器层级盖住面板。
         isWindows
-          ? cn("top-[37px] h-7 z-[52]", hasPanelButton ? "right-9" : "right-1")
-          : cn("inset-y-0 items-end pb-[3px] z-10", hasPanelButton ? "right-9" : "right-1"),
+          ? (tabbarRightCollapsed ? "right-1" : WINDOW_CONTROLS_INSET_RIGHT)
+          : (hasPanelButton ? "right-9" : "right-1"),
       )}
     >
       {/* FAQ 快捷按钮（在快捷键地图左边） */}


### PR DESCRIPTION
## 概述

Windows 平台 TabBar 右上角「查看常见问题」「查看快捷键地图」两个按钮（ShortcutGuideButton），原先为避开右上角 WindowControls（Proma 自绘最小化/最大化/关闭，占右缘 126px）而下移到 TabBar 下方（top-[37px]）悬浮在内容区，与 preview 页（PreviewTabContent → DiffTabContent）顶部工具栏右侧按钮重叠，点击会互相干扰。本 PR 将按钮放回 TabBar 内部（inset-y-0 items-end pb-[3px]），水平位置复用 WINDOW_CONTROLS_INSET_RIGHT（right-[126px]）让出 WindowControls，不再悬浮遮挡内容区，与非 Windows 平台布局一致。

## 改动

- `apps/electron/src/renderer/components/tabs/TabBar.tsx`：
  - ShortcutGuideButton Windows 定位改为**感知右侧面板状态**：面板实际渲染并展开（TabBar 右缘缩进到面板左缘）时贴 TabBar 右缘（`right-1`），否则避开 WindowControls（`right-[126px]`），两种位置间有 `transition-[right] duration-200` 平滑衔接
  - 面板状态判断与 AppShell 的 `showRightPanel` 保持一致（appMode=agent + 有会话 + 非 planning/agent-skills + 非定时任务表单），且要求面板展开（`agentSidePanelOpenAtom`）
  - 按钮逻辑/图标/Tooltip 未动；非 Windows 定位不变

## 修复的三个问题

1. **悬浮遮挡预览页**：原 Windows 定位 `top-[37px]` 使按钮悬浮在 TabBar 下方内容区，与 preview 页（DiffTabContent）顶部工具栏按钮重叠
2. **右侧面板打开时按钮与 WindowControls 之间出现大片空白**：原 `absolute right-[126px]` 相对 TabBar 右缘，而右侧文件面板打开时 TabBar 右缘缩进到面板左缘（WindowControls 是 fixed 在窗口右上角）——按钮与右上角系统按钮之间隔出面板宽度空白带。改为感知面板状态：面板打开时按钮贴 TabBar 右缘（右侧即面板，无空白带）
3. **面板状态误判导致与 WindowControls 重叠**：曾尝试 fixed 定位贴窗口右缘，但面板（z-[60]）与 MainArea（z-[60]）同级且 DOM 靠后，fixed 子元素无法越过父容器层级盖住面板（按钮被面板遮挡）；且 isPanelOpen atom（默认 true）不等于面板实际渲染，非 Agent 视图下会造成与 WindowControls 重叠。最终采用面板状态感知的 absolute 定位，按钮始终在 TabBar 带内、与面板水平不重叠，无需竞争 z-index

## 测试

- `bun run typecheck`：全部 6 包 exit 0
- BDD 自审（独立 review 子会话）：approve
- Playwright 模拟验证（几何数据 + 视觉双确认）：
  - 修复前（absolute 相对 TabBar 右缘）：面板打开时按钮距窗口右缘 494px（126 预留 + 368 面板宽），与预览工具栏重叠 28×28
  - 修复后（面板状态感知）：非 Agent/面板收起 → 按钮在 `right-126` 避开 WindowControls 不重叠；Agent+面板展开 → 按钮贴 TabBar 右缘（面板左缘）无空白带；面板收起/展开切换有 `transition-[right]` 平滑动画
  - 滚动区 padding-right 滚动到底时保持空隙可见、内容右缘与按钮左缘零重叠（浏览器实测）
- 已在 Windows dev 实测：三种状态（非 Agent / Agent+面板开 / Agent+面板关）均无重叠、无空白带、衔接平滑

## 紧急度

常规

## 备注

- **已知限制（已登记代码注释）**：Windows 下多标签溢出并滚动到底时，最右标签右端可能被带内按钮（z-10）遮挡，与非 Windows 既有模式同源；如需彻底避免需将按钮改为文档流布局（flex 兄弟），暂不处理
- 非 Windows 布局零回归（分支字符串与改动前逐字一致）
- 无关联 upstream issue
