### PR TITLE
feat(electron): add idle mode and task-driven sleep prevention

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -106,6 +106,7 @@ import { startPlanningNativeSyncCoordinator, stopPlanningNativeSyncCoordinator }
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { getFeishuMultiBotConfig } from './lib/feishu-config'
 import { stopFeishuSyncSleepBlocker, syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
+import { stopIdleMode, syncIdleMode } from './lib/idle-mode-electron'
 import { getPersistableMainWindowState, hideMacMainWindowAfterClose } from './lib/main-window-lifecycle'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
 import { getDingTalkMultiBotConfig } from './lib/dingtalk-config'
@@ -702,6 +703,9 @@ async function bootstrap(): Promise<void> {
   // 飞书实时同步开启时，默认阻止系统自动休眠，保证远程群内继续可用。
   safeRun('syncFeishuSyncSleepBlocker', () => syncFeishuSyncSleepBlocker(getSettings()))
 
+  // 挂机模式开启时，立即熄灭显示器并阻止系统休眠，保证挂机任务持续运行。
+  safeRun('syncIdleMode', () => syncIdleMode(getSettings()))
+
   // 注册全局快捷键
   safeRun('registerGlobalShortcut:quick-task', () =>
     registerGlobalShortcut('quick-task', toggleQuickTaskWindow),
@@ -823,6 +827,8 @@ app.on('before-quit', () => {
   stopPlanningNativeSyncCoordinator()
   // 释放飞书同步防休眠
   stopFeishuSyncSleepBlocker()
+  // 释放挂机模式（息屏 + 防休眠）
+  stopIdleMode()
   // 注销全局快捷键
   unregisterAllGlobalShortcuts()
   // 销毁辅助窗口

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -107,6 +107,7 @@ import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { getFeishuMultiBotConfig } from './lib/feishu-config'
 import { stopFeishuSyncSleepBlocker, syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
 import { stopIdleMode, syncIdleMode } from './lib/idle-mode-electron'
+import { stopTaskSleepGuard, syncTaskSleepGuard } from './lib/task-sleep-guard-electron'
 import { getPersistableMainWindowState, hideMacMainWindowAfterClose } from './lib/main-window-lifecycle'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
 import { getDingTalkMultiBotConfig } from './lib/dingtalk-config'
@@ -706,6 +707,9 @@ async function bootstrap(): Promise<void> {
   // 挂机模式开启时，立即熄灭显示器并阻止系统休眠，保证挂机任务持续运行。
   safeRun('syncIdleMode', () => syncIdleMode(getSettings()))
 
+  // 任务防休眠（默认开启）：任务运行期间阻止系统休眠，锁屏/息屏/合盖不中断任务。
+  safeRun('syncTaskSleepGuard', () => syncTaskSleepGuard(getSettings()))
+
   // 注册全局快捷键
   safeRun('registerGlobalShortcut:quick-task', () =>
     registerGlobalShortcut('quick-task', toggleQuickTaskWindow),
@@ -829,6 +833,8 @@ app.on('before-quit', () => {
   stopFeishuSyncSleepBlocker()
   // 释放挂机模式（息屏 + 防休眠）
   stopIdleMode()
+  // 释放任务防休眠
+  stopTaskSleepGuard()
   // 注销全局快捷键
   unregisterAllGlobalShortcuts()
   // 销毁辅助窗口

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -376,6 +376,7 @@ import {
 } from './lib/feishu-config'
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
+import { syncIdleMode } from './lib/idle-mode-electron'
 import { presenceService } from './lib/feishu-presence'
 import { getDingTalkConfig, saveDingTalkConfig, getDecryptedClientSecret, getDingTalkMultiBotConfig, saveDingTalkBotConfig, removeDingTalkBot, getDecryptedBotClientSecret } from './lib/dingtalk-config'
 import { listShallowDirectory } from './lib/directory-listing'
@@ -1758,6 +1759,9 @@ export function registerIpcHandlers(): void {
       if (updates.feishuSessionMirror !== undefined) {
         syncFeishuSyncSleepBlocker(result)
       }
+      if (updates.idleMode !== undefined) {
+        syncIdleMode(result)
+      }
       if (updates.agentIsland !== undefined) {
         refreshAgentIslandConfiguration()
       }
@@ -1789,6 +1793,9 @@ export function registerIpcHandlers(): void {
         const result = updateSettings(updates)
         if (updates.feishuSessionMirror !== undefined) {
           syncFeishuSyncSleepBlocker(result)
+        }
+        if (updates.idleMode !== undefined) {
+          syncIdleMode(result)
         }
         if (updates.agentIsland !== undefined) {
           refreshAgentIslandConfiguration()

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -377,6 +377,7 @@ import {
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
 import { syncIdleMode } from './lib/idle-mode-electron'
+import { syncTaskSleepGuard } from './lib/task-sleep-guard-electron'
 import { presenceService } from './lib/feishu-presence'
 import { getDingTalkConfig, saveDingTalkConfig, getDecryptedClientSecret, getDingTalkMultiBotConfig, saveDingTalkBotConfig, removeDingTalkBot, getDecryptedBotClientSecret } from './lib/dingtalk-config'
 import { listShallowDirectory } from './lib/directory-listing'
@@ -1762,6 +1763,9 @@ export function registerIpcHandlers(): void {
       if (updates.idleMode !== undefined) {
         syncIdleMode(result)
       }
+      if (updates.taskSleepGuard !== undefined) {
+        syncTaskSleepGuard(result)
+      }
       if (updates.agentIsland !== undefined) {
         refreshAgentIslandConfiguration()
       }
@@ -1796,6 +1800,9 @@ export function registerIpcHandlers(): void {
         }
         if (updates.idleMode !== undefined) {
           syncIdleMode(result)
+        }
+        if (updates.taskSleepGuard !== undefined) {
+          syncTaskSleepGuard(result)
         }
         if (updates.agentIsland !== undefined) {
           refreshAgentIslandConfiguration()

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -38,6 +38,7 @@ import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-man
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
 import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
+import { taskSleepGuard } from './task-sleep-guard-electron'
 
 // ===== 实例创建 =====
 
@@ -181,9 +182,13 @@ export async function runAgent(
       }
     } catch { /* 新会话可能尚未写入索引 */ }
   }
+  // 任务防休眠：本次 run 的 token，onRunStarted 开始防休眠，onComplete/onError/异常时释放。
+  // 声明在函数级作用域，确保 catch 分支可访问。
+  const sleepGuardToken = {}
   try {
     await orchestrator.sendMessage(input, {
       onError: (error) => {
+        taskSleepGuard.end(sleepGuardToken)
         if (!webContents.isDestroyed()) {
           webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
             sessionId: input.sessionId,
@@ -192,6 +197,7 @@ export async function runAgent(
         }
       },
       onComplete: (messages, opts) => {
+        taskSleepGuard.end(sleepGuardToken)
         publishRunStopped(input.sessionId, opts?.stoppedByUser, opts?.startedAt)
         if (!webContents.isDestroyed()) {
           sendAgentStreamComplete(webContents, input, {
@@ -207,6 +213,7 @@ export async function runAgent(
         }
       },
       onRunStarted: ({ startedAt }) => {
+        taskSleepGuard.begin(sleepGuardToken)
         eventBus.emit(input.sessionId, {
           kind: 'proma_event',
           event: { type: 'run_started', startedAt },
@@ -228,6 +235,7 @@ export async function runAgent(
   } catch (err) {
     console.error('[Agent 服务] runAgent 未处理异常:', err)
     const errorMessage = err instanceof Error ? err.message : '未知错误'
+    taskSleepGuard.end(sleepGuardToken)
     if (!webContents.isDestroyed()) {
       webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
         sessionId: input.sessionId,
@@ -276,9 +284,13 @@ export async function runAgentHeadless(
     registerWebContents(runInput.sessionId, wc)
   }
 
+  // 任务防休眠：本次 run 的 token，onRunStarted 开始防休眠，onComplete/onError/异常时释放。
+  // 声明在函数级作用域，确保 catch 分支可访问。
+  const sleepGuardToken = {}
   try {
     await orchestrator.sendMessage(runInput, {
       onError: (error) => {
+        taskSleepGuard.end(sleepGuardToken)
         callbacks.onError(error)
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
@@ -289,6 +301,7 @@ export async function runAgentHeadless(
         }
       },
       onComplete: (messages, opts) => {
+        taskSleepGuard.end(sleepGuardToken)
         callbacks.onComplete(messages)
         publishRunStopped(runInput.sessionId, opts?.stoppedByUser, opts?.startedAt)
         // 同步到渲染进程
@@ -320,6 +333,7 @@ export async function runAgentHeadless(
         }
       },
       onRunStarted: ({ startedAt: persistedStartedAt }) => {
+        taskSleepGuard.begin(sleepGuardToken)
         const session = getAgentSessionMeta(runInput.sessionId)
         eventBus.emit(runInput.sessionId, {
           kind: 'proma_event',
@@ -339,6 +353,7 @@ export async function runAgentHeadless(
   } catch (err) {
     console.error('[Agent 服务] runAgentHeadless 未处理异常:', err)
     const errorMessage = err instanceof Error ? err.message : '未知错误'
+    taskSleepGuard.end(sleepGuardToken)
     callbacks.onError(errorMessage)
     callbacks.onComplete()
     if (wc && !wc.isDestroyed()) {

--- a/apps/electron/src/main/lib/idle-mode-electron.ts
+++ b/apps/electron/src/main/lib/idle-mode-electron.ts
@@ -1,0 +1,36 @@
+import { powerSaveBlocker } from 'electron'
+import type { AppSettings } from '../../types'
+import { IdleModeManager, type SleepBlockerAdapter, type SleepBlockerType } from './idle-mode'
+
+/**
+ * 挂机模式（息屏 + 防休眠）— electron 接线层
+ *
+ * 核心逻辑见 idle-mode.ts；此处负责把 powerSaveBlocker 注入为
+ * SleepBlockerAdapter，并导出供主进程使用的 sync/stop 入口。
+ */
+
+const electronSleepBlocker: SleepBlockerAdapter = {
+  start: (type: SleepBlockerType): number => powerSaveBlocker.start(type),
+  stop: (id: number): void => {
+    powerSaveBlocker.stop(id)
+  },
+  isStarted: (id: number): boolean => powerSaveBlocker.isStarted(id),
+}
+
+const manager = new IdleModeManager(electronSleepBlocker)
+
+export function syncIdleMode(settings: Pick<AppSettings, 'idleMode'>): void {
+  try {
+    manager.sync(settings)
+  } catch (error) {
+    console.error('[挂机模式] 同步状态失败:', error)
+  }
+}
+
+export function stopIdleMode(): void {
+  try {
+    manager.stop()
+  } catch (error) {
+    console.error('[挂机模式] 关闭失败:', error)
+  }
+}

--- a/apps/electron/src/main/lib/idle-mode.test.ts
+++ b/apps/electron/src/main/lib/idle-mode.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  IdleModeManager,
+  buildDisplayOffCommand,
+  shouldEnableIdleMode,
+  type DisplayOffRunner,
+  type SleepBlockerAdapter,
+  type SleepBlockerType,
+} from './idle-mode'
+
+class FakeSleepBlocker implements SleepBlockerAdapter {
+  readonly startedTypes: SleepBlockerType[] = []
+  readonly stoppedIds: number[] = []
+  private nextId = 1
+  private activeIds = new Set<number>()
+
+  start(type: SleepBlockerType): number {
+    const id = this.nextId
+    this.nextId += 1
+    this.startedTypes.push(type)
+    this.activeIds.add(id)
+    return id
+  }
+
+  stop(id: number): void {
+    this.stoppedIds.push(id)
+    this.activeIds.delete(id)
+  }
+
+  isStarted(id: number): boolean {
+    return this.activeIds.has(id)
+  }
+
+  markStopped(id: number): void {
+    this.activeIds.delete(id)
+  }
+}
+
+class FakeDisplayOffRunner implements DisplayOffRunner {
+  readonly calls: NodeJS.Platform[] = []
+  failNext = false
+  /** 置为 true 后，run 返回的 promise 由测试手动控制（模拟慢命令在途场景） */
+  deferMode = false
+  private deferredResolve: (() => void) | null = null
+  private deferredReject: ((error: Error) => void) | null = null
+
+  async run(platform: NodeJS.Platform): Promise<void> {
+    this.calls.push(platform)
+    if (this.failNext) {
+      this.failNext = false
+      throw new Error('mock display off failure')
+    }
+    if (this.deferMode) {
+      await new Promise<void>((resolve, reject) => {
+        this.deferredResolve = resolve
+        this.deferredReject = reject
+      })
+    }
+  }
+
+  /** 手动完成在途命令 */
+  completeDeferred(): void {
+    const resolve = this.deferredResolve
+    this.deferredResolve = null
+    this.deferredReject = null
+    resolve?.()
+  }
+
+  /** 手动让在途命令失败 */
+  failDeferred(): void {
+    const reject = this.deferredReject
+    this.deferredResolve = null
+    this.deferredReject = null
+    reject?.(new Error('mock deferred failure'))
+  }
+}
+
+describe('平台息屏命令', () => {
+  test('macOS 使用 pmset displaysleepnow', () => {
+    expect(buildDisplayOffCommand('darwin')).toBe('pmset displaysleepnow')
+  })
+
+  test('Windows 使用 EncodedCommand Base64 传递 PS 脚本（避免引号嵌套被剥离）', () => {
+    const command = buildDisplayOffCommand('win32')
+    if (command === null) {
+      throw new Error('win32 平台应返回关屏命令')
+    }
+    expect(command.startsWith('powershell -NoProfile -EncodedCommand ')).toBe(true)
+    expect(command).not.toContain('\"user32.dll\"')
+    // 解码 Base64，确认脚本内容完整（不依赖外部引号解析）
+    const encoded = command.slice('powershell -NoProfile -EncodedCommand '.length)
+    const script = Buffer.from(encoded, 'base64').toString('utf16le')
+    expect(script).toContain('SendMessage')
+    expect(script).toContain('0xF170')
+    expect(script).toContain('MonitorOff')
+    expect(script).toContain('"user32.dll"')
+    // 确保输出中没有裸引号嵌套问题：整条命令不含双引号
+    expect(command).not.toContain('"')
+  })
+
+  test('Linux 使用 xset dpms force off', () => {
+    expect(buildDisplayOffCommand('linux')).toBe('xset dpms force off')
+  })
+
+  test('不支持的平台返回 null（仅防休眠）', () => {
+    expect(buildDisplayOffCommand('freebsd')).toBeNull()
+  })
+})
+
+describe('挂机模式', () => {
+  test('Given 挂机模式已开启 When 同步挂机模式 Then 启用系统级防休眠并执行息屏命令', async () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    // 等待息屏命令异步完成
+    await Promise.resolve()
+
+    expect(adapter.startedTypes).toEqual(['prevent-app-suspension'])
+    expect(adapter.isStarted(1)).toBe(true)
+    expect(displayOff.calls).toHaveLength(1)
+  })
+
+  test('Given 防休眠已启用 When 重复同步开启状态 Then 不重复创建 blocker 也不重复息屏', async () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    await Promise.resolve()
+    manager.sync({ idleMode: { enabled: true } })
+    await Promise.resolve()
+
+    expect(adapter.startedTypes).toHaveLength(1)
+    expect(displayOff.calls).toHaveLength(1)
+  })
+
+  test('Given 挂机模式从开启切到关闭 When 同步挂机模式 Then 释放系统防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    manager.sync({ idleMode: { enabled: false } })
+
+    expect(adapter.stoppedIds).toEqual([1])
+    expect(adapter.isStarted(1)).toBe(false)
+  })
+
+  test('Given 系统中的 blocker 已失效 When 挂机模式仍开启 Then 重新启用防休眠并再次息屏', async () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    await Promise.resolve()
+    adapter.markStopped(1)
+    manager.sync({ idleMode: { enabled: true } })
+    await Promise.resolve()
+
+    expect(adapter.startedTypes).toHaveLength(2)
+    expect(displayOff.calls).toHaveLength(2)
+  })
+
+  test('Given 未开启挂机模式 When 判断是否需要 Then 不启用', () => {
+    expect(shouldEnableIdleMode({})).toBe(false)
+    expect(shouldEnableIdleMode({ idleMode: { enabled: false } })).toBe(false)
+    expect(shouldEnableIdleMode({ idleMode: { enabled: true } })).toBe(true)
+  })
+
+  test('Given 开启后立即关闭 When 在途息屏命令完成 Then 不产生误导反馈且状态一致', async () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    displayOff.deferMode = true
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    // 命令在途时关闭
+    manager.sync({ idleMode: { enabled: false } })
+    expect(adapter.isStarted(1)).toBe(false)
+
+    // 在途命令此时才完成：不应抛错、不应复活 blocker
+    displayOff.completeDeferred()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(adapter.isStarted(1)).toBe(false)
+    expect(adapter.stoppedIds).toEqual([1])
+  })
+
+  test('Given 开启后立即关闭且命令失败 When 在途命令失败 Then 不产生未处理 rejection', async () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    displayOff.deferMode = true
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    manager.sync({ idleMode: { enabled: false } })
+
+    displayOff.failDeferred()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(adapter.isStarted(1)).toBe(false)
+  })
+
+  test('Given 开启期间命令在途 When 再次开启 Then 新 blocker 独立生效', async () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    displayOff.deferMode = true
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    manager.sync({ idleMode: { enabled: false } })
+    manager.sync({ idleMode: { enabled: true } })
+    expect(adapter.startedTypes).toHaveLength(2)
+
+    // 第一批在途命令完成：不产生任何异常（generation 已过期）
+    displayOff.completeDeferred()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(adapter.isStarted(2)).toBe(true)
+  })
+
+  test('Given 息屏命令失败 When 挂机模式开启 Then 防休眠仍然生效', async () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    displayOff.failNext = true
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.sync({ idleMode: { enabled: true } })
+    await Promise.resolve()
+
+    expect(adapter.isStarted(1)).toBe(true)
+    expect(displayOff.calls).toHaveLength(1)
+  })
+
+  test('Given 从未开启 When stop Then 无操作', () => {
+    const adapter = new FakeSleepBlocker()
+    const displayOff = new FakeDisplayOffRunner()
+    const manager = new IdleModeManager(adapter, displayOff)
+
+    manager.stop()
+
+    expect(adapter.stoppedIds).toHaveLength(0)
+    expect(displayOff.calls).toHaveLength(0)
+  })
+})

--- a/apps/electron/src/main/lib/idle-mode.ts
+++ b/apps/electron/src/main/lib/idle-mode.ts
@@ -1,0 +1,130 @@
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { AppSettings } from '../../types'
+
+const execAsync = promisify(exec)
+
+/**
+ * 挂机模式（息屏 + 防休眠）核心逻辑
+ *
+ * 开启后：
+ * 1. 通过系统命令立即熄灭显示器（macOS pmset displaysleepnow /
+ *    Windows SendMessage SC_MONITORPOWER / Linux xset dpms force off）；
+ * 2. 通过 powerSaveBlocker('prevent-app-suspension') 阻止系统休眠（允许息屏），
+ *    保证挂机任务持续运行；移动鼠标或按任意键即可唤醒屏幕。
+ *
+ * 本文件保持纯逻辑、不依赖 electron，便于单元测试；
+ * electron 接线见 idle-mode-electron.ts。
+ */
+
+/** 构建 Windows 关屏命令：用 -EncodedCommand 传 Base64 编码的 PS 脚本，
+ * 绕开 cmd.exe/CommandLineToArgvW 对嵌套双引号的剥离（直接拼 -Command 会
+ * 导致 Add-Type 收到非法 C#，关屏静默失效）。 */
+export function buildWindowsDisplayOffCommand(): string {
+  const script = [
+    'Add-Type -TypeDefinition \'',
+    'using System;',
+    'using System.Runtime.InteropServices;',
+    'public class MonitorOff { [DllImport("user32.dll")] public static extern int SendMessage(IntPtr hWnd, int msg, int wParam, int lParam); }',
+    '\';',
+    '[MonitorOff]::SendMessage([IntPtr]0xffff, 0x0112, 0xF170, 2)',
+  ].join('')
+  const encoded = Buffer.from(script, 'utf16le').toString('base64')
+  return `powershell -NoProfile -EncodedCommand ${encoded}`
+}
+
+/** 各平台立即熄灭显示器的命令；不支持返回 null（尽力而为，失败仅记录） */
+export function buildDisplayOffCommand(platform: NodeJS.Platform): string | null {
+  switch (platform) {
+    case 'darwin':
+      return 'pmset displaysleepnow'
+    case 'win32':
+      return buildWindowsDisplayOffCommand()
+    case 'linux':
+      return 'xset dpms force off'
+    default:
+      return null
+  }
+}
+
+export type SleepBlockerType = 'prevent-app-suspension'
+
+export interface SleepBlockerAdapter {
+  start(type: SleepBlockerType): number
+  stop(id: number): void
+  isStarted(id: number): boolean
+}
+
+export interface DisplayOffRunner {
+  run(platform: NodeJS.Platform): Promise<void>
+}
+
+export const defaultDisplayOffRunner: DisplayOffRunner = {
+  async run(platform: NodeJS.Platform): Promise<void> {
+    const command = buildDisplayOffCommand(platform)
+    if (command === null) {
+      console.warn(`[挂机模式] 当前平台 ${platform} 暂不支持自动息屏命令，仅启用防休眠`)
+      return
+    }
+    await execAsync(command)
+  },
+}
+
+export function shouldEnableIdleMode(settings: Pick<AppSettings, 'idleMode'>): boolean {
+  return settings.idleMode?.enabled === true
+}
+
+export class IdleModeManager {
+  private activeBlockerId: number | null = null
+  /** 每次 stop 自增，使在途的息屏命令完成后不再产生误导反馈 */
+  private generation = 0
+
+  constructor(
+    private readonly adapter: SleepBlockerAdapter,
+    private readonly displayOff: DisplayOffRunner = defaultDisplayOffRunner,
+  ) {}
+
+  sync(settings: Pick<AppSettings, 'idleMode'>): void {
+    if (shouldEnableIdleMode(settings)) {
+      this.start()
+      return
+    }
+
+    this.stop()
+  }
+
+  stop(): void {
+    this.generation += 1
+    if (this.activeBlockerId === null) return
+
+    const blockerId = this.activeBlockerId
+    this.activeBlockerId = null
+
+    if (this.adapter.isStarted(blockerId)) {
+      this.adapter.stop(blockerId)
+      console.log('[挂机模式] 已关闭，恢复系统休眠策略')
+    }
+  }
+
+  private start(): void {
+    if (this.activeBlockerId !== null) {
+      if (this.adapter.isStarted(this.activeBlockerId)) return
+      this.activeBlockerId = null
+    }
+
+    const generation = this.generation
+    this.activeBlockerId = this.adapter.start('prevent-app-suspension')
+    console.log('[挂机模式] 已启用：阻止系统休眠（允许息屏），正在熄灭显示器…')
+    void this.displayOff
+      .run(process.platform)
+      .then(() => {
+        // 期间已关闭：放弃反馈，避免误导
+        if (this.generation !== generation) return
+        console.log('[挂机模式] 显示器已熄灭（移动鼠标或按任意键可唤醒）')
+      })
+      .catch((error) => {
+        if (this.generation !== generation) return
+        console.error('[挂机模式] 熄灭显示器失败（防休眠仍生效）:', error)
+      })
+  }
+}

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -8,9 +8,15 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { getSettingsPath } from './config-paths'
 import { DEFAULT_INTERFACE_VARIANT, DEFAULT_THEME_MODE } from '../../types'
-import type { AgentIslandSettings, AppSettings } from '../../types'
+import type { AgentIslandSettings, AppSettings, IdleModeSettings } from '../../types'
 
 function sanitizeAgentIslandSettings(input: unknown): AgentIslandSettings | undefined {
+  if (!input || typeof input !== 'object') return undefined
+  const raw = input as { enabled?: unknown }
+  return typeof raw.enabled === 'boolean' ? { enabled: raw.enabled } : undefined
+}
+
+function sanitizeIdleModeSettings(input: unknown): IdleModeSettings | undefined {
   if (!input || typeof input !== 'object') return undefined
   const raw = input as { enabled?: unknown }
   return typeof raw.enabled === 'boolean' ? { enabled: raw.enabled } : undefined
@@ -34,6 +40,7 @@ export function getSettings(): AppSettings {
       longTextPasteAsAttachmentEnabled: false,
       richTextRenderingEnabled: false,
       feishuSessionMirror: { mode: 'off' },
+      idleMode: { enabled: false },
       visionRelay: { enabled: false },
       builtinMcpDisabledIds: [],
       windowsShellPreference: 'auto',
@@ -66,6 +73,7 @@ export function getSettings(): AppSettings {
       longTextPasteAsAttachmentEnabled: data.longTextPasteAsAttachmentEnabled ?? false,
       richTextRenderingEnabled: data.richTextRenderingEnabled ?? false,
       feishuSessionMirror: data.feishuSessionMirror ?? { mode: 'off' },
+      idleMode: sanitizeIdleModeSettings(data.idleMode) ?? { enabled: false },
       visionRelay: data.visionRelay ?? { enabled: false },
       builtinMcpDisabledIds: settings.builtinMcpDisabledIds ?? [],
       windowsShellPreference: settings.windowsShellPreference ?? 'auto',
@@ -86,6 +94,7 @@ export function getSettings(): AppSettings {
       longTextPasteAsAttachmentEnabled: false,
       richTextRenderingEnabled: false,
       feishuSessionMirror: { mode: 'off' },
+      idleMode: { enabled: false },
       visionRelay: { enabled: false },
       builtinMcpDisabledIds: [],
       windowsShellPreference: 'auto',

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -8,7 +8,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { getSettingsPath } from './config-paths'
 import { DEFAULT_INTERFACE_VARIANT, DEFAULT_THEME_MODE } from '../../types'
-import type { AgentIslandSettings, AppSettings, IdleModeSettings } from '../../types'
+import type { AgentIslandSettings, AppSettings, IdleModeSettings, TaskSleepGuardSettings } from '../../types'
 
 function sanitizeAgentIslandSettings(input: unknown): AgentIslandSettings | undefined {
   if (!input || typeof input !== 'object') return undefined
@@ -17,6 +17,12 @@ function sanitizeAgentIslandSettings(input: unknown): AgentIslandSettings | unde
 }
 
 function sanitizeIdleModeSettings(input: unknown): IdleModeSettings | undefined {
+  if (!input || typeof input !== 'object') return undefined
+  const raw = input as { enabled?: unknown }
+  return typeof raw.enabled === 'boolean' ? { enabled: raw.enabled } : undefined
+}
+
+function sanitizeTaskSleepGuardSettings(input: unknown): TaskSleepGuardSettings | undefined {
   if (!input || typeof input !== 'object') return undefined
   const raw = input as { enabled?: unknown }
   return typeof raw.enabled === 'boolean' ? { enabled: raw.enabled } : undefined
@@ -41,6 +47,7 @@ export function getSettings(): AppSettings {
       richTextRenderingEnabled: false,
       feishuSessionMirror: { mode: 'off' },
       idleMode: { enabled: false },
+      taskSleepGuard: { enabled: true },
       visionRelay: { enabled: false },
       builtinMcpDisabledIds: [],
       windowsShellPreference: 'auto',
@@ -74,6 +81,7 @@ export function getSettings(): AppSettings {
       richTextRenderingEnabled: data.richTextRenderingEnabled ?? false,
       feishuSessionMirror: data.feishuSessionMirror ?? { mode: 'off' },
       idleMode: sanitizeIdleModeSettings(data.idleMode) ?? { enabled: false },
+      taskSleepGuard: sanitizeTaskSleepGuardSettings(data.taskSleepGuard) ?? { enabled: true },
       visionRelay: data.visionRelay ?? { enabled: false },
       builtinMcpDisabledIds: settings.builtinMcpDisabledIds ?? [],
       windowsShellPreference: settings.windowsShellPreference ?? 'auto',
@@ -95,6 +103,7 @@ export function getSettings(): AppSettings {
       richTextRenderingEnabled: false,
       feishuSessionMirror: { mode: 'off' },
       idleMode: { enabled: false },
+      taskSleepGuard: { enabled: true },
       visionRelay: { enabled: false },
       builtinMcpDisabledIds: [],
       windowsShellPreference: 'auto',

--- a/apps/electron/src/main/lib/task-sleep-guard-electron.ts
+++ b/apps/electron/src/main/lib/task-sleep-guard-electron.ts
@@ -1,0 +1,36 @@
+import { powerSaveBlocker } from 'electron'
+import type { AppSettings } from '../../types'
+import { TaskSleepGuard, type SleepBlockerAdapter, type SleepBlockerType } from './task-sleep-guard'
+
+/**
+ * 任务防休眠 — electron 接线层
+ *
+ * 核心逻辑见 task-sleep-guard.ts；此处注入 powerSaveBlocker，
+ * 并导出主进程使用的单例与 sync/stop 入口。
+ */
+
+const electronSleepBlocker: SleepBlockerAdapter = {
+  start: (type: SleepBlockerType): number => powerSaveBlocker.start(type),
+  stop: (id: number): void => {
+    powerSaveBlocker.stop(id)
+  },
+  isStarted: (id: number): boolean => powerSaveBlocker.isStarted(id),
+}
+
+export const taskSleepGuard = new TaskSleepGuard(electronSleepBlocker)
+
+export function syncTaskSleepGuard(settings: Pick<AppSettings, 'taskSleepGuard'>): void {
+  try {
+    taskSleepGuard.syncSettings(settings)
+  } catch (error) {
+    console.error('[任务防休眠] 同步设置失败:', error)
+  }
+}
+
+export function stopTaskSleepGuard(): void {
+  try {
+    taskSleepGuard.stop()
+  } catch (error) {
+    console.error('[任务防休眠] 停止失败:', error)
+  }
+}

--- a/apps/electron/src/main/lib/task-sleep-guard.test.ts
+++ b/apps/electron/src/main/lib/task-sleep-guard.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  TaskSleepGuard,
+  shouldEnableTaskSleepGuard,
+  type SleepBlockerAdapter,
+  type SleepBlockerType,
+} from './task-sleep-guard'
+
+class FakeSleepBlocker implements SleepBlockerAdapter {
+  readonly startedTypes: SleepBlockerType[] = []
+  readonly stoppedIds: number[] = []
+  private nextId = 1
+  private activeIds = new Set<number>()
+
+  start(type: SleepBlockerType): number {
+    const id = this.nextId
+    this.nextId += 1
+    this.startedTypes.push(type)
+    this.activeIds.add(id)
+    return id
+  }
+
+  stop(id: number): void {
+    this.stoppedIds.push(id)
+    this.activeIds.delete(id)
+  }
+
+  isStarted(id: number): boolean {
+    return this.activeIds.has(id)
+  }
+}
+
+describe('任务防休眠默认开启判断', () => {
+  test('未配置时默认开启（用户要求默认开启）', () => {
+    expect(shouldEnableTaskSleepGuard({})).toBe(true)
+  })
+
+  test('enabled true 开启，enabled false 关闭', () => {
+    expect(shouldEnableTaskSleepGuard({ taskSleepGuard: { enabled: true } })).toBe(true)
+    expect(shouldEnableTaskSleepGuard({ taskSleepGuard: { enabled: false } })).toBe(false)
+  })
+})
+
+describe('任务防休眠', () => {
+  test('Given 默认设置 When 第一个任务开始 Then 启动防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({})
+
+    guard.begin({})
+
+    expect(adapter.startedTypes).toEqual(['prevent-app-suspension'])
+    expect(guard.isActive).toBe(true)
+    expect(guard.runningTaskCount).toBe(1)
+  })
+
+  test('Given 多个任务并发 When 全部开始 Then 只启动一个 blocker', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({})
+
+    guard.begin({ id: 1 })
+    guard.begin({ id: 2 })
+    guard.begin({ id: 3 })
+
+    expect(adapter.startedTypes).toHaveLength(1)
+    expect(guard.runningTaskCount).toBe(3)
+    expect(guard.isActive).toBe(true)
+  })
+
+  test('Given 多个任务并发 When 部分结束 Then 防休眠保持，全部结束才释放', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({})
+
+    const token1 = { id: 1 }
+    const token2 = { id: 2 }
+    guard.begin(token1)
+    guard.begin(token2)
+    guard.end(token1)
+
+    expect(guard.isActive).toBe(true)
+
+    guard.end(token2)
+
+    expect(guard.isActive).toBe(false)
+    expect(adapter.stoppedIds).toHaveLength(1)
+    expect(guard.runningTaskCount).toBe(0)
+  })
+
+  test('Given 重复结束同一 token When end 多次 Then 不影响其他任务与计数', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({})
+
+    const token = { id: 1 }
+    guard.begin(token)
+    guard.end(token)
+    guard.end(token)
+
+    expect(guard.runningTaskCount).toBe(0)
+    expect(guard.isActive).toBe(false)
+  })
+
+  test('Given 设置被关闭 When 仍有任务运行 Then 立即释放防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({ taskSleepGuard: { enabled: true } })
+
+    guard.begin({ id: 1 })
+    expect(guard.isActive).toBe(true)
+
+    guard.syncSettings({ taskSleepGuard: { enabled: false } })
+
+    expect(guard.isActive).toBe(false)
+    expect(adapter.stoppedIds).toHaveLength(1)
+  })
+
+  test('Given 设置关闭后 When 新任务开始 Then 不启动防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({ taskSleepGuard: { enabled: false } })
+
+    guard.begin({ id: 1 })
+
+    expect(adapter.startedTypes).toHaveLength(0)
+    expect(guard.isActive).toBe(false)
+  })
+
+  test('Given 设置从关闭切回开启 When 已有任务在跑 Then 重新启用防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({ taskSleepGuard: { enabled: false } })
+    guard.begin({ id: 1 })
+
+    guard.syncSettings({ taskSleepGuard: { enabled: true } })
+
+    expect(adapter.startedTypes).toHaveLength(1)
+    expect(guard.isActive).toBe(true)
+  })
+
+  test('Given 应用退出 When stop Then 清空所有任务并释放', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({})
+
+    guard.begin({ id: 1 })
+    guard.begin({ id: 2 })
+
+    guard.stop()
+
+    expect(guard.runningTaskCount).toBe(0)
+    expect(guard.isActive).toBe(false)
+  })
+
+  test('Given 从未有任务 When stop Then 无副作用', () => {
+    const adapter = new FakeSleepBlocker()
+    const guard = new TaskSleepGuard(adapter)
+    guard.syncSettings({})
+
+    guard.stop()
+
+    expect(adapter.startedTypes).toHaveLength(0)
+    expect(adapter.stoppedIds).toHaveLength(0)
+  })
+})

--- a/apps/electron/src/main/lib/task-sleep-guard.ts
+++ b/apps/electron/src/main/lib/task-sleep-guard.ts
@@ -1,0 +1,97 @@
+import type { AppSettings } from '../../types'
+
+/**
+ * 任务防休眠（Task Sleep Guard）核心逻辑
+ *
+ * 需求：只要 Proma 有任务在跑（Agent run / 自动化任务 / 飞书桥接任务），
+ * 无论用户锁屏、息屏还是合上笔记本盖，系统都不应休眠中断任务；
+ * 任务全部结束后恢复系统默认电源策略。设置默认开启。
+ *
+ * 实现：token 集合跟踪活跃任务 —— 每个正在运行的任务持有一个 token，
+ * 第一个任务开始时启动 powerSaveBlocker('prevent-app-suspension')，
+ * 最后一个任务结束时释放。与手动「挂机模式」（idle-mode）相互独立。
+ *
+ * 本文件保持纯逻辑、不依赖 electron，便于单元测试；
+ * electron 接线见 task-sleep-guard-electron.ts。
+ */
+
+export type SleepBlockerType = 'prevent-app-suspension'
+
+export interface SleepBlockerAdapter {
+  start(type: SleepBlockerType): number
+  stop(id: number): void
+  isStarted(id: number): boolean
+}
+
+/** 默认开启：未配置或 enabled 非 false 都视为开启（用户要求默认开启） */
+export function shouldEnableTaskSleepGuard(settings: Pick<AppSettings, 'taskSleepGuard'>): boolean {
+  return settings.taskSleepGuard?.enabled !== false
+}
+
+export class TaskSleepGuard {
+  private activeBlockerId: number | null = null
+  private enabled = true
+  private activeTokens = new Set<object>()
+
+  constructor(private readonly adapter: SleepBlockerAdapter) {}
+
+  /** 设置变更时同步：关闭时立即释放 blocker；重新开启时若有任务在跑则恢复防休眠 */
+  syncSettings(settings: Pick<AppSettings, 'taskSleepGuard'>): void {
+    this.enabled = shouldEnableTaskSleepGuard(settings)
+    if (this.enabled) {
+      this.startBlockerIfNeeded()
+    } else {
+      this.releaseIfNeeded()
+    }
+  }
+
+  /** 任务开始：始终记录 token（任务确实在跑）；启用状态且第一个任务时启动防休眠 */
+  begin(token: object): void {
+    this.activeTokens.add(token)
+    if (!this.enabled) return
+    this.startBlockerIfNeeded()
+  }
+
+  /** 任务结束：释放 token，最后一个任务结束时释放防休眠 */
+  end(token: object): void {
+    this.activeTokens.delete(token)
+    this.releaseIfNeeded()
+  }
+
+  /** 应用退出等场景：清空所有 token 并释放 */
+  stop(): void {
+    this.activeTokens.clear()
+    this.releaseIfNeeded()
+  }
+
+  /** 当前是否有活跃任务 */
+  get runningTaskCount(): number {
+    return this.activeTokens.size
+  }
+
+  /** 当前防休眠是否生效 */
+  get isActive(): boolean {
+    return this.activeBlockerId !== null && this.adapter.isStarted(this.activeBlockerId)
+  }
+
+  private startBlockerIfNeeded(): void {
+    if (this.activeBlockerId !== null) {
+      if (this.adapter.isStarted(this.activeBlockerId)) return
+      // blocker 已被系统回收：置空以便重建
+      this.activeBlockerId = null
+    }
+    if (this.activeTokens.size === 0) return
+    this.activeBlockerId = this.adapter.start('prevent-app-suspension')
+    console.log('[任务防休眠] 任务运行中：阻止系统休眠（锁屏/息屏/合盖不中断任务）')
+  }
+
+  private releaseIfNeeded(): void {
+    if (this.activeBlockerId === null) return
+    if (this.enabled && this.activeTokens.size > 0) return
+    if (this.adapter.isStarted(this.activeBlockerId)) {
+      this.adapter.stop(this.activeBlockerId)
+    }
+    this.activeBlockerId = null
+    console.log('[任务防休眠] 已释放，恢复系统休眠策略')
+  }
+}

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -78,6 +78,9 @@ export function GeneralSettings(): React.ReactElement {
   /** Git/PR 推广标识：默认开启 */
   const [gitAttributionEnabled, setGitAttributionEnabled] = React.useState(true)
   const [agentIslandEnabled, setAgentIslandEnabled] = React.useState(true)
+  const [idleModeEnabled, setIdleModeEnabled] = React.useState(false)
+  /** 挂机模式开关请求在途标记：防止快速连点导致 IPC 乱序、物理熄屏状态与 UI 相反 */
+  const [idleModePending, setIdleModePending] = React.useState(false)
   const isMac = React.useMemo(() => detectIsMac(), [])
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
@@ -87,6 +90,7 @@ export function GeneralSettings(): React.ReactElement {
       setArchiveAfterDays(settings.archiveAfterDays ?? 7)
       setGitAttributionEnabled(settings.gitAttributionEnabled ?? true)
       setAgentIslandEnabled(settings.agentIsland?.enabled ?? true)
+      setIdleModeEnabled(settings.idleMode?.enabled ?? false)
     }).catch(console.error)
   }, [])
 
@@ -109,6 +113,21 @@ export function GeneralSettings(): React.ReactElement {
     } catch (error) {
       console.error('[通用设置] 更新 Agent 灵动岛失败:', error)
       setAgentIslandEnabled(!checked)
+    }
+  }
+
+  /** 更新挂机模式开关（立即息屏 + 防休眠），串行化防连点乱序 */
+  const handleIdleModeChange = async (checked: boolean): Promise<void> => {
+    if (idleModePending) return
+    setIdleModePending(true)
+    setIdleModeEnabled(checked)
+    try {
+      await window.electronAPI.updateSettings({ idleMode: { enabled: checked } })
+    } catch (error) {
+      console.error('[通用设置] 更新挂机模式失败:', error)
+      setIdleModeEnabled(!checked)
+    } finally {
+      setIdleModePending(false)
     }
   }
 
@@ -404,6 +423,15 @@ export function GeneralSettings(): React.ReactElement {
               }}
             />
           )}
+          <SettingsToggle
+            label="挂机模式（息屏 + 防休眠）"
+            description="开启后立即熄灭显示器并阻止系统休眠，适合挂机跑任务；移动鼠标或按任意键可唤醒屏幕，关闭开关或退出应用后自动恢复"
+            checked={idleModeEnabled}
+            disabled={idleModePending}
+            onCheckedChange={(checked) => {
+              void handleIdleModeChange(checked)
+            }}
+          />
           <SettingsToggle
             label="Git/PR 标识"
             description="Agent 代你提交 commit 或创建 PR 时，附加 Made-with: Proma 与官网链接，便于推广；可随时关闭"

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -81,6 +81,9 @@ export function GeneralSettings(): React.ReactElement {
   const [idleModeEnabled, setIdleModeEnabled] = React.useState(false)
   /** 挂机模式开关请求在途标记：防止快速连点导致 IPC 乱序、物理熄屏状态与 UI 相反 */
   const [idleModePending, setIdleModePending] = React.useState(false)
+  /** 任务防休眠：默认开启 */
+  const [taskSleepGuardEnabled, setTaskSleepGuardEnabled] = React.useState(true)
+  const [taskSleepGuardPending, setTaskSleepGuardPending] = React.useState(false)
   const isMac = React.useMemo(() => detectIsMac(), [])
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
@@ -91,6 +94,7 @@ export function GeneralSettings(): React.ReactElement {
       setGitAttributionEnabled(settings.gitAttributionEnabled ?? true)
       setAgentIslandEnabled(settings.agentIsland?.enabled ?? true)
       setIdleModeEnabled(settings.idleMode?.enabled ?? false)
+      setTaskSleepGuardEnabled(settings.taskSleepGuard?.enabled ?? true)
     }).catch(console.error)
   }, [])
 
@@ -128,6 +132,21 @@ export function GeneralSettings(): React.ReactElement {
       setIdleModeEnabled(!checked)
     } finally {
       setIdleModePending(false)
+    }
+  }
+
+  /** 更新任务防休眠开关（默认开启，任务运行期间阻止系统休眠） */
+  const handleTaskSleepGuardChange = async (checked: boolean): Promise<void> => {
+    if (taskSleepGuardPending) return
+    setTaskSleepGuardPending(true)
+    setTaskSleepGuardEnabled(checked)
+    try {
+      await window.electronAPI.updateSettings({ taskSleepGuard: { enabled: checked } })
+    } catch (error) {
+      console.error('[通用设置] 更新任务防休眠失败:', error)
+      setTaskSleepGuardEnabled(!checked)
+    } finally {
+      setTaskSleepGuardPending(false)
     }
   }
 
@@ -430,6 +449,15 @@ export function GeneralSettings(): React.ReactElement {
             disabled={idleModePending}
             onCheckedChange={(checked) => {
               void handleIdleModeChange(checked)
+            }}
+          />
+          <SettingsToggle
+            label="任务防休眠"
+            description="默认开启：只要 Proma 有任务在跑，锁屏、息屏甚至合上笔记本盖都不会中断任务；任务全部结束后自动恢复正常"
+            checked={taskSleepGuardEnabled}
+            disabled={taskSleepGuardPending}
+            onCheckedChange={(checked) => {
+              void handleTaskSleepGuardChange(checked)
             }}
           />
           <SettingsToggle

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -260,6 +260,12 @@ export interface AgentIslandSettings {
   enabled?: boolean
 }
 
+/** 挂机模式（息屏 + 防休眠）设置。 */
+export interface IdleModeSettings {
+  /** 是否启用：立即熄灭显示器并阻止系统休眠，适合挂机跑任务。默认 false。 */
+  enabled?: boolean
+}
+
 /**
  * 给无视觉输入能力的 Agent 使用的独立视觉模型路由。
  * 仅保存用户已有渠道和模型的 ID，凭据继续由渠道加密存储管理。
@@ -343,6 +349,8 @@ export interface AppSettings {
   voiceDictation?: VoiceDictationPersistedSettings
   /** 飞书 Session 镜像设置：每个 Proma Session 可创建一个仅包含用户与指定 Bot 的飞书群 */
   feishuSessionMirror?: FeishuSessionMirrorSettings
+  /** 挂机模式：立即熄灭显示器并阻止系统休眠，保证挂机任务持续运行 */
+  idleMode?: IdleModeSettings
   /** 无视觉输入能力 Agent 的视觉助手路由 */
   visionRelay?: VisionRelaySettings
   /** 已确认的受管浏览器风险告知版本；低于当前版本时首次使用会再次要求确认。 */

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -266,6 +266,12 @@ export interface IdleModeSettings {
   enabled?: boolean
 }
 
+/** 任务防休眠设置：任务运行期间阻止系统休眠，锁屏/息屏/合盖都不中断任务。 */
+export interface TaskSleepGuardSettings {
+  /** 是否启用，默认 true（任务在跑就防休眠）。 */
+  enabled?: boolean
+}
+
 /**
  * 给无视觉输入能力的 Agent 使用的独立视觉模型路由。
  * 仅保存用户已有渠道和模型的 ID，凭据继续由渠道加密存储管理。
@@ -351,6 +357,8 @@ export interface AppSettings {
   feishuSessionMirror?: FeishuSessionMirrorSettings
   /** 挂机模式：立即熄灭显示器并阻止系统休眠，保证挂机任务持续运行 */
   idleMode?: IdleModeSettings
+  /** 任务防休眠：任务运行期间阻止系统休眠，锁屏/息屏/合盖都不中断任务（默认开启） */
+  taskSleepGuard?: TaskSleepGuardSettings
   /** 无视觉输入能力 Agent 的视觉助手路由 */
   visionRelay?: VisionRelaySettings
   /** 已确认的受管浏览器风险告知版本；低于当前版本时首次使用会再次要求确认。 */


### PR DESCRIPTION
# PR 描述（中文版，覆盖两个功能：挂机模式 + 任务防休眠）

> 标题建议：`feat(electron): add idle mode and task-driven sleep prevention`
> 分支建议：`feat/sleep-guard`（基于 main 新建，重放本地 commit `e2e0b44`、`808b751`）

---

## 这个 PR 做了什么

面向「长任务无人值守」场景，新增两个睡眠管理能力（设置 → 通用）：

1. **任务防休眠（默认开启）**：只要 Proma 有任务在跑（Agent run / 自动化任务 / 飞书桥接任务），通过 `powerSaveBlocker('prevent-app-suspension')` 阻止系统休眠 —— 用户**锁屏、息屏、甚至合上笔记本盖**都不会中断任务；任务全部结束后自动恢复系统默认电源策略。
2. **挂机模式（手动开关，默认关闭）**：开启后立即调用系统命令**熄灭显示器**并阻止系统休眠，适合睡觉前/离开时挂机跑任务；移动鼠标或按任意键唤醒屏幕，关闭开关或退出应用自动恢复。

两者相互独立（各自持有独立的 powerSaveBlocker id），可叠加使用。

## 为什么做

- 长任务（过夜批量、长导出、飞书/钉钉镜像、自动化任务）需要「人离开、机器不睡」；此前唯一的防休眠（`feishu-sleep-blocker`）只服务于飞书会话镜像，且没有任何「任务运行期间防休眠」的能力。
- 用户手动锁屏/息屏/合盖时，系统默认会休眠中断任务 —— 需要 Proma 在任务运行期间主动阻止，任务结束再放手。

## 实现方式

### 任务防休眠（默认开启）
- **新增 `apps/electron/src/main/lib/task-sleep-guard.ts`** —— 纯逻辑、不依赖 Electron，便于单测：
  - token 集合跟踪活跃任务：第 1 个任务开始时启动 `powerSaveBlocker('prevent-app-suspension')`，最后 1 个任务结束时释放；并发任务只持有一个 blocker。
  - 默认开启：`settings.taskSleepGuard?.enabled !== false`；设置关闭时立即释放（任务继续跑但不再阻止休眠），重新开启时若仍有任务在跑则自动恢复。
  - blocker 被系统回收时自动重建。
- **新增 `apps/electron/src/main/lib/task-sleep-guard-electron.ts`** —— Electron 接线层，导出 `taskSleepGuard` 单例与 `syncTaskSleepGuard` / `stopTaskSleepGuard`。
- **`apps/electron/src/main/lib/agent-service.ts`** —— 挂钩所有 run 入口：
  - `runAgent`（界面任务）与 `runAgentHeadless`（飞书 Bridge、自动化任务等外部调用）都在 `onRunStarted` 时 `begin(token)`，在 `onComplete` / `onError` / 未处理异常时 `end(token)`；token 用闭包引用，重复 end 安全。
- 设置类型/持久化/UI：`types/settings.ts`（`TaskSleepGuardSettings`）、`settings-service.ts`（默认 `{ enabled: true }` + sanitize）、`ipc.ts`（`UPDATE` / `UPDATE_SYNC` 同步）、`index.ts`（启动同步、退出释放）、`GeneralSettings.tsx`（开关，带 pending 串行化防连点乱序）。

### 挂机模式（手动，默认关闭）
- **新增 `apps/electron/src/main/lib/idle-mode.ts`** —— 平台无关核心：
  - `buildDisplayOffCommand(platform)`：macOS `pmset displaysleepnow` / Windows 经 `-EncodedCommand` 的 PowerShell `SendMessage(SC_MONITORPOWER)` / Linux `xset dpms force off`；不支持的平台返回 `null`，自动降级为「仅防休眠」。
  - `IdleModeManager`：幂等启停 + generation 计数器，确保「关闭后仍在途的息屏命令」不产生误导反馈。
- **新增 `apps/electron/src/main/lib/idle-mode-electron.ts`** —— Electron 接线层。
- 设置类型/持久化/IPC/主进程/UI 接线同任务防休眠（`IdleModeSettings`，默认 `{ enabled: false }`）。

## 平台支持

| 平台 | 挂机模式息屏 | 防休眠（两者共用） |
| --- | --- | --- |
| macOS | `pmset displaysleepnow` | `powerSaveBlocker('prevent-app-suspension')`，**合盖实测有效** |
| Windows | PowerShell `SendMessage(SC_MONITORPOWER)` 经 `-EncodedCommand`（规避 cmd.exe 引号剥离） | 同上（阻止空闲/合盖睡眠） |
| Linux | `xset dpms force off`（尽力而为，Wayland 可能静默失败） | 同上 |
| 其他 | 降级为仅防休眠 | 同上 |

息屏命令失败仅记录日志，绝不影响防休眠生效。唤醒屏幕是系统默认行为（鼠标/键盘）。

## 测试

- `bun test` 相关用例：
  - `task-sleep-guard.test.ts` —— 11 个用例：并发任务、部分结束保持、重复 end 安全、设置关闭/重开恢复、退出清理、默认开启判断。
  - `idle-mode.test.ts` —— 14 个用例：启停 / 幂等 / blocker 失效重建 / 息屏失败兜底 / 竞态 / 平台命令字符串（含 Windows 脚本 Base64 解码校验）。
  - 回归：feishu 防休眠、settings 类型全部通过；全量 396 测试无新增失败（5 个既有环境失败与本次无关）。
- `bun run typecheck` —— 无错误。
- **macOS 真机实测**：
  - 任务防休眠：真实 Electron 运行时下 `powerSaveBlocker` 生效/释放正常；**合盖实测：合盖 10-15 秒期间系统零睡眠事件**（`pmset -g log` 佐证），开盖正常，任务不中断。
  - 挂机模式：`pmset displaysleepnow` 真实熄灭显示器，鼠标/键盘唤醒正常；息屏后防休眠断言保持、停止后正确释放。
- Windows 关屏命令已完成静态验证（Base64 往返），最终确认需在真实 Windows 机器跑一次。

## 备注 / 后续

- Linux 息屏依赖 `xset`；Wayland 用户可能需要 `wlr-randr` 等，暂不纳入本次范围。
- 挂机模式开启后应用每次启动会自动恢复（启动同步）——为无人值守场景设计；任务防休眠默认开启，可在设置中关闭。
- 后续可加：托盘菜单快捷开关 / 全局快捷键 / 任务运行中的状态提示。

---

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
