### PR TITLE
fix(shortcuts): support file panel toggle in preview tabs

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.16.39",
+  "version": "0.16.40",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -210,6 +210,11 @@ export function isPreviewTab(tab: TabItem): boolean {
   return tab.type === 'preview' || tab.id.startsWith(PREVIEW_TAB_PREFIX)
 }
 
+/** Agent 会话及其归属的文件预览 Tab 都可操作 Agent 侧面板。 */
+export function isAgentContextTab(tab: TabItem | undefined): boolean {
+  return tab?.type === 'agent' || (tab !== undefined && isPreviewTab(tab))
+}
+
 function isSessionTab(tab: TabItem): boolean {
   return tab.type === 'chat' || tab.type === 'agent'
 }

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -15,6 +15,7 @@ import {
   tabsAtom,
   activeTabIdAtom,
   tabIndicatorMapAtom,
+  isAgentContextTab,
 } from '@/atoms/tab-atoms'
 import type { TabItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -228,7 +229,8 @@ function TabBarInner({
   const fadeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const isWindows = React.useMemo(() => detectIsWindows(), [])
 
-  // 文件面板切换（全局共享）：活动 Tab 是 Agent 且面板关闭时，在 TabBar 右上角展示"打开"按钮。
+  // 文件面板切换（全局共享）：Agent 会话及其归属的预览 Tab 都可切换面板；
+  // 仅 Agent 会话 Tab 在面板关闭时展示右上角"打开"按钮。
   // 该按钮的 absolute 定位与 DiffPanelTabBar.PanelRightClose 的 mr-1 mb-[3px] 坐标耦合，
   // 若右侧关闭按钮样式变化，这里需同步调整。
   const [isPanelOpen, setSidePanelOpen] = useAtom(agentSidePanelOpenAtom)
@@ -238,7 +240,7 @@ function TabBarInner({
   const showOpenPanelButton = !isPanelOpen && activeTab?.type === 'agent'
 
   const togglePanel = React.useCallback(() => {
-    if (activeTab?.type !== 'agent') return
+    if (!isAgentContextTab(activeTab)) return
     setSidePanelOpen((v) => !v)
   }, [setSidePanelOpen, activeTab])
 


### PR DESCRIPTION
## Summary

- 允许文件预览 Tab 继承所属 Agent 会话的文件面板快捷键上下文。
- 现在在预览 Tab 按下 Cmd+Shift+B 也会切换对应会话的文件面板状态。

## Test plan

- [x] `bun run typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)