### PR TITLE
fix(agent): 显示生成文件改动

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -955,6 +955,12 @@ function releaseDirectoryWatcherIfUnreferenced(dirPath: string): void {
   if (!isStillReferenced) unwatchAttachedDirectory(dirPath)
 }
 
+function releaseAttachedFileWatchers(filePaths: readonly string[] | undefined): void {
+  for (const dirPath of new Set((filePaths ?? []).map((filePath) => dirname(filePath)))) {
+    releaseDirectoryWatcherIfUnreferenced(dirPath)
+  }
+}
+
 async function withOAuthDeviceCodeQr<T extends CodexOAuthDeviceCode | XaiOAuthDeviceCode>(deviceCode: T): Promise<T> {
   try {
     const QRCode = (await import('qrcode')).default
@@ -2094,6 +2100,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.DELETE_SESSION,
     async (_, id: string): Promise<void> => {
+      const attachedFiles = getAgentSessionMeta(id)?.attachedFiles
       // 清理权限服务中该会话的白名单
       permissionService.clearSessionWhitelist(id)
       permissionService.clearSessionPending(id)
@@ -2101,7 +2108,8 @@ export function registerIpcHandlers(): void {
       askUserService.clearSessionPending(id)
       // 清理 ExitPlanMode 服务中的待处理请求
       exitPlanService.clearSessionPending(id)
-      return deleteAgentSession(id)
+      deleteAgentSession(id)
+      releaseAttachedFileWatchers(attachedFiles)
     }
   )
 
@@ -2334,9 +2342,13 @@ export function registerIpcHandlers(): void {
         throw new Error('至少需要保留一个项目')
       }
 
-      const affectedSessionIds = listAgentSessions()
+      const affectedSessions = listAgentSessions()
         .filter((session) => session.workspaceId === id)
-        .map((session) => session.id)
+      const affectedSessionIds = affectedSessions.map((session) => session.id)
+      const deletedAttachedFiles = [
+        ...affectedSessions.flatMap((session) => session.attachedFiles ?? []),
+        ...getWorkspaceAttachedFiles(deletingWorkspace.slug),
+      ]
       const affectedAutomationIds = listAutomations()
         .filter((automation) => automation.workspaceId === id)
         .map((automation) => automation.id)
@@ -2369,6 +2381,7 @@ export function registerIpcHandlers(): void {
       }
       deleteAgentWorkspace(id)
 
+      releaseAttachedFileWatchers(deletedAttachedFiles)
       if (deletedProjectRoot) releaseDirectoryWatcherIfUnreferenced(deletedProjectRoot)
     }
   )

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -945,9 +945,11 @@ export function resolveAppIconPath(variantId: string): string | null {
 function releaseDirectoryWatcherIfUnreferenced(dirPath: string): void {
   const isStillReferenced = listAgentWorkspaces().some((workspace) =>
     workspace.projectRootPath === dirPath
-    || getWorkspaceAttachedDirectories(workspace.slug).includes(dirPath),
+    || getWorkspaceAttachedDirectories(workspace.slug).includes(dirPath)
+    || getWorkspaceAttachedFiles(workspace.slug).some((filePath) => dirname(filePath) === dirPath),
   ) || listAgentSessions().some((session) =>
-    session.attachedDirectories?.includes(dirPath),
+    session.attachedDirectories?.includes(dirPath)
+    || session.attachedFiles?.some((filePath) => dirname(filePath) === dirPath),
   )
 
   if (!isStillReferenced) unwatchAttachedDirectory(dirPath)
@@ -2240,6 +2242,9 @@ export function registerIpcHandlers(): void {
       const workspaces = listAgentWorkspaces()
       for (const workspace of workspaces) {
         if (workspace.projectRootPath) watchAttachedDirectory(workspace.projectRootPath)
+        for (const filePath of getWorkspaceAttachedFiles(workspace.slug)) {
+          watchAttachedDirectory(dirname(filePath))
+        }
       }
       return workspaces
     }
@@ -3121,6 +3126,7 @@ export function registerIpcHandlers(): void {
 
       const updated = [...existing, safePath]
       updateAgentSessionMeta(input.sessionId, { attachedFiles: updated })
+      watchAttachedDirectory(dirname(safePath))
       return updated
     }
   )
@@ -3135,6 +3141,7 @@ export function registerIpcHandlers(): void {
       const existing = meta.attachedFiles ?? []
       const updated = existing.filter((f) => f !== input.filePath)
       updateAgentSessionMeta(input.sessionId, { attachedFiles: updated })
+      releaseDirectoryWatcherIfUnreferenced(dirname(input.filePath))
       return updated
     }
   )
