### PR TITLE
修复 Pi MCP Streamable HTTP Session 过期后无法恢复

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-mcp-tools.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-mcp-tools.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
+import { buildPiMcpTools, disposePiMcpConnections } from './pi-mcp-tools'
+
+interface SessionServerStats {
+  sessionsCreated: number
+  rejectedSessions: number
+  toolCalls: number
+}
+
+interface SessionServerOptions {
+  expiredStatus: 400 | 404
+  expireAfterFirstTool?: boolean
+  expireReplacementOnInitialized?: boolean
+  failToolAfterFirstWithStatus?: number
+  onSessionRejected?: () => void
+}
+
+interface SessionTestServer {
+  url: string
+  stats: SessionServerStats
+}
+
+const cleanups: Array<() => Promise<void>> = []
+
+function requestMethod(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object' || !('method' in body)) return undefined
+  return typeof body.method === 'string' ? body.method : undefined
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  const parsed: unknown = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+  return parsed
+}
+
+function sendJsonError(response: ServerResponse, status: number, message: string): void {
+  response.writeHead(status, { 'content-type': 'application/json' })
+  response.end(JSON.stringify({
+    jsonrpc: '2.0',
+    error: { code: -32000, message },
+    id: null,
+  }))
+}
+
+async function startSessionTestServer(options: SessionServerOptions): Promise<SessionTestServer> {
+  const transports = new Map<string, StreamableHTTPServerTransport>()
+  const servers = new Set<McpServer>()
+  const stats: SessionServerStats = {
+    sessionsCreated: 0,
+    rejectedSessions: 0,
+    toolCalls: 0,
+  }
+
+  const httpServer = createServer(async (request, response) => {
+    if (request.method === 'GET') {
+      response.writeHead(405).end()
+      return
+    }
+    if (request.method !== 'POST') {
+      response.writeHead(405).end()
+      return
+    }
+
+    try {
+      const body = await readJsonBody(request)
+      const rawSessionId = request.headers['mcp-session-id']
+      const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId
+      const method = requestMethod(body)
+
+      if (sessionId) {
+        const transport = transports.get(sessionId)
+        if (!transport) {
+          stats.rejectedSessions += 1
+          sendJsonError(response, options.expiredStatus, 'No valid session ID provided')
+          options.onSessionRejected?.()
+          return
+        }
+
+        if (
+          options.failToolAfterFirstWithStatus &&
+          stats.toolCalls > 0 &&
+          method === 'tools/call'
+        ) {
+          sendJsonError(response, options.failToolAfterFirstWithStatus, 'Unrelated server failure')
+          return
+        }
+
+        await transport.handleRequest(request, response, body)
+        if (
+          options.expireReplacementOnInitialized &&
+          stats.sessionsCreated > 1 &&
+          method === 'notifications/initialized'
+        ) {
+          transports.delete(sessionId)
+        }
+        return
+      }
+
+      if (!isInitializeRequest(body)) {
+        sendJsonError(response, 400, 'Mcp-Session-Id header is required')
+        return
+      }
+
+      let transport!: StreamableHTTPServerTransport
+      const mcpServer = new McpServer({ name: 'pi-mcp-session-test', version: '1.0.0' })
+      mcpServer.registerTool('ping', { description: '返回 pong' }, async () => {
+        stats.toolCalls += 1
+        if ((options.expireAfterFirstTool ?? true) && stats.toolCalls === 1 && transport.sessionId) {
+          transports.delete(transport.sessionId)
+        }
+        return { content: [{ type: 'text' as const, text: 'pong' }] }
+      })
+
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        enableJsonResponse: true,
+        onsessioninitialized: (newSessionId) => {
+          stats.sessionsCreated += 1
+          transports.set(newSessionId, transport)
+        },
+      })
+      servers.add(mcpServer)
+      await mcpServer.connect(transport)
+      await transport.handleRequest(request, response, body)
+    } catch (error) {
+      if (!response.headersSent) {
+        sendJsonError(response, 500, error instanceof Error ? error.message : String(error))
+      }
+    }
+  })
+
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve))
+  const address = httpServer.address()
+  if (!address || typeof address === 'string') throw new Error('无法获取测试服务器端口')
+
+  const close = async (): Promise<void> => {
+    await Promise.allSettled([...servers].map((server) => server.close()))
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error) => error ? reject(error) : resolve())
+    })
+  }
+  cleanups.push(close)
+
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    stats,
+  }
+}
+
+async function buildPingTool(serverName: string, url: string): Promise<ToolDefinition> {
+  const tools = await buildPiMcpTools({
+    [serverName]: { type: 'http', url, required: true },
+  })
+  const ping = tools.find((tool) => tool.name === `mcp__${serverName}__ping`)
+  if (!ping) throw new Error(`未找到 ${serverName} 的 ping 工具`)
+  return ping
+}
+
+// MCP 桥接工具不会读取 ExtensionContext；测试只验证其公开 execute 行为。
+const unusedExtensionContext = undefined as unknown as Parameters<ToolDefinition['execute']>[4]
+
+async function callPing(
+  tool: ToolDefinition,
+  callId: string,
+  signal: AbortSignal = new AbortController().signal,
+): Promise<void> {
+  await tool.execute(callId, {}, signal, undefined, unusedExtensionContext)
+}
+
+afterEach(async () => {
+  await disposePiMcpConnections()
+  const pendingCleanups = cleanups.splice(0)
+  await Promise.allSettled(pendingCleanups.map((cleanup) => cleanup()))
+})
+
+describe('Pi MCP Streamable HTTP Session 恢复', () => {
+  test.each([400, 404] as const)('已建立的 Session 收到 HTTP %i 后重新握手并重试一次', async (expiredStatus) => {
+    const server = await startSessionTestServer({ expiredStatus })
+    const ping = await buildPingTool(`session_${expiredStatus}`, server.url)
+
+    await callPing(ping, 'first-call')
+    await callPing(ping, 'recovered-call')
+
+    expect(server.stats).toEqual({
+      sessionsCreated: 2,
+      rejectedSessions: 1,
+      toolCalls: 2,
+    })
+  })
+
+  test('并发调用发现同一 Session 失效时只建立一个替代连接', async () => {
+    const server = await startSessionTestServer({ expiredStatus: 404 })
+    const ping = await buildPingTool('concurrent_recovery', server.url)
+
+    await callPing(ping, 'first-call')
+    await Promise.all([
+      callPing(ping, 'concurrent-call-a'),
+      callPing(ping, 'concurrent-call-b'),
+    ])
+
+    expect(server.stats).toEqual({
+      sessionsCreated: 2,
+      rejectedSessions: 2,
+      toolCalls: 3,
+    })
+  })
+
+  test('替代 Session 仍失效时不进行第三次重试', async () => {
+    const server = await startSessionTestServer({
+      expiredStatus: 400,
+      expireReplacementOnInitialized: true,
+    })
+    const ping = await buildPingTool('single_retry', server.url)
+
+    await callPing(ping, 'first-call')
+    await expect(callPing(ping, 'failed-recovery')).rejects.toThrow('No valid session ID provided')
+
+    expect(server.stats).toEqual({
+      sessionsCreated: 2,
+      rejectedSessions: 2,
+      toolCalls: 1,
+    })
+  })
+
+  test('Session 失效与调用取消同时发生时淘汰旧连接但不重试', async () => {
+    let reportAborted = false
+    const server = await startSessionTestServer({
+      expiredStatus: 404,
+      onSessionRejected: () => {
+        reportAborted = true
+      },
+    })
+    const ping = await buildPingTool('cancelled_recovery', server.url)
+    const controller = new AbortController()
+    // 模拟 HTTP 拒绝已经发生，而恢复 catch 执行时调用恰好被取消。
+    Object.defineProperty(controller.signal, 'aborted', {
+      configurable: true,
+      get: () => reportAborted,
+    })
+
+    await callPing(ping, 'first-call')
+    await expect(callPing(ping, 'cancelled-call', controller.signal)).rejects.toThrow('No valid session ID provided')
+    expect(server.stats).toEqual({
+      sessionsCreated: 1,
+      rejectedSessions: 1,
+      toolCalls: 1,
+    })
+
+    await callPing(ping, 'next-call')
+    expect(server.stats).toEqual({
+      sessionsCreated: 2,
+      rejectedSessions: 1,
+      toolCalls: 2,
+    })
+  })
+
+  test.each([400, 500])('非 Session HTTP %i 错误不重建连接或重试工具', async (status) => {
+    const server = await startSessionTestServer({
+      expiredStatus: 404,
+      expireAfterFirstTool: false,
+      failToolAfterFirstWithStatus: status,
+    })
+    const ping = await buildPingTool(`non_session_error_${status}`, server.url)
+
+    await callPing(ping, 'first-call')
+    await expect(callPing(ping, 'server-error')).rejects.toThrow('Unrelated server failure')
+
+    expect(server.stats).toEqual({
+      sessionsCreated: 1,
+      rejectedSessions: 0,
+      toolCalls: 1,
+    })
+  })
+})

