### PR TITLE
feat: 持久化 Agent 会话活动 worktree

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -47,6 +47,7 @@ import type {
   FileOrFolderDialogResult,
   RecentMessagesResult,
   AgentSessionMeta,
+  SetAgentSessionActiveWorktreeInput,
   AgentSendInput,
   AgentThinkingLevel,
   AgentWorkspace,
@@ -410,6 +411,9 @@ function getAuthorizedRoots(options?: FileAccessOptions): string[] {
     const meta = getAgentSessionMeta(options.sessionId)
     if (meta?.attachedDirectories) {
       roots.push(...meta.attachedDirectories)
+    }
+    if (meta?.activeWorktree?.path) {
+      roots.push(meta.activeWorktree.path)
     }
     if (meta?.attachedFiles) {
       roots.push(...meta.attachedFiles)
@@ -2039,6 +2043,43 @@ export function registerIpcHandlers(): void {
       // 模型切换允许在运行中提交；当前 query 继续使用启动时的模型，下一轮读取新配置。
       return updateAgentSessionMeta(id, { channelId, modelId })
     }
+  )
+
+  // 选择或清除 Agent 会话的活动 worktree
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SET_ACTIVE_WORKTREE,
+    async (_, input: SetAgentSessionActiveWorktreeInput): Promise<AgentSessionMeta> => {
+      if (!input || typeof input.sessionId !== 'string' || (input.worktreePath !== null && typeof input.worktreePath !== 'string')) {
+        throw new Error('活动 worktree 参数无效')
+      }
+      const session = getAgentSessionMeta(input.sessionId)
+      if (!session) throw new Error(`Agent 会话不存在: ${input.sessionId}`)
+      if (input.worktreePath === null) {
+        return updateAgentSessionMeta(input.sessionId, { activeWorktree: undefined })
+      }
+
+      const access = normalizeFileAccessOptions({ sessionId: input.sessionId })
+      if (!(await ensurePathAllowedWithWorktree(input.worktreePath, access))) {
+        throw new Error('无权将该目录设为活动 worktree')
+      }
+
+      const requestedPath = normalizePathForCompare(realpathOrResolve(input.worktreePath))
+      const selected = (await listWorktrees(input.worktreePath)).find((worktree) =>
+        !worktree.isMain && normalizePathForCompare(realpathOrResolve(worktree.path)) === requestedPath,
+      )
+      if (!selected) throw new Error('指定目录不是可用的 linked worktree')
+
+      const mainRepoRoot = await getMainRepoRoot(selected.path)
+      if (!mainRepoRoot) throw new Error('无法确认 worktree 的主仓库')
+      return updateAgentSessionMeta(input.sessionId, {
+        activeWorktree: {
+          path: realpathOrResolve(selected.path),
+          mainRepoRoot: realpathOrResolve(mainRepoRoot),
+          branch: selected.branch,
+          selectedAt: Date.now(),
+        },
+      })
+    },
   )
 
   // 生成 Agent 会话标题

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -36,6 +36,7 @@ import {
 } from '@proma/shared'
 import type { PromaPermissionMode, AskUserRequest, ExitPlanModeRequest, SDKSystemMessage } from '@proma/shared'
 import type { PiAgentQueryOptions } from './adapters/pi-agent-adapter'
+import { getMainRepoRoot } from './git-diff-service'
 import { getPiAssistantErrorDetails, hasPiAssistantTextContent, stripPiAssistantError } from './adapters/pi-message-adapter'
 import { friendlyErrorMessage, isPromptTooLongError, isThinkingSignatureError, mapAgentErrorToTypedError } from './agent-error-utils'
 import { isSessionNotFoundError } from './error-patterns'
@@ -45,7 +46,7 @@ import { getAdapter, fetchTitle } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
-import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, removeSDKErrorMessage, rewindPiAgentSession, resolveAgentCwd, getAgentCwdMode, getSessionWorkbenchLayout } from './agent-session-manager'
+import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, removeSDKErrorMessage, rewindPiAgentSession, resolveAgentCwd, getActiveWorktreePath, getAgentCwdMode, getSessionWorkbenchLayout } from './agent-session-manager'
 import { getAgentWorkspace, getLocalProjectRootStatus, getProjectFilesPath, getWorkspaceMcpConfig, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles, getWorkspaceAgentsMdPath, readWorkspaceAgentsMd, getWorkspaceMemoryGuidance, isWorkspaceProjectKnowledgeMaintenanceApproved } from './agent-workspace-manager'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceSkillsDir } from './config-paths'
 import { getRuntimeStatus } from './runtime-init'