@@ -3169,7 +3176,9 @@ export function registerIpcHandlers(): void {
       const stats = statSync(safePath)
       if (!stats.isFile()) throw new Error('只能附加文件')
 
-      return attachWorkspaceFile(input.workspaceSlug, safePath)
+      const updated = attachWorkspaceFile(input.workspaceSlug, safePath)
+      watchAttachedDirectory(dirname(safePath))
+      return updated
     }
   )
 
@@ -3177,7 +3186,9 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.DETACH_WORKSPACE_FILE,
     async (_, input: WorkspaceAttachFileInput): Promise<string[]> => {
-      return detachWorkspaceFile(input.workspaceSlug, input.filePath)
+      const updated = detachWorkspaceFile(input.workspaceSlug, input.filePath)
+      releaseDirectoryWatcherIfUnreferenced(dirname(input.filePath))
+      return updated
     }
   )
 

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -13,6 +13,7 @@
 
 import { watch, existsSync, statSync } from 'node:fs'
 import type { FSWatcher } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import type { BrowserWindow } from 'electron'
 import { AGENT_IPC_CHANNELS } from '@proma/shared'
@@ -68,11 +69,14 @@ function notifyWorkspaceFilesChanged(changedPath?: string): void {
   if (attachedFilesTimer) clearTimeout(attachedFilesTimer)
   if (changedPath) attachedChangedPaths.add(changedPath)
   attachedFilesTimer = setTimeout(() => {
-    if (mainWin && !mainWin.isDestroyed()) {
-      mainWin.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, [...attachedChangedPaths])
-    }
+    const changedPaths = [...attachedChangedPaths]
     attachedChangedPaths.clear()
     attachedFilesTimer = null
+    void filterExistingFiles(changedPaths).then((filePaths) => {
+      if (mainWin && !mainWin.isDestroyed()) {
+        mainWin.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, filePaths)
+      }
+    })
   }, DEBOUNCE_MS)
 }
 
@@ -85,13 +89,16 @@ function isExistingDirectory(dirPath: string): boolean {
   }
 }
 
-/** 文件删除后路径不可 stat，仍需发出刷新；存在时跳过纯目录事件。 */
-function isFileOrMissing(filePath: string): boolean {
-  try {
-    return !statSync(filePath).isDirectory()
-  } catch {
-    return true
-  }
+/** debounce 后异步筛选存在的普通文件，目录和已删除路径仍会触发空刷新事件。 */
+async function filterExistingFiles(paths: readonly string[]): Promise<string[]> {
+  const results = await Promise.all(paths.map(async (filePath) => {
+    try {
+      return (await stat(filePath)).isFile() ? filePath : null
+    } catch {
+      return null
+    }
+  }))
+  return results.filter((filePath): filePath is string => filePath !== null)
 }
 
 function findNearestExistingDirectory(dirPath: string): string | null {
@@ -249,16 +256,19 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
           capabilitiesTimer = null
         }, DEBOUNCE_MS)
       } else {
-        if (!isFileOrMissing(join(watchDir, normalizedFilename))) return
-        // 其他文件变化 → 通知文件浏览器刷新
+        // 其他文件变化 → 通知文件浏览器刷新。删除或目录事件会发送空路径列表，
+        // 仍让 Git Diff 刷新，但不会把非文件路径记录到会话改动中。
         if (filesTimer) clearTimeout(filesTimer)
         changedFilePaths.add(join(watchDir, normalizedFilename))
         filesTimer = setTimeout(() => {
-          if (!win.isDestroyed()) {
-            win.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, [...changedFilePaths])
-          }
+          const paths = [...changedFilePaths]
           changedFilePaths.clear()
           filesTimer = null
+          void filterExistingFiles(paths).then((filePaths) => {
+            if (!win.isDestroyed()) {
+              win.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, filePaths)
+            }
+          })
         }, DEBOUNCE_MS)
       }
     })
