### PR TITLE
fix: 修复浏览器关闭按钮与 Windows 控件重叠

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.15",
+  "version": "0.17.16",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { BROWSER_RISK_DISCLAIMER_VERSION } from '@/types/settings'
+import { detectIsWindows, getWindowControlsPaddingClass } from '@/lib/platform'
+import { cn } from '@/lib/utils'
 import { BrowserSlot } from './BrowserSlot'
 
 interface BrowserPanelProps {
@@ -111,9 +113,10 @@ export function BrowserPanel({ sessionId, state, onClose }: BrowserPanelProps): 
   }, [onClose, sessionId])
 
   const title = state?.title || '受管浏览器'
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
   return (
     <div className="flex flex-col h-full min-w-0 overflow-hidden bg-content-area titlebar-no-drag">
-      <div className="flex items-center h-[42px] gap-1 px-2 border-b border-border/40 bg-muted/20">
+      <div className={cn('flex items-center h-[42px] gap-1 px-2 border-b border-border/40 bg-muted/20', getWindowControlsPaddingClass(isWindows))}>
         <Globe2 className="size-4 shrink-0 text-primary ml-1" />
         <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" disabled={riskBlocked || !state?.canGoBack} onClick={() => void window.electronAPI.goBackAgentBrowser?.(sessionId)}><ArrowLeft className="size-3.5" /></Button></TooltipTrigger><TooltipContent>后退</TooltipContent></Tooltip>
         <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" disabled={riskBlocked || !state?.canGoForward} onClick={() => void window.electronAPI.goForwardAgentBrowser?.(sessionId)}><ArrowRight className="size-3.5" /></Button></TooltipTrigger><TooltipContent>前进</TooltipContent></Tooltip>

--- a/apps/electron/src/renderer/lib/platform.ts
+++ b/apps/electron/src/renderer/lib/platform.ts
@@ -6,6 +6,10 @@ export const WINDOW_CONTROLS_WIDTH_PX = 126
 export const WINDOW_CONTROLS_INSET_RIGHT = 'right-[126px]'
 export const WINDOW_CONTROLS_PADDING_RIGHT = 'pr-[126px]'
 
+export function getWindowControlsPaddingClass(isWindows: boolean): string {
+  return isWindows ? WINDOW_CONTROLS_PADDING_RIGHT : ''
+}
+
 export function detectIsWindows(): boolean {
   const platform =
     typeof navigator !== 'undefined' &&


### PR DESCRIPTION
## 变更摘要
- Windows 下为受管浏览器顶栏增加窗口控制区安全内边距。
- 浏览器关闭按钮、加载状态和后台停止按钮避开右上角 Windows 窗口控制区。
- Electron 应用 patch 版本更新至 `0.17.16`。

## 变更动机
最新 Windows 版本中，受管浏览器顶栏的关闭按钮与窗口右上角自定义控制按钮命中区域重叠，可能导致点击误触或关闭行为异常。本次复用现有窗口控制区宽度常量，仅调整 Windows 布局，保持其他平台不变。

## 测试计划
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] 手动启动 `bun run dev` 验证开发环境可运行

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