@@ -143,6 +144,7 @@ function collectAttachedDirectories(params: {
   }
 
   for (const d of extraDirs ?? []) push(d)
+  if (sessionMeta?.activeWorktree?.path) push(sessionMeta.activeWorktree.path)
   if (workspaceSlug && sessionMeta) push(getAgentSessionWorkspacePath(workspaceSlug, sessionMeta.id))
   for (const d of sessionMeta?.attachedDirectories ?? []) push(d)
   for (const file of sessionMeta?.attachedFiles ?? []) push(dirname(file))
@@ -849,12 +851,23 @@ export class AgentOrchestrator {
         if (!ws) {
           throw new Error(`指定的 Agent 项目不存在或已删除: ${workspaceId}`)
         }
-        agentCwd = resolveAgentCwd(ws, sessionId, sessionMeta?.agentCwdMode) ?? homedir()
+        let activeWorktree = sessionMeta?.activeWorktree
+        if (activeWorktree) {
+          const activeWorktreePath = getActiveWorktreePath(sessionMeta)
+          const currentMainRepoRoot = activeWorktreePath ? await getMainRepoRoot(activeWorktreePath) : null
+          if (!activeWorktreePath || !currentMainRepoRoot || normalizePathForCompare(currentMainRepoRoot) !== normalizePathForCompare(activeWorktree.mainRepoRoot)) {
+            console.warn(`[Agent 编排] 活动 worktree 已失效，回退默认 cwd: ${activeWorktree.path}`)
+            sessionMeta = updateAgentSessionMeta(sessionId, { activeWorktree: undefined })
+            activeWorktree = undefined
+          }
+        }
+        agentCwd = resolveAgentCwd(ws, sessionId, sessionMeta?.agentCwdMode, activeWorktree) ?? homedir()
         workspaceSlug = ws.slug
         workspace = ws
         runtimeEnv.env.PROMA_WORKSPACE_DIR = getAgentWorkspacePath(ws.slug)
         runtimeEnv.env.PROMA_WORKSPACE_SLUG = ws.slug
-        console.log(`[Agent 编排] 使用 ${getAgentCwdMode(sessionMeta)} cwd: ${agentCwd} (${ws.name}/${sessionId})`)
+        const cwdKind = activeWorktree ? `worktree ${activeWorktree.branch}` : getAgentCwdMode(sessionMeta)
+        console.log(`[Agent 编排] 使用 ${cwdKind} cwd: ${agentCwd} (${ws.name}/${sessionId})`)
 
 
         if (existingSdkSessionId) {

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -279,6 +279,45 @@ describe('Agent 会话 runtime 元数据', () => {
     expect(manager.getAgentSessionMeta(session.id)).toMatchObject({ reasoningLevel: 'xhigh' })
   })
 
+  test('Given an explicitly selected worktree When session metadata is reloaded Then it persists the active context', () => {
+    const session = manager.createAgentSession('Worktree 会话')
+    const worktreePath = join(tempHome, 'linked-worktree')
+    mkdirSync(worktreePath, { recursive: true })
+
+    const updated = manager.updateAgentSessionMeta(session.id, {
+      activeWorktree: {
+        path: worktreePath,
+        mainRepoRoot: join(tempHome, 'main-repo'),
+        branch: 'feat/session-worktree',
+        selectedAt: 123,
+      },
+    })
+
+    expect(updated.activeWorktree?.path).toBe(worktreePath)
+    expect(manager.getAgentSessionMeta(session.id)?.activeWorktree).toMatchObject({
+      path: worktreePath,
+      branch: 'feat/session-worktree',
+    })
+    expect(manager.getActiveWorktreePath(updated)).toBe(worktreePath)
+  })
+
+  test('Given a removed active worktree When resolving its path Then it falls back safely', () => {
+    const session = manager.createAgentSession('失效 Worktree 会话')
+    const worktreePath = join(tempHome, 'removed-worktree')
+    mkdirSync(worktreePath, { recursive: true })
+    const updated = manager.updateAgentSessionMeta(session.id, {
+      activeWorktree: {
+        path: worktreePath,
+        mainRepoRoot: join(tempHome, 'main-repo'),
+        branch: 'feat/removed-worktree',
+        selectedAt: 123,
+      },
+    })
+    rmSync(worktreePath, { recursive: true, force: true })
+
+    expect(manager.getActiveWorktreePath(updated)).toBeUndefined()
+  })
+
   test('Given a session When star state is updated Then it persists without changing freshness or archive state', () => {
     const session = manager.createAgentSession('星标会话')
     const archived = manager.updateAgentSessionMeta(session.id, { archived: true })

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -279,45 +279,6 @@ describe('Agent 会话 runtime 元数据', () => {
     expect(manager.getAgentSessionMeta(session.id)).toMatchObject({ reasoningLevel: 'xhigh' })
   })
 
-  test('Given an explicitly selected worktree When session metadata is reloaded Then it persists the active context', () => {
-    const session = manager.createAgentSession('Worktree 会话')
-    const worktreePath = join(tempHome, 'linked-worktree')
-    mkdirSync(worktreePath, { recursive: true })
-
-    const updated = manager.updateAgentSessionMeta(session.id, {
-      activeWorktree: {
-        path: worktreePath,
-        mainRepoRoot: join(tempHome, 'main-repo'),
-        branch: 'feat/session-worktree',
-        selectedAt: 123,
-      },
-    })
-
-    expect(updated.activeWorktree?.path).toBe(worktreePath)
-    expect(manager.getAgentSessionMeta(session.id)?.activeWorktree).toMatchObject({
-      path: worktreePath,
-      branch: 'feat/session-worktree',
-    })
-    expect(manager.getActiveWorktreePath(updated)).toBe(worktreePath)
-  })
-
-  test('Given a removed active worktree When resolving its path Then it falls back safely', () => {
-    const session = manager.createAgentSession('失效 Worktree 会话')
-    const worktreePath = join(tempHome, 'removed-worktree')
-    mkdirSync(worktreePath, { recursive: true })
-    const updated = manager.updateAgentSessionMeta(session.id, {
-      activeWorktree: {
-        path: worktreePath,
-        mainRepoRoot: join(tempHome, 'main-repo'),
-        branch: 'feat/removed-worktree',
-        selectedAt: 123,
-      },
-    })
-    rmSync(worktreePath, { recursive: true, force: true })
-
-    expect(manager.getActiveWorktreePath(updated)).toBeUndefined()
-  })
-
   test('Given a session When star state is updated Then it persists without changing freshness or archive state', () => {
     const session = manager.createAgentSession('星标会话')
     const archived = manager.updateAgentSessionMeta(session.id, { archived: true })

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -8,12 +8,12 @@
  * 照搬 conversation-manager.ts 的模式。
  */
 
-import { readFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, createReadStream, createWriteStream, type WriteStream } from 'node:fs'
+import { readFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, createReadStream, createWriteStream, statSync, type WriteStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 import { writeJsonFileAtomic, writeTextFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
 import { rmSyncWithRetry, renameWithRetry } from './fs-retry'
-import { join } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import {
   getAgentSessionsIndexPath,
   getAgentSessionsDir,
@@ -39,6 +39,7 @@ import type {
   AgentSessionReferenceSearchInput,
   AgentSessionReferenceSearchResult,
   AgentCwdMode,
+  AgentActiveWorktree,
   SessionWorkbenchLayout,
 } from '@proma/shared'
 import { migratePermissionMode } from '@proma/shared'
@@ -265,6 +266,19 @@ export function getAgentCwdMode(meta?: Pick<AgentSessionMeta, 'agentCwdMode'>): 
   return meta?.agentCwdMode ?? 'session'
 }
 
+/** 只接受仍存在的绝对目录；Git 归属校验由调用主进程在启动 Agent 前完成。 */
+export function getActiveWorktreePath(
+  meta?: Pick<AgentSessionMeta, 'activeWorktree'>,
+): string | undefined {
+  const activeWorktree = meta?.activeWorktree
+  if (!activeWorktree?.path || !isAbsolute(activeWorktree.path)) return undefined
+  try {
+    return statSync(activeWorktree.path).isDirectory() ? activeWorktree.path : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /** 缺少标记的历史会话继续使用 `.context/`，避免失效的计划和工具历史路径。 */
 export function getSessionWorkbenchLayout(
   meta?: Pick<AgentSessionMeta, 'sessionWorkbenchLayout'>,
@@ -288,8 +302,11 @@ export function resolveAgentCwd(
   workspace: Pick<AgentWorkspace, 'slug'> | undefined,
   sessionId: string,
   agentCwdMode?: AgentCwdMode,
+  activeWorktree?: AgentActiveWorktree,
 ): string | undefined {
   if (!workspace) return undefined
+  const activeWorktreePath = getActiveWorktreePath({ activeWorktree })
+  if (activeWorktreePath) return activeWorktreePath
   return getAgentCwdMode({ agentCwdMode }) === 'project'
     ? getProjectFilesPath(workspace.slug)
     : getAgentSessionWorkspacePath(workspace.slug, sessionId)
@@ -505,7 +522,7 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'codexFastMode' | 'reasoningLevel' | 'openAIThinkingLevel' | 'workspaceId' | 'pinned' | 'starred' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'codexFastMode' | 'reasoningLevel' | 'openAIThinkingLevel' | 'workspaceId' | 'activeWorktree' | 'pinned' | 'starred' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -686,6 +703,8 @@ export function moveSessionToWorkspace(sessionId: string, targetWorkspaceId: str
       sdkSessionId: undefined,
       piSessionFile: undefined,
       piEntryBindings: undefined,
+      // 已切换到另一项目，不能沿用旧项目授权下选择的 worktree。
+      activeWorktree: undefined,
       updatedAt: now,
     }
     index.sessions[i] = updated
@@ -771,7 +790,8 @@ async function forkPiAgentSession(sourceMeta: AgentSessionMeta, input: ForkSessi
   const workspace = sourceMeta.workspaceId ? getAgentWorkspace(sourceMeta.workspaceId) : undefined
   const sourceCwdMode = getAgentCwdMode(sourceMeta)
   const sourceWorkbenchLayout = getSessionWorkbenchLayout(sourceMeta)
-  const sourceDir = resolveAgentCwd(workspace, sourceMeta.id, sourceCwdMode)
+  const sourceActiveWorktree = getActiveWorktreePath(sourceMeta) ? sourceMeta.activeWorktree : undefined
+  const sourceDir = resolveAgentCwd(workspace, sourceMeta.id, sourceCwdMode, sourceActiveWorktree)
   const sourceWorkbenchDir = resolveAgentWorkbenchDir(workspace, sourceMeta.id)
   const newMeta = createAgentSession(
     `${sourceMeta.title} (fork)`,
@@ -781,7 +801,7 @@ async function forkPiAgentSession(sourceMeta: AgentSessionMeta, input: ForkSessi
     sourceCwdMode,
     sourceWorkbenchLayout,
   )
-  const destDir = resolveAgentCwd(workspace, newMeta.id, newMeta.agentCwdMode)
+  const destDir = resolveAgentCwd(workspace, newMeta.id, newMeta.agentCwdMode, sourceActiveWorktree)
   const destWorkbenchDir = resolveAgentWorkbenchDir(workspace, newMeta.id)
 
   try {
@@ -805,11 +825,13 @@ async function forkPiAgentSession(sourceMeta: AgentSessionMeta, input: ForkSessi
       sdkSessionId: forkedManager.getSessionId(),
       piSessionFile,
       piEntryBindings: branchBindings,
+      activeWorktree: sourceActiveWorktree,
       forkSourceDir: sourceDir,
     })
     newMeta.sdkSessionId = forkedManager.getSessionId()
     newMeta.piSessionFile = piSessionFile
     newMeta.piEntryBindings = branchBindings
+    newMeta.activeWorktree = sourceActiveWorktree
 
     if (sourceWorkbenchDir && destWorkbenchDir) copyForkWorkspaceFiles(sourceWorkbenchDir, destWorkbenchDir)
     await copyForkStoredSDKMessages({
@@ -851,7 +873,7 @@ export async function rewindPiAgentSession(sessionId: string, assistantMessageUu
   const truncatedContent = kept.map((message) => JSON.stringify(message)).join('\n') + (kept.length > 0 ? '\n' : '')
 
   const workspace = meta.workspaceId ? getAgentWorkspace(meta.workspaceId) : undefined
-  const cwd = resolveAgentCwd(workspace, meta.id, meta.agentCwdMode) ?? process.cwd()
+  const cwd = resolveAgentCwd(workspace, meta.id, meta.agentCwdMode, meta.activeWorktree) ?? process.cwd()
   const sdk = await import('@earendil-works/pi-coding-agent')
   const manager = sdk.SessionManager.open(meta.piSessionFile, join(getSdkConfigDir(), 'sessions'), cwd)
   const branchFile = manager.createBranchedSession(entryId)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -38,6 +38,7 @@ import type {
   RecentMessagesResult,
   MessageSearchResult,
   AgentSessionMeta,
+  SetAgentSessionActiveWorktreeInput,
   SDKMessage,
   AgentSendInput,
   AgentThinkingLevel,
@@ -508,6 +509,9 @@ export interface ElectronAPI {
 
   /** 更新 Agent 会话模型选择 */
   updateAgentSessionModel: (id: string, channelId?: string, modelId?: string) => Promise<AgentSessionMeta>
+
+  /** 选择或清除当前会话的活动 worktree */
+  setAgentSessionActiveWorktree: (input: SetAgentSessionActiveWorktreeInput) => Promise<AgentSessionMeta>
 
   /** 删除 Agent 会话 */
   deleteAgentSession: (id: string) => Promise<void>
@@ -1681,6 +1685,10 @@ const electronAPI: ElectronAPI = {
 
   updateAgentSessionModel: (id: string, channelId?: string, modelId?: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.UPDATE_SESSION_MODEL, id, channelId, modelId)
+  },
+
+  setAgentSessionActiveWorktree: (input: SetAgentSessionActiveWorktreeInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SET_ACTIVE_WORKTREE, input)
   },
 
   deleteAgentSession: (id: string) => {

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -10,7 +10,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
-import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom, workspaceGitDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom, agentSessionsAtom, workspaceGitDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
 import { WorktreeSelector } from './WorktreeSelector'
 import { groupSessionFileChanges } from '@/lib/session-file-changes'
@@ -92,19 +92,43 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   // Worktree 选择状态（内联 WorktreeSelector）
   const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
   const setSelectedWorktreeMap = useSetAtom(agentSelectedWorktreeAtom)
-  const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
+  const sessions = useAtomValue(agentSessionsAtom)
+  const setSessions = useSetAtom(agentSessionsAtom)
+  const persistedWorktreePath = sessions.find((session) => session.id === sessionId)?.activeWorktree?.path ?? null
+  const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? persistedWorktreePath
   const diffCacheKey = selectedWorktreePath ? `${sessionId}:worktree:${selectedWorktreePath}` : `${sessionId}:session`
   const worktreeMode = React.useMemo(
     () => selectedWorktreePath ? { path: selectedWorktreePath, baseBranch: 'origin/main' } : undefined,
     [selectedWorktreePath],
   )
-  const handleWorktreeSelect = React.useCallback((worktree: WorktreeInfo | null) => {
+
+  React.useEffect(() => {
     setSelectedWorktreeMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, worktree?.path ?? null)
-      return m
+      const previous = prev.get(sessionId) ?? null
+      if (previous === persistedWorktreePath) return prev
+      const next = new Map(prev)
+      next.set(sessionId, persistedWorktreePath)
+      return next
     })
-  }, [sessionId, setSelectedWorktreeMap])
+  }, [persistedWorktreePath, sessionId, setSelectedWorktreeMap])
+
+  const handleWorktreeSelect = React.useCallback(async (worktree: WorktreeInfo | null) => {
+    try {
+      const updated = await window.electronAPI.setAgentSessionActiveWorktree({
+        sessionId,
+        worktreePath: worktree?.path ?? null,
+      })
+      setSessions((previous) => previous.map((session) => session.id === sessionId ? updated : session))
+      setSelectedWorktreeMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, updated.activeWorktree?.path ?? null)
+        return next
+      })
+    } catch (error) {
+      console.error('[DiffChangesList] 保存活动 worktree 失败:', error)
+      window.alert(`切换 worktree 失败：${error instanceof Error ? error.message : '未知错误'}`)
+    }
+  }, [sessionId, setSelectedWorktreeMap, setSessions])
 
   // Diff 数据缓存：mount 时若已有上次结果，立即用作初值，避免空数组闪 1s "没有代码改动"
   const diffDataMap = useAtomValue(agentDiffDataAtom)

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -637,6 +637,24 @@ export type AgentCwdMode = 'session' | 'project'
 /** 会话私有工作台的文件布局。缺失字段兼容旧版 `.context/` 子目录。 */
 export type SessionWorkbenchLayout = 'legacy-context' | 'root'
 
+/** 经主进程校验后持久化的 Agent 会话活动 worktree。 */
+export interface AgentActiveWorktree {
+  /** linked worktree 的绝对路径 */
+  path: string
+  /** worktree 所属主仓库根目录 */
+  mainRepoRoot: string
+  /** 选择时 Git 报告的分支名 */
+  branch: string
+  /** 用户明确选择的时间戳 */
+  selectedAt: number
+}
+
+/** 更新 Agent 会话活动 worktree 的输入；null 表示回到默认 cwd。 */
+export interface SetAgentSessionActiveWorktreeInput {
+  sessionId: string
+  worktreePath: string | null
+}
+
 /**
  * Agent 会话轻量索引项
  *
@@ -676,6 +694,11 @@ export interface AgentSessionMeta {
    * session workbench cwd。
    */
   agentCwdMode?: AgentCwdMode
+  /**
+   * 当前会话显式激活的 linked worktree。缺失时保持 agentCwdMode 定义的默认 cwd；
+   * worktree 失效时主进程会主动清除，不会猜测切换到其它分支。
+   */
+  activeWorktree?: AgentActiveWorktree
   /**
    * 会话私有工作台的文件布局。新会话在 workbench 根目录直接存放计划、handoff
    * 等私有资料；缺失字段的历史会话保留 `.context/` 路径以兼容工具历史。
@@ -1559,6 +1582,8 @@ export const AGENT_IPC_CHANNELS = {
   UPDATE_TITLE: 'agent:update-title',
   /** 更新会话模型选择 */
   UPDATE_SESSION_MODEL: 'agent:update-session-model',
+  /** 选择或清除当前会话的活动 worktree */
+  SET_ACTIVE_WORKTREE: 'agent:set-active-worktree',
   /** 删除会话 */
   DELETE_SESSION: 'agent:delete-session',
   /** 迁移 Chat 对话记录到 Agent 会话 */


### PR DESCRIPTION
## 变更摘要
- 在 AgentSessionMeta 中持久化经 Git 校验的活动 worktree。
- 右侧 worktree 下拉框改为读写会话状态，刷新后保持同一选择。
- Agent runtime、文件授权、diff 与预览共同使用活动 worktree。
- worktree 失效或会话迁移时显式清除状态并回退默认 cwd。

## 变更动机
让 Agent 的实际执行目录与用户在文件改动面板中选择的 worktree 保持一致，避免仅切换 diff 视图而仍在默认目录执行。

## 测试计划
- [x] agent-session-manager 测试（19/19）
- [x] git-diff-service 测试（3/3）
- [x] Electron typecheck
- [x] Electron main/preload build

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)