@@ -330,7 +340,6 @@ export function watchAttachedDirectory(dirPath: string): void {
       const normalizedFilename = normalizeWatchFilename(filename)
       if (normalizedFilename === null || !shouldNotifyForWatchFilename(normalizedFilename)) return
       const changedPath = join(dirPath, normalizedFilename)
-      if (!isFileOrMissing(changedPath)) return
       invalidateGitDiffCache(changedPath)
       notifyWorkspaceFilesChanged(changedPath)
     })

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -57,17 +57,21 @@ const unavailableDirectoryParents = new Map<string, string>()
 
 /** 附加目录防抖定时器 */
 let attachedFilesTimer: ReturnType<typeof setTimeout> | null = null
+/** 附加目录最近一次变化路径，随 debounce 事件一起发送。 */
+const attachedChangedPaths = new Set<string>()
 /** 主窗口引用（供附加目录监听器使用） */
 let mainWin: BrowserWindow | null = null
 
-function notifyWorkspaceFilesChanged(): void {
+function notifyWorkspaceFilesChanged(changedPath?: string): void {
   if (!mainWin || mainWin.isDestroyed()) return
 
   if (attachedFilesTimer) clearTimeout(attachedFilesTimer)
+  if (changedPath) attachedChangedPaths.add(changedPath)
   attachedFilesTimer = setTimeout(() => {
     if (mainWin && !mainWin.isDestroyed()) {
-      mainWin.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED)
+      mainWin.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, [...attachedChangedPaths])
     }
+    attachedChangedPaths.clear()
     attachedFilesTimer = null
   }, DEBOUNCE_MS)
 }
@@ -78,6 +82,15 @@ function isExistingDirectory(dirPath: string): boolean {
     return statSync(dirPath).isDirectory()
   } catch {
     return false
+  }
+}
+
+/** 文件删除后路径不可 stat，仍需发出刷新；存在时跳过纯目录事件。 */
+function isFileOrMissing(filePath: string): boolean {
+  try {
+    return !statSync(filePath).isDirectory()
+  } catch {
+    return true
   }
 }
 
@@ -199,6 +212,7 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
   // 防抖定时器：按事件类型分别 debounce
   let capabilitiesTimer: ReturnType<typeof setTimeout> | null = null
   let filesTimer: ReturnType<typeof setTimeout> | null = null
+  const changedFilePaths = new Set<string>
 
   try {
     watcher = watch(watchDir, { recursive: true }, (_eventType, filename) => {
@@ -235,12 +249,15 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
           capabilitiesTimer = null
         }, DEBOUNCE_MS)
       } else {
+        if (!isFileOrMissing(join(watchDir, normalizedFilename))) return
         // 其他文件变化 → 通知文件浏览器刷新
         if (filesTimer) clearTimeout(filesTimer)
+        changedFilePaths.add(join(watchDir, normalizedFilename))
         filesTimer = setTimeout(() => {
           if (!win.isDestroyed()) {
-            win.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED)
+            win.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, [...changedFilePaths])
           }
+          changedFilePaths.clear()
           filesTimer = null
         }, DEBOUNCE_MS)
       }
@@ -289,6 +306,7 @@ export function stopWorkspaceWatcher(): void {
   unavailableDirectoryParents.clear()
   if (attachedFilesTimer) clearTimeout(attachedFilesTimer)
   attachedFilesTimer = null
+  attachedChangedPaths.clear()
   mainWin = null
 }
 
