### PR TITLE
fix: hide delegated sessions from agent island

### DIFF
--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -114,6 +114,15 @@ function getTitle(sessionId: string): string {
   }
 }
 
+/** 协作子会话的结果由父会话汇总，不进入用户级未读收件箱。 */
+function isDelegatedChildSession(sessionId: string): boolean {
+  try {
+    return Boolean(getAgentSessionMeta(sessionId)?.sourceDelegationId)
+  } catch {
+    return false
+  }
+}
+
 function ensureSession(sessionId: string): InternalSessionSnapshot {
   let s = sessions.get(sessionId)
   if (!s) {
@@ -285,10 +294,11 @@ function handleSdkMessage(sessionId: string, message: import('@proma/shared').SD
       if (aMsg.isReplay) return
       if (aMsg.error) {
         const session = ensureSession(sessionId)
+        const isChildSession = isDelegatedChildSession(sessionId)
         session.phase = 'error'
         session.detail = truncate(aMsg.error.message || '发生错误', 60)
-        session.unread = true
-        session.attention = true
+        session.unread = !isChildSession
+        session.attention = !isChildSession
         session.terminalAt = Date.now()
         session.lastActivityAt = Date.now()
         pushActivity(session, 'status', `❌ ${truncate(aMsg.error.message || '错误', 50)}`)
@@ -332,18 +342,19 @@ function handleSdkMessage(sessionId: string, message: import('@proma/shared').SD
     case 'result': {
       const rMsg = message as import('@proma/shared').SDKResultMessage
       const session = ensureSession(sessionId)
+      const isChildSession = isDelegatedChildSession(sessionId)
       if (rMsg.subtype === 'success') {
         session.phase = 'completed'
         session.detail = '已完成'
-        session.unread = true
-        session.attention = true
+        session.unread = !isChildSession
+        session.attention = !isChildSession
         session.terminalAt = Date.now()
         pushActivity(session, 'status', '✅ 任务完成')
       } else {
         session.phase = 'error'
         session.detail = truncate(rMsg.errors?.[0] || rMsg.terminal_reason || '执行出错', 60)
-        session.unread = true
-        session.attention = true
+        session.unread = !isChildSession
+        session.attention = !isChildSession
         session.terminalAt = Date.now()
         pushActivity(session, 'status', `❌ ${truncate(rMsg.errors?.[0] || rMsg.terminal_reason || '错误', 50)}`)
       }
@@ -414,6 +425,8 @@ function handleSdkMessage(sessionId: string, message: import('@proma/shared').SD
 
 function isIslandSession(session: InternalSessionSnapshot, now: number): boolean {
   if (now - session.lastActivityAt >= 24 * 60 * 60_000) return false
+  // 委派子会话只在需要用户交互时露出；执行和结束均由父会话收敛。
+  if (isDelegatedChildSession(session.sessionId)) return session.phase === 'needs-interaction'
   // Running is deliberately visible: the island is also a live execution pulse,
   // not only a handoff/error inbox. Terminal sessions retain their existing
   // unread window to avoid becoming permanent history.

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -1139,7 +1139,7 @@ export function useGlobalAgentListeners(): void {
         }
 
         // 发送桌面通知（仅真正成功完成时播放提示音，错误/中断/异常完成不伪装成完成）
-        const completionSession = store.get(agentSessionsAtom)
+        const completionSession = data.session ?? store.get(agentSessionsAtom)
           .find((session) => session.id === data.sessionId)
         const enabled = store.get(notificationsEnabledAtom)
         const soundEnabled = store.get(notificationSoundEnabledAtom)
@@ -1198,6 +1198,7 @@ export function useGlobalAgentListeners(): void {
           activeTabId: store.get(activeTabIdAtom),
           currentAgentSessionId: currentSessionId,
           sessionId: data.sessionId,
+          session: completionSession,
           documentHasFocus: document.hasFocus(),
         })
         if (completionMarkers.markUnviewedCompleted && !backgroundTasksPending) {

--- a/apps/electron/src/renderer/lib/agent-completion-presence.ts
+++ b/apps/electron/src/renderer/lib/agent-completion-presence.ts
@@ -6,6 +6,8 @@ export interface AgentCompletionPresenceInput {
   activeTabId: string | null
   currentAgentSessionId: string | null
   sessionId: string
+  /** 委派子会话由父会话汇总，不计入用户级未读完成。 */
+  session?: Pick<AgentSessionMeta, 'sourceDelegationId'>
   /** 完成发生时应用窗口是否处于前台。窗口失焦时即使是当前 Tab 也不算"正在查看"。 */
   documentHasFocus: boolean
 }
@@ -74,6 +76,6 @@ export function isAgentSessionActiveForCompletion({
 export function getAgentCompletionMarkers(input: AgentCompletionPresenceInput): AgentCompletionMarkers {
   const isActiveSession = isAgentSessionActiveForCompletion(input)
   return {
-    markUnviewedCompleted: !isActiveSession,
+    markUnviewedCompleted: !input.session?.sourceDelegationId && !isActiveSession,
   }
 }


### PR DESCRIPTION
## Summary
- Hide delegated child sessions from Agent Island while they are running or terminal; keep only user-interaction requests visible.
- Exclude delegated child completions from the sidebar unviewed marker.

## Test plan
- `cd apps/electron && bun test src/renderer/lib/agent-completion-presence.test.ts`
- `bun run typecheck` *(blocked: this worktree has no `tsc` binary)*

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)