### PR TITLE
feat: 添加 provider 无关的渠道用量统计引擎（M1）

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/usage-stats-service.test.ts
+++ b/apps/electron/src/main/lib/usage-stats-service.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getChannelUsageStats } from './usage-stats-service'
+
+interface AssistantFixtureOptions {
+  provider?: string
+  modelId?: string
+  createdAt: number
+  input?: number
+  output?: number
+  cacheRead?: number
+  cacheCreation?: number
+  includeUsage?: boolean
+}
+
+interface ResultFixtureOptions {
+  provider?: string
+  modelId?: string
+  createdAt: number
+  cost?: number
+  subtype?: string
+  durationMs?: number
+  includeUsage?: boolean
+  usageInput?: number
+}
+
+let sessionsDir: string
+
+beforeEach(() => {
+  sessionsDir = mkdtempSync(join(tmpdir(), 'proma-usage-stats-'))
+})
+
+afterEach(() => {
+  rmSync(sessionsDir, { recursive: true, force: true })
+})
+
+function assistant(options: AssistantFixtureOptions): Record<string, unknown> {
+  const message: Record<string, unknown> = { model: options.modelId ?? 'model-default' }
+  if (options.includeUsage !== false) {
+    message.usage = {
+      input_tokens: options.input ?? 0,
+      output_tokens: options.output ?? 0,
+      cache_read_input_tokens: options.cacheRead ?? 0,
+      cache_creation_input_tokens: options.cacheCreation ?? 0,
+    }
+  }
+  return {
+    type: 'assistant',
+    message,
+    _channelProvider: options.provider,
+    _channelModelId: options.modelId,
+    _createdAt: options.createdAt,
+  }
+}
+
+function result(options: ResultFixtureOptions): Record<string, unknown> {
+  const row: Record<string, unknown> = {
+    type: 'result',
+    subtype: options.subtype ?? 'success',
+    total_cost_usd: options.cost,
+    _channelProvider: options.provider,
+    _channelModelId: options.modelId,
+    _createdAt: options.createdAt,
+    _durationMs: options.durationMs,
+  }
+  if (options.includeUsage !== false) {
+    row.usage = {
+      input_tokens: options.usageInput ?? 999,
+      output_tokens: 999,
+      cache_read_input_tokens: 999,
+      cache_creation_input_tokens: 999,
+    }
+  }
+  return row
+}
+
+function writeSession(
+  sessionId: string,
+  rows: Array<Record<string, unknown> | string>,
+): void {
+  const jsonl = rows
+    .map((row) => typeof row === 'string' ? row : JSON.stringify(row))
+    .join('\n')
+  writeFileSync(join(sessionsDir, `${sessionId}.jsonl`), `${jsonl}\n`, 'utf-8')
+}
+
+describe('渠道用量统计', () => {
+  test('Given 多 provider、model、day 的 JSONL When 统计 Then 按各维度聚合', () => {
+    const firstDay = new Date(2026, 7, 9, 10, 0).getTime()
+    const secondDay = new Date(2026, 7, 10, 11, 0).getTime()
+
+    writeSession('session-a', [
+      assistant({ provider: 'anthropic', modelId: 'claude-a', createdAt: firstDay, input: 10, output: 2 }),
+      result({ provider: 'anthropic', modelId: 'claude-a', createdAt: firstDay, cost: 0.1 }),
+    ])
+    writeSession('session-b', [
+      // 未绑定 ProviderType 联合类型的新 provider 也能原样统计。
+      assistant({ provider: 'future-provider', modelId: 'model-b', createdAt: secondDay, input: 20, output: 4 }),
+      result({ provider: 'future-provider', modelId: 'model-b', createdAt: secondDay, cost: 0.2 }),
+    ])
+
+    const stats = getChannelUsageStats({}, { sessionsDir, now: secondDay })
+
+    expect(stats.summary.requestCount).toBe(2)
+    expect(stats.summary.costUsd).toBeCloseTo(0.3)
+    expect(stats.byProvider.anthropic?.requestCount).toBe(1)
+    expect(stats.byProvider['future-provider']?.requestCount).toBe(1)
+    expect(stats.byModel['claude-a']?.totalTokens).toBe(12)
+    expect(stats.byModel['model-b']?.totalTokens).toBe(24)
+    expect(stats.byDay['2026-08-09']?.requestCount).toBe(1)
+    expect(stats.byDay['2026-08-10']?.requestCount).toBe(1)
+  })
+
+  test('Given assistant 带 usage When 统计 Then Token 和缓存命中率使用锁定口径', () => {
+    const createdAt = new Date(2026, 7, 10, 9, 0).getTime()
+    writeSession('tokens', [
+      assistant({
+        provider: 'openai',
+        modelId: 'gpt-test',
+        createdAt,
+        input: 10,
+        output: 5,
+        cacheRead: 20,
+        cacheCreation: 5,
+      }),
+    ])
+
+    const stats = getChannelUsageStats({}, { sessionsDir, now: createdAt })
+
+    expect(stats.summary).toMatchObject({
+      requestCount: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheReadTokens: 20,
+      cacheCreationTokens: 5,
+      totalTokens: 40,
+    })
+    expect(stats.summary.cacheHitRate).toBeCloseTo(20 / 35)
+  })
+
+  test('Given result 带费用、耗时和失败状态 When 统计 Then 费用来自 result 并回填明细', () => {
+    const createdAt = new Date(2026, 7, 10, 12, 0).getTime()
+    writeSession('cost', [
+      assistant({ provider: 'deepseek', modelId: 'deepseek-test', createdAt, input: 3, output: 2 }),
+      result({
+        provider: 'deepseek',
+        modelId: 'deepseek-test',
+        createdAt,
+        cost: 0.42,
+        durationMs: 1_234,
+        subtype: 'error_during_execution',
+      }),
+    ])
+
+    const stats = getChannelUsageStats({}, { sessionsDir, now: createdAt })
+
+    expect(stats.summary.costUsd).toBeCloseTo(0.42)
+    expect(stats.summary.successCount).toBe(0)
+    expect(stats.summary.errorCount).toBe(1)
+    expect(stats.records[0]).toMatchObject({
+      costUsd: 0.42,
+      durationMs: 1_234,
+      status: 'error',
+    })
+  })
+
+  test('Given assistant 和 result 都带 usage When 统计 Then result Token 不重复累计', () => {
+    const createdAt = new Date(2026, 7, 10, 13, 0).getTime()
+    writeSession('no-double-count', [
+      assistant({
+        provider: 'openai',
+        modelId: 'gpt-test',
+        createdAt,
+        input: 1,
+        output: 2,
+        cacheRead: 3,
+        cacheCreation: 4,
+      }),
+      result({
+        provider: 'openai',
+        modelId: 'gpt-test',
+        createdAt,
+        cost: 0.01,
+        usageInput: 10_000,
+      }),
+    ])
+
+    const stats = getChannelUsageStats({}, { sessionsDir, now: createdAt })
+
+    expect(stats.summary.requestCount).toBe(1)
+    expect(stats.summary.totalTokens).toBe(10)
+    expect(stats.records[0]?.totalTokens).toBe(10)
+  })
+
+  test('Given 老数据缺 usage/provider 且混入坏行 When 统计 Then 安静跳过', () => {
+    const createdAt = new Date(2026, 7, 10, 14, 0).getTime()
+    writeSession('legacy', [
+      assistant({ provider: 'openai', modelId: 'missing-usage', createdAt, includeUsage: false }),
+      assistant({ modelId: 'missing-provider', createdAt, input: 100 }),
+      '{ 不是合法 JSON',
+      result({ provider: 'openai', modelId: 'fee-without-usage', createdAt, cost: 9, includeUsage: false }),
+      assistant({ provider: 'openai', modelId: 'valid', createdAt, input: 2, output: 1 }),
+    ])
+
+    const stats = getChannelUsageStats({}, { sessionsDir, now: createdAt })
+
+    expect(stats.summary.requestCount).toBe(1)
+    expect(stats.summary.totalTokens).toBe(3)
+    expect(stats.summary.costUsd).toBe(0)
+    expect(stats.records.map((record) => record.modelId)).toEqual(['valid'])
+  })
+
+  test('Given 今天与历史小时数据 When 统计 Then byHour 只聚合今天', () => {
+    const todayNine = new Date(2026, 7, 10, 9, 10).getTime()
+    const todayNineLater = new Date(2026, 7, 10, 9, 50).getTime()
+    const todaySeventeen = new Date(2026, 7, 10, 17, 5).getTime()
+    const yesterdayNine = new Date(2026, 7, 9, 9, 10).getTime()
+    const rows = [todayNine, todayNineLater, todaySeventeen, yesterdayNine].flatMap((createdAt, index) => [
+      assistant({ provider: 'openai', modelId: 'hourly', createdAt, input: index + 1 }),
+      result({ provider: 'openai', modelId: 'hourly', createdAt, cost: 0.01 }),
+    ])
+    writeSession('hourly', rows)
+
+    const stats = getChannelUsageStats({}, { sessionsDir, now: todaySeventeen })
+
+    expect(Object.keys(stats.byHour)).toEqual(['09:00', '17:00'])
+    expect(stats.byHour['09:00']?.requestCount).toBe(2)
+    expect(stats.byHour['09:00']?.costUsd).toBeCloseTo(0.02)
+    expect(stats.byHour['17:00']?.requestCount).toBe(1)
+    expect(stats.summary.requestCount).toBe(4)
+  })
+
+  test('Given provider/model/time 筛选与分页 When 查询 Then 聚合基于全量筛选结果、明细按页返回', () => {
+    const first = new Date(2026, 7, 10, 8, 0).getTime()
+    const second = new Date(2026, 7, 10, 9, 0).getTime()
+    const third = new Date(2026, 7, 10, 10, 0).getTime()
+    const fourth = new Date(2026, 7, 10, 11, 0).getTime()
+    writeSession('filters', [
+      assistant({ provider: 'openai', modelId: 'target', createdAt: first, input: 1 }),
+      result({ provider: 'openai', modelId: 'target', createdAt: first, cost: 0.01 }),
+      assistant({ provider: 'anthropic', modelId: 'target', createdAt: second, input: 2 }),
+      result({ provider: 'anthropic', modelId: 'target', createdAt: second, cost: 0.02 }),
+      assistant({ provider: 'openai', modelId: 'target', createdAt: third, input: 3 }),
+      result({ provider: 'openai', modelId: 'target', createdAt: third, cost: 0.03 }),
+      assistant({ provider: 'openai', modelId: 'other', createdAt: fourth, input: 4 }),
+      result({ provider: 'openai', modelId: 'other', createdAt: fourth, cost: 0.04 }),
+    ])
+
+    const stats = getChannelUsageStats({
+      startAt: first,
+      endAt: third,
+      provider: 'openai',
+      modelId: 'target',
+      page: 2,
+      pageSize: 1,
+    }, { sessionsDir, now: fourth })
+
+    expect(stats.summary.requestCount).toBe(2)
+    expect(stats.summary.totalTokens).toBe(4)
+    expect(stats.summary.costUsd).toBeCloseTo(0.04)
+    expect(stats.totalRecords).toBe(2)
+    expect(stats.page).toBe(2)
+    expect(stats.pageSize).toBe(1)
+    expect(stats.records).toHaveLength(1)
+    expect(stats.records[0]).toMatchObject({ createdAt: first, provider: 'openai', modelId: 'target' })
+  })
+})

