### PR TITLE
feat(agent): 历史消息选区引用——输入框 chip、正文渲染与点击跳转高亮【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.13",
+  "version": "0.17.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -91,6 +91,12 @@ export interface QuotedSelection {
   startLine?: number
   /** 结束行号（1-based） */
   endLine?: number
+  /** Agent 历史消息内选区的起始字符偏移（0-based） */
+  selectionStart?: number
+  /** Agent 历史消息内选区的结束字符偏移（0-based、exclusive） */
+  selectionEnd?: number
+  /** Agent 历史中的所属轮次（1-based；用户消息和对应回复共用同一轮） */
+  turn?: number
   /** 捕获时间戳 */
   capturedAt: number
 }

--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -16,6 +16,7 @@ import {
   selectedModelAtom,
 } from '@/atoms/chat-atoms'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
 import { agentDiffPanelTabAtom, agentSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
 import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
@@ -30,11 +31,16 @@ interface AgentHistorySelection {
   sourceLabel: string
   messageId?: string
   messageRole?: 'user' | 'assistant' | 'system'
+  selectionStart?: number
+  selectionEnd?: number
+  turn?: number
 }
 
 interface AgentHistorySelectionLayerProps {
   sessionId: string
   rootRef: React.RefObject<HTMLDivElement>
+  /** 同一消息内的历史选区优先插入当前 Agent 富文本输入框。 */
+  onAddToAgent?: (quote: QuotedSelection) => boolean
 }
 
 function getElementFromNode(node: Node | null): Element | null {
@@ -53,9 +59,30 @@ function getRoleLabel(role?: string): string {
   return 'Agent 历史'
 }
 
+function getTextOffsetWithin(messageElement: Element, container: Node, offset: number): number | undefined {
+  try {
+    const range = document.createRange()
+    range.selectNodeContents(messageElement)
+    range.setEnd(container, offset)
+    return range.toString().length
+  } catch {
+    return undefined
+  }
+}
+
+function getMessageTurn(root: HTMLElement, messageElement: Element): number {
+  let turn = 0
+  for (const element of root.querySelectorAll<HTMLElement>('[data-message-id][data-message-role]')) {
+    if (element.dataset.messageRole === 'user') turn += 1
+    if (element === messageElement) return Math.max(turn, 1)
+  }
+  return 1
+}
+
 export function AgentHistorySelectionLayer({
   sessionId,
   rootRef,
+  onAddToAgent,
 }: AgentHistorySelectionLayerProps): React.ReactElement {
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
   const selectedChatModel = useAtomValue(selectedModelAtom)
@@ -119,6 +146,16 @@ export function AgentHistorySelectionLayer({
       ? (startMessageEl.getAttribute('data-message-role') as AgentHistorySelection['messageRole'] | null)
       : null
     const messageId = sameMessage ? startMessageEl.getAttribute('data-message-id') ?? undefined : undefined
+    const selectionStart = sameMessage
+      ? getTextOffsetWithin(startMessageEl, range.startContainer, range.startOffset)
+      : undefined
+    const unboundedSelectionEnd = sameMessage
+      ? getTextOffsetWithin(endMessageEl, range.endContainer, range.endOffset)
+      : undefined
+    const selectionEnd = truncated && selectionStart !== undefined && unboundedSelectionEnd !== undefined
+      ? Math.min(unboundedSelectionEnd, selectionStart + text.length)
+      : unboundedSelectionEnd
+    const turn = sameMessage ? getMessageTurn(root, startMessageEl) : undefined
 
     setSelection({
       text,
@@ -127,6 +164,9 @@ export function AgentHistorySelectionLayer({
       sourceLabel: sameMessage ? getRoleLabel(role ?? undefined) : 'Agent 历史 · 多条消息',
       messageId,
       messageRole: role ?? undefined,
+      selectionStart,
+      selectionEnd,
+      turn,
     })
 
     if (truncated) {
@@ -196,24 +236,31 @@ export function AgentHistorySelectionLayer({
 
   const handleAddToAgent = React.useCallback((): void => {
     if (!selection) return
-    setQuotedSelectionMap((prev) => {
-      const next = new Map(prev)
-      next.set(sessionId, {
-        text: selection.text,
-        filePath: selection.sourceLabel,
-        sourceType: 'agent-history',
-        sourceLabel: selection.sourceLabel,
-        messageId: selection.messageId,
-        messageRole: selection.messageRole,
-        capturedAt: Date.now(),
+    const quotedSelection: QuotedSelection = {
+      text: selection.text,
+      filePath: selection.sourceLabel,
+      sourceType: 'agent-history',
+      sourceLabel: selection.sourceLabel,
+      messageId: selection.messageId,
+      messageRole: selection.messageRole,
+      selectionStart: selection.selectionStart,
+      selectionEnd: selection.selectionEnd,
+      turn: selection.turn,
+      capturedAt: Date.now(),
+    }
+    const insertedInline = onAddToAgent?.(quotedSelection) ?? false
+    if (!insertedInline) {
+      setQuotedSelectionMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, quotedSelection)
+        return next
       })
-      return next
-    })
+    }
     window.getSelection()?.removeAllRanges()
     clearSelection()
     focusAgentSessionInput(sessionId)
     toast.success('已添加到 Agent 引用')
-  }, [clearSelection, focusAgentSessionInput, selection, sessionId, setQuotedSelectionMap])
+  }, [clearSelection, focusAgentSessionInput, onAddToAgent, selection, sessionId, setQuotedSelectionMap])
 
   const handleOpenChatTab = React.useCallback(async (): Promise<void> => {
     if (!selection) return
@@ -243,6 +290,9 @@ export function AgentHistorySelectionLayer({
           sourceLabel: selection.sourceLabel,
           messageId: selection.messageId,
           messageRole: selection.messageRole,
+          selectionStart: selection.selectionStart,
+          selectionEnd: selection.selectionEnd,
+          turn: selection.turn,
           capturedAt: Date.now(),
         })
         return next

--- a/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
@@ -168,6 +168,7 @@ const QUEUED_REFERENCE_STYLES = {
   skill: { icon: Sparkles, className: 'bg-[hsl(270_60%_60%/0.15)] text-[hsl(270_60%_50%)]' },
   mcp: { icon: Server, className: 'bg-[hsl(160_60%_45%/0.15)] text-[hsl(160_60%_35%)]' },
   session: { icon: MessageSquareText, className: 'bg-[hsl(200_80%_50%/0.14)] text-[hsl(200_80%_40%)]' },
+  quote: { icon: Quote, className: 'bg-primary/10 text-primary' },
   todo: { icon: ListTodo, className: 'bg-amber-500/15 text-amber-800 dark:text-amber-200' },
   calendar_event: { icon: CalendarDays, className: 'bg-cyan-500/15 text-cyan-800 dark:text-cyan-200' },
 } as const

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -41,6 +41,7 @@ import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgr
 import type { AgentEventUsage, RetryAttempt, SDKMessage, SDKSystemMessage } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
 
 function stableStringify(value: unknown): string {
   if (value == null || typeof value !== 'object') return JSON.stringify(value) ?? String(value)
@@ -176,6 +177,12 @@ export function getContextCompactionProgress(
   return undefined
 }
 
+export interface AgentHistoryQuoteNavigationRequest {
+  sessionId: string
+  quote: QuotedSelection
+  requestId: number
+}
+
 /** AgentMessages 属性接口 */
 interface AgentMessagesProps {
   sessionId: string
@@ -203,6 +210,87 @@ interface AgentMessagesProps {
   onRewind?: (assistantMessageUuid: string) => void
   onCreateTodo?: (text: string) => void
   onCompact?: () => void
+  /** 将单条 Agent 历史选区写为当前 RichTextInput 的内联 mention。 */
+  onAddHistoryQuote?: (quote: QuotedSelection) => boolean
+  /** 已发送的 Agent 历史引用 chip 点击后请求定位与高亮。 */
+  onAgentHistoryQuoteClick?: (quote: QuotedSelection) => void
+  /** 输入框 quote chip 请求定位时的精确范围。 */
+  historyQuoteNavigation?: AgentHistoryQuoteNavigationRequest | null
+}
+
+const AGENT_HISTORY_QUOTE_HIGHLIGHT_NAME = 'proma-agent-history-quote'
+
+interface TextPosition {
+  node: Node
+  offset: number
+}
+
+interface CustomHighlightRegistry {
+  set: (name: string, highlight: unknown) => void
+  delete: (name: string) => boolean
+}
+
+type HighlightConstructor = new (...ranges: Range[]) => unknown
+
+function getMessageTextPosition(messageElement: HTMLElement, offset: number): TextPosition | null {
+  if (!Number.isInteger(offset) || offset < 0) return null
+
+  const walker = document.createTreeWalker(messageElement, NodeFilter.SHOW_TEXT)
+  let consumed = 0
+  let lastTextNode: Node | null = null
+  let node = walker.nextNode()
+  while (node) {
+    const length = node.textContent?.length ?? 0
+    if (offset <= consumed + length) {
+      return { node, offset: offset - consumed }
+    }
+    consumed += length
+    lastTextNode = node
+    node = walker.nextNode()
+  }
+
+  if (offset === consumed && lastTextNode) {
+    return { node: lastTextNode, offset: lastTextNode.textContent?.length ?? 0 }
+  }
+  return null
+}
+
+function getAgentHistoryQuoteRange(messageElement: HTMLElement, quote: QuotedSelection): Range | null {
+  if (
+    quote.sourceType !== 'agent-history'
+    || quote.selectionStart == null
+    || quote.selectionEnd == null
+    || quote.selectionEnd <= quote.selectionStart
+  ) {
+    return null
+  }
+
+  const start = getMessageTextPosition(messageElement, quote.selectionStart)
+  const end = getMessageTextPosition(messageElement, quote.selectionEnd)
+  if (!start || !end) return null
+
+  const range = document.createRange()
+  range.setStart(start.node, start.offset)
+  range.setEnd(end.node, end.offset)
+  return range
+}
+
+function getCustomHighlightRegistry(): CustomHighlightRegistry | undefined {
+  return (globalThis.CSS as unknown as { highlights?: CustomHighlightRegistry }).highlights
+}
+
+function applyAgentHistoryQuoteHighlight(range: Range): boolean {
+  const registry = getCustomHighlightRegistry()
+  const Highlight = (globalThis as unknown as { Highlight?: HighlightConstructor }).Highlight
+  if (registry && Highlight) {
+    registry.set(AGENT_HISTORY_QUOTE_HIGHLIGHT_NAME, new Highlight(range))
+    return false
+  }
+
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+  return true
 }
 
 /** 空状态引导 — 使用 WelcomeEmptyState */
@@ -496,11 +584,41 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
   )
 }
 
-export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, attachedDirs, stoppedByUser, onRetry, onRetryInNewSession, onRelinkProjectRoot, onRestoreProjectRoot, onFork, onRewind, onCreateTodo, onCompact }: AgentMessagesProps): React.ReactElement {
+export function AgentMessages({
+  sessionId,
+  sessionModelId,
+  messagesLoaded,
+  persistedSDKMessages,
+  streaming,
+  streamState,
+  liveMessages,
+  sessionPath,
+  attachedDirs,
+  stoppedByUser,
+  onRetry,
+  onRetryInNewSession,
+  onRelinkProjectRoot,
+  onRestoreProjectRoot,
+  onFork,
+  onRewind,
+  onCreateTodo,
+  onCompact,
+  onAddHistoryQuote,
+  onAgentHistoryQuoteClick,
+  historyQuoteNavigation,
+}: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
   const historySelectionRootRef = React.useRef<HTMLDivElement>(null)
+  const selectionHighlightUsesBrowserSelectionRef = React.useRef(false)
+  const clearHistoryQuoteHighlight = React.useCallback((): void => {
+    getCustomHighlightRegistry()?.delete(AGENT_HISTORY_QUOTE_HIGHLIGHT_NAME)
+    if (selectionHighlightUsesBrowserSelectionRef.current) {
+      window.getSelection()?.removeAllRanges()
+      selectionHighlightUsesBrowserSelectionRef.current = false
+    }
+  }, [])
   /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
   const [ready, setReady] = React.useState(false)
   // 空会话无需淡入过渡（无消息则无滚动位置问题）
@@ -514,6 +632,46 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
       setSkipFadeIn(false)
     }
   }, [sessionId])
+
+  React.useEffect(() => {
+    const clearOnPointerDown = (): void => {
+      clearHistoryQuoteHighlight()
+    }
+    document.addEventListener('pointerdown', clearOnPointerDown, true)
+    return () => {
+      document.removeEventListener('pointerdown', clearOnPointerDown, true)
+      clearHistoryQuoteHighlight()
+    }
+  }, [clearHistoryQuoteHighlight])
+
+  React.useEffect(() => {
+    clearHistoryQuoteHighlight()
+    if (
+      !historyQuoteNavigation
+      || historyQuoteNavigation.sessionId !== sessionId
+      || historyQuoteNavigation.quote.sourceType !== 'agent-history'
+      || !historyQuoteNavigation.quote.messageId
+    ) {
+      return
+    }
+
+    const navigation = historyQuoteNavigation
+    const frame = window.requestAnimationFrame(() => {
+      const root = historySelectionRootRef.current
+      if (!root) return
+      const target = Array.from(root.querySelectorAll<HTMLElement>('[data-message-id]')).find(
+        (element) => element.dataset.messageId === navigation.quote.messageId,
+      )
+      if (!target) return
+
+      const range = getAgentHistoryQuoteRange(target, navigation.quote)
+      if (!range) return
+      target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
+      selectionHighlightUsesBrowserSelectionRef.current = applyAgentHistoryQuoteHighlight(range)
+    })
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [clearHistoryQuoteHighlight, historyQuoteNavigation, sessionId])
 
   React.useEffect(() => {
     if (ready) return
@@ -729,6 +887,12 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   return (
     <BasePathsProvider basePaths={messageBasePaths}>
     <div ref={historySelectionRootRef} className="relative flex min-h-0 flex-1 flex-col">
+      <style>{`
+        ::highlight(${AGENT_HISTORY_QUOTE_HIGHLIGHT_NAME}) {
+          background-color: hsl(var(--primary) / 0.28);
+          color: inherit;
+        }
+      `}</style>
       <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
         <ScrollPositionManager id={sessionId} ready={ready} />
         <ConversationContent>
@@ -754,6 +918,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                     basePath={sessionPath || undefined}
                     onFork={shouldDisableActions ? undefined : onFork}
                     onRewind={shouldDisableActions ? undefined : onRewind}
+                    onAgentHistoryQuoteClick={onAgentHistoryQuoteClick}
                     onCreateTodo={shouldDisableActions ? undefined : onCreateTodo}
                     onRetry={shouldDisableActions ? undefined : onRetry}
                     onRetryInNewSession={shouldDisableActions ? undefined : onRetryInNewSession}
@@ -827,7 +992,11 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
           <StickyUserMessage userMessages={allUserMessagesData} />
         )}
       </Conversation>
-      <AgentHistorySelectionLayer sessionId={sessionId} rootRef={historySelectionRootRef} />
+      <AgentHistorySelectionLayer
+        sessionId={sessionId}
+        rootRef={historySelectionRootRef}
+        onAddToAgent={onAddHistoryQuote}
+      />
     </div>
     </BasePathsProvider>
   )

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -18,7 +18,7 @@ import { unstable_batchedUpdates } from 'react-dom'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
 import { CornerDownLeft, Square, Settings, X, Copy, Check, Brain, Sparkles, ListTodo, Paperclip } from 'lucide-react'
-import { AgentMessages } from './AgentMessages'
+import { AgentMessages, type AgentHistoryQuoteNavigationRequest } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { AgentMessageQueue } from './AgentMessageQueue'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -120,7 +120,7 @@ import type { AgentSendInput, AgentPendingFile, AgentThinkingLevel, FileDialogLa
 import { inferContextWindow, inferReasoningTransport, isCodexFastModeSupportedModel, MAX_ATTACHMENT_SIZE, normalizeReasoningCapabilityLevel, normalizeReasoningLevel, resolveReasoningCapability, resolveReasoningProfile } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
 import { getFilePanelDragData, INSERT_FILE_MENTION_EVENT, type FilePanelDragItem } from '@/lib/file-panel-drag'
-import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
+import { buildQuotedSelectionBlock, expandAgentHistoryQuoteMentions } from '@/lib/quoted-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import {
@@ -621,6 +621,31 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const pendingFilesRef = React.useRef(pendingFiles)
   // RichTextInput 命令接口 ref（右侧文件面板拖入时插入 @file 引用）
   const richTextInputRef = React.useRef<RichTextInputHandle>(null)
+  const historyQuoteNavigationRequestIdRef = React.useRef(0)
+  const [historyQuoteNavigation, setHistoryQuoteNavigation] = React.useState<AgentHistoryQuoteNavigationRequest | null>(null)
+  const handleAddHistoryQuote = React.useCallback((quote: QuotedSelection): boolean => {
+    return richTextInputRef.current?.insertAgentHistoryQuoteMention(quote) ?? false
+  }, [])
+  const handleAgentHistoryQuoteClick = React.useCallback((quote: QuotedSelection): void => {
+    if (
+      quote.sourceType !== 'agent-history'
+      || !quote.messageId
+      || quote.selectionStart == null
+      || quote.selectionEnd == null
+      || quote.selectionEnd <= quote.selectionStart
+    ) {
+      return
+    }
+    historyQuoteNavigationRequestIdRef.current += 1
+    setHistoryQuoteNavigation({
+      sessionId,
+      quote,
+      requestId: historyQuoteNavigationRequestIdRef.current,
+    })
+  }, [sessionId])
+  React.useEffect(() => {
+    setHistoryQuoteNavigation(null)
+  }, [sessionId])
   // 父组件同步生成的 ID，同时提供给 RichTextInput 与 SpeechButton，避免工具栏 memo 捕获空值。
   const agentVoiceInputId = React.useId()
   React.useEffect(() => {
@@ -2146,11 +2171,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
 
     // 2. 构建最终消息
-    const finalMessage = fileReferences + effectiveText
+    const finalMessage = fileReferences + expandAgentHistoryQuoteMentions(effectiveText)
     const mentions = parseQueuedMessageMentions(effectiveText)
     // Agent 侧使用解码后的 SDK 文本（@file 路径还原为真实路径，Agent 可读取）；
-    // 气泡展示/持久化使用编码原文（remarkMentions 解码显示），与排队路径 rawText/sdkText 分离语义一致。
-    const sdkMessage = fileReferences + mentions.cleanedText
+    // 历史 quote marker 仅在此刻展开为精确上下文，草稿本身始终保持可编辑 chip。
+    const sdkMessage = fileReferences + expandAgentHistoryQuoteMentions(mentions.cleanedText)
 
     // 清除打断状态（上一轮的打断标记不再显示）
     store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
@@ -2930,6 +2955,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onRewind={isLegacyTranscript ? undefined : handleRewindRequest}
           onCreateTodo={handleOpenReplyTodoDialog}
           onCompact={handleCompact}
+          onAddHistoryQuote={handleAddHistoryQuote}
+          onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
+          historyQuoteNavigation={historyQuoteNavigation}
         />
 
         {/* 权限请求横幅 */}
@@ -3075,6 +3103,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               htmlValue={inputHtmlContent}
               onHtmlChange={setInputHtmlContent}
               sendWithCmdEnter={sendWithCmdEnter}
+              onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
             />
 
             {/* Footer 工具栏 — 容器变窄时尾部按钮自动折叠进「更多」Popover */}

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -63,7 +63,8 @@ import { environmentCheckDialogOpenAtom } from '@/atoms/environment'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { getFileParentPath } from '@/lib/file-utils'
-import { parseQuotedSelectionRefs } from '@/lib/quoted-selection'
+import { parseQuotedSelectionRefs, replaceAgentHistoryQuoteMentionsWithLabels } from '@/lib/quoted-selection'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
 import type { ParsedQuotedSelectionRef } from '@/lib/quoted-selection'
 import type {
   SDKMessage,
@@ -742,8 +743,11 @@ export interface AttachedFileRef {
 export type QuotedFileRef = ParsedQuotedSelectionRef
 
 /** 解析消息中的 <attached_files>、<quoted_file> 和 <quoted_context> 块，返回文件列表、引用列表和剩余文本 */
-export function parseAttachedFiles(content: string): { files: AttachedFileRef[]; quotes: QuotedFileRef[]; text: string } {
-  const parsedQuotes = parseQuotedSelectionRefs(content)
+export function parseAttachedFiles(
+  content: string,
+  options: { inlineAgentHistoryQuotes?: boolean } = {},
+): { files: AttachedFileRef[]; quotes: QuotedFileRef[]; text: string } {
+  const parsedQuotes = parseQuotedSelectionRefs(content, options)
   const quotes: QuotedFileRef[] = parsedQuotes.quotes
 
   const regex = /<attached_files>\n?([\s\S]*?)\n?<\/attached_files>\n*/
@@ -863,6 +867,7 @@ function AttachedFileChip({ file }: { file: AttachedFileRef }): React.ReactEleme
   )
 }
 
+
 /** 引用文件 Chip（显示在用户消息中，表示该消息引用了某个文件的选中内容） */
 function QuoteChip({ quote }: { quote: QuotedFileRef }): React.ReactElement {
   const label = quote.label ?? quote.filename
@@ -917,11 +922,17 @@ function ScheduledRunBadge(): React.ReactElement {
   )
 }
 
-function UserInputMessage({ message }: { message: SDKUserMessage }): React.ReactElement {
+function UserInputMessage({ message, onAgentHistoryQuoteClick }: {
+  message: SDKUserMessage
+  onAgentHistoryQuoteClick?: (quote: QuotedSelection) => void
+}): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const rawText = extractUserText(message) ?? ''
   const isScheduledRun = rawText.includes(SCHEDULED_RUN_MARKER)
-  const { files: attachedFiles, quotes, text } = parseAttachedFiles(stripScheduledRunMarker(rawText))
+  const { files: attachedFiles, quotes, text } = parseAttachedFiles(
+    stripScheduledRunMarker(rawText),
+    { inlineAgentHistoryQuotes: true },
+  )
   const imageFiles = attachedFiles.filter((f) => isImageFile(f.filename))
   const activeSessionId = useAtomValue(activeSessionIdAtom)
   const setSessionPendingFiles = useSetAtom(agentSessionPendingFilesAtom)
@@ -1000,11 +1011,13 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
       </div>
       <MessageContent>
         {/* 引用文件 Chip */}
-        {quotes.length > 0 && (
+        {quotes.filter((quote) => quote.sourceType !== 'agent-history').length > 0 && (
           <div className="flex flex-wrap gap-1.5 mb-2">
-            {quotes.map((q, i) => (
-              <QuoteChip key={`${q.path}:${i}`} quote={q} />
-            ))}
+            {quotes
+              .filter((quote) => quote.sourceType !== 'agent-history')
+              .map((q, i) => (
+                <QuoteChip key={`${q.path}:${i}`} quote={q} />
+              ))}
           </div>
         )}
         {/* 图片缩略图 */}
@@ -1029,7 +1042,11 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
             ))}
           </div>
         )}
-        {text && <UserMessageContent>{text}</UserMessageContent>}
+        {text && (
+          <UserMessageContent onAgentHistoryQuoteClick={onAgentHistoryQuoteClick}>
+            {text}
+          </UserMessageContent>
+        )}
       </MessageContent>
       {/* 共享大图预览 — 单图时无翻页，行为同以前 */}
       {imageFiles.length > 0 && (
@@ -1043,7 +1060,7 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
       )}
       {text && (
         <MessageActions className="pl-[46px] mt-0.5">
-          <CopyButton content={text} />
+          <CopyButton content={replaceAgentHistoryQuoteMentionsWithLabels(text)} />
         </MessageActions>
       )}
     </Message>
@@ -1362,6 +1379,8 @@ export interface MessageGroupRendererProps {
   basePath?: string
   onFork?: (upToMessageUuid: string) => void
   onRewind?: (assistantMessageUuid: string) => void
+  /** 已发送的 Agent 历史引用 chip 请求定位时的精确范围。 */
+  onAgentHistoryQuoteClick?: (quote: QuotedSelection) => void
   /** 将 assistant 回复标记为 Todo */
   onCreateTodo?: (text: string) => void
   /** 错误重试回调（传入本轮开始前应删除的错误 UUID） */
@@ -1426,13 +1445,13 @@ export function getGroupId(group: MessageGroup): string {
 
 // getGroupPreview 已迁移至 @proma/session-core（本文件从该包 import 并 re-export）
 
-export function MessageGroupRenderer({ group, allMessages, basePath, onFork, onRewind, onCreateTodo, onRetry, onRetryInNewSession, onCompact, onRelinkProjectRoot, onRestoreProjectRoot, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
+export function MessageGroupRenderer({ group, allMessages, basePath, onFork, onRewind, onAgentHistoryQuoteClick, onCreateTodo, onRetry, onRetryInNewSession, onCompact, onRelinkProjectRoot, onRestoreProjectRoot, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
   const groupId = getGroupId(group)
 
   if (group.type === 'user') {
     return (
       <div data-message-id={groupId} data-message-role="user">
-        <UserInputMessage message={group.message} />
+        <UserInputMessage message={group.message} onAgentHistoryQuoteClick={onAgentHistoryQuoteClick} />
       </div>
     )
   }

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -22,7 +22,7 @@ import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
-import { CalendarDays, ChevronDown, ChevronUp, Paperclip, FileText, ListTodo, Sparkles, Server, Download, MessageSquareText } from 'lucide-react'
+import { CalendarDays, ChevronDown, ChevronUp, Paperclip, FileText, ListTodo, Sparkles, Server, Download, MessageSquareText, Quote } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { shouldInspectMermaidCodeBlock, shouldRenderMermaidCodeBlock } from '@/lib/mermaid-detection'
 import { normalizeLatexDelimiters } from '@/lib/normalize-latex'
@@ -39,8 +39,10 @@ import { LoadingIndicator } from '@/components/ui/loading-indicator'
 import { CodeBlock, MermaidBlock } from '@proma/ui'
 import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isImageFilePath, isRelativeFilePath } from './file-path-chip'
+import { buildAgentHistoryQuoteLabel, parseAgentHistoryQuoteMention } from '@/lib/quoted-selection'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
 
 // ===== Message 根容器 =====
 
@@ -255,7 +257,7 @@ function walkMdastText(
 
 // ----- MentionChip 组件 -----
 
-type MentionType = 'file' | 'skill' | 'mcp' | 'session' | 'todo' | 'calendar_event'
+type MentionType = 'file' | 'skill' | 'mcp' | 'session' | 'todo' | 'calendar_event' | 'quote'
 
 const MENTION_STYLES: Record<MentionType, { icon: typeof FileText; className: string }> = {
   file: { icon: FileText, className: 'bg-primary/10 text-primary' },
@@ -264,6 +266,7 @@ const MENTION_STYLES: Record<MentionType, { icon: typeof FileText; className: st
   session: { icon: MessageSquareText, className: 'bg-[hsl(200_80%_50%/0.14)] text-[hsl(200_80%_40%)]' },
   todo: { icon: ListTodo, className: 'bg-amber-500/15 text-amber-800 dark:text-amber-200' },
   calendar_event: { icon: CalendarDays, className: 'bg-cyan-500/15 text-cyan-800 dark:text-cyan-200' },
+  quote: { icon: Quote, className: 'bg-primary/10 text-primary' },
 }
 
 function safeDecode(raw: string): string {
@@ -278,6 +281,7 @@ function safeDecode(raw: string): string {
  * 附加 basePaths 上下文 — 用于把会话目录与附加目录穿透到各类文件 chip。
  */
 const BasePathsContext = React.createContext<string[] | undefined>(undefined)
+const AgentHistoryQuoteClickContext = React.createContext<((quote: QuotedSelection) => void) | undefined>(undefined)
 
 /** 提供附加目录候选给所有内嵌的 MessageResponse。 */
 export function BasePathsProvider({ basePaths, children }: { basePaths?: string[]; children: React.ReactNode }): React.ReactElement {
@@ -335,10 +339,40 @@ export function normalizeNamedReferenceDelimiters(markdown: string): string {
 function MentionChip({ type, value }: { type: MentionType; value: string }): React.ReactElement {
   const style = MENTION_STYLES[type]
   const Icon = style.icon
-  const decoded = safeDecode(value)
   const contextBasePaths = React.useContext(BasePathsContext)
+  const onAgentHistoryQuoteClick = React.useContext(AgentHistoryQuoteClickContext)
 
-  // 图片引用原先会以内联图片显示。改为 chip 后仍沿用同一文件预览入口，
+  if (type === 'quote') {
+    const quote = parseAgentHistoryQuoteMention(`&quote:${value}`)
+    if (!quote) {
+      return <span>{`&quote:${value}`}</span>
+    }
+    const canNavigate = Boolean(
+      onAgentHistoryQuoteClick
+        && quote.messageId
+        && quote.selectionStart != null
+        && quote.selectionEnd != null
+        && quote.selectionEnd > quote.selectionStart,
+    )
+    return (
+      <button
+        type="button"
+        disabled={!canNavigate}
+        onClick={canNavigate ? () => onAgentHistoryQuoteClick?.(quote) : undefined}
+        className={cn(
+          'inline-flex items-center gap-0.5 rounded px-1 py-[1px] text-[13px] font-medium whitespace-nowrap align-baseline',
+          style.className,
+          canNavigate ? 'cursor-pointer hover:bg-primary/[0.16]' : 'cursor-default',
+        )}
+        title={canNavigate ? '点击跳转到原消息并高亮引用内容' : buildAgentHistoryQuoteLabel(quote)}
+      >
+        <Icon className="size-3 inline shrink-0" />
+        {buildAgentHistoryQuoteLabel(quote)}
+      </button>
+    )
+  }
+
+  const decoded = safeDecode(value)
   // 避免用户只能看到文件名而无法查看内容。
   if (type === 'file' && isImageFilePath(decoded)) {
     return <FilePathChip filePath={decoded} basePaths={contextBasePaths} />
@@ -377,7 +411,7 @@ export function remarkMentions() {
     walkMdastText(tree, (node, index, parent) => {
       const text = node.value
       // 每次调用创建独立正则实例，避免 /g 状态在并发 remark pipeline 间互相干扰
-      const mentionPattern = /@file:(\S+)|\/skill:(\S+)|#mcp:(\S+)|&session:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?/g
+      const mentionPattern = /@file:(\S+)|\/skill:(\S+)|#mcp:(\S+)|&session:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&quote:([A-Za-z0-9%_.!~*'()-]+)/g
       if (!mentionPattern.test(text)) return
       mentionPattern.lastIndex = 0
 
@@ -399,8 +433,10 @@ export function remarkMentions() {
                 ? 'session'
                 : m[6]
                   ? 'todo'
-                  : 'calendar_event'
-        const referenceId = m[1] ?? m[2] ?? m[3] ?? m[4] ?? m[6] ?? m[8] ?? ''
+                  : m[8]
+                    ? 'calendar_event'
+                    : 'quote'
+        const referenceId = m[1] ?? m[2] ?? m[3] ?? m[4] ?? m[6] ?? m[8] ?? m[10] ?? ''
         const encodedLabel = m[5] ?? m[7] ?? m[9]
         const rawValue = encodedLabel ? `${referenceId}::${safeDecode(encodedLabel)}` : referenceId
         // 文件/Skill/MCP 旧消息可能已经编码；带标题的 named reference 始终重新编码整个值。
@@ -487,7 +523,7 @@ function mentionUrlTransform(url: string): string {
 // ===== Memo'd Markdown 子组件（稳定引用，避免 react-markdown 每帧重建组件映射） =====
 
 /** mention:// URL 匹配 */
-const MENTION_URL_RE = /^mention:\/\/(file|skill|mcp|session|todo|calendar_event)\/(.+)$/
+const MENTION_URL_RE = /^mention:\/\/(file|skill|mcp|session|todo|calendar_event|quote)\/(.+)$/
 
 /** 外部链接 / mention chip 渲染器 */
 const MarkdownLink = React.memo(function MarkdownLink({
@@ -704,6 +740,7 @@ const USER_REMARK_PLUGINS: RemarkPluginFn[] = [remarkMentions, remarkPreserveBre
 
 interface UserMessageContentProps extends HTMLAttributes<HTMLDivElement> {
   children: string
+  onAgentHistoryQuoteClick?: (quote: QuotedSelection) => void
 }
 
 /**
@@ -712,7 +749,7 @@ interface UserMessageContentProps extends HTMLAttributes<HTMLDivElement> {
  * - 点击展开/收起，底部使用低对比度文字提示
  */
 export const UserMessageContent = React.memo(
-  function UserMessageContent({ children, className, ...props }: UserMessageContentProps): React.ReactElement {
+  function UserMessageContent({ children, onAgentHistoryQuoteClick, className, ...props }: UserMessageContentProps): React.ReactElement {
     const [isExpanded, setIsExpanded] = React.useState(false)
     const [shouldCollapse, setShouldCollapse] = React.useState(false)
     const contentRef = React.useRef<HTMLDivElement>(null)
@@ -743,7 +780,9 @@ export const UserMessageContent = React.memo(
             shouldCollapse && !isExpanded && 'max-h-[6.5em]'
           )}
         >
-          <MessageResponse className="prose-p:my-0.5 prose-headings:my-1.5" remarkPlugins={USER_REMARK_PLUGINS}>{children}</MessageResponse>
+          <AgentHistoryQuoteClickContext.Provider value={onAgentHistoryQuoteClick}>
+            <MessageResponse className="prose-p:my-0.5 prose-headings:my-1.5" remarkPlugins={USER_REMARK_PLUGINS}>{children}</MessageResponse>
+          </AgentHistoryQuoteClickContext.Provider>
         </div>
         {shouldCollapse && (
           <button
@@ -770,7 +809,9 @@ export const UserMessageContent = React.memo(
       </div>
     )
   },
-  (prevProps, nextProps) => prevProps.children === nextProps.children
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children
+      && prevProps.onAgentHistoryQuoteClick === nextProps.onAgentHistoryQuoteClick
 )
 
 // ===== MessageLoading 加载动画 =====

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -29,6 +29,12 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
+import {
+  buildAgentHistoryQuoteLabel,
+  parseAgentHistoryQuoteMention,
+  serializeAgentHistoryQuoteMention,
+} from '@/lib/quoted-selection'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { isImageFilePath } from './file-path-chip'
 import { consumeLocalDraftEcho, recordLocalDraftEcho } from '@/lib/input-draft-echo'
@@ -161,6 +167,8 @@ interface RichTextInputProps {
   onHtmlChange?: (html: string) => void
   /** 是否使用 Cmd/Ctrl+Enter 发送（而非 Enter） */
   sendWithCmdEnter?: boolean
+  /** 点击 Agent 历史引用 chip 时，用其消息范围触发定位与高亮。 */
+  onAgentHistoryQuoteClick?: (quote: QuotedSelection) => void
   className?: string
 }
 
@@ -168,6 +176,8 @@ interface RichTextInputProps {
 export interface RichTextInputHandle {
   /** 在光标处插入文件引用（右侧文件面板拖入时调用） */
   insertFileMentions: (items: FilePanelDragItem[]) => void
+  /** 在光标处插入可定位的 Agent 历史引用 chip。 */
+  insertAgentHistoryQuoteMention: (quote: QuotedSelection) => boolean
 }
 
 /**
@@ -201,6 +211,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   htmlValue,
   onHtmlChange,
   sendWithCmdEnter = false,
+  onAgentHistoryQuoteClick,
 }: RichTextInputProps, ref: React.Ref<RichTextInputHandle>): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
   const inputIdRef = useRef(voiceInputId ?? `rich-text-input-${Math.random().toString(36).slice(2)}`)
@@ -232,6 +243,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   // 保持 onHtmlChange 引用最新
   const onHtmlChangeRef = useRef(onHtmlChange)
   onHtmlChangeRef.current = onHtmlChange
+  // 历史引用 chip 的点击需要跨过 TipTap DOM 回调到 AgentView。
+  const onAgentHistoryQuoteClickRef = useRef(onAgentHistoryQuoteClick)
+  onAgentHistoryQuoteClickRef.current = onAgentHistoryQuoteClick
   // 发送模式引用
   const sendWithCmdEnterRef = useRef(sendWithCmdEnter)
   sendWithCmdEnterRef.current = sendWithCmdEnter
@@ -290,6 +304,26 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
     })
     return true
   }, [openPreview])
+
+  const handleAgentHistoryQuoteClick = useCallback((event: MouseEvent): boolean => {
+    const target = event.target
+    if (!(target instanceof Element)) return false
+
+    const mention = target.closest<HTMLElement>('[data-type="mention"][data-mention-quote]')
+    const payload = mention?.getAttribute('data-mention-quote')
+    const quote = payload ? parseAgentHistoryQuoteMention(`&quote:${payload}`) : null
+    if (!quote || !onAgentHistoryQuoteClickRef.current) return false
+
+    event.preventDefault()
+    event.stopPropagation()
+    onAgentHistoryQuoteClickRef.current(quote)
+    return true
+  }, [])
+
+  const handleAgentHistoryQuoteKeyDown = useCallback((event: KeyboardEvent): boolean => {
+    if (event.key !== 'Enter' && event.key !== ' ') return false
+    return handleAgentHistoryQuoteClick(event as unknown as MouseEvent)
+  }, [handleAgentHistoryQuoteClick])
 
   const forwardSessionQuickSwitchKeyEvent = useCallback((event: React.KeyboardEvent<HTMLDivElement>, type: 'keydown' | 'keyup'): void => {
     const nativeEvent = event.nativeEvent
@@ -402,6 +436,16 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
                     : {}
                 ),
               },
+              // 单条 Agent 历史选区会保存为可恢复的 URL 编码 payload，而不是外置附件状态。
+              agentHistoryQuote: {
+                default: null,
+                parseHTML: (el: HTMLElement) => el.getAttribute('data-mention-quote'),
+                renderHTML: (attrs: Record<string, unknown>) => (
+                  typeof attrs.agentHistoryQuote === 'string' && attrs.agentHistoryQuote.length > 0
+                    ? { 'data-mention-quote': attrs.agentHistoryQuote }
+                    : {}
+                ),
+              },
               // 文件夹引用（右侧文件面板拖入的目录）：渲染为文件夹样式 chip
               isDirectory: {
                 default: false,
@@ -425,7 +469,10 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
           renderText({ node, suggestion }) {
             const char = resolveMentionSuggestionChar(node.attrs.mentionSuggestionChar, suggestion?.char)
             const label = node.attrs.label ?? node.attrs.id
-            return `${char}${label}`
+            const quotePayload = node.attrs.agentHistoryQuote
+            return typeof quotePayload === 'string' && quotePayload.length > 0
+              ? label
+              : `${char}${label}`
           },
           renderHTML({ node, suggestion }) {
             // 旧草稿中的节点也会带有原始字符。不能在未匹配到旧 suggestion 时
@@ -434,8 +481,12 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
             const label = node.attrs.label ?? node.attrs.id
             const referenceType = node.attrs.referenceType
             const isDirectory = node.attrs.isDirectory === true
+            const quotePayload = typeof node.attrs.agentHistoryQuote === 'string' && node.attrs.agentHistoryQuote.length > 0
+              ? node.attrs.agentHistoryQuote
+              : null
             let chipClass = isDirectory ? 'directory-mention-chip' : 'mention-chip'
-            if (referenceType === 'todo') chipClass = 'todo-mention-chip'
+            if (quotePayload) chipClass = 'agent-history-quote-chip'
+            else if (referenceType === 'todo') chipClass = 'todo-mention-chip'
             else if (referenceType === 'calendar_event') chipClass = 'calendar-event-mention-chip'
             else if (char === '/') chipClass = 'skill-mention-chip'
             else if (char === '#') chipClass = 'mcp-mention-chip'
@@ -450,6 +501,15 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
                 ...(referenceType === 'todo' || referenceType === 'calendar_event'
                   ? { 'data-mention-reference-type': referenceType }
                   : {}),
+                ...(quotePayload
+                  ? {
+                      'data-mention-quote': quotePayload,
+                      title: '跳转到引用位置并高亮',
+                      role: 'button',
+                      tabindex: '0',
+                      'aria-label': `跳转到${label}的引用位置并高亮`,
+                    }
+                  : {}),
                 ...(node.attrs.commandMenuMention ? { 'data-command-menu-mention': 'true' } : {}),
                 ...(isDirectory ? { 'data-mention-is-directory': 'true' } : {}),
                 ...(char === '@' && !isDirectory && isImageFilePath(String(node.attrs.id))
@@ -457,7 +517,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
                   : {}),
                 class: chipClass,
               },
-              `${char === '@' ? '@' : ''}${label}`,
+              `${quotePayload ? '' : char === '@' ? '@' : ''}${label}`,
             ]
           },
           suggestions: [
@@ -483,8 +543,11 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
         return false
       },
       // TipTap mention 节点由 ProseMirror 直接输出 DOM，不能在这里挂 React onClick。
-      // 仅拦截图片 @ 引用，其余 chip 保持编辑器的原有选择行为。
-      handleClick: (_view, _pos, event) => handleImageMentionClick(event),
+      // 历史引用 chip 需要回流定位；图片 @ 引用则继续打开文件预览。
+      handleClick: (_view, _pos, event) => {
+        if (handleAgentHistoryQuoteClick(event)) return true
+        return handleImageMentionClick(event)
+      },
       attributes: {
         class: cn(
           'prose dark:prose-invert max-w-none focus:outline-none',
@@ -497,6 +560,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
       },
       // 监听 IME 输入状态
       handleDOMEvents: {
+        keydown: (_view, event) => handleAgentHistoryQuoteKeyDown(event),
         focus: () => {
           setLastFocusedVoiceInputId(inputIdRef.current)
           return false
@@ -852,6 +916,28 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
       }
       chain.run()
     },
+    insertAgentHistoryQuoteMention(quote: QuotedSelection): boolean {
+      if (!editor) return false
+      const marker = serializeAgentHistoryQuoteMention(quote)
+      if (!marker) return false
+
+      const payload = marker.slice('&quote:'.length)
+      const label = buildAgentHistoryQuoteLabel(quote)
+      const id = `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`
+      editor.chain().focus()
+        .insertContent({
+          type: 'mention',
+          attrs: {
+            id,
+            label,
+            mentionSuggestionChar: '&',
+            agentHistoryQuote: payload,
+          },
+        })
+        .insertContent(' ')
+        .run()
+      return true
+    },
   }), [editor])
 
   // 将预览范围映射到每次用户编辑后的文档位置，避免流式更新覆盖邻近输入。
@@ -1186,6 +1272,38 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
           height: 12px;
           background-color: currentColor;
           mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/%3E%3Cpath d='M8 9h8'/%3E%3Cpath d='M8 13h6'/%3E%3C/svg%3E");
+          mask-size: contain;
+          mask-repeat: no-repeat;
+          flex-shrink: 0;
+        }
+        .agent-history-quote-chip {
+          background-color: hsl(var(--primary) / 0.12);
+          color: hsl(var(--primary));
+          border-radius: 4px;
+          padding: 1px 4px 1px 2px;
+          font-size: 13px;
+          font-weight: 500;
+          white-space: nowrap;
+          display: inline-flex;
+          align-items: center;
+          gap: 2px;
+          vertical-align: baseline;
+          cursor: pointer;
+        }
+        .agent-history-quote-chip:hover {
+          background-color: hsl(var(--primary) / 0.2);
+        }
+        .agent-history-quote-chip:focus-visible {
+          outline: 2px solid hsl(var(--ring));
+          outline-offset: 2px;
+        }
+        .agent-history-quote-chip::before {
+          content: '';
+          display: inline-block;
+          width: 12px;
+          height: 12px;
+          background-color: currentColor;
+          mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 21c3 0 7-1 7-8V5H3v8h4c0 1.1-.9 2-2 2H3z'/%3E%3Cpath d='M14 21c3 0 7-1 7-8V5h-7v8h4c0 1.1-.9 2-2 2h-2z'/%3E%3C/svg%3E");
           mask-size: contain;
           mask-repeat: no-repeat;
           flex-shrink: 0;

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -1,4 +1,9 @@
 import type { QuotedSelection } from '@/atoms/preview-atoms'
+import {
+  buildAgentHistoryQuoteLabel,
+  expandAgentHistoryQuoteMentions,
+  parseAgentHistoryQuoteMention,
+} from './quoted-selection'
 
 export type QueueDropPlacement = 'before' | 'after'
 
@@ -96,7 +101,7 @@ export interface QueuedMessageSendPayload {
 }
 
 /** 队列预览专用片段：保留原始消息用于发送，同时把引用协议渲染为可读芯片。 */
-export type QueuedMessageReferenceType = 'file' | 'skill' | 'mcp' | 'session' | 'todo' | 'calendar_event'
+export type QueuedMessageReferenceType = 'file' | 'skill' | 'mcp' | 'session' | 'todo' | 'calendar_event' | 'quote'
 
 export type QueuedMessageDisplayPart =
   | { type: 'text'; value: string }
@@ -114,6 +119,39 @@ function escapeHtml(text: string): string {
     .replace(/>/g, '&gt;')
 }
 
+function escapeHtmlAttribute(text: string): string {
+  return escapeHtml(text)
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function renderQueuedParagraphHtml(text: string): string {
+  const quoteMarkerPattern = /&quote:[A-Za-z0-9%_.!~*'()-]+/g
+  let html = ''
+  let lastIndex = 0
+
+  for (const match of text.matchAll(quoteMarkerPattern)) {
+    if (match.index > lastIndex) {
+      html += escapeHtml(text.slice(lastIndex, match.index))
+    }
+
+    const marker = match[0]
+    const quote = parseAgentHistoryQuoteMention(marker)
+    if (!quote) {
+      html += escapeHtml(marker)
+    } else {
+      const payload = marker.slice('&quote:'.length)
+      const id = `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`
+      const label = buildAgentHistoryQuoteLabel(quote)
+      html += `<span data-type="mention" data-id="${escapeHtmlAttribute(id)}" data-label="${escapeHtmlAttribute(label)}" data-mention-suggestion-char="&" data-mention-quote="${escapeHtmlAttribute(payload)}">${escapeHtml(label)}</span>`
+    }
+    lastIndex = match.index + marker.length
+  }
+
+  html += escapeHtml(text.slice(lastIndex))
+  return html.replace(/\n/g, '<br>')
+}
+
 /**
  * 把纯文本队列消息转成与 RichTextInput 段落渲染一致的 HTML：
  * 双换行分段落，单换行转 <br>，并转义 HTML 特殊字符避免破坏结构。
@@ -124,13 +162,12 @@ export function queuedTextToParagraphHtml(text: string): string {
   if (!normalized) return ''
   return normalized
     .split(/\n\n+/)
-    .map((para) => `<p>${escapeHtml(para).replace(/\n/g, '<br>')}</p>`)
+    .map((para) => `<p>${renderQueuedParagraphHtml(para)}</p>`)
     .join('')
 }
 
-
 const REF_PATTERN = /\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?/g
-const DISPLAY_REFERENCE_PATTERN = /@file:(?<file>\S+)|\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>\S+))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>\S+))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>\S+))?/g
+const DISPLAY_REFERENCE_PATTERN = /&quote:(?<quote>[A-Za-z0-9%_.!~*'()-]+)|@file:(?<file>\S+)|\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>\S+))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>\S+))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>\S+))?/g
 
 function decodeReferenceLabel(value: string): string {
   try {
@@ -141,7 +178,7 @@ function decodeReferenceLabel(value: string): string {
 }
 
 /**
- * 将排队消息中的文件、Skill、MCP、会话和规划协议转换为展示片段。
+ * 将排队消息中的文件、Skill、MCP、会话、历史引用和规划协议转换为展示片段。
  * `item.text` 仍完整保留，发送时继续通过 parseQueuedMessageMentions 提取原始 ID。
  */
 export function getQueuedMessageDisplayParts(text: string): QueuedMessageDisplayPart[] {
@@ -154,6 +191,22 @@ export function getQueuedMessageDisplayParts(text: string): QueuedMessageDisplay
     }
 
     const groups = match.groups ?? {}
+    if (groups.quote) {
+      const quote = parseAgentHistoryQuoteMention(`&quote:${groups.quote}`)
+      if (quote) {
+        parts.push({
+          type: 'reference',
+          referenceType: 'quote',
+          id: `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`,
+          label: buildAgentHistoryQuoteLabel(quote),
+        })
+      } else {
+        parts.push({ type: 'text', value: match[0] })
+      }
+      lastIndex = match.index + match[0].length
+      continue
+    }
+
     let referenceType: QueuedMessageReferenceType
     let id: string
     let rawLabel: string | undefined
@@ -258,8 +311,8 @@ export function buildQueuedMessageSendPayload(
     : ''
 
   return {
-    rawText: `${prefix}${text}`.trim(),
-    sdkText: `${prefix}${mentions.cleanedText}`.trim(),
+    rawText: `${prefix}${expandAgentHistoryQuoteMentions(text)}`.trim(),
+    sdkText: `${prefix}${expandAgentHistoryQuoteMentions(mentions.cleanedText)}`.trim(),
     mentions,
   }
 }

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -529,7 +529,9 @@ export function htmlToMarkdown(
         const dataLabel = el.getAttribute('data-label')
         const suggestionChar = el.getAttribute('data-mention-suggestion-char') || '@'
         const referenceType = el.getAttribute('data-mention-reference-type')
+        const agentHistoryQuote = el.getAttribute('data-mention-quote')
         if (dataType === 'mention') {
+          if (agentHistoryQuote) return `&quote:${agentHistoryQuote}`
           if (referenceType === 'todo') return serializeNamedMention('&todo', dataId, dataLabel)
           if (referenceType === 'calendar_event') return serializeNamedMention('&calendar_event', dataId, dataLabel)
           if (suggestionChar === '/') return `/skill:${dataId}`

--- a/apps/electron/src/renderer/lib/quoted-selection.test.ts
+++ b/apps/electron/src/renderer/lib/quoted-selection.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test'
-import { buildQuotedSelectionBlock, parseQuotedSelectionRefs } from './quoted-selection'
+import {
+  buildQuotedSelectionBlock,
+  expandAgentHistoryQuoteMentions,
+  parseAgentHistoryQuoteMention,
+  parseQuotedSelectionRefs,
+  serializeAgentHistoryQuoteMention,
+} from './quoted-selection'
 
 describe('quoted selection XML', () => {
   test('Given 文件引用 When 构建并解析引用块 Then 保留文件名并移除隐藏 XML', () => {
@@ -42,6 +48,15 @@ describe('quoted selection XML', () => {
         filename: 'Agent 历史 · Agent 回复',
         sourceType: 'agent-history',
         label: 'Agent 历史 · Agent 回复',
+        quote: {
+          text: '历史内容',
+          filePath: 'Agent 历史 · Agent 回复',
+          sourceType: 'agent-history',
+          sourceLabel: 'Agent 历史 · Agent 回复',
+          messageId: 'm1',
+          messageRole: 'assistant',
+          capturedAt: 0,
+        },
       },
       {
         path: '草稿页',
@@ -51,5 +66,35 @@ describe('quoted selection XML', () => {
       },
     ])
     expect(parsed.text).toBe('继续提问')
+  })
+
+  test('Given 可定位的 Agent 历史选区 When 序列化、发送并解析 Then 保留范围且用 inline marker 展示', () => {
+    const quote = {
+      text: '第二轮的关键内容',
+      filePath: 'Agent 历史 · Agent 回复',
+      sourceType: 'agent-history' as const,
+      sourceLabel: 'Agent 历史 · Agent 回复',
+      messageId: 'message-2',
+      messageRole: 'assistant' as const,
+      selectionStart: 12,
+      selectionEnd: 20,
+      turn: 2,
+      capturedAt: 1,
+    }
+    const marker = serializeAgentHistoryQuoteMention(quote)
+
+    expect(marker).not.toBeNull()
+    const expanded = expandAgentHistoryQuoteMentions(`问题前 ${marker} 问题后`).replace(/\n/g, '\r\n')
+    const parsed = parseQuotedSelectionRefs(expanded, { inlineAgentHistoryQuotes: true })
+
+    expect(parsed.text).toBe(`问题前 ${marker} 问题后`)
+    expect(parseAgentHistoryQuoteMention(parsed.text.match(/&quote:\S+/)?.[0] ?? '')).toMatchObject({
+      text: quote.text,
+      messageId: quote.messageId,
+      messageRole: quote.messageRole,
+      selectionStart: quote.selectionStart,
+      selectionEnd: quote.selectionEnd,
+      turn: quote.turn,
+    })
   })
 })

--- a/apps/electron/src/renderer/lib/quoted-selection.ts
+++ b/apps/electron/src/renderer/lib/quoted-selection.ts
@@ -1,17 +1,33 @@
-import type { QuotedSelection } from '@/atoms/preview-atoms'
-import type { QuotedSelectionSourceType } from '@/atoms/preview-atoms'
+import type { QuotedSelection, QuotedSelectionSourceType } from '@/atoms/preview-atoms'
 
 export interface ParsedQuotedSelectionRef {
   path: string
   filename: string
   sourceType: QuotedSelectionSourceType
   label?: string
+  /** 可恢复定位的 Agent 历史引用元数据。 */
+  quote?: QuotedSelection
 }
 
 export const SELECTION_ACTION_POPOVER_SELECTOR = '[data-selection-action-popover]'
 
-const QUOTED_FILE_REGEX = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g
-const QUOTED_CONTEXT_REGEX = /<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g
+const QUOTED_FILE_REGEX = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>(?:\r?\n)*/g
+const QUOTED_CONTEXT_REGEX = /<quoted_context[^>]*>[\s\S]*?<\/quoted_context>(?:\r?\n)*/g
+const AGENT_HISTORY_QUOTE_MENTION_PREFIX = '&quote:'
+const AGENT_HISTORY_QUOTE_MENTION_REGEX = /&quote:[A-Za-z0-9%_.!~*'()-]+/g
+
+type AgentHistoryMessageRole = Exclude<QuotedSelection['messageRole'], undefined>
+
+interface AgentHistoryQuoteMarkerPayload {
+  version: 1
+  text: string
+  sourceLabel: string
+  messageId: string
+  messageRole?: AgentHistoryMessageRole
+  selectionStart?: number
+  selectionEnd?: number
+  turn?: number
+}
 
 export function escapeXmlAttribute(value: string): string {
   return value
@@ -35,6 +51,159 @@ function sanitizeQuotedText(value: string): string {
     .replace(/<\/quoted_context>/gi, '</quoted_context_>')
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function isAgentHistoryMessageRole(value: unknown): value is AgentHistoryMessageRole {
+  return value === 'user' || value === 'assistant' || value === 'system'
+}
+
+type NavigableAgentHistoryQuote = QuotedSelection & {
+  sourceType: 'agent-history'
+  messageId: string
+  selectionStart: number
+  selectionEnd: number
+  turn: number
+}
+
+function isNavigableAgentHistoryQuote(quote: QuotedSelection): quote is NavigableAgentHistoryQuote {
+  return quote.sourceType === 'agent-history'
+    && isNonEmptyString(quote.text)
+    && isNonEmptyString(quote.messageId)
+    && isNonNegativeInteger(quote.selectionStart)
+    && isNonNegativeInteger(quote.selectionEnd)
+    && quote.selectionEnd > quote.selectionStart
+    && isPositiveInteger(quote.turn)
+}
+
+function parseAgentHistoryQuotePayload(payload: string): QuotedSelection | null {
+  try {
+    const value: unknown = JSON.parse(decodeURIComponent(payload))
+    if (!value || typeof value !== 'object') return null
+
+    const record = value as Record<string, unknown>
+    const text = record.text
+    const sourceLabel = record.sourceLabel
+    const messageId = record.messageId
+    const selectionStart = record.selectionStart
+    const selectionEnd = record.selectionEnd
+    const turn = record.turn
+    const messageRole = record.messageRole
+    const hasPositionFields = record.selectionStart !== undefined
+      || record.selectionEnd !== undefined
+      || record.turn !== undefined
+    const hasValidPosition = isNonNegativeInteger(selectionStart)
+      && isNonNegativeInteger(selectionEnd)
+      && selectionEnd > selectionStart
+      && isPositiveInteger(turn)
+
+    if (
+      record.version !== 1
+      || !isNonEmptyString(text)
+      || !isNonEmptyString(sourceLabel)
+      || !isNonEmptyString(messageId)
+      || (hasPositionFields && !hasValidPosition)
+      || (messageRole !== undefined && !isAgentHistoryMessageRole(messageRole))
+    ) {
+      return null
+    }
+
+    return {
+      text,
+      filePath: sourceLabel,
+      sourceType: 'agent-history',
+      sourceLabel,
+      messageId,
+      ...(messageRole !== undefined && { messageRole }),
+      ...(hasValidPosition && { selectionStart, selectionEnd, turn }),
+      capturedAt: 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+/** 构建内联 Agent 历史引用 chip 的固定展示文案。 */
+export function buildAgentHistoryQuoteLabel(quote: Pick<QuotedSelection, 'text' | 'turn'>): string {
+  const preview = Array.from(quote.text.replace(/\s+/g, ' ').trim()).slice(0, 25).join('')
+  const prefix = isPositiveInteger(quote.turn) ? `第${quote.turn}轮` : '历史引用'
+  return `${prefix}：${preview}`
+}
+
+/** 将可定位的 Agent 历史选区编码为 TipTap 草稿和队列使用的内联 marker。 */
+export function serializeAgentHistoryQuoteMention(quote: QuotedSelection): string | null {
+  if (!isNavigableAgentHistoryQuote(quote)) return null
+
+  const payload: AgentHistoryQuoteMarkerPayload = {
+    version: 1,
+    text: quote.text,
+    sourceLabel: quote.sourceLabel?.trim() || quote.filePath,
+    messageId: quote.messageId,
+    ...(isAgentHistoryMessageRole(quote.messageRole) && { messageRole: quote.messageRole }),
+    selectionStart: quote.selectionStart,
+    selectionEnd: quote.selectionEnd,
+    turn: quote.turn,
+  }
+
+  return `${AGENT_HISTORY_QUOTE_MENTION_PREFIX}${encodeURIComponent(JSON.stringify(payload))}`
+}
+
+/** 为已发送消息生成展示用历史引用 marker，允许缺少旧版本的定位字段。 */
+export function serializeAgentHistoryQuoteDisplayMention(quote: QuotedSelection): string | null {
+  if (quote.sourceType !== 'agent-history' || !isNonEmptyString(quote.text) || !isNonEmptyString(quote.messageId)) {
+    return null
+  }
+
+  const payload: AgentHistoryQuoteMarkerPayload = {
+    version: 1,
+    text: quote.text,
+    sourceLabel: quote.sourceLabel?.trim() || quote.filePath,
+    messageId: quote.messageId,
+    ...(isAgentHistoryMessageRole(quote.messageRole) && { messageRole: quote.messageRole }),
+    ...(isNonNegativeInteger(quote.selectionStart)
+      && isNonNegativeInteger(quote.selectionEnd)
+      && quote.selectionEnd > quote.selectionStart
+      && isPositiveInteger(quote.turn)
+      && { selectionStart: quote.selectionStart, selectionEnd: quote.selectionEnd, turn: quote.turn }),
+  }
+
+  return `${AGENT_HISTORY_QUOTE_MENTION_PREFIX}${encodeURIComponent(JSON.stringify(payload))}`
+}
+
+/** 将历史引用 marker 替换为可复制的 chip 文案，避免把内部 payload 暴露给剪贴板。 */
+export function replaceAgentHistoryQuoteMentionsWithLabels(text: string): string {
+  return text.replace(AGENT_HISTORY_QUOTE_MENTION_REGEX, (marker) => {
+    const quote = parseAgentHistoryQuoteMention(marker)
+    return quote ? buildAgentHistoryQuoteLabel(quote) : marker
+  })
+}
+
+/** 解码单个内联 Agent 历史引用 marker；无效输入保持为普通文本。 */
+export function parseAgentHistoryQuoteMention(marker: string): QuotedSelection | null {
+  if (!marker.startsWith(AGENT_HISTORY_QUOTE_MENTION_PREFIX)) return null
+  const payload = marker.slice(AGENT_HISTORY_QUOTE_MENTION_PREFIX.length)
+  if (!payload || /\s/.test(payload)) return null
+  return parseAgentHistoryQuotePayload(payload)
+}
+
+/** 在真正发送给 Agent 前，将草稿内联 marker 替换为既有 XML 上下文块。 */
+export function expandAgentHistoryQuoteMentions(text: string): string {
+  return text.replace(AGENT_HISTORY_QUOTE_MENTION_REGEX, (marker) => {
+    const quote = parseAgentHistoryQuoteMention(marker)
+    if (!quote) return marker
+    return buildQuotedSelectionBlock(quote)
+  })
+}
+
 export function buildQuotedSelectionBlock(quotedSelection: QuotedSelection): string {
   const safeText = sanitizeQuotedText(quotedSelection.text)
 
@@ -43,7 +212,13 @@ export function buildQuotedSelectionBlock(quotedSelection: QuotedSelection): str
     const safeLabel = escapeXmlAttribute(quotedSelection.sourceLabel ?? quotedSelection.filePath)
     const safeMessageId = escapeXmlAttribute(quotedSelection.messageId ?? '')
     const safeRole = escapeXmlAttribute(quotedSelection.messageRole ?? '')
-    return `<quoted_context source="${safeSource}" label="${safeLabel}" message_id="${safeMessageId}" role="${safeRole}">\n${safeText}\n</quoted_context>\n\n`
+    const historyMetadata = quotedSelection.sourceType === 'agent-history'
+      && isNonNegativeInteger(quotedSelection.selectionStart)
+      && isNonNegativeInteger(quotedSelection.selectionEnd)
+      && isPositiveInteger(quotedSelection.turn)
+      ? ` turn="${quotedSelection.turn}" selection_start="${quotedSelection.selectionStart}" selection_end="${quotedSelection.selectionEnd}"`
+      : ''
+    return `<quoted_context source="${safeSource}" label="${safeLabel}" message_id="${safeMessageId}" role="${safeRole}"${historyMetadata}>\n${safeText}\n</quoted_context>\n\n`
   }
 
   const safePath = escapeXmlAttribute(quotedSelection.filePath)
@@ -55,7 +230,15 @@ function normalizeContextSourceType(value: string | undefined): QuotedSelectionS
   return 'agent-history'
 }
 
-export function parseQuotedSelectionRefs(content: string): { quotes: ParsedQuotedSelectionRef[]; text: string } {
+export interface ParseQuotedSelectionRefsOptions {
+  /** 将 Agent 历史引用保留为展示用 inline mention marker。 */
+  inlineAgentHistoryQuotes?: boolean
+}
+
+export function parseQuotedSelectionRefs(
+  content: string,
+  options: ParseQuotedSelectionRefsOptions = {},
+): { quotes: ParsedQuotedSelectionRef[]; text: string } {
   const quotes: ParsedQuotedSelectionRef[] = []
 
   let quoteMatch: RegExpExecArray | null
@@ -71,23 +254,61 @@ export function parseQuotedSelectionRefs(content: string): { quotes: ParsedQuote
     })
   }
 
+  const contextQuotes: Array<QuotedSelection | undefined> = []
   QUOTED_CONTEXT_REGEX.lastIndex = 0
   while ((quoteMatch = QUOTED_CONTEXT_REGEX.exec(content)) !== null) {
     const labelMatch = quoteMatch[0].match(/label="([^"]*)"/)
     const sourceMatch = quoteMatch[0].match(/source="([^"]*)"/)
+    const messageIdMatch = quoteMatch[0].match(/message_id="([^"]*)"/)
+    const roleMatch = quoteMatch[0].match(/role="([^"]*)"/)
     const label = labelMatch ? decodeXmlAttribute(labelMatch[1]!) : 'Agent 历史'
     const sourceType = normalizeContextSourceType(sourceMatch ? decodeXmlAttribute(sourceMatch[1]!) : 'agent-history')
+    const quoteBodyMatch = quoteMatch[0].match(/>\r?\n([\s\S]*?)\r?\n<\/quoted_context>/)
+    const turnMatch = quoteMatch[0].match(/\bturn="(\d+)"/)
+    const selectionStartMatch = quoteMatch[0].match(/\bselection_start="(\d+)"/)
+    const selectionEndMatch = quoteMatch[0].match(/\bselection_end="(\d+)"/)
+    const turn = turnMatch ? Number(turnMatch[1]) : undefined
+    const selectionStart = selectionStartMatch ? Number(selectionStartMatch[1]) : undefined
+    const selectionEnd = selectionEndMatch ? Number(selectionEndMatch[1]) : undefined
+    const messageId = messageIdMatch ? decodeXmlAttribute(messageIdMatch[1]!) : ''
+    const role = roleMatch ? decodeXmlAttribute(roleMatch[1]!) : undefined
+    const quote = sourceType === 'agent-history'
+      && isNonEmptyString(messageId)
+      && quoteBodyMatch
+      ? {
+          text: quoteBodyMatch[1]!,
+          filePath: label,
+          sourceType: 'agent-history' as const,
+          sourceLabel: label,
+          messageId,
+          ...(isAgentHistoryMessageRole(role) && { messageRole: role }),
+          ...(isPositiveInteger(turn)
+            && isNonNegativeInteger(selectionStart)
+            && isNonNegativeInteger(selectionEnd)
+            && selectionEnd > selectionStart
+            ? { selectionStart, selectionEnd, turn }
+            : {}),
+          capturedAt: 0,
+        }
+      : undefined
+    contextQuotes.push(quote)
     quotes.push({
       path: label,
       filename: label,
       sourceType,
       label,
+      ...(quote && { quote }),
     })
   }
 
+  let contextQuoteIndex = 0
   const text = content
     .replace(QUOTED_FILE_REGEX, '')
-    .replace(QUOTED_CONTEXT_REGEX, '')
+    .replace(QUOTED_CONTEXT_REGEX, () => {
+      const quote = contextQuotes[contextQuoteIndex++]
+      if (!options.inlineAgentHistoryQuotes || !quote) return ''
+      return serializeAgentHistoryQuoteDisplayMention(quote) ?? ''
+    })
     .trim()
 
   return { quotes, text }


### PR DESCRIPTION
## 概述
本 PR 为 Proma Agent 会话输入框新增「会话历史选区引用」能力：用户可在历史消息中精确选择一段文本，在输入框中以 inline chip 形式引用（chip 前后仍可继续输入），发送后该引用以与 Skill、会话引用一致的 mention chip 渲染在已发送消息正文内，并可点击跳转回原消息、高亮精确引用范围。

## 改动
- `apps/electron/package.json` — 版本号递增至 `0.17.14`。
- `apps/electron/src/renderer/atoms/preview-atoms.ts` — `QuotedSelection` 扩展 `selectionStart` / `selectionEnd` / `turn` 定位元数据。
- `apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx` — 同一消息内计算文本偏移与轮次；超过 2000 字符的选区仅保留实际发送给 Agent 的截断范围。
- `apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx` / `agent-message-queue.ts` — 队列消息支持 quote marker，发送 payload 展开为 `<quoted_context>`，展示时渲染为 chip。
- `apps/electron/src/renderer/components/agent/AgentMessages.tsx` — 滚动定位、Custom Highlight API / 浏览器 Selection 回退高亮，以及全局 `pointerdown` 清除高亮。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 输入框插入、点击导航与发送前 marker 展开接入。
- `apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx` — 已发送用户消息将历史引用改为在正文内 inline 渲染，移除原消息上方附件式引用区。
- `apps/electron/src/renderer/components/ai-elements/message.tsx` — `quote` mention 类型接入与 `/skill`、`&session` 相同的 Markdown mention 渲染管线；非法 marker 保留原文显示，不吞内容。
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — TipTap 原子节点 chip：前后可编辑、tooltip、键盘激活、草稿持久化。
- `apps/electron/src/renderer/lib/markdown-rich-text.ts` — 序列化 quote mention。
- `apps/electron/src/renderer/lib/quoted-selection.ts` — 引用协议：编码/解码/展开/label；保留 `turn`、`selection_start`、`selection_end` 以恢复精确导航；兼容 CRLF 格式旧 `<quoted_context>`；复制已发送消息时输出 chip 标签而非内部 marker。

## 测试方法
1. `bun run typecheck` — 全部 workspace 包通过。
2. `bun run --filter='@proma/electron' build:renderer` — 构建通过（仅既有 chunk 体积警告）。
3. `git diff --check` — 无空白错误。
4. 手工验证：选中历史消息文本 → 输入框出现 inline chip 且前后可继续输入 → 发送后用户气泡正文内显示同款 chip → 点击 chip 滚动并高亮精确范围 → 点击任意位置清除高亮。
5. 旧消息兼容：无定位字段的旧 `<quoted_context>` 仍显示为 inline chip（不可点击）。

## 备注
- 按用户要求，本次测试代码与计划文档 `docs/plans/2026-08-11-session-quote-chip.md` 不包含在本 PR。
- 全量测试 4 个失败均来自未修改的 Electron mock、OAuth proxy scope 与 planning manager 环境测试，与本次改动无关。
- 版本号相对最新 upstream 的 `0.17.13` 递增为 `0.17.14`。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
