### PR TITLE
fix(mention): support TipTap async suggestion startup

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -117,7 +117,9 @@ function createMentionSuggestion<T>(
 
       return {
         onStart(props) {
-          if (!requestGuard.isLatest(props.items)) {
+          // TipTap 3.29 会在 items() 异步读取前以未登记的空数组调用 onStart。
+          // 仅拒绝已知的旧请求，不能用 isLatest() 拒绝该初始生命周期，否则弹窗永远不会创建。
+          if (requestGuard.isStale(props.items)) {
             return
           }
           if (popup || renderer) {

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -146,7 +146,9 @@ export function createFileMentionSuggestion(
 
       return {
         onStart(props) {
-          if (!requestGuard.isLatest(props.items)) {
+          // TipTap 3.29 会在 items() 异步读取前以未登记的空数组调用 onStart。
+          // 仅拒绝已知的旧请求，不能用 isLatest() 拒绝该初始生命周期，否则弹窗永远不会创建。
+          if (requestGuard.isStale(props.items)) {
             return
           }
           // 防御竞态：如果上一次弹窗未被正确清理，先清理残留


### PR DESCRIPTION
## Summary

- 兼容 TipTap 3.29 在异步获取建议项前调用 `onStart` 的生命周期，避免初始空数组被误判为过期请求。
- 保留实际过期请求的竞态防护，修复 Skill、MCP、会话与文件引用菜单无法唤起的问题。
- 将桌面端版本提升至 0.17.2。

## Verification

- `bun run --filter=@proma/electron typecheck`
- 已在开发态手动验证 Mention 菜单恢复

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)