### PR TITLE
fix(release): fail mac builds after exhausted retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,18 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           for i in 1 2 3; do
-            npx electron-builder --mac --arm64 --publish always && break
-            echo "Attempt $i failed, retrying in 10s..."
-            sleep 10
+            if npx electron-builder --mac --arm64 --publish always; then
+              exit 0
+            fi
+
+            if [ "$i" -lt 3 ]; then
+              echo "Attempt $i failed, retrying in 10s..."
+              sleep 10
+            fi
           done
+
+          echo "macOS ARM64 packaging failed after 3 attempts"
+          exit 1
         working-directory: apps/electron
 
   build-mac-x64:
@@ -142,10 +150,18 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           for i in 1 2 3; do
-            npx electron-builder --mac --x64 --publish always && break
-            echo "Attempt $i failed, retrying in 15s..."
-            sleep 15
+            if npx electron-builder --mac --x64 --publish always; then
+              exit 0
+            fi
+
+            if [ "$i" -lt 3 ]; then
+              echo "Attempt $i failed, retrying in 15s..."
+              sleep 15
+            fi
           done
+
+          echo "macOS x64 packaging failed after 3 attempts"
+          exit 1
         working-directory: apps/electron
 
   merge-mac-yml:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proma",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The next gen ai software with general agents",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary

- 让 macOS ARM64/x64 打包在三次 `electron-builder` 重试全部失败后明确退出非零。
- 防止上传失败被错误标记为成功、后续 `latest-mac.yml` 合并才以缺少产物失败。
- 递增根 workspace 版本至 `0.1.1`。

## Validation

- YAML 解析
- 重试耗尽分支 shell 模拟（确认退出码为 1）
- `bun install --frozen-lockfile`（Bun 1.3.14）

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)