--- a/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
@@ -11,7 +11,7 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
 import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import type { TextContent, ImageContent } from '@earendil-works/pi-ai'
@@ -21,6 +21,7 @@ import { Type } from 'typebox'
 const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_MCP_STARTUP_TIMEOUT_MS = 30_000
 const OPTIONAL_MCP_BOOTSTRAP_TIMEOUT_MS = 500
+const HTTP_SESSION_REJECTION_PATTERN = /missing session id|no valid session id provided|mcp-session-id header is required/i
 
 interface PiMcpServerConfig {
   type?: unknown
@@ -43,8 +44,22 @@ type McpCallToolResult = Awaited<ReturnType<Client['callTool']>>
 interface McpConnection {
   client: Client
   transport: Transport
+  close: () => Promise<void>
   tools?: McpToolInfo[]
   toolsPromise?: Promise<McpToolInfo[]>
+}
+
+interface McpConnectionEntry {
+  promise: Promise<McpConnection>
+  activeLeases: number
+  stale: boolean
+  closed: boolean
+}
+
+interface McpConnectionLease {
+  key: string
+  entry: McpConnectionEntry
+  connection: McpConnection
 }
 
 interface McpToolBinding {
@@ -229,20 +244,22 @@ async function listOptionalMcpTools(
 }
 
 class PiMcpClientManager {
-  private readonly connections = new Map<string, Promise<McpConnection>>()
+  private readonly connections = new Map<string, McpConnectionEntry>()
+  private lifecycleGeneration = 0
 
   /**
    * 关闭所有活跃的 MCP 连接，释放 stdio 子进程和网络资源。
    * 应在 app quit 或 agent session 结束时调用。
    */
   async dispose(): Promise<void> {
-    const entries = [...this.connections.entries()]
+    this.lifecycleGeneration += 1
+    const entries = [...this.connections.values()]
     this.connections.clear()
     await Promise.allSettled(
-      entries.map(async ([, connPromise]) => {
+      entries.map(async (entry) => {
         try {
-          const conn = await connPromise
-          await conn.transport.close()
+          const conn = await entry.promise
+          await conn.close()
         } catch {
           // 连接本身就失败了，忽略
         }
@@ -251,63 +268,179 @@ class PiMcpClientManager {
   }
 
   async listTools(serverName: string, config: PiMcpServerConfig): Promise<McpToolInfo[]> {
-    const connection = await this.getConnection(serverName, config)
-    if (connection.tools) return connection.tools
-    if (!connection.toolsPromise) {
-      connection.toolsPromise = connection.client.listTools(undefined, { timeout: DEFAULT_MCP_REQUEST_TIMEOUT_MS })
-        .then((result) => {
-          connection.tools = result.tools
-          return result.tools
-        })
-        .catch((error) => {
-          connection.toolsPromise = undefined
-          throw error
-        })
-    }
-    return await connection.toolsPromise
+    return this.executeWithSessionRecovery(serverName, config, undefined, async (connection) => {
+      if (connection.tools) return connection.tools
+      if (!connection.toolsPromise) {
+        connection.toolsPromise = connection.client.listTools(undefined, { timeout: DEFAULT_MCP_REQUEST_TIMEOUT_MS })
+          .then((result) => {
+            connection.tools = result.tools
+            return result.tools
+          })
+          .catch((error) => {
+            connection.toolsPromise = undefined
+            throw error
+          })
+      }
+      return connection.toolsPromise
+    })
   }
 
   async callTool(serverName: string, config: PiMcpServerConfig, toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpCallToolResult> {
-    const connection = await this.getConnection(serverName, config)
-    return connection.client.callTool(
-      { name: toolName, arguments: args },
-      undefined,
-      { signal, timeout: DEFAULT_MCP_REQUEST_TIMEOUT_MS, resetTimeoutOnProgress: true },
-    )
+    return this.executeWithSessionRecovery(serverName, config, signal, (connection) =>
+      connection.client.callTool(
+        { name: toolName, arguments: args },
+        undefined,
+        { signal, timeout: DEFAULT_MCP_REQUEST_TIMEOUT_MS, resetTimeoutOnProgress: true },
+      ))
   }
 
-  private async getConnection(serverName: string, config: PiMcpServerConfig): Promise<McpConnection> {
+  private async executeWithSessionRecovery<T>(
+    serverName: string,
+    config: PiMcpServerConfig,
+    signal: AbortSignal | undefined,
+    operation: (connection: McpConnection) => Promise<T>,
+  ): Promise<T> {
+    const lifecycleGeneration = this.lifecycleGeneration
+    const lease = await this.acquireConnection(serverName, config)
+    let leaseReleased = false
+    try {
+      try {
+        return await operation(lease.connection)
+      } catch (error) {
+        if (!this.isRejectedHttpSession(error, lease.connection)) {
+          throw error
+        }
+
+        this.markConnectionStale(lease)
+        await this.releaseConnection(lease)
+        leaseReleased = true
+        if (signal?.aborted || this.lifecycleGeneration !== lifecycleGeneration) throw error
+
+        console.info(`[Pi MCP] MCP 服务器 ${serverName} Session 已失效，正在重新握手`)
+
+        const replacement = await this.acquireConnection(serverName, config)
+        try {
+          try {
+            return await operation(replacement.connection)
+          } catch (retryError) {
+            if (this.isRejectedHttpSession(retryError, replacement.connection)) {
+              this.markConnectionStale(replacement)
+            }
+            throw retryError
+          }
+        } finally {
+          await this.releaseConnection(replacement)
+        }
+      }
+    } finally {
+      if (!leaseReleased) {
+        await this.releaseConnection(lease)
+      }
+    }
+  }
+
+  private isRejectedHttpSession(error: unknown, connection: McpConnection): boolean {
+    if (!(connection.transport instanceof StreamableHTTPClientTransport)) return false
+    if (connection.transport.sessionId === undefined) return false
+    if (!(error instanceof StreamableHTTPError)) return false
+    if (error.code === 404) return true
+    return error.code === 400 && HTTP_SESSION_REJECTION_PATTERN.test(error.message)
+  }
+
+  private async acquireConnection(serverName: string, config: PiMcpServerConfig): Promise<McpConnectionLease> {
     const key = `${serverName}:${configHash(config)}`
-    const existing = this.connections.get(key)
-    if (existing) return existing
+    let entry = this.connections.get(key)
 
-    const connectionPromise = this.createConnection(serverName, config, key).catch((error) => {
-      this.connections.delete(key)
+    if (!entry) {
+      let createdEntry!: McpConnectionEntry
+      const promise = this.createConnection(serverName, config, () => {
+        createdEntry.stale = true
+        createdEntry.closed = true
+        if (this.connections.get(key) === createdEntry) {
+          this.connections.delete(key)
+        }
+      }).catch((error) => {
+        createdEntry.stale = true
+        if (this.connections.get(key) === createdEntry) {
+          this.connections.delete(key)
+        }
+        throw error
+      })
+      createdEntry = {
+        promise,
+        activeLeases: 0,
+        stale: false,
+        closed: false,
+      }
+      entry = createdEntry
+      this.connections.set(key, entry)
+    }
+
+    entry.activeLeases += 1
+    try {
+      return {
+        key,
+        entry,
+        connection: await entry.promise,
+      }
+    } catch (error) {
+      entry.activeLeases -= 1
       throw error
-    })
-    this.connections.set(key, connectionPromise)
-    return connectionPromise
+    }
   }
 
-  private async createConnection(serverName: string, config: PiMcpServerConfig, key: string): Promise<McpConnection> {
+  private markConnectionStale(lease: McpConnectionLease): void {
+    lease.entry.stale = true
+    if (this.connections.get(lease.key) === lease.entry) {
+      this.connections.delete(lease.key)
+    }
+  }
+
+  private async releaseConnection(lease: McpConnectionLease): Promise<void> {
+    lease.entry.activeLeases -= 1
+    if (!lease.entry.stale || lease.entry.closed || lease.entry.activeLeases > 0) return
+    try {
+      await lease.connection.close()
+    } catch {
+      // Session 已由服务端终止，关闭旧 transport 失败不影响重新握手。
+    }
+  }
+
+  private async createConnection(
+    serverName: string,
+    config: PiMcpServerConfig,
+    onClose: () => void,
+  ): Promise<McpConnection> {
     const transport = createTransport(serverName, config)
     if (!transport) throw new Error(`无法创建 MCP transport: ${serverName}`)
 
     const client = new Client({ name: 'proma-pi-agent-mcp-bridge', version: '0.1.0' }, { capabilities: {} })
     await client.connect(transport, { timeout: getTimeoutMs(config) })
 
+    let closing = false
+
     const previousOnError = transport.onerror
     transport.onerror = (error) => {
       previousOnError?.(error)
-      console.warn(`[Pi MCP] MCP 服务器 ${serverName} transport error:`, error)
+      if (!closing) {
+        console.warn(`[Pi MCP] MCP 服务器 ${serverName} transport error:`, error)
+      }
     }
     const previousOnClose = transport.onclose
     transport.onclose = () => {
+      closing = true
       previousOnClose?.()
-      this.connections.delete(key)
+      onClose()
     }
 
-    return { client, transport }
+    return {
+      client,
+      transport,
+      close: async () => {
+        closing = true
+        await transport.close()
+      },
+    }
   }
 }
 


### PR DESCRIPTION
## 背景

Stateful Streamable HTTP MCP 会在 `initialize` 响应中返回 `Mcp-Session-Id`。服务端可以因为 TTL、重启或状态清理终止 Session；客户端此后必须丢弃旧 Session 并重新初始化。

Issue #1519 中，Bocha MCP 的 Session 过期后持续返回：

```text
HTTP 400
No valid session ID provided
```

Proma 新建 Agent 会话仍无法恢复，只有重启应用或修改 MCP 配置才会重新握手。

Fixes #1519

## 根因

`PiMcpClientManager` 以 `serverName + configHash` 为 key，在 Electron 主进程级 Map 中缓存 MCP Client/Transport：

```text
Agent 会话 → PiMcpClientManager 单例 → 缓存的 StreamableHTTPClientTransport
```

原实现只在以下情况删除缓存：

- 初次连接失败；
- `transport.onclose`；
- 配置变化产生新的 `configHash`；
- Electron 主进程退出。

Session 过期的 HTTP 400/404 只触发 `transport.onerror`，不会触发 `onclose`。因此旧 Transport 及其过期 `Mcp-Session-Id` 会一直留在 Map，后续调用持续复用同一个坏连接。

新建 Agent 会话无效，是因为 manager 的生命周期属于 Electron 主进程，而不是单个 Agent 会话。

## 修复方案

### 1. 识别已建立 Session 的拒绝响应

仅当连接满足以下条件时进入 Session 恢复：

- Transport 是 `StreamableHTTPClientTransport`；
- Transport 已持有 `sessionId`；
- 错误是 `StreamableHTTPError`；
- HTTP 404，或 HTTP 400 且错误包含明确的 Session 缺失/无效语义。

标准 MCP Streamable HTTP Session 失效使用 404；同时兼容 Bocha 等返回明确 Session 错误的 400 实现。普通业务 400、协议错误和 HTTP 500 不会触发重连。

### 2. 统一恢复 `listTools` 与 `callTool`

两条调用路径统一经过 Session 恢复执行器：

```text
操作失败
→ 确认 Session 被拒绝
→ 从缓存淘汰旧连接
→ 创建新 Client/Transport
→ 重新执行 initialize
→ 原操作重试一次
```

替代 Session 再失败时直接返回第二次错误，不进行第三次重试，避免无限恢复和请求风暴。

### 3. 并发安全的连接淘汰

多个工具调用可能同时使用同一个过期连接。如果第一个失败请求立即关闭旧 Transport，其他仍在执行的请求会收到非预期的 `Connection closed`。

连接 entry 现在记录活跃 lease 数量：

- 首个失败请求将旧 entry 标记为 stale 并从 Map 删除；
- 新请求只会创建并共享一个替代连接；
- 仍在使用旧连接的请求可以完成错误处理；
- 活跃 lease 归零后再关闭旧 Transport；
- 旧 Transport 的延迟 `onclose` 通过 entry 身份检查，不能误删新连接。

### 4. 取消与生命周期处理

- Session 失效与用户取消同时发生时，仍先淘汰已确认失效的连接；
- 已取消的当前操作不会自动重试；
- 下一次调用直接建立新 Session，不会再次复用坏连接；
- `dispose()` 会推进生命周期 generation，阻止迟到的恢复流程在退出期间重新握手；
- 主动关闭旧 Transport 产生的预期 AbortError 不再作为真实 transport 错误记录。

## 行为边界

| 场景 | 淘汰连接 | 自动重试 |
|---|---:|---:|
| 已建立 Session + HTTP 404 | 是 | 是，最多一次 |
| 已建立 Session + 明确 Session 语义的 HTTP 400 | 是 | 是，最多一次 |
| 普通 HTTP 400 | 否 | 否 |
| HTTP 500 | 否 | 否 |
| 替代 Session 再次失效 | 是 | 否 |
| Session 失效且调用已取消 | 是 | 否 |

本次不扩展到旧 SSE transport；SSE 缺少与 Streamable HTTP 相同的结构化 Session 信号，需要独立复现和设计。

## 变更内容

- 重构 `PiMcpClientManager` 的缓存 entry 与连接 lease 生命周期；
- 为 `listTools`、`callTool` 增加统一的一次性 Session 恢复；
- 增加 400/404 Session 拒绝分类；
- 修复并发恢复、取消竞态和 dispose 生命周期竞态；
- 增加真实 stateful Streamable HTTP MCP 回归测试；
- Electron 应用版本 `0.17.2` → `0.17.3`。

## Test plan

- [x] `bun test src/main/lib/adapters/pi-mcp-tools.test.ts`
  - HTTP 400 Session 失效后重新握手并成功重试
  - HTTP 404 Session 失效后重新握手并成功重试
  - 并发失败只创建一个替代连接
  - 替代 Session 再失败时不进行第三次重试
  - 普通 HTTP 400/500 不重连
  - Session 失效与调用取消同时发生时，淘汰旧连接但不重试
- [x] `bun run typecheck`
- [x] 本地 stateful MCP 冒烟验证

验证结果：

```text
7 pass
0 fail
12 expect() calls
```

冒烟流程：

```text
Session A 首次调用成功
→ 服务端删除 Session A
→ 下次请求返回 HTTP 400
→ Proma 淘汰旧连接并重新 initialize
→ 服务端创建 Session B
→ 原工具调用自动重试成功
```
