### PR TITLE
fix(island): clear viewed error attention

### DIFF
--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -33,6 +33,7 @@ import { getAgentIslandTodoAttentionKeys, selectAgentIslandTodos } from './agent
 import { selectAgentIslandCompactPlanQuota } from './agent-island-plan-quota'
 import { getAgentIslandPhasePriority } from './agent-island-priority'
 import { buildVisibilityKey } from './agent-island-visibility'
+import { shouldRetainAgentIslandSession } from './agent-island-session-visibility'
 import { listCalendarEvents, listTodos } from './planning-manager'
 import { onPlanningChanged } from './planning-events'
 import { getChannelPlanQuota, listChannels } from './channel-manager'
@@ -428,13 +429,9 @@ function isIslandSession(session: InternalSessionSnapshot, now: number): boolean
   // 委派子会话只在需要用户交互时露出；执行和结束均由父会话收敛。
   if (isDelegatedChildSession(session.sessionId)) return session.phase === 'needs-interaction'
   // Running is deliberately visible: the island is also a live execution pulse,
-  // not only a handoff/error inbox. Terminal sessions retain their existing
-  // unread window to avoid becoming permanent history.
-  if (session.phase === 'running' || session.phase === 'needs-interaction' || session.phase === 'error') return true
-  return session.phase === 'completed'
-    && session.unread
-    && session.terminalAt !== undefined
-    && now - session.terminalAt < UNREAD_RETAIN_MS
+  // not only a handoff/error inbox. Viewed errors leave the Island immediately,
+  // while completed sessions retain their unread window to avoid permanent history.
+  return shouldRetainAgentIslandSession(session, now, UNREAD_RETAIN_MS)
 }
 
 function attentionScore(session: InternalSessionSnapshot): number {
@@ -807,12 +804,14 @@ export function initAgentIslandService(deps: AgentIslandServiceDeps): void {
 }
 
 /**
- * 完成态的未读由主进程管理；主应用确认用户已经看过结果后，在此统一清除。
- * 错误和需要交互的会话必须保留 attention，不能被普通查看动作吞掉。
+ * 完成和异常态的未读由主进程管理；主应用确认用户已经看过后，在此统一清除。
+ * 待接手会话仍保持 attention，直到用户实际完成权限确认、回答或计划审批。
  */
 function markAgentIslandSessionViewed(sessionId: string): void {
   const session = sessions.get(sessionId)
-  if (session?.phase !== 'completed' || !session.unread) return
+  if (!session || (session.phase !== 'completed' && session.phase !== 'error')) return
+  if (session.phase === 'completed' && !session.unread) return
+  if (!session.attention && !session.unread) return
   session.unread = false
   session.attention = false
   schedulePush()

--- a/apps/electron/src/main/lib/agent-island-session-visibility.ts
+++ b/apps/electron/src/main/lib/agent-island-session-visibility.ts
@@ -1,0 +1,28 @@
+import type { AgentIslandPhase } from '@proma/shared'
+
+/** 影响 Island 会话保留的最小状态；保持为纯函数以便回归测试。 */
+export interface AgentIslandSessionVisibilityInput {
+  phase: AgentIslandPhase
+  attention: boolean
+  unread: boolean
+  terminalAt?: number
+}
+
+/**
+ * 决定终态会话是否仍应保留在 Island。
+ *
+ * 运行与待接手会话持续可见；异常仅在尚未查看时作为“需关注”保留。
+ * 已查看的异常不再占据 Island，用户可在已打开的会话中处理详情。
+ */
+export function shouldRetainAgentIslandSession(
+  session: AgentIslandSessionVisibilityInput,
+  now: number,
+  unreadRetainMs: number,
+): boolean {
+  if (session.phase === 'running' || session.phase === 'needs-interaction') return true
+  if (session.phase === 'error') return session.attention
+  return session.phase === 'completed'
+    && session.unread
+    && session.terminalAt !== undefined
+    && now - session.terminalAt < unreadRetainMs
+}


### PR DESCRIPTION
## Summary
- Clear an error session\u2019s Island attention state after the user opens it.
- Keep genuinely actionable interaction requests visible until resolved.

## Validation
- `bun run --filter='@proma/electron' typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)