### PR TITLE
fix(agent): expose files beyond session attachments

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -450,6 +450,9 @@ function isPathAllowed(filePath: string, options?: FileAccessOptions): boolean {
   } catch {
     return false
   }
+  // 文件面板应反映 Agent 实际可访问的路径。调用方已明确开启 unrestricted 时，
+  // 保留 realpath 校验以拒绝不存在的目标，但不再按会话附件重复收窄范围。
+  if (options?.unrestricted) return true
   return getAuthorizedRoots(options).some((root) => isUnderRoot(resolved, root))
 }
 
@@ -461,6 +464,7 @@ function normalizeFileAccessOptions(value?: FileAccessOptions | string[]): FileA
     candidateBasePaths: Array.isArray(value.candidateBasePaths)
       ? value.candidateBasePaths.filter((p): p is string => typeof p === 'string' && p.length > 0)
       : undefined,
+    unrestricted: value.unrestricted === true,
   }
 }
 
@@ -3321,11 +3325,11 @@ export function registerIpcHandlers(): void {
   // 使用 macOS 系统 Terminal 在指定工作目录打开会话/工作区文件夹
   ipcMain.handle(
     AGENT_IPC_CHANNELS.OPEN_FOLDER_IN_TERMINAL,
-    async (_, folderPath: string): Promise<void> => {
+    async (_, folderPath: string, access?: FileAccessOptions): Promise<void> => {
       if (process.platform !== 'darwin') {
         throw new Error('当前仅支持在 macOS 终端中打开文件夹')
       }
-      if (!isPathAllowed(folderPath)) {
+      if (!isPathAllowed(folderPath, normalizeFileAccessOptions(access))) {
         throw new Error('访问路径超出当前会话的授权范围')
       }
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -840,7 +840,7 @@ export interface ElectronAPI {
   showInFolder: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<void>
 
   /** 使用系统终端打开文件夹 */
-  openFolderInTerminal: (folderPath: string) => Promise<void>
+  openFolderInTerminal: (folderPath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<void>
 
   /** 在系统文件管理器中显示文件（无工作区限制，支持候选基础目录） */
   showItemInFolder: (filePath: string, candidateBasePaths?: string[]) => Promise<boolean>
@@ -2169,8 +2169,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SHOW_IN_FOLDER, filePath, access)
   },
 
-  openFolderInTerminal: (folderPath: string) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FOLDER_IN_TERMINAL, folderPath)
+  openFolderInTerminal: (folderPath: string, access?: import('@proma/shared').FileAccessOptions) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FOLDER_IN_TERMINAL, folderPath, access)
   },
 
   /** 在系统文件管理器中显示文件（无工作区限制，支持候选基础目录） */

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -140,7 +140,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     && currentWorkspace.projectRootStatus
     && currentWorkspace.projectRootStatus !== 'available',
   )
-  const fileAccess = React.useMemo(() => ({ sessionId }), [sessionId])
+  // 文件面板展示的是 Agent 实际操作的文件系统，不能再被会话附件范围二次截断。
+  const fileAccess = React.useMemo(() => ({ sessionId, unrestricted: true }), [sessionId])
 
   // 附加目录列表（会话级）
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -460,7 +460,7 @@ function NonGitFileList({
                 <button
                   type="button"
                   aria-label="在文件夹中显示"
-                  onClick={() => window.electronAPI.showInFolder(change.path, { sessionId }).catch(console.error)}
+                  onClick={() => window.electronAPI.showInFolder(change.path, { sessionId, unrestricted: true }).catch(console.error)}
                   className="mr-1 flex size-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground"
                 >
                   <FolderSearch className="size-3.5" />

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -546,6 +546,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   const fileAccess = React.useMemo(() => ({
     sessionId,
+    // 预览必须覆盖 Agent 实际操作的外部文件，与右侧文件面板保持一致。
+    unrestricted: true,
     // 历史工具调用的预览仅有相对 filePath；以当前 dirPath（通常是会话 CWD）补全解析上下文。
     // 绝对路径不追加该回退，避免失效路径按同名文件误命中会话目录。
     candidateBasePaths: getPreviewCandidateBasePaths(basePaths, isAbsoluteFilePath(filePath) ? undefined : dirPath),

--- a/apps/electron/src/renderer/components/diff/preview-open-path.ts
+++ b/apps/electron/src/renderer/components/diff/preview-open-path.ts
@@ -54,6 +54,8 @@ export function getPreviewFileAccess(
 ): FileAccessOptions {
   return {
     sessionId,
+    // 与右侧文件面板一致：预览 Agent 实际操作过的外部路径不受附件白名单限制。
+    unrestricted: true,
     candidateBasePaths: getPreviewCandidateBasePaths(
       file.basePaths,
       file.gitRoot,

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -252,8 +252,8 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
 
   /** 在系统终端中打开文件夹 */
   const handleOpenInTerminal = React.useCallback((entry: FileEntry) => {
-    window.electronAPI.openFolderInTerminal(entry.path).catch(console.error)
-  }, [])
+    window.electronAPI.openFolderInTerminal(entry.path, access).catch(console.error)
+  }, [access])
 
   /** 开始重命名 */
   const handleStartRename = React.useCallback((entry: FileEntry) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -648,31 +648,12 @@ export function useGlobalAgentListeners(): void {
         }
       }
 
-      // 检查文件是否落在当前会话的 diff scope 内（与 getUnstagedChanges 的 candidates 对齐）
-      // 注：未纳入 dirPath，因为 DiffChangesList 调用时 dirPath 始终等于 sessionPath
-      // 路径分隔符统一为正斜杠，避免 Windows 下 client 与服务端（path.sep='\\'）方向不一致导致反向错配
-      const toForwardSlash = (p: string) => p.replace(/\\/g, '/')
-      const sessionScopePaths = uniqueTruthyPaths([
-        sessionPath,
-        workspaceFilesPath,
-        ...sessionAttachedDirs,
-        ...workspaceAttachedDirs,
-      ]).map(toForwardSlash)
-      const absTarget = toForwardSlash(
-        isAbsolutePath(targetPath)
-          ? targetPath
-          : (sessionPath ? `${sessionPath.replace(/[/\\]+$/, '')}/${targetPath}` : targetPath)
-      )
-      const inDiffScope = sessionScopePaths.some((root) => {
-        const r = root.replace(/\/+$/, '') + '/'
-        return absTarget === root || absTarget.startsWith(r)
-      })
-
+      // 右侧改动面板应记录 Agent 实际写入的所有路径；会话附件只约束初始上下文，
+      // 不应让已完成的外部文件操作从用户可见的变更记录中消失。
       return {
         filePath: targetPath,
         dirPath: dirPath || undefined,
         previewOnly,
-        inDiffScope,
         basePaths: basePaths.length > 0 ? basePaths : undefined,
       }
     }
@@ -965,7 +946,7 @@ export function useGlobalAgentListeners(): void {
               })
               if (writtenPath) {
                 buildWrittenFilePreviewInfo(sessionId, writtenPath).then((previewFile) => {
-                  if (!previewFile || !previewFile.inDiffScope) return
+                  if (!previewFile) return
 
                   store.set(agentDiffUnseenChangesAtom, (prev) => {
                     const m = new Map(prev); m.set(sessionId, true); return m

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -207,6 +207,11 @@ export interface FileAccessOptions {
   workspaceSlug?: string
   /** 路径解析候选目录；主进程会先过滤到已授权目录内再使用 */
   candidateBasePaths?: string[]
+  /**
+   * 文件面板以 Agent 实际可操作的文件系统为准，不再按会话附件二次收窄。
+   * 启用后，调用方可以操作任意已存在的本地路径。
+   */
+  unrestricted?: boolean
 }
 
 /** 已授权本地文件的 proma-file URL */


### PR DESCRIPTION
## Summary
- Allow the right-side file panel and previews to operate on Agent-accessible local paths beyond session attachments.
- Surface Agent writes outside session/project attachment roots in the session change list.
- Pass the expanded access context to Finder and Terminal actions.

## Validation
- `bun run --filter=@proma/electron typecheck`
- `bun run --filter=@proma/electron build:main`
- `bun run --filter=@proma/electron build:preload`
- `bun run --filter=@proma/electron build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
