### PR TITLE
fix(feishu): 保留每个聊天的渠道和模型绑定

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -41,7 +41,7 @@ import {
   getWorkspaceCapabilities,
 } from './agent-workspace-manager'
 import { getFeishuBotBindingsPath, getFeishuBotMetadataPath } from './config-paths'
-import { writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { readFileSync, existsSync } from 'node:fs'
 import { readJsonFileSafe, writeJsonFileAtomic } from './safe-file'
 import {
   inferImageMediaType as inferImageMediaTypeShared,
@@ -84,6 +84,11 @@ import {
 } from './feishu/card-run-state'
 import { renderCard as renderRunCard } from './feishu/card-renderer-v2'
 import { buildSessionMirrorGroupName, normalizeSessionMirrorUserOpenId } from './feishu/session-mirror'
+import {
+  initializeBindingModelSelection,
+  resolveFeishuRunTarget,
+  resolveSessionMirrorModelSelection,
+} from './feishu/model-binding'
 import { resolveGroupMessageAccess } from './feishu/group-message-policy'
 import { ScopedQueue } from './feishu/scoped-queue'
 import { RunCoordinator } from './feishu/run-coordinator'
@@ -378,13 +383,20 @@ class FeishuBridge {
             b.archived = true
             b.archivedAt ??= session.updatedAt
           }
-          // 同步最新的渠道和模型设置（用户可能已更改）
-          if (appSettings.agentChannelId) {
-            b.channelId = appSettings.agentChannelId
-          }
-          if (appSettings.agentModelId) {
-            b.modelId = appSettings.agentModelId
-          }
+          // 已有 binding 是当前聊天的显式选择；全局设置只补空值，不覆盖。
+          const selection = initializeBindingModelSelection(
+            b,
+            {
+              channelId: this.botConfig.defaultChannelId,
+              modelId: this.botConfig.defaultModelId,
+            },
+            {
+              channelId: appSettings.agentChannelId,
+              modelId: appSettings.agentModelId,
+            },
+          )
+          b.channelId = selection.channelId
+          b.modelId = selection.modelId
           this.chatBindings.set(b.chatId, b)
           if (!b.archived) {
             this.sessionToChat.set(b.sessionId, b.chatId)
@@ -405,7 +417,7 @@ class FeishuBridge {
     try {
       const bindings = Array.from(this.chatBindings.values())
       const bindingsPath = getFeishuBotBindingsPath(this.botConfig.id)
-      writeFileSync(bindingsPath, JSON.stringify(bindings, null, 2), 'utf-8')
+      writeJsonFileAtomic(bindingsPath, bindings)
     } catch (error) {
       console.error('[飞书 Bridge] 保存绑定失败:', redactSensitiveLogValue(error))
     }
@@ -545,7 +557,8 @@ class FeishuBridge {
 
     const appSettings = getSettings()
     const workspaceId = session.workspaceId ?? this.botConfig.defaultWorkspaceId ?? appSettings.agentWorkspaceId
-    const channelId = session.channelId ?? this.botConfig.defaultChannelId ?? appSettings.agentChannelId
+    const sessionSelection = resolveSessionMirrorModelSelection(session)
+    const channelId = sessionSelection.channelId
     if (!workspaceId || !channelId) {
       console.warn('[飞书 Session 镜像] 缺少 workspaceId 或 channelId，跳过镜像群创建', {
         sessionId: session.id,
@@ -566,7 +579,7 @@ class FeishuBridge {
       sessionId: session.id,
       workspaceId,
       channelId,
-      modelId: this.botConfig.defaultModelId ?? appSettings.agentModelId ?? undefined,
+      modelId: sessionSelection.modelId,
       source: 'session-mirror',
       chatType: 'group',
       groupName,
@@ -1401,12 +1414,15 @@ class FeishuBridge {
       const session = getAgentSessionMeta(binding.sessionId)
       lines.push(`**会话**: ${session?.title ?? '未知'} (\`${binding.sessionId.slice(0, 8)}\`)`)
 
-      // 模型信息（与发送路径同序解析：binding > Bot 配置 > 应用设置）
-      const nowSettings = getSettings()
-      const effChannelId = binding.channelId || this.botConfig.defaultChannelId || nowSettings.agentChannelId
-      const effModelId = binding.modelId || this.botConfig.defaultModelId || nowSettings.agentModelId
-      const modelInfo = describeBindingModel(effChannelId, effModelId)
-      lines.push(`**模型**: ${modelInfo.channelName} / ${modelInfo.modelName}${modelInfo.valid ? '' : '（已失效）'}`)
+      // 与实际发送使用同一解析器，避免 /now 展示失效 binding 而发送时已回落。
+      try {
+        const target = this.resolveRunTarget(binding)
+        const modelInfo = describeBindingModel(target.channelId, target.modelId)
+        lines.push(`**模型**: ${modelInfo.channelName} / ${modelInfo.modelName}`)
+      } catch {
+        const modelInfo = describeBindingModel(binding.channelId, binding.modelId)
+        lines.push(`**模型**: ${modelInfo.channelName} / ${modelInfo.modelName}（已失效）`)
+      }
     } else {
       lines.push('**会话**: 未绑定（发送消息将自动创建）')
     }
@@ -1576,6 +1592,22 @@ class FeishuBridge {
 
   // ===== 用户消息处理 =====
 
+  private resolveRunTarget(binding: FeishuChatBinding): ReturnType<typeof resolveFeishuRunTarget> {
+    const settings = getSettings()
+    return resolveFeishuRunTarget({
+      binding,
+      botDefaults: {
+        channelId: this.botConfig.defaultChannelId,
+        modelId: this.botConfig.defaultModelId,
+      },
+      globalDefaults: {
+        channelId: settings.agentChannelId,
+        modelId: settings.agentModelId,
+      },
+      channels: listSwitchableChannels(),
+    })
+  }
+
   private async handleUserMessage(
     msgCtx: FeishuMessageContext,
     text: string,
@@ -1591,6 +1623,31 @@ class FeishuBridge {
       await this.createNewSession(msgCtx)
       binding = this.chatBindings.get(chatId)
       if (!binding) return
+    }
+
+    let runTarget: ReturnType<typeof resolveFeishuRunTarget>
+    try {
+      runTarget = this.resolveRunTarget(binding)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '无法解析飞书 Agent 使用的渠道和模型。'
+      await this.sendCardMessage(chatId, buildErrorCard(message))
+      return
+    }
+
+    // 记录本次实际运行目标；失效 binding 回落后，下次不再重复使用旧快照。
+    if (binding.channelId !== runTarget.channelId || binding.modelId !== runTarget.modelId) {
+      console.warn(
+        `[飞书 Bridge] 模型绑定已回落并更新: source=${runTarget.source}, `
+        + `channel=${runTarget.channelId}, model=${runTarget.modelId}`,
+      )
+      binding.channelId = runTarget.channelId
+      binding.modelId = runTarget.modelId
+      this.saveBindings()
+    } else {
+      console.log(
+        `[飞书 Bridge] Agent 运行目标: source=${runTarget.source}, `
+        + `channel=${runTarget.channelId}, model=${runTarget.modelId}`,
+      )
     }
 
     // 注：之前在此处有 isAgentSessionActive silent skip 兜底，会在
@@ -1730,16 +1787,11 @@ class FeishuBridge {
       ? [this.buildPiFeishuChatHistoryTool(chatId)]
       : undefined
 
-    // 渠道/模型解析：binding（per-chat 用户在 IM 里切过的）优先，其次 Bot 配置、应用设置
-    const latestSettings = getSettings()
-    const channelId = binding.channelId || this.botConfig.defaultChannelId || latestSettings.agentChannelId || ''
-    const modelId = binding.modelId || this.botConfig.defaultModelId || latestSettings.agentModelId
-
     const input: AgentSendInput = {
       sessionId: binding.sessionId,
       userMessage: agentMessage,
-      channelId,
-      modelId,
+      channelId: runTarget.channelId,
+      modelId: runTarget.modelId,
       workspaceId: binding.workspaceId,
       permissionModeOverride: 'bypassPermissions',
     }

--- a/apps/electron/src/main/lib/feishu/model-binding.test.ts
+++ b/apps/electron/src/main/lib/feishu/model-binding.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test'
+import type { Channel } from '@proma/shared'
+import {
+  initializeBindingModelSelection,
+  resolveFeishuRunTarget,
+  resolveSessionMirrorModelSelection,
+} from './model-binding'
+
+function makeChannel(
+  id: string,
+  modelId: string,
+  enabled = true,
+  modelEnabled = true,
+): Channel {
+  return {
+    id,
+    name: id,
+    provider: 'deepseek',
+    baseUrl: 'https://api.example.com',
+    apiKey: 'encrypted',
+    enabled,
+    models: [{ id: modelId, name: modelId, enabled: modelEnabled }],
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+describe('飞书模型绑定初始化', () => {
+  test('Given 已有聊天绑定 When Bridge 重启加载 Then 保留原渠道和模型', () => {
+    const result = initializeBindingModelSelection(
+      { channelId: 'binding-channel', modelId: 'binding-model' },
+      { channelId: 'bot-channel', modelId: 'bot-model' },
+      { channelId: 'global-channel', modelId: 'global-model' },
+    )
+
+    expect(result).toEqual({
+      channelId: 'binding-channel',
+      modelId: 'binding-model',
+    })
+  })
+
+  test('Given 绑定字段为空 When Bridge 重启加载 Then 只用 Bot 或全局默认补空值', () => {
+    expect(initializeBindingModelSelection(
+      { channelId: '', modelId: undefined },
+      { channelId: 'bot-channel', modelId: undefined },
+      { channelId: 'global-channel', modelId: 'global-model' },
+    )).toEqual({
+      channelId: 'bot-channel',
+      modelId: 'global-model',
+    })
+  })
+})
+
+describe('飞书 Session 镜像模型绑定', () => {
+  test('Given 桌面会话有独立渠道和模型 When 创建镜像 Then 成对使用会话值', () => {
+    expect(resolveSessionMirrorModelSelection({
+      channelId: 'session-channel',
+      modelId: 'session-model',
+    })).toEqual({
+      channelId: 'session-channel',
+      modelId: 'session-model',
+    })
+  })
+
+  test('Given 桌面会话缺少模型 When 创建镜像 Then 不混入全局模型', () => {
+    expect(resolveSessionMirrorModelSelection({
+      channelId: 'session-channel',
+    })).toEqual({
+      channelId: 'session-channel',
+      modelId: undefined,
+    })
+  })
+})
+
+describe('飞书发送模型解析', () => {
+  const bindingChannel = makeChannel('binding-channel', 'binding-model')
+  const botChannel = makeChannel('bot-channel', 'bot-model')
+  const globalChannel = makeChannel('global-channel', 'global-model')
+
+  test('Given 三级来源都有效 When 发送消息 Then 优先使用聊天绑定', () => {
+    expect(resolveFeishuRunTarget({
+      binding: { channelId: bindingChannel.id, modelId: 'binding-model' },
+      botDefaults: { channelId: botChannel.id, modelId: 'bot-model' },
+      globalDefaults: { channelId: globalChannel.id, modelId: 'global-model' },
+      channels: [bindingChannel, botChannel, globalChannel],
+    })).toEqual({
+      channelId: bindingChannel.id,
+      modelId: 'binding-model',
+      source: 'binding',
+    })
+  })
+
+  test('Given 绑定渠道已停用 When 发送消息 Then 回落到 Bot 默认并返回实际来源', () => {
+    expect(resolveFeishuRunTarget({
+      binding: { channelId: 'disabled-channel', modelId: 'disabled-model' },
+      botDefaults: { channelId: botChannel.id, modelId: 'bot-model' },
+      globalDefaults: { channelId: globalChannel.id, modelId: 'global-model' },
+      channels: [makeChannel('disabled-channel', 'disabled-model', false), botChannel, globalChannel],
+    })).toEqual({
+      channelId: botChannel.id,
+      modelId: 'bot-model',
+      source: 'bot-default',
+    })
+  })
+
+  test('Given 旧绑定只有渠道 When 发送消息 Then 保留该渠道并选首个启用模型', () => {
+    expect(resolveFeishuRunTarget({
+      binding: { channelId: bindingChannel.id, modelId: undefined },
+      botDefaults: { channelId: botChannel.id, modelId: 'bot-model' },
+      globalDefaults: { channelId: globalChannel.id, modelId: 'global-model' },
+      channels: [bindingChannel, botChannel, globalChannel],
+    })).toEqual({
+      channelId: bindingChannel.id,
+      modelId: 'binding-model',
+      source: 'binding',
+    })
+  })
+
+  test('Given 绑定和 Bot 模型均不存在 When 发送消息 Then 回落到全局默认', () => {
+    expect(resolveFeishuRunTarget({
+      binding: { channelId: bindingChannel.id, modelId: 'missing-binding-model' },
+      botDefaults: { channelId: botChannel.id, modelId: 'missing-bot-model' },
+      globalDefaults: { channelId: globalChannel.id, modelId: 'global-model' },
+      channels: [bindingChannel, botChannel, globalChannel],
+    })).toEqual({
+      channelId: globalChannel.id,
+      modelId: 'global-model',
+      source: 'global-default',
+    })
+  })
+
+  test('Given 所有来源都不可用 When 发送消息 Then 给出清晰错误', () => {
+    expect(() => resolveFeishuRunTarget({
+      binding: { channelId: 'missing-channel', modelId: 'missing-model' },
+      botDefaults: {},
+      globalDefaults: {},
+      channels: [],
+    })).toThrow('没有可用的渠道/模型')
+  })
+})

--- a/apps/electron/src/main/lib/feishu/model-binding.ts
+++ b/apps/electron/src/main/lib/feishu/model-binding.ts
@@ -1,0 +1,90 @@
+import type { AgentSessionMeta, Channel, FeishuChatBinding } from '@proma/shared'
+
+export interface ModelSelectionDefaults {
+  channelId?: string
+  modelId?: string
+}
+
+export interface FeishuRunTarget {
+  channelId: string
+  modelId: string
+  source: 'binding' | 'bot-default' | 'global-default'
+}
+
+interface ResolveFeishuRunTargetInput {
+  binding: Pick<FeishuChatBinding, 'channelId' | 'modelId'>
+  botDefaults: ModelSelectionDefaults
+  globalDefaults: ModelSelectionDefaults
+  channels: readonly Channel[]
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value?.trim() ? value : undefined
+}
+
+/** Bridge 启动时只补齐空字段，绝不覆盖聊天已经显式选择的渠道或模型。 */
+export function initializeBindingModelSelection(
+  binding: Pick<FeishuChatBinding, 'channelId' | 'modelId'>,
+  botDefaults: ModelSelectionDefaults,
+  globalDefaults: ModelSelectionDefaults,
+): Pick<FeishuChatBinding, 'channelId' | 'modelId'> {
+  return {
+    channelId: nonEmpty(binding.channelId)
+      ?? nonEmpty(botDefaults.channelId)
+      ?? nonEmpty(globalDefaults.channelId)
+      ?? '',
+    modelId: nonEmpty(binding.modelId)
+      ?? nonEmpty(botDefaults.modelId)
+      ?? nonEmpty(globalDefaults.modelId),
+  }
+}
+
+/** Session 镜像必须成对继承桌面会话，不能把会话渠道和全局模型拼在一起。 */
+export function resolveSessionMirrorModelSelection(
+  session: Pick<AgentSessionMeta, 'channelId' | 'modelId'>,
+): ModelSelectionDefaults {
+  return {
+    channelId: nonEmpty(session.channelId),
+    modelId: nonEmpty(session.modelId),
+  }
+}
+
+/**
+ * 按聊天绑定 → Bot 默认 → 全局默认解析可运行的渠道/模型。
+ *
+ * 指定模型失效时跳到下一级完整来源；来源未指定模型时，使用该渠道第一个
+ * 启用模型，兼容旧绑定只有 channelId 的情况。
+ */
+export function resolveFeishuRunTarget(input: ResolveFeishuRunTargetInput): FeishuRunTarget {
+  const candidates: Array<{
+    source: FeishuRunTarget['source']
+    selection: ModelSelectionDefaults
+  }> = [
+    { source: 'binding', selection: input.binding },
+    { source: 'bot-default', selection: input.botDefaults },
+    { source: 'global-default', selection: input.globalDefaults },
+  ]
+
+  for (const candidate of candidates) {
+    const channelId = nonEmpty(candidate.selection.channelId)
+    if (!channelId) continue
+
+    const channel = input.channels.find((item) => item.id === channelId && item.enabled)
+    if (!channel) continue
+
+    const enabledModels = channel.models.filter((model) => model.enabled)
+    const configuredModelId = nonEmpty(candidate.selection.modelId)
+    const model = configuredModelId
+      ? enabledModels.find((item) => item.id === configuredModelId)
+      : enabledModels[0]
+    if (!model) continue
+
+    return {
+      channelId: channel.id,
+      modelId: model.id,
+      source: candidate.source,
+    }
+  }
+
+  throw new Error('没有可用的渠道/模型。已按聊天绑定 → Bot 默认 → 全局默认检查，请在 Proma 设置中启用渠道和模型。')
+}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -121,6 +121,7 @@ import { inferContextWindow, inferReasoningTransport, isCodexFastModeSupportedMo
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
 import { getFilePanelDragData, INSERT_FILE_MENTION_EVENT, type FilePanelDragItem } from '@/lib/file-panel-drag'
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
+import { resolveAgentSessionModelSelection } from '@/lib/agent-session-model-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import {
@@ -386,8 +387,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const sessionModelMap = useAtomValue(agentSessionModelMapAtom)
   const setSessionChannelMap = useSetAtom(agentSessionChannelMapAtom)
   const setSessionModelMap = useSetAtom(agentSessionModelMapAtom)
-  const [defaultChannelId, setDefaultChannelId] = useAtom(agentChannelIdAtom)
-  const [defaultModelId, setDefaultModelId] = useAtom(agentModelIdAtom)
+  const defaultChannelId = useAtomValue(agentChannelIdAtom)
+  const defaultModelId = useAtomValue(agentModelIdAtom)
   const sessions = useAtomValue(agentSessionsAtom)
   const planningGroups = useAtomValue(todoPlanningGroupsAtom)
   const [todoDialogOpen, setTodoDialogOpen] = React.useState(false)
@@ -409,8 +410,17 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const sessionMetaModelId = sessionMeta?.modelId
   const hasSessionMeta = Boolean(sessionMeta)
   const isLegacyTranscript = sessionMeta?.legacyTranscript?.continuationRequired === true
-  const agentChannelId = sessionMetaChannelId ?? sessionChannelMap.get(sessionId) ?? defaultChannelId
-  const agentModelId = sessionMetaModelId ?? sessionModelMap.get(sessionId) ?? defaultModelId
+  const sessionModelSelection = resolveAgentSessionModelSelection({
+    hasSessionMeta,
+    sessionChannelId: sessionMetaChannelId,
+    sessionModelId: sessionMetaModelId,
+    cachedChannelId: sessionChannelMap.get(sessionId),
+    cachedModelId: sessionModelMap.get(sessionId),
+    defaultChannelId,
+    defaultModelId,
+  })
+  const agentChannelId = sessionModelSelection.channelId
+  const agentModelId = sessionModelSelection.modelId
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const agentEffort = useAtomValue(agentEffortAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
@@ -704,23 +714,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const firstModel = channel.models.find((m) => m.enabled)
     if (!firstModel) return
 
-    // 更新 per-session map（带幂等守卫，避免无意义写入导致 effect 自循环）
+    // 只更新当前 session 的本地选择；打开会话不能反向改写全局默认渠道/模型。
     setSessionModelMap((prev) => {
       if (prev.get(sessionId) === firstModel.id) return prev
       const map = new Map(prev)
       map.set(sessionId, firstModel.id)
       return map
     })
-    // 全局默认值 + 持久化 IPC 也加幂等：firstModel 与当前 defaultModelId 相同时跳过，
-    // 避免每次 agentChannelId / globalChannels 变化都重复写盘和触发 agentModelIdAtom 更新。
-    if (defaultModelId !== firstModel.id) {
-      setDefaultModelId(firstModel.id)
-      window.electronAPI.updateSettings({
-        agentChannelId,
-        agentModelId: firstModel.id,
-      }).catch(console.error)
-    }
-  }, [agentChannelId, agentModelId, globalChannels, sessionId, setSessionModelMap, setDefaultModelId])
+  }, [agentChannelId, agentModelId, globalChannels, sessionId, setSessionModelMap])
 
   // 获取当前 session 的工作路径（文件浏览器需要）
   React.useEffect(() => {
@@ -1925,16 +1926,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
     }
 
-    // 同时更新全局默认值（新会话继承）
-    setDefaultChannelId(option.channelId)
-    setDefaultModelId(option.modelId)
-
-    // 持久化到设置
-    window.electronAPI.updateSettings({
-      agentChannelId: option.channelId,
-      agentModelId: option.modelId,
-    }).catch(console.error)
-
     window.electronAPI.updateAgentSessionModel(sessionId, option.channelId, option.modelId)
       .then((updated) => {
         setAgentSessions((prev) => prev.map((session) => (
@@ -1946,7 +1937,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (modelSwitchDeferred) {
       toast.info('模型已切换，本轮结束后生效')
     }
-  }, [sessionId, streaming, backgroundWaiting, setSessionChannelMap, setSessionModelMap, setDefaultChannelId, setDefaultModelId, setAgentSessions])
+  }, [sessionId, streaming, backgroundWaiting, setSessionChannelMap, setSessionModelMap, setAgentSessions])
 
   const handleCodexFastModeChange = React.useCallback(async (): Promise<void> => {
     if (!isCodexFastModeAvailable || streaming || backgroundWaiting || !sessionMeta) return

--- a/apps/electron/src/renderer/lib/agent-session-model-selection.test.ts
+++ b/apps/electron/src/renderer/lib/agent-session-model-selection.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveAgentSessionModelSelection } from './agent-session-model-selection'
+
+describe('Agent 会话模型选择', () => {
+  test('Given 已有 Codex 会话 When 打开会话 Then 使用会话绑定且不改变全局默认', () => {
+    const globalDefaults = {
+      channelId: 'global-channel',
+      modelId: 'global-model',
+    }
+
+    const selection = resolveAgentSessionModelSelection({
+      hasSessionMeta: true,
+      sessionChannelId: 'codex-channel',
+      sessionModelId: 'gpt-5.6-codex',
+      cachedChannelId: undefined,
+      cachedModelId: undefined,
+      defaultChannelId: globalDefaults.channelId,
+      defaultModelId: globalDefaults.modelId,
+    })
+
+    expect(selection).toEqual({
+      channelId: 'codex-channel',
+      modelId: 'gpt-5.6-codex',
+    })
+    expect(globalDefaults).toEqual({
+      channelId: 'global-channel',
+      modelId: 'global-model',
+    })
+  })
+
+  test('Given 已有会话只有渠道 When 打开会话 Then 不拼入另一渠道的全局模型', () => {
+    expect(resolveAgentSessionModelSelection({
+      hasSessionMeta: true,
+      sessionChannelId: 'session-channel',
+      sessionModelId: undefined,
+      cachedChannelId: undefined,
+      cachedModelId: undefined,
+      defaultChannelId: 'global-channel',
+      defaultModelId: 'global-model',
+    })).toEqual({
+      channelId: 'session-channel',
+      modelId: undefined,
+    })
+  })
+
+  test('Given 新会话尚无元数据 When 初始化 Then 成对继承全局默认', () => {
+    expect(resolveAgentSessionModelSelection({
+      hasSessionMeta: false,
+      sessionChannelId: undefined,
+      sessionModelId: undefined,
+      cachedChannelId: undefined,
+      cachedModelId: undefined,
+      defaultChannelId: 'global-channel',
+      defaultModelId: 'global-model',
+    })).toEqual({
+      channelId: 'global-channel',
+      modelId: 'global-model',
+    })
+  })
+})

--- a/apps/electron/src/renderer/lib/agent-session-model-selection.ts
+++ b/apps/electron/src/renderer/lib/agent-session-model-selection.ts
@@ -1,0 +1,44 @@
+export interface AgentSessionModelSelectionInput {
+  hasSessionMeta: boolean
+  sessionChannelId?: string
+  sessionModelId?: string
+  cachedChannelId?: string
+  cachedModelId?: string
+  defaultChannelId: string | null
+  defaultModelId: string | null
+}
+
+export interface AgentSessionModelSelection {
+  channelId: string | null | undefined
+  modelId: string | null | undefined
+}
+
+/**
+ * 按完整来源解析会话渠道/模型，避免把已有会话的渠道与另一渠道的全局模型拼接。
+ * 该函数只读取全局默认，不修改它；会话内切换由调用方单独持久化到 session。
+ */
+export function resolveAgentSessionModelSelection(
+  input: AgentSessionModelSelectionInput,
+): AgentSessionModelSelection {
+  if (input.hasSessionMeta && input.sessionChannelId) {
+    const cachedModelId = input.cachedChannelId === input.sessionChannelId
+      ? input.cachedModelId
+      : undefined
+    return {
+      channelId: input.sessionChannelId,
+      modelId: input.sessionModelId ?? cachedModelId,
+    }
+  }
+
+  if (input.cachedChannelId) {
+    return {
+      channelId: input.cachedChannelId,
+      modelId: input.cachedModelId,
+    }
+  }
+
+  return {
+    channelId: input.defaultChannelId,
+    modelId: input.defaultModelId,
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.17.0",
+      "version": "0.17.2",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.82.1",
         "@earendil-works/pi-ai": "0.82.1",


### PR DESCRIPTION
## 问题

飞书 Bridge 会在启动时用桌面全局 Agent 设置覆盖所有已有聊天 binding；Session Mirror 又可能把会话渠道与全局模型拼成错误组合。AgentView 打开或切换现有会话时还会反向改写全局默认，最终导致飞书群原本选择的渠道/模型漂移。

Fixes #1463

## 方案

- `loadBindings()` 仅为缺失字段补充 Bot / 全局默认，保留已有聊天的显式渠道和模型。
- Session Mirror 的 `channelId` 与 `modelId` 成对取自桌面 session，不再混入全局模型。
- 新增统一发送目标解析器，严格按 binding → Bot 默认 → 全局默认检查渠道和启用模型。
  - 旧 binding 只有渠道时，使用该渠道第一个启用模型。
  - binding 渠道停用或模型失效时回落到下一完整来源。
  - 将实际使用的渠道/模型写回该聊天 binding，并让 `/now` 使用同一解析结果。
  - 所有来源均不可用时返回清晰错误。
- AgentView 只更新当前 session 的模型选择，不再通过 `updateSettings` 污染全局默认。
- binding 持久化改用已有的原子 JSON 写入封装。
- 按仓库版本规则将 Electron 版本递增到 `0.17.2`。

## 测试证据

先提交失败测试（目标模块尚不存在时 2 个测试文件失败），再实现修复。

- `bun test apps/electron/src/main/lib/bridge-binding-store.test.ts apps/electron/src/main/lib/feishu/sleep-blocker.test.ts apps/electron/src/main/lib/feishu/session-mirror.test.ts apps/electron/src/main/lib/feishu/model-binding.test.ts apps/electron/src/main/lib/feishu/card-renderer-v2.test.ts apps/electron/src/renderer/lib/agent-session-model-selection.test.ts apps/electron/src/renderer/lib/feishu-bindings.test.ts`
  - 32 pass / 0 fail
- `bun run typecheck`
  - shared、session-core、core、cli、ui、electron 全部通过
- `bun run electron:build`
  - 通过；仅保留仓库已有的 Vite 大 chunk / 动静态 import 与 macOS `@available` 警告
- 仓库当前没有 lint script，因此没有可执行的 lint 命令。

自动化回归覆盖原复现链路：已有 binding 重启后保持、空字段初始化、Session Mirror 成对取值、打开 Codex 会话不改变全局默认、发送目标三级优先级及失效回落。

## 兼容性

- 已有且有效的 per-chat binding 保持不变。
- 仅缺失字段会读取默认值，兼容旧 binding。
- 未指定模型的旧 binding 会继续留在原渠道，并选用该渠道首个启用模型。
- 不依赖任何商业版 provider 或 cloud usage 代码，所有渠道使用统一 `Channel` 数据校验。