@@ -311,8 +329,10 @@ export function watchAttachedDirectory(dirPath: string): void {
     const w = watch(dirPath, { recursive: true }, (_eventType, filename) => {
       const normalizedFilename = normalizeWatchFilename(filename)
       if (normalizedFilename === null || !shouldNotifyForWatchFilename(normalizedFilename)) return
-      invalidateGitDiffCache(join(dirPath, normalizedFilename))
-      notifyWorkspaceFilesChanged()
+      const changedPath = join(dirPath, normalizedFilename)
+      if (!isFileOrMissing(changedPath)) return
+      invalidateGitDiffCache(changedPath)
+      notifyWorkspaceFilesChanged(changedPath)
     })
 
     // 同主 watcher：监听 'error' 防止运行时异常拖死主进程。

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -132,6 +132,9 @@ function restoreAgentSessionAttachedDirectoryWatchers(): void {
     for (const dirPath of session.attachedDirectories ?? []) {
       watchAttachedDirectory(dirPath)
     }
+    for (const filePath of session.attachedFiles ?? []) {
+      watchAttachedDirectory(dirname(filePath))
+    }
   }
 }
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -953,9 +953,10 @@ export interface ElectronAPI {
   listReleases: (options?: GitHubReleaseListOptions) => Promise<GitHubRelease[]>
   getReleaseByTag: (tag: string) => Promise<GitHubRelease | null>
 
-  // 工作区文件变化通知
+  /** 工作区能力变化通知 */
   onCapabilitiesChanged: (callback: () => void) => () => void
-  onWorkspaceFilesChanged: (callback: () => void) => () => void
+  /** 工作区文件变化通知；可选携带 debounce 窗口内的实际变化绝对路径 */
+  onWorkspaceFilesChanged: (callback: (changedPaths?: string[]) => void) => () => void
 
   // ===== 飞书集成 =====
 
@@ -2061,8 +2062,12 @@ const electronAPI: ElectronAPI = {
     return () => { ipcRenderer.removeListener(AGENT_IPC_CHANNELS.CAPABILITIES_CHANGED, listener) }
   },
 
-  onWorkspaceFilesChanged: (callback: () => void) => {
-    const listener = (): void => callback()
+  onWorkspaceFilesChanged: (callback: (changedPaths?: string[]) => void) => {
+    const listener = (_event: unknown, changedPaths?: unknown): void => {
+      callback(Array.isArray(changedPaths)
+        ? changedPaths.filter((path): path is string => typeof path === 'string')
+        : undefined)
+    }
     ipcRenderer.on(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, listener)
     return () => { ipcRenderer.removeListener(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, listener) }
   },

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -75,7 +75,8 @@ import {
 } from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
-import { getSessionFileChangeKind, upsertSessionFileChange } from '@/lib/session-file-changes'
+import { detectIsWindows } from '@/lib/platform'
+import { getSessionFileChangeKind, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -657,6 +658,64 @@ export function useGlobalAgentListeners(): void {
         basePaths: basePaths.length > 0 ? basePaths : undefined,
       }
     }
+
+    const isWindows = detectIsWindows()
+
+    const cleanupWatchedFileChanges = window.electronAPI.onWorkspaceFilesChanged((changedPaths) => {
+      const filePaths = (changedPaths ?? []).filter(isAbsolutePath)
+      if (filePaths.length === 0) return
+
+      void (async () => {
+        const streamingStates = store.get(agentStreamingStatesAtom)
+        const sessionPaths = store.get(agentSessionPathMapAtom)
+        const currentSessionId = store.get(currentAgentSessionIdAtom)
+        const candidateIds = [...streamingStates.entries()]
+          .filter(([, state]) => state.running)
+          .map(([sessionId]) => sessionId)
+          .sort((a, b) => Number(b === currentSessionId) - Number(a === currentSessionId))
+
+        for (const sessionId of candidateIds) {
+          const sessionPath = sessionPaths.get(sessionId)
+          const workspaceFilesPath = await getWorkspaceFilesPathForSession(sessionId)
+          const matchingPaths = filePaths.filter((changedPath) => (
+            (sessionPath && isPathWithinRoot(sessionPath, changedPath, isWindows))
+            || (workspaceFilesPath && isPathWithinRoot(workspaceFilesPath, changedPath, isWindows))
+          ))
+          if (matchingPaths.length === 0) continue
+
+          const runId = store.get(agentFileChangesCurrentRunAtom).get(sessionId)
+            ?? String(streamingStates.get(sessionId)?.startedAt ?? Date.now())
+          for (const changedPath of matchingPaths) {
+            const previewFile = await buildWrittenFilePreviewInfo(sessionId, changedPath)
+            if (!previewFile.previewOnly) continue
+            store.set(agentNonGitFileChangesAtom, (prev) => {
+              const map = new Map(prev)
+              const current = map.get(sessionId) ?? []
+              map.set(sessionId, upsertSessionFileChange(current, {
+                path: changedPath,
+                kind: 'edited',
+                runId,
+                updatedAt: Date.now(),
+              }))
+              return map
+            })
+            if (
+              store.get(currentAgentSessionIdAtom) === sessionId
+              && autoActivatedChangeTurns.get(sessionId) !== runId
+            ) {
+              autoActivatedChangeTurns.set(sessionId, runId)
+              store.set(agentSidePanelOpenAtom, true)
+              store.set(agentDiffPanelTabAtom, (prev) => {
+                const map = new Map(prev)
+                map.set(sessionId, 'changes')
+                return map
+              })
+            }
+          }
+          return
+        }
+      })().catch(() => { /* 文件监听不应影响会话流 */ })
+    })
 
     // ===== 0. 初始化：从持久化 meta 恢复 stoppedByUser 状态 =====
     window.electronAPI.listAgentSessions().then((sessions) => {
@@ -1474,6 +1533,7 @@ export function useGlobalAgentListeners(): void {
       cleanupError()
       cleanupTodoAgentSessionReady()
       cleanupTitleUpdated()
+      cleanupWatchedFileChanges()
       clearInterval(pruneTimer)
       window.removeEventListener('focus', onWindowFocus)
     }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -672,7 +672,7 @@ export function useGlobalAgentListeners(): void {
           .filter(([, state]) => state.running)
           .map(([sessionId]) => sessionId)
 
-        for (const sessionId of candidateIds) {
+        const candidates = await Promise.all(candidateIds.map(async (sessionId) => {
           const sessionPath = sessionPaths.get(sessionId)
           const workspaceId = getWorkspaceIdForSession(sessionId)
           const workspaceFilesPath = await getWorkspaceFilesPathForSession(sessionId)
@@ -698,11 +698,20 @@ export function useGlobalAgentListeners(): void {
             directoryRoots.some((rootPath) => isPathWithinRoot(rootPath, changedPath, isWindows))
             || attachedFiles.some((filePath) => arePathsEqual(filePath, changedPath, isWindows))
           ))
-          if (matchingPaths.length === 0) continue
+          return { sessionId, matchingPaths }
+        }))
+
+        for (const { sessionId, matchingPaths } of candidates) {
+          // watcher 事件没有来源 session。路径被多个运行中会话覆盖时不能可靠归属，
+          // 因此仅记录唯一匹配的路径，避免把后台会话的写入显示在错误会话中。
+          const uniquelyMatchingPaths = matchingPaths.filter((changedPath) => (
+            candidates.filter((candidate) => candidate.matchingPaths.includes(changedPath)).length === 1
+          ))
+          if (uniquelyMatchingPaths.length === 0) continue
 
           const runId = store.get(agentFileChangesCurrentRunAtom).get(sessionId)
             ?? String(streamingStates.get(sessionId)?.startedAt ?? Date.now())
-          for (const changedPath of matchingPaths) {
+          for (const changedPath of uniquelyMatchingPaths) {
             const previewFile = await buildWrittenFilePreviewInfo(sessionId, changedPath)
             if (!previewFile.previewOnly) continue
             store.set(agentNonGitFileChangesAtom, (prev) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -615,6 +615,24 @@ export function useGlobalAgentListeners(): void {
       }
     }
 
+    const getWorkspaceAttachmentsForSession = async (sid: string): Promise<{
+      directories: string[]
+      files: string[]
+      complete: boolean
+    }> => {
+      const slug = getWorkspaceSlugForSession(sid)
+      if (!slug) return { directories: [], files: [], complete: true }
+      try {
+        const [directories, files] = await Promise.all([
+          window.electronAPI.getWorkspaceDirectories(slug),
+          window.electronAPI.getWorkspaceAttachedFiles(slug),
+        ])
+        return { directories, files, complete: true }
+      } catch {
+        return { directories: [], files: [], complete: false }
+      }
+    }
+
     const buildWrittenFilePreviewInfo = async (sid: string, targetPath: string) => {
       const sessionPath = store.get(agentSessionPathMapAtom).get(sid) ?? ''
       const parentDir = getParentDir(targetPath)
@@ -673,26 +691,23 @@ export function useGlobalAgentListeners(): void {
           .map(([sessionId]) => sessionId)
 
         const candidates = await Promise.all(candidateIds.map(async (sessionId) => {
+          const session = store.get(agentSessionsAtom).find((item) => item.id === sessionId)
           const sessionPath = sessionPaths.get(sessionId)
-          const workspaceId = getWorkspaceIdForSession(sessionId)
           const workspaceFilesPath = await getWorkspaceFilesPathForSession(sessionId)
-          const sessionAttachedDirs = store.get(agentAttachedDirectoriesMapAtom).get(sessionId) ?? []
-          const sessionAttachedFiles = store.get(agentAttachedFilesMapAtom).get(sessionId) ?? []
-          const workspaceAttachedDirs = workspaceId
-            ? (store.get(workspaceAttachedDirectoriesMapAtom).get(workspaceId) ?? [])
-            : []
-          const workspaceAttachedFiles = workspaceId
-            ? (store.get(workspaceAttachedFilesMapAtom).get(workspaceId) ?? [])
-            : []
+          const workspaceAttachments = await getWorkspaceAttachmentsForSession(sessionId)
+          if (!session || !workspaceAttachments.complete) {
+            // 缺少运行会话的权威附件配置时，任何路径都不能安全归属给其他会话。
+            return { sessionId, matchingPaths: [...filePaths] }
+          }
           const directoryRoots = uniqueTruthyPaths([
             sessionPath,
             workspaceFilesPath,
-            ...sessionAttachedDirs,
-            ...workspaceAttachedDirs,
+            ...(session.attachedDirectories ?? []),
+            ...workspaceAttachments.directories,
           ])
           const attachedFiles = uniqueTruthyPaths([
-            ...sessionAttachedFiles,
-            ...workspaceAttachedFiles,
+            ...(session.attachedFiles ?? []),
+            ...workspaceAttachments.files,
           ])
           const matchingPaths = filePaths.filter((changedPath) => (
             directoryRoots.some((rootPath) => isPathWithinRoot(rootPath, changedPath, isWindows))

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -76,7 +76,7 @@ import {
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
 import { detectIsWindows } from '@/lib/platform'
-import { getSessionFileChangeKind, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
+import { getSessionFileChangeKind, arePathsEqual, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -668,18 +668,35 @@ export function useGlobalAgentListeners(): void {
       void (async () => {
         const streamingStates = store.get(agentStreamingStatesAtom)
         const sessionPaths = store.get(agentSessionPathMapAtom)
-        const currentSessionId = store.get(currentAgentSessionIdAtom)
         const candidateIds = [...streamingStates.entries()]
           .filter(([, state]) => state.running)
           .map(([sessionId]) => sessionId)
-          .sort((a, b) => Number(b === currentSessionId) - Number(a === currentSessionId))
 
         for (const sessionId of candidateIds) {
           const sessionPath = sessionPaths.get(sessionId)
+          const workspaceId = getWorkspaceIdForSession(sessionId)
           const workspaceFilesPath = await getWorkspaceFilesPathForSession(sessionId)
+          const sessionAttachedDirs = store.get(agentAttachedDirectoriesMapAtom).get(sessionId) ?? []
+          const sessionAttachedFiles = store.get(agentAttachedFilesMapAtom).get(sessionId) ?? []
+          const workspaceAttachedDirs = workspaceId
+            ? (store.get(workspaceAttachedDirectoriesMapAtom).get(workspaceId) ?? [])
+            : []
+          const workspaceAttachedFiles = workspaceId
+            ? (store.get(workspaceAttachedFilesMapAtom).get(workspaceId) ?? [])
+            : []
+          const directoryRoots = uniqueTruthyPaths([
+            sessionPath,
+            workspaceFilesPath,
+            ...sessionAttachedDirs,
+            ...workspaceAttachedDirs,
+          ])
+          const attachedFiles = uniqueTruthyPaths([
+            ...sessionAttachedFiles,
+            ...workspaceAttachedFiles,
+          ])
           const matchingPaths = filePaths.filter((changedPath) => (
-            (sessionPath && isPathWithinRoot(sessionPath, changedPath, isWindows))
-            || (workspaceFilesPath && isPathWithinRoot(workspaceFilesPath, changedPath, isWindows))
+            directoryRoots.some((rootPath) => isPathWithinRoot(rootPath, changedPath, isWindows))
+            || attachedFiles.some((filePath) => arePathsEqual(filePath, changedPath, isWindows))
           ))
           if (matchingPaths.length === 0) continue
 
@@ -696,7 +713,7 @@ export function useGlobalAgentListeners(): void {
                 kind: 'edited',
                 runId,
                 updatedAt: Date.now(),
-              }))
+              }, isWindows))
               return map
             })
             if (
@@ -712,7 +729,6 @@ export function useGlobalAgentListeners(): void {
               })
             }
           }
-          return
         }
       })().catch(() => { /* 文件监听不应影响会话流 */ })
     })
@@ -1027,7 +1043,7 @@ export function useGlobalAgentListeners(): void {
                         kind: getSessionFileChangeKind(entry.toolName, entry.existedBefore),
                         runId: entry.runId,
                         updatedAt: Date.now(),
-                      }))
+                      }, isWindows))
                       return m
                     })
 

--- a/apps/electron/src/renderer/lib/session-file-changes.ts
+++ b/apps/electron/src/renderer/lib/session-file-changes.ts
@@ -1,3 +1,13 @@
+export function isPathWithinRoot(rootPath: string, targetPath: string, caseInsensitive = false): boolean {
+  const normalize = (value: string): string => {
+    const normalized = value.replace(/\\/g, '/').replace(/\/+/g, '/')
+    return caseInsensitive ? normalized.toLowerCase() : normalized
+  }
+  const root = normalize(rootPath).replace(/\/$/, '')
+  const target = normalize(targetPath)
+  return target === root || target.startsWith(`${root}/`)
+}
+
 export type SessionFileChangeKind = "created" | "edited";
 
 export interface SessionFileChange {

--- a/apps/electron/src/renderer/lib/session-file-changes.ts
+++ b/apps/electron/src/renderer/lib/session-file-changes.ts
@@ -1,10 +1,15 @@
+function normalizePath(path: string, caseInsensitive: boolean): string {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/\/+$/, '')
+  return caseInsensitive ? normalized.toLowerCase() : normalized
+}
+
+export function arePathsEqual(leftPath: string, rightPath: string, caseInsensitive = false): boolean {
+  return normalizePath(leftPath, caseInsensitive) === normalizePath(rightPath, caseInsensitive)
+}
+
 export function isPathWithinRoot(rootPath: string, targetPath: string, caseInsensitive = false): boolean {
-  const normalize = (value: string): string => {
-    const normalized = value.replace(/\\/g, '/').replace(/\/+/g, '/')
-    return caseInsensitive ? normalized.toLowerCase() : normalized
-  }
-  const root = normalize(rootPath).replace(/\/$/, '')
-  const target = normalize(targetPath)
+  const root = normalizePath(rootPath, caseInsensitive)
+  const target = normalizePath(targetPath, caseInsensitive)
   return target === root || target.startsWith(`${root}/`)
 }
 
@@ -28,8 +33,9 @@ export function getSessionFileChangeKind(
 export function upsertSessionFileChange(
   changes: readonly SessionFileChange[],
   next: SessionFileChange,
+  caseInsensitive = false,
 ): SessionFileChange[] {
-  const index = changes.findIndex((change) => change.path === next.path);
+  const index = changes.findIndex((change) => arePathsEqual(change.path, next.path, caseInsensitive));
   if (index < 0) return [next, ...changes];
 
   const current = changes[index]!;


### PR DESCRIPTION
## 变更摘要
- 工作区文件监听在 debounce 窗口内批量传递实际变化路径。
- 将运行中会话工作目录里的非 Git 文件写入“文件改动”面板。
- Bash、脚本及图片生成工具写入的生成文件会自动打开并显示在该面板。
- 升级 Electron 应用版本至 0.17.3。

## 变更动机
图片生成通常由 Bash 或 MCP 直接写入工作目录，未经过 Write/Edit 工具事件，导致非 Git 工作区的生成图片没有出现在“文件改动”中。

## 测试计划
- [x] `bun test src/main/lib/workspace-watcher.test.ts`
- [x] `bun run typecheck`
- [x] `bun run build:main`
- [x] `bun run build:preload`
- [x] `bun run build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)