--- a/apps/electron/src/main/lib/usage-stats-service.ts
+++ b/apps/electron/src/main/lib/usage-stats-service.ts
@@ -1,0 +1,402 @@
+import type {
+  ChannelUsageRecord,
+  ChannelUsageStats,
+  ChannelUsageSummary,
+  UsageLogQuery,
+} from '@proma/shared'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { basename, extname, join } from 'node:path'
+import { getAgentSessionsDir } from './config-paths'
+
+const DEFAULT_PAGE_SIZE = 50
+const MAX_PAGE_SIZE = 200
+
+export interface ChannelUsageStatsOptions {
+  /** 测试、迁移或其它 profile 可显式传入；默认复用应用现有配置路径 API。 */
+  sessionsDir?: string
+  /** 仅用于确定 byHour 的“今天”，默认 Date.now()。 */
+  now?: number
+}
+
+interface CostEvent {
+  provider: string
+  modelId: string
+  createdAt: number
+  costUsd: number
+}
+
+interface ScannedUsage {
+  records: ChannelUsageRecord[]
+  costs: CostEvent[]
+}
+
+interface MutableSummary {
+  requestCount: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  totalTokens: number
+  costUsd: number
+  successCount: number
+  errorCount: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined
+}
+
+function asTimestamp(value: unknown): number | undefined {
+  const timestamp = asNonNegativeNumber(value)
+  if (timestamp === undefined || Number.isNaN(new Date(timestamp).getTime())) return undefined
+  return timestamp
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  return normalized || undefined
+}
+
+function readOptionalToken(value: unknown): number | undefined {
+  return value === undefined ? 0 : asNonNegativeNumber(value)
+}
+
+function readCreatedAt(message: Record<string, unknown>): number | undefined {
+  return asTimestamp(message._createdAt ?? message.createdAt)
+}
+
+function readAssistantRecord(
+  message: Record<string, unknown>,
+  sessionId: string,
+  lineNumber: number,
+): ChannelUsageRecord | undefined {
+  if (message.type !== 'assistant' || !isRecord(message.message)) return undefined
+
+  const usage = message.message.usage
+  if (!isRecord(usage)) return undefined
+
+  const provider = asNonEmptyString(message._channelProvider)
+  const modelId = asNonEmptyString(message._channelModelId)
+    ?? asNonEmptyString(message.message.model)
+  const createdAt = readCreatedAt(message)
+  const inputTokens = asNonNegativeNumber(usage.input_tokens)
+  const outputTokens = readOptionalToken(usage.output_tokens)
+  const cacheReadTokens = readOptionalToken(usage.cache_read_input_tokens)
+  const cacheCreationTokens = readOptionalToken(usage.cache_creation_input_tokens)
+
+  if (
+    provider === undefined
+    || modelId === undefined
+    || createdAt === undefined
+    || inputTokens === undefined
+    || outputTokens === undefined
+    || cacheReadTokens === undefined
+    || cacheCreationTokens === undefined
+  ) {
+    return undefined
+  }
+
+  const totalTokens = inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens
+  if (!Number.isFinite(totalTokens)) return undefined
+
+  return {
+    id: `${sessionId}:${lineNumber}`,
+    sessionId,
+    provider,
+    modelId,
+    createdAt,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+    totalTokens,
+    costUsd: 0,
+    status: isRecord(message.error) ? 'error' : 'success',
+  }
+}
+
+function readResultModelId(
+  message: Record<string, unknown>,
+  fallbackRecord: ChannelUsageRecord | undefined,
+): string | undefined {
+  const channelModelId = asNonEmptyString(message._channelModelId)
+  if (channelModelId !== undefined) return channelModelId
+
+  if (isRecord(message.modelUsage)) {
+    const modelIds = Object.keys(message.modelUsage)
+    if (modelIds.length === 1) return asNonEmptyString(modelIds[0])
+  }
+
+  return fallbackRecord?.modelId
+}
+
+function readResultCost(
+  message: Record<string, unknown>,
+  fallbackRecord: ChannelUsageRecord | undefined,
+): CostEvent | undefined {
+  if (message.type !== 'result' || !isRecord(message.usage)) return undefined
+
+  const provider = asNonEmptyString(message._channelProvider)
+  const modelId = readResultModelId(message, fallbackRecord)
+  const createdAt = readCreatedAt(message)
+  const costUsd = asNonNegativeNumber(message.total_cost_usd)
+
+  if (
+    provider === undefined
+    || modelId === undefined
+    || createdAt === undefined
+    || costUsd === undefined
+  ) {
+    return undefined
+  }
+
+  return { provider, modelId, createdAt, costUsd }
+}
+
+function scanUsageFile(filePath: string): ScannedUsage {
+  let content: string
+  try {
+    content = readFileSync(filePath, 'utf-8')
+  } catch {
+    return { records: [], costs: [] }
+  }
+
+  const records: ChannelUsageRecord[] = []
+  const costs: CostEvent[] = []
+  const sessionId = basename(filePath, extname(filePath))
+  let pendingRecordIndex: number | undefined
+
+  for (const [lineIndex, line] of content.split('\n').entries()) {
+    if (!line.trim()) continue
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (!isRecord(parsed)) continue
+
+    if (parsed.type === 'assistant') {
+      const record = readAssistantRecord(parsed, sessionId, lineIndex + 1)
+      if (record !== undefined) {
+        records.push(record)
+        pendingRecordIndex = records.length - 1
+      }
+      continue
+    }
+
+    if (parsed.type !== 'result') continue
+
+    const pendingRecord = pendingRecordIndex === undefined
+      ? undefined
+      : records[pendingRecordIndex]
+
+    if (pendingRecord !== undefined) {
+      const subtype = asNonEmptyString(parsed.subtype)
+      if (subtype !== undefined && subtype !== 'success') {
+        pendingRecord.status = 'error'
+      }
+      const durationMs = asNonNegativeNumber(parsed._durationMs)
+      if (durationMs !== undefined) pendingRecord.durationMs = durationMs
+    }
+
+    const cost = readResultCost(parsed, pendingRecord)
+    if (cost !== undefined) {
+      costs.push(cost)
+      // result 是整轮汇总，只挂到最近一条 assistant 供明细展示；聚合不会再次读取此字段。
+      if (
+        pendingRecord !== undefined
+        && pendingRecord.provider === cost.provider
+        && pendingRecord.modelId === cost.modelId
+      ) {
+        pendingRecord.costUsd = cost.costUsd
+      }
+    }
+
+    pendingRecordIndex = undefined
+  }
+
+  return { records, costs }
+}
+
+function scanUsageDirectory(sessionsDir: string): ScannedUsage {
+  if (!existsSync(sessionsDir)) return { records: [], costs: [] }
+
+  let fileNames: string[]
+  try {
+    fileNames = readdirSync(sessionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && extname(entry.name) === '.jsonl')
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return { records: [], costs: [] }
+  }
+
+  const records: ChannelUsageRecord[] = []
+  const costs: CostEvent[] = []
+  for (const fileName of fileNames) {
+    const scanned = scanUsageFile(join(sessionsDir, fileName))
+    records.push(...scanned.records)
+    costs.push(...scanned.costs)
+  }
+  return { records, costs }
+}
+
+function matchesQuery(
+  value: Pick<ChannelUsageRecord, 'provider' | 'modelId' | 'createdAt'>,
+  query: UsageLogQuery,
+): boolean {
+  if (query.startAt !== undefined && value.createdAt < query.startAt) return false
+  if (query.endAt !== undefined && value.createdAt > query.endAt) return false
+  if (query.provider !== undefined && value.provider !== query.provider) return false
+  if (query.modelId !== undefined && value.modelId !== query.modelId) return false
+  return true
+}
+
+function createMutableSummary(): MutableSummary {
+  return {
+    requestCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+    successCount: 0,
+    errorCount: 0,
+  }
+}
+
+function addRecord(summary: MutableSummary, record: ChannelUsageRecord): void {
+  summary.requestCount += 1
+  summary.inputTokens += record.inputTokens
+  summary.outputTokens += record.outputTokens
+  summary.cacheReadTokens += record.cacheReadTokens
+  summary.cacheCreationTokens += record.cacheCreationTokens
+  summary.totalTokens += record.totalTokens
+  if (record.status === 'success') summary.successCount += 1
+  else summary.errorCount += 1
+}
+
+function addCost(summary: MutableSummary, cost: CostEvent): void {
+  summary.costUsd += cost.costUsd
+}
+
+function finishSummary(summary: MutableSummary): ChannelUsageSummary {
+  const cacheDenominator = summary.cacheReadTokens
+    + summary.cacheCreationTokens
+    + summary.inputTokens
+
+  return {
+    ...summary,
+    successRate: summary.requestCount === 0
+      ? 0
+      : summary.successCount / summary.requestCount,
+    cacheHitRate: cacheDenominator === 0
+      ? 0
+      : summary.cacheReadTokens / cacheDenominator,
+  }
+}
+
+function addToGroup<T>(
+  groups: Map<string, MutableSummary>,
+  key: string,
+  value: T,
+  add: (summary: MutableSummary, value: T) => void,
+): void {
+  const summary = groups.get(key) ?? createMutableSummary()
+  add(summary, value)
+  groups.set(key, summary)
+}
+
+function finishGroups(groups: Map<string, MutableSummary>): Record<string, ChannelUsageSummary> {
+  return Object.fromEntries(
+    [...groups.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, summary]) => [key, finishSummary(summary)]),
+  )
+}
+
+function localDayKey(timestamp: number): string {
+  const date = new Date(timestamp)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function localHourKey(timestamp: number): string {
+  return `${String(new Date(timestamp).getHours()).padStart(2, '0')}:00`
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  return Number.isInteger(value) && value !== undefined && value > 0 ? value : fallback
+}
+
+/**
+ * 扫描 Agent session JSONL，并按查询条件返回聚合与分页明细。
+ *
+ * Token 只累计 assistant.message.usage；费用只累计 result.total_cost_usd。
+ */
+export function getChannelUsageStats(
+  query: UsageLogQuery = {},
+  options: ChannelUsageStatsOptions = {},
+): ChannelUsageStats {
+  const sessionsDir = options.sessionsDir ?? getAgentSessionsDir()
+  const now = asTimestamp(options.now) ?? Date.now()
+  const scanned = scanUsageDirectory(sessionsDir)
+  const records = scanned.records.filter((record) => matchesQuery(record, query))
+  const costs = scanned.costs.filter((cost) => matchesQuery(cost, query))
+  const todayKey = localDayKey(now)
+
+  const summary = createMutableSummary()
+  const byDay = new Map<string, MutableSummary>()
+  const byHour = new Map<string, MutableSummary>()
+  const byProvider = new Map<string, MutableSummary>()
+  const byModel = new Map<string, MutableSummary>()
+
+  for (const record of records) {
+    addRecord(summary, record)
+    addToGroup(byDay, localDayKey(record.createdAt), record, addRecord)
+    addToGroup(byProvider, record.provider, record, addRecord)
+    addToGroup(byModel, record.modelId, record, addRecord)
+    if (localDayKey(record.createdAt) === todayKey) {
+      addToGroup(byHour, localHourKey(record.createdAt), record, addRecord)
+    }
+  }
+
+  for (const cost of costs) {
+    addCost(summary, cost)
+    addToGroup(byDay, localDayKey(cost.createdAt), cost, addCost)
+    addToGroup(byProvider, cost.provider, cost, addCost)
+    addToGroup(byModel, cost.modelId, cost, addCost)
+    if (localDayKey(cost.createdAt) === todayKey) {
+      addToGroup(byHour, localHourKey(cost.createdAt), cost, addCost)
+    }
+  }
+
+  records.sort((left, right) => right.createdAt - left.createdAt || left.id.localeCompare(right.id))
+  const page = normalizePositiveInteger(query.page, 1)
+  const pageSize = Math.min(normalizePositiveInteger(query.pageSize, DEFAULT_PAGE_SIZE), MAX_PAGE_SIZE)
+  const start = (page - 1) * pageSize
+
+  return {
+    summary: finishSummary(summary),
+    byDay: finishGroups(byDay),
+    byHour: finishGroups(byHour),
+    byProvider: finishGroups(byProvider),
+    byModel: finishGroups(byModel),
+    records: records.slice(start, start + pageSize),
+    totalRecords: records.length,
+    page,
+    pageSize,
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -59,3 +59,6 @@ export * from './planning'
 
 // Agent 灵动岛相关类型
 export * from './agent-island'
+
+// 渠道 Token / 费用统计
+export * from './usage'

--- a/packages/shared/src/types/usage.ts
+++ b/packages/shared/src/types/usage.ts
@@ -1,0 +1,73 @@
+/** 渠道用量明细中的执行状态。 */
+export type ChannelUsageStatus = 'success' | 'error'
+
+/**
+ * 一次模型请求的渠道用量明细。
+ *
+ * 请求与 Token 来自 assistant 消息；同一轮 result 的费用、耗时和最终状态
+ * 会附着到最近一条 assistant 明细，便于后续 UI 按行展示。
+ */
+export interface ChannelUsageRecord {
+  /** `${sessionId}:${lineNumber}`，在一次扫描中稳定且唯一。 */
+  id: string
+  sessionId: string
+  /** 保留日志中的原始 provider 字符串，避免绑定到特定 ProviderType 联合类型。 */
+  provider: string
+  modelId: string
+  createdAt: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  /** input + output + cacheRead + cacheCreation。 */
+  totalTokens: number
+  /** 只从 result.total_cost_usd 读取；没有费用信息时为 0。 */
+  costUsd: number
+  durationMs?: number
+  status: ChannelUsageStatus
+}
+
+/** 渠道用量汇总，可用于总览以及各维度分组。 */
+export interface ChannelUsageSummary {
+  requestCount: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  totalTokens: number
+  costUsd: number
+  successCount: number
+  errorCount: number
+  /** 成功请求数 / 请求总数；没有请求时为 0。 */
+  successRate: number
+  /** cacheRead / (cacheRead + cacheCreation + input)；分母为 0 时为 0。 */
+  cacheHitRate: number
+}
+
+/** 一次扫描、筛选与分页后的统计结果。 */
+export interface ChannelUsageStats {
+  summary: ChannelUsageSummary
+  byDay: Record<string, ChannelUsageSummary>
+  /** 仅包含扫描时“今天”的小时桶，key 为 `HH:00`。 */
+  byHour: Record<string, ChannelUsageSummary>
+  byProvider: Record<string, ChannelUsageSummary>
+  byModel: Record<string, ChannelUsageSummary>
+  records: ChannelUsageRecord[]
+  totalRecords: number
+  page: number
+  pageSize: number
+}
+
+/** 渠道用量筛选与明细分页参数。 */
+export interface UsageLogQuery {
+  /** 起始时间（Unix 毫秒），包含边界。 */
+  startAt?: number
+  /** 结束时间（Unix 毫秒），包含边界。 */
+  endAt?: number
+  provider?: string
+  modelId?: string
+  /** 从 1 开始。非法值会回退到 1。 */
+  page?: number
+  /** 默认 50，最大 200。 */
+  pageSize?: number
+}


### PR DESCRIPTION
## 问题

Issue #1464 需要在开源版提供 provider 无关的渠道 Token / 费用统计。现有 Agent session JSONL 同时在 `assistant` 和 `result` 中携带 usage；若直接累加会重复计算 Token，而且老日志可能缺少渠道或 usage 字段。

本 PR 只交付 #1464 的 M1（统计引擎、共享类型和 fixture 测试），不提前加入 IPC 或 UI。

## 方案

- 新增共享类型：`ChannelUsageRecord`、`ChannelUsageSummary`、`ChannelUsageStats`、`UsageLogQuery`。
- 新增主进程统计服务，扫描现有 `getAgentSessionsDir()` 返回的 `*.jsonl`；测试及其它 profile 可显式传入目录。
- 支持时间、provider、model 筛选和明细分页。
- 聚合 `byDay`、今日 `byHour`、`byProvider`、`byModel` 与总览。
- 递增受影响包版本：`@proma/shared` 0.1.52 → 0.1.53，`@proma/electron` 0.17.1 → 0.17.2。

## 统计口径

- 请求数与 Token 只取 `assistant.message.usage`。
- 费用只取 `result.total_cost_usd`，不会再次累计 `result.usage` 的 Token。
- 真实消耗 Token = input + output + cache_read + cache_creation。
- 缓存命中率 = cache_read / (cache_read + cache_creation + input)。
- 缺少 `_channelProvider`、usage 或必要时间/模型字段的旧记录，以及损坏 JSONL 行，均跳过且不中断扫描。

## 测试

- `bun test apps/electron/src/main/lib/usage-stats-service.test.ts`：7 pass / 0 fail（34 assertions）。
- `bun run typecheck`：shared、session-core、core、cli、ui、electron 全部通过。
- 仓库当前没有 lint script，因此无可执行 lint 命令。

Fixture 覆盖多 provider/model/day、assistant Token、result 费用、不双计、旧数据缺字段、今日小时聚合，以及筛选分页。

## 兼容性与边界

- provider 使用日志原始字符串，不依赖商业版专有 `ProviderType: 'proma'`，也支持未来新增 provider。
- 不硬编码 `~/.proma`，默认复用现有配置路径 API；未引入 personal 分支的 `PROMA_HOME` 补丁。
- 本 PR 不含 IPC/UI；大目录增量缓存和异步解析按 #1464 后续 M4 处理。

Refs #1464