### PR TITLE
fix(agent): tolerate disappearing directory entries

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -371,12 +371,10 @@ import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
 import { presenceService } from './lib/feishu-presence'
 import { getDingTalkConfig, saveDingTalkConfig, getDecryptedClientSecret, getDingTalkMultiBotConfig, saveDingTalkBotConfig, removeDingTalkBot, getDecryptedBotClientSecret } from './lib/dingtalk-config'
+import { listShallowDirectory } from './lib/directory-listing'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
 import { getWeChatConfig } from './lib/wechat-config'
 import { wechatBridge } from './lib/wechat-bridge'
-
-/** 文件浏览器中需要隐藏的系统文件 */
-const HIDDEN_FS_ENTRIES = new Set(['.DS_Store', 'Thumbs.db'])
 
 /** 已知编辑器应用名称白名单（macOS） */
 const KNOWN_EDITORS = [
@@ -3238,44 +3236,16 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_DIRECTORY,
     async (_, dirPath: string, access?: FileAccessOptions): Promise<FileEntry[]> => {
-      const { existsSync, readdirSync, statSync } = await import('node:fs')
-      const { resolve } = await import('node:path')
-
       const safePath = resolve(dirPath)
-      // 目录可能已被删除（如删除 Agent 会话后面板仍持有旧路径），优雅返回空列表
-      if (!existsSync(safePath)) {
-        return []
-      }
+      // 目录可能已被删除（如删除 Agent 会话后面板仍持有旧路径），优雅返回空列表。
+      if (!existsSync(safePath)) return []
       if (!isPathAllowed(safePath, normalizeFileAccessOptions(access))) {
+        // 路径可能刚好在 existsSync 与 realpath 校验之间被删除。
+        if (!existsSync(safePath)) return []
         throw new Error('访问路径超出当前会话的授权范围')
       }
 
-      const entries: FileEntry[] = []
-      const items = readdirSync(safePath, { withFileTypes: true })
-
-      for (const item of items) {
-        if (HIDDEN_FS_ENTRIES.has(item.name)) continue
-        const fullPath = resolve(safePath, item.name)
-        const isDirectory = item.isDirectory()
-        const size = isDirectory ? undefined : statSync(fullPath).size
-        entries.push({
-          name: item.name,
-          path: fullPath,
-          isDirectory,
-          size,
-        })
-      }
-
-      // 目录在前，文件在后；隐藏文件（.开头）排在同类末尾，各自按名称排序
-      entries.sort((a, b) => {
-        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
-        const aHidden = a.name.startsWith('.')
-        const bHidden = b.name.startsWith('.')
-        if (aHidden !== bHidden) return aHidden ? 1 : -1
-        return a.name.localeCompare(b.name)
-      })
-
-      return entries
+      return listShallowDirectory(safePath)
     }
   )
 
@@ -3565,40 +3535,15 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_ATTACHED_DIRECTORY,
     async (_, dirPath: string, access?: FileAccessOptions | string[]): Promise<FileEntry[]> => {
-      const { readdirSync, statSync } = await import('node:fs')
-      const { resolve } = await import('node:path')
-
       const safePath = resolve(dirPath)
       const options = normalizeFileAccessOptions(access)
       if (!isPathAllowed(safePath, options)) {
+        // 已解绑或被删除的附加目录不应让文件面板持续报错。
+        if (!existsSync(safePath)) return []
         throw new Error('访问路径不在允许范围内')
       }
-      const entries: FileEntry[] = []
-      const items = readdirSync(safePath, { withFileTypes: true })
 
-      for (const item of items) {
-        if (HIDDEN_FS_ENTRIES.has(item.name)) continue
-        const fullPath = resolve(safePath, item.name)
-        const isDirectory = item.isDirectory()
-        const size = isDirectory ? undefined : statSync(fullPath).size
-        entries.push({
-          name: item.name,
-          path: fullPath,
-          isDirectory,
-          size,
-        })
-      }
-
-      // 目录在前，文件在后；隐藏文件（.开头）排在同类末尾
-      entries.sort((a, b) => {
-        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
-        const aHidden = a.name.startsWith('.')
-        const bHidden = b.name.startsWith('.')
-        if (aHidden !== bHidden) return aHidden ? 1 : -1
-        return a.name.localeCompare(b.name)
-      })
-
-      return entries
+      return listShallowDirectory(safePath)
     }
   )
 

--- a/apps/electron/src/main/lib/directory-listing.ts
+++ b/apps/electron/src/main/lib/directory-listing.ts
@@ -1,0 +1,76 @@
+import { readdirSync, statSync, type Dirent, type Stats } from 'node:fs'
+import { resolve } from 'node:path'
+import type { FileEntry } from '@proma/shared'
+
+/** 文件浏览器中不展示的系统文件。 */
+const HIDDEN_FS_ENTRIES = new Set(['.DS_Store', 'Thumbs.db'])
+
+interface DirectoryListingFs {
+  readdirSync(path: string, options: { withFileTypes: true }): Dirent[]
+  statSync(path: string): Stats
+}
+
+const nativeFs: DirectoryListingFs = { readdirSync, statSync }
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === code
+}
+
+/**
+ * 浅层列出目录内容。
+ *
+ * 目录在枚举后可能被 Git、构建工具或同步服务修改；悬空符号链接也会在 stat 时返回
+ * ENOENT。此时跳过失效条目，避免一个无效条目阻断整个文件面板。
+ */
+export function listShallowDirectory(
+  directoryPath: string,
+  fs: DirectoryListingFs = nativeFs,
+): FileEntry[] {
+  let items: Dirent[]
+  try {
+    items = fs.readdirSync(directoryPath, { withFileTypes: true })
+  } catch (error) {
+    // 根目录在请求期间被删除时，文件面板应退化为空列表。
+    if (hasErrorCode(error, 'ENOENT')) return []
+    throw error
+  }
+
+  const entries: FileEntry[] = []
+  for (const item of items) {
+    if (HIDDEN_FS_ENTRIES.has(item.name)) continue
+
+    const fullPath = resolve(directoryPath, item.name)
+    const isDirectory = item.isDirectory()
+    let size: number | undefined
+
+    if (!isDirectory) {
+      try {
+        size = fs.statSync(fullPath).size
+      } catch (error) {
+        // readdir 与 stat 之间条目可能消失；悬空符号链接也属于该情况。
+        if (hasErrorCode(error, 'ENOENT')) continue
+        throw error
+      }
+    }
+
+    entries.push({
+      name: item.name,
+      path: fullPath,
+      isDirectory,
+      size,
+    })
+  }
+
+  entries.sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
+    const aHidden = a.name.startsWith('.')
+    const bHidden = b.name.startsWith('.')
+    if (aHidden !== bHidden) return aHidden ? 1 : -1
+    return a.name.localeCompare(b.name)
+  })
+
+  return entries
+}


### PR DESCRIPTION
## Summary

- 容错处理目录枚举期间消失的文件和悬空符号链接，避免单个 `ENOENT` 阻断整个文件面板。
- 统一普通目录与附加目录的浅层枚举逻辑，并保留现有访问范围校验。
- 将 Electron 版本递增至 `0.17.4`。

## Test plan

- [x] `bun run --cwd apps/electron typecheck`
- [x] `bun run --cwd apps/electron build:main`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)