### PR TITLE
fix: 防止不支持的文件预览导致崩溃

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
@@ -3472,10 +3472,18 @@ export function registerIpcHandlers(): void {
       const { readFileSync, statSync } = await import('node:fs')
       const { resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
-      const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
-      if (!resolved) return null
+      // 该接口会把原始文件内容送回 renderer，只允许读取已授权路径；不能接受
+      // 预览场景使用的 unrestricted 标志，避免 renderer 借此读取任意本地文件。
+      const restrictedOptions = options?.unrestricted ? { ...options, unrestricted: false } : options
+      const allowedBasePaths = getAllowedCandidateBasePaths(restrictedOptions)
+      const resolved = resolveFilePath(filePath, allowedBasePaths)
+      if (!resolved || !isPathAllowed(resolved, restrictedOptions)) return null
+      const requestedMaxSize = typeof maxSize === 'number' && Number.isFinite(maxSize) && maxSize > 0
+        ? maxSize
+        : MAX_ATTACHMENT_SIZE
+      const effectiveMaxSize = Math.min(requestedMaxSize, MAX_ATTACHMENT_SIZE)
       const st = statSync(resolved)
-      if (maxSize && st.size > maxSize) return null
+      if (st.size > effectiveMaxSize) return null
       return readFileSync(resolved).toString('base64')
     }
   )

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3371,7 +3371,7 @@ export function registerIpcHandlers(): void {
   // 解析文件路径并读取内容（供内联预览使用）
   ipcMain.handle(
     'file:resolve-and-read',
-    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<{ resolvedPath: string; content: string } | null> => {
+    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<{ resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null> => {
       const { resolveAndReadFile, resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
       const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -449,7 +449,15 @@ export function saveFilesToAgentSession(input: AgentSaveFilesInput): AgentSavedF
   const results: AgentSavedFile[] = []
   const usedPaths = new Set<string>()
 
-  for (const file of input.files) {
+  const decodedFiles = input.files.map((file) => {
+    const buffer = Buffer.from(file.data, 'base64')
+    if (buffer.length > MAX_ATTACHMENT_SIZE) {
+      throw new Error(`文件超过 100MB 限制: ${file.filename}`)
+    }
+    return { file, buffer }
+  })
+
+  for (const { file, buffer } of decodedFiles) {
     let targetPath = resolveSafeWorkspaceFilePath(attachmentsDir, file.filename)
 
     // 防止同名文件覆盖
@@ -468,15 +476,6 @@ export function saveFilesToAgentSession(input: AgentSaveFilesInput): AgentSavedF
     usedPaths.add(targetPath)
 
     mkdirSync(dirname(targetPath), { recursive: true })
-
-    // 防御性检查：base64 字符串长度估算是否超 100MB 限制
-    // base64 编码膨胀率约 4/3，data.length * 0.75 ≈ 原始字节数
-    if (file.data.length * 0.75 > MAX_ATTACHMENT_SIZE) {
-      console.warn(`[Agent 服务] 文件超过 100MB 限制，跳过: ${file.filename} (预估 ${(file.data.length * 0.75 / 1024 / 1024).toFixed(1)}MB)`)
-      continue
-    }
-
-    const buffer = Buffer.from(file.data, 'base64')
     writeFileSync(targetPath, buffer)
 
     const actualFilename = targetPath.slice(sessionDir.length + 1)
@@ -546,10 +545,17 @@ export function saveFilesToWorkspaceFiles(input: AgentSaveWorkspaceFilesInput): 
     file,
     initialTargetPath: resolveSafeWorkspaceFilePath(wsFilesDir, file.filename),
   }))
+  const decodedFiles = files.map(({ file, initialTargetPath }) => {
+    const buffer = Buffer.from(file.data, 'base64')
+    if (buffer.length > MAX_ATTACHMENT_SIZE) {
+      throw new Error(`文件超过 100MB 限制: ${file.filename}`)
+    }
+    return { file, initialTargetPath, buffer }
+  })
   const results: AgentSavedFile[] = []
   const usedPaths = new Set<string>()
 
-  for (const { file, initialTargetPath } of files) {
+  for (const { file, initialTargetPath, buffer } of decodedFiles) {
     let targetPath = initialTargetPath
 
     // 防止同名文件覆盖
@@ -569,13 +575,6 @@ export function saveFilesToWorkspaceFiles(input: AgentSaveWorkspaceFilesInput): 
     usedPaths.add(targetPath)
 
     mkdirSync(dirname(targetPath), { recursive: true })
-
-    if (file.data.length * 0.75 > MAX_ATTACHMENT_SIZE) {
-      console.warn(`[Agent 服务] 项目文件超过 100MB 限制，跳过: ${file.filename} (预估 ${(file.data.length * 0.75 / 1024 / 1024).toFixed(1)}MB)`)
-      continue
-    }
-
-    const buffer = Buffer.from(file.data, 'base64')
     writeFileSync(targetPath, buffer)
 
     const actualFilename = relative(wsFilesDir, targetPath)

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -19,6 +19,8 @@ const PDFJS_PACKAGE = 'pdfjs-dist'
 
 /** 文件大小限制：50MB */
 const MAX_FILE_SIZE = 50 * 1024 * 1024
+/** 文本预览上限：高亮器会把内容转为大量 DOM，不能沿用文档转换的 50MB 上限。 */
+const MAX_TEXT_PREVIEW_SIZE = 5 * 1024 * 1024
 const MAX_XLSX_SHEETS = 8
 const MAX_XLSX_ROWS = 200
 const MAX_XLSX_COLUMNS = 40
@@ -530,15 +532,48 @@ function convertPptxToHtml(filePath: string, resolvedPath: string): OfficePrevie
 
 // ─── 导出：内联预览 API ───
 
+/**
+ * 判断文件内容是否像二进制数据。
+ *
+ * 不能只依赖扩展名：Agent 可能引用任意路径，且扩展名可缺失或伪装。
+ * 预览文本交给 @pierre/diffs 前，先在主进程验证整个文件都是安全文本；
+ * 否则诸如 DMG 的二进制内容会被当作 UTF-8 传入高亮器，可能造成渲染进程崩溃。
+ */
+function isLikelyBinaryFile(content: Buffer): boolean {
+  if (content.includes(0)) return true
+
+  // 只有严格合法的 UTF-8 才能进入基于文本的高亮器。readFile(..., 'utf-8')
+  // 会把非法字节替换成 U+FFFD，掩盖二进制内容并把风险留给渲染进程。
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(content)
+  } catch {
+    return true
+  }
+
+  // 纯 7-bit 二进制可能没有 NUL 且也能通过 UTF-8 校验。正常文本只会使用
+  // tab、换行和回车等控制字符；其他控制字符超过 1% 时按二进制处理。
+  let unsafeControlCount = 0
+  for (const byte of content) {
+    if (byte < 0x20 && byte !== 0x09 && byte !== 0x0a && byte !== 0x0d) unsafeControlCount += 1
+  }
+  return unsafeControlCount > Math.max(4, Math.floor(content.length * 0.01))
+}
+
 /** 解析文件路径并读取内容（供内联文本/代码预览使用） */
-export function resolveAndReadFile(filePath: string, basePaths?: string[]): { resolvedPath: string; content: string } | null {
+export function resolveAndReadFile(filePath: string, basePaths?: string[]): { resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null {
   const safePath = resolveTargetPath(filePath, basePaths)
   if (!existsSync(safePath)) return null
   try {
     const st = statSync(safePath)
-    if (st.size > MAX_FILE_SIZE) return null
-    const content = readFileSync(safePath, 'utf-8')
-    return { resolvedPath: safePath, content }
+    if (st.size > MAX_TEXT_PREVIEW_SIZE) {
+      return { resolvedPath: safePath, content: '', isBinary: false, isTooLarge: true }
+    }
+    const rawContent = readFileSync(safePath)
+    if (isLikelyBinaryFile(rawContent)) {
+      return { resolvedPath: safePath, content: '', isBinary: true, isTooLarge: false }
+    }
+    const content = new TextDecoder('utf-8', { fatal: true }).decode(rawContent)
+    return { resolvedPath: safePath, content, isBinary: false, isTooLarge: false }
   } catch {
     return null
   }

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -533,30 +533,36 @@ function convertPptxToHtml(filePath: string, resolvedPath: string): OfficePrevie
 // ─── 导出：内联预览 API ───
 
 /**
- * 判断文件内容是否像二进制数据。
+ * 读取并验证文件内容是否适合内联文本预览，返回已完成严格校验的文本。
  *
  * 不能只依赖扩展名：Agent 可能引用任意路径，且扩展名可缺失或伪装。
  * 预览文本交给 @pierre/diffs 前，先在主进程验证整个文件都是安全文本；
  * 否则诸如 DMG 的二进制内容会被当作 UTF-8 传入高亮器，可能造成渲染进程崩溃。
  */
-function isLikelyBinaryFile(content: Buffer): boolean {
-  if (content.includes(0)) return true
+function readSafeText(content: Buffer): string | null {
+  if (content.includes(0)) return null
 
   // 只有严格合法的 UTF-8 才能进入基于文本的高亮器。readFile(..., 'utf-8')
   // 会把非法字节替换成 U+FFFD，掩盖二进制内容并把风险留给渲染进程。
+  let text: string
   try {
-    new TextDecoder('utf-8', { fatal: true }).decode(content)
+    text = new TextDecoder('utf-8', { fatal: true }).decode(content)
   } catch {
-    return true
+    return null
   }
 
   // 纯 7-bit 二进制可能没有 NUL 且也能通过 UTF-8 校验。正常文本只会使用
-  // tab、换行和回车等控制字符；其他控制字符超过 1% 时按二进制处理。
+  // tab、换行和回车等控制字符；标准 ANSI CSI 转义（ESC [）也允许出现在日志中。
   let unsafeControlCount = 0
-  for (const byte of content) {
-    if (byte < 0x20 && byte !== 0x09 && byte !== 0x0a && byte !== 0x0d) unsafeControlCount += 1
+  for (let index = 0; index < content.length; index++) {
+    const byte = content[index]!
+    if (byte < 0x20 && byte !== 0x09 && byte !== 0x0a && byte !== 0x0d) {
+      if (byte === 0x1b && content[index + 1] === 0x5b) continue
+      unsafeControlCount += 1
+    }
   }
-  return unsafeControlCount > Math.max(4, Math.floor(content.length * 0.01))
+  if (unsafeControlCount > Math.max(4, Math.floor(content.length * 0.01))) return null
+  return text
 }
 
 /** 解析文件路径并读取内容（供内联文本/代码预览使用） */
@@ -569,10 +575,10 @@ export function resolveAndReadFile(filePath: string, basePaths?: string[]): { re
       return { resolvedPath: safePath, content: '', isBinary: false, isTooLarge: true }
     }
     const rawContent = readFileSync(safePath)
-    if (isLikelyBinaryFile(rawContent)) {
+    const content = readSafeText(rawContent)
+    if (content === null) {
       return { resolvedPath: safePath, content: '', isBinary: true, isTooLarge: false }
     }
-    const content = new TextDecoder('utf-8', { fatal: true }).decode(rawContent)
     return { resolvedPath: safePath, content, isBinary: false, isTooLarge: false }
   } catch {
     return null

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -846,7 +846,7 @@ export interface ElectronAPI {
   showItemInFolder: (filePath: string, candidateBasePaths?: string[]) => Promise<boolean>
 
   /** 解析文件路径并读取内容（供内联预览使用） */
-  resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<{ resolvedPath: string; content: string } | null>
+  resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<{ resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null>
 
   /** 写入文本文件（供 Markdown 内联编辑使用） */
   writeTextFile: (filePath: string, content: string, access?: import('@proma/shared').FileAccessOptions) => Promise<boolean>
@@ -2179,7 +2179,7 @@ const electronAPI: ElectronAPI = {
   },
 
   resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
-    return ipcRenderer.invoke('file:resolve-and-read', filePath, access) as Promise<{ resolvedPath: string; content: string } | null>
+    return ipcRenderer.invoke('file:resolve-and-read', filePath, access) as Promise<{ resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null>
   },
 
   writeTextFile: (filePath: string, content: string, access?: import('@proma/shared').FileAccessOptions) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1328,15 +1328,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const sourcePath = f.sourcePath!
       const parentPath = getFileParentPath(sourcePath)
       try {
-        const read = await window.electronAPI.resolveAndReadFile(sourcePath, {
+        const data = await window.electronAPI.readBinaryBase64(sourcePath, {
           sessionId,
           candidateBasePaths: parentPath ? [parentPath] : undefined,
-        })
-        if (!read) {
+        }, MAX_ATTACHMENT_SIZE)
+        if (!data) {
           staleDraftFiles.push(f.filename)
           continue
         }
-        const data = await fileToBase64(new File([read.content], f.filename, { type: f.mediaType }))
         draftFilesToSave.push({ sourceFile: f, filename: f.filename, data })
       } catch (error) {
         console.error('[AgentView] 读取剪贴板草稿失败:', error)

--- a/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
+++ b/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
@@ -11,6 +11,7 @@ import type { DetachedPreviewWindowData } from '@proma/shared'
 import { agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
 import { DiffTabContent } from './DiffTabContent'
+import { PreviewContentErrorBoundary } from './PreviewContentErrorBoundary'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
 import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
@@ -110,15 +111,17 @@ export function DetachedPreviewApp(): React.ReactElement {
       </div>
 
       <div className="flex-1 min-h-0 overflow-hidden">
-        <DiffTabContent
-          filePath={data.filePath}
-          dirPath={data.dirPath}
-          sessionId={data.sessionId}
-          gitRoot={data.gitRoot}
-          previewOnly={data.previewOnly}
-          readOnly={data.readOnly}
-          basePaths={data.basePaths}
-        />
+        <PreviewContentErrorBoundary resetKey={`${data.sessionId}:${data.filePath}`}>
+          <DiffTabContent
+            filePath={data.filePath}
+            dirPath={data.dirPath}
+            sessionId={data.sessionId}
+            gitRoot={data.gitRoot}
+            previewOnly={data.previewOnly}
+            readOnly={data.readOnly}
+            basePaths={data.basePaths}
+          />
+        </PreviewContentErrorBoundary>
       </div>
     </div>
   )

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -82,6 +82,8 @@ type CacheEntry = {
   docxHtml?: string
   officeHtml?: string
   officeText?: string
+  /** 二进制或其他不可安全内联渲染的文件提示 */
+  unsupportedPreviewReason?: string
 }
 
 interface DeepSelection {
@@ -273,6 +275,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [viewMode, setViewMode] = useAtom(agentDiffViewModeAtom)
   const [oldContent, setOldContent] = React.useState('')
   const [newContent, setNewContent] = React.useState('')
+  const [unsupportedPreviewReason, setUnsupportedPreviewReason] = React.useState('')
   const [markdownEditing, setMarkdownEditing] = React.useState(
     () => Boolean(initialMarkdownEditorState?.editing),
   )
@@ -771,6 +774,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       setDocxHtml(cached.docxHtml ?? '')
       setOfficeHtml(cached.officeHtml ?? '')
       setOfficeText(cached.officeText ?? '')
+      setUnsupportedPreviewReason(cached.unsupportedPreviewReason ?? '')
       setPdfSrc(cached.pdfSrc ?? '')
       setPdfZoom(100)
       setImagePath(cached.imagePath ?? '')
@@ -791,6 +795,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         setDocxHtml('')
         setOfficeHtml('')
         setOfficeText('')
+        setUnsupportedPreviewReason('')
         setPdfSrc('')
         setPdfZoom(100)
         setImagePath('')
@@ -859,6 +864,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             }
             const result = await window.electronAPI.resolveAndReadFile(filePath, fileAccess)
             if (cancelled) return
+            if (result?.isBinary || result?.isTooLarge) {
+              const reason = result.isTooLarge
+                ? '此文本文件超过 5 MB，无法安全进行内联预览，请使用默认应用打开。'
+                : '此二进制或编码异常文件暂不支持内联预览，请使用默认应用打开。'
+              setUnsupportedPreviewReason(reason)
+              cacheSet(cacheKey, { oldContent: '', newContent: '', unsupportedPreviewReason: reason })
+              return
+            }
             content = result?.content ?? ''
           } else {
             const result = await window.electronAPI.getDiffContents({ dirPath, filePath, gitRoot, sessionId, baseRef })
@@ -1617,7 +1630,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           {loading ? (
             <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">加载中...</div>
           ) : previewOnly ? (
-            isPdf ? (
+            unsupportedPreviewReason ? (
+              <div className="flex h-full items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
+                {unsupportedPreviewReason}
+              </div>
+            ) : isPdf ? (
               pdfSrc ? (
                 <div className="relative h-full">
                 <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-2 px-2 py-1 rounded-lg bg-background/80 backdrop-filter backdrop-blur-sm border border-border/30 shadow-sm">

--- a/apps/electron/src/renderer/components/diff/PreviewContentErrorBoundary.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewContentErrorBoundary.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react'
+import { AlertTriangle, RotateCw } from 'lucide-react'
+
+interface PreviewContentErrorBoundaryProps {
+  /** 文件切换时自动清除上一个文件的错误状态。 */
+  resetKey: string
+  children: React.ReactNode
+}
+
+interface PreviewContentErrorBoundaryState {
+  hasError: boolean
+}
+
+/**
+ * 将单个文件预览的渲染异常限制在预览内容区域。
+ *
+ * 文件内容由外部路径提供，任何专用渲染器都不应使整个 Agent 会话或窗口失效。
+ */
+export class PreviewContentErrorBoundary extends React.Component<
+  PreviewContentErrorBoundaryProps,
+  PreviewContentErrorBoundaryState
+> {
+  constructor(props: PreviewContentErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): PreviewContentErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  override componentDidCatch(error: unknown, info: React.ErrorInfo): void {
+    console.error('[PreviewContentErrorBoundary] 文件预览渲染异常:', error, info.componentStack)
+  }
+
+  override componentDidUpdate(prevProps: PreviewContentErrorBoundaryProps): void {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false })
+    }
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ hasError: false })
+  }
+
+  override render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-muted-foreground">
+          <AlertTriangle className="size-7 text-destructive/70" />
+          <p className="text-[13px]">此文件无法安全渲染预览，请使用默认应用打开。</p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            <RotateCw className="size-3.5" />
+            重试预览
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -28,6 +28,7 @@ import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-regi
 import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import { DiffTabContent } from './DiffTabContent'
+import { PreviewContentErrorBoundary } from './PreviewContentErrorBoundary'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
 import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
@@ -177,18 +178,20 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
       {/* 内容区 */}
       <div className="flex-1 min-h-0 overflow-hidden">
         {currentFile ? (
-          <DiffTabContent
-            key={`${sessionId}:${currentFile.filePath}`}
-            filePath={currentFile.filePath}
-            dirPath={currentFile.dirPath || sessionPath}
-            sessionId={sessionId}
-            gitRoot={currentFile.gitRoot}
-            previewOnly={currentFile.previewOnly}
-            readOnly={currentFile.readOnly}
-            basePaths={currentFile.basePaths}
-            baseRef={currentFile.baseRef}
-            onEmptyDiff={handleClosePanel}
-          />
+          <PreviewContentErrorBoundary resetKey={`${sessionId}:${currentFile.filePath}`}>
+            <DiffTabContent
+              key={`${sessionId}:${currentFile.filePath}`}
+              filePath={currentFile.filePath}
+              dirPath={currentFile.dirPath || sessionPath}
+              sessionId={sessionId}
+              gitRoot={currentFile.gitRoot}
+              previewOnly={currentFile.previewOnly}
+              readOnly={currentFile.readOnly}
+              basePaths={currentFile.basePaths}
+              baseRef={currentFile.baseRef}
+              onEmptyDiff={handleClosePanel}
+            />
+          </PreviewContentErrorBoundary>
         ) : (
           <div className="flex items-center justify-center h-full text-muted-foreground text-xs">
             点击文件查看预览

--- a/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
@@ -21,6 +21,7 @@ import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import { tearOffPreviewToSplit } from './preview-opener'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
 import { DiffTabContent } from './DiffTabContent'
+import { PreviewContentErrorBoundary } from './PreviewContentErrorBoundary'
 import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
 /** 切换为侧边分屏的小按钮 — 与拖拽 Tab 出 TabBar 触发的 tear-off 等价 */
@@ -111,18 +112,20 @@ export function PreviewTabContent({ sessionId }: PreviewTabContentProps): React.
   return (
     <div className="flex h-full flex-col overflow-hidden bg-content-area">
       <div className="min-h-0 flex-1 overflow-hidden">
-        <DiffTabContent
-          key={`${sessionId}:${currentFile.filePath}`}
-          filePath={currentFile.filePath}
-          dirPath={dirPath}
-          sessionId={sessionId}
-          gitRoot={currentFile.gitRoot}
-          previewOnly={currentFile.previewOnly}
-          readOnly={currentFile.readOnly}
-          basePaths={currentFile.basePaths}
-          baseRef={currentFile.baseRef}
-          toolbarActions={toolbarActions}
-        />
+        <PreviewContentErrorBoundary resetKey={`${sessionId}:${currentFile.filePath}`}>
+          <DiffTabContent
+            key={`${sessionId}:${currentFile.filePath}`}
+            filePath={currentFile.filePath}
+            dirPath={dirPath}
+            sessionId={sessionId}
+            gitRoot={currentFile.gitRoot}
+            previewOnly={currentFile.previewOnly}
+            readOnly={currentFile.readOnly}
+            basePaths={currentFile.basePaths}
+            baseRef={currentFile.baseRef}
+            toolbarActions={toolbarActions}
+          />
+        </PreviewContentErrorBoundary>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- 2880b13c fix: 防止不支持的文件预览导致崩溃

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)