### PR TITLE
fix(browser): reject invalid screenshot image content

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -61,6 +61,7 @@ import { createCodexFastModeExtension, withCodexFastModeServiceTier } from './pi
 import { createDeepSeekReasoningRequestExtension } from './pi-deepseek-reasoning-request-settings'
 import { createOpenAIReasoningRequestExtension } from './pi-openai-reasoning-request-settings'
 import { mergeRuntimeEnv, type AgentRuntimeEnv } from '../agent-runtime-env'
+import { sanitizePiMessageImageContent, sanitizeToolResultImageContent } from '../image-content-validation'
 import {
   convertPiMessage,
   convertResultMessage,
@@ -1217,14 +1218,23 @@ export function installRuntimeGuardHooks(session: AgentSession, guard: AgentRunt
       details: previousResult?.details ?? context.result.details,
       terminate: previousResult?.terminate ?? context.result.terminate,
     }
-    const guardedResult = guard.applyToolResult(resultAfterPreviousHooks)
+    const sanitizedContent = sanitizeToolResultImageContent(resultAfterPreviousHooks.content)
+    const guardedResult = guard.applyToolResult({
+      ...resultAfterPreviousHooks,
+      content: sanitizedContent,
+    })
 
-    if (!previousResult && guardedResult.terminate === context.result.terminate) {
+    if (
+      !previousResult
+      && guardedResult.terminate === context.result.terminate
+      && sanitizedContent === context.result.content
+    ) {
       return undefined
     }
 
     return {
       ...previousResult,
+      content: sanitizedContent,
       terminate: guardedResult.terminate,
     }
   }
@@ -1414,6 +1424,12 @@ export class PiAgentAdapter implements AgentProviderAdapter {
         customTools,
       })
       session.agent.toolExecution = 'sequential'
+      // Pi session artifact 可以来自旧版本，不能假设其历史 tool_result 已通过当前校验。
+      // transformContext 在每个 provider 请求前执行，能隔离 resume 的坏图片而不篡改原 artifact。
+      const previousTransformContext = session.agent.transformContext
+      session.agent.transformContext = async (messages, signal) => sanitizePiMessageImageContent(
+        await previousTransformContext?.(messages, signal) ?? messages,
+      )
       if (projectInstructionScope) {
         const previousPrepareNextTurnWithContext = session.agent.prepareNextTurnWithContext
         session.agent.prepareNextTurnWithContext = async (context, signal) => {

--- a/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
@@ -17,6 +17,7 @@ import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import type { TextContent, ImageContent } from '@earendil-works/pi-ai'
 import type { TSchema } from 'typebox'
 import { Type } from 'typebox'
+import { sanitizeToolResultImageContent } from '../image-content-validation'
 
 const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_MCP_STARTUP_TIMEOUT_MS = 30_000
@@ -215,7 +216,7 @@ function convertMcpResult(result: McpCallToolResult): AgentToolResult<unknown> {
   }
 
   return {
-    content,
+    content: sanitizeToolResultImageContent(content),
     details: result,
   } as AgentToolResult<unknown>
 }

--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
@@ -11,6 +11,7 @@ import type { AssistantMessage, ToolResultMessage, UserMessage } from '@earendil
 import type { SDKAssistantMessage, SDKMessage } from '@proma/shared'
 import type { RuntimeGuardResultOverride } from '../agent-runtime-guards'
 import { isMalformedResponseError, isTransientNetworkError } from '../error-patterns'
+import { sanitizeToolResultImageContent } from '../image-content-validation'
 
 function getPiEditItems(input: Record<string, unknown>): Array<Record<string, unknown>> {
   return Array.isArray(input.edits)
@@ -127,7 +128,7 @@ export function restorePiInput(
 
 function normalizeToolResultContent(content: unknown): unknown {
   if (!Array.isArray(content)) return content
-  return content.map((item) => {
+  const normalized = content.map((item) => {
     if (!item || typeof item !== 'object') return item
     const record = item as Record<string, unknown>
     if (record.type === 'text' && typeof record.text === 'string') {
@@ -138,6 +139,7 @@ function normalizeToolResultContent(content: unknown): unknown {
     }
     return record
   })
+  return sanitizeToolResultImageContent(normalized as Parameters<typeof sanitizeToolResultImageContent>[0])
 }
 
 function contentToText(content: unknown): string {

--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -12,6 +12,7 @@ import { hasAcknowledgedBrowserRiskDisclaimer } from './browser-risk-disclaimer'
 import { buildPromaBrowserUserAgent } from './browser-identity'
 import { assertBrowserScript, buildBrowserDomActionExpression, type BrowserDomActionInput } from './browser-script-policy'
 import { getSettings } from './settings-service'
+import { isValidImageBytes } from './image-content-validation'
 
 const MAX_TRACE_ITEMS = 30
 /** 总数超限时只回收 Agent 创建且未在使用的标签，绝不自动关闭用户标签。 */
@@ -1094,7 +1095,20 @@ export class BrowserController {
       throwIfBrowserOperationAborted(operationSignal)
       const image = await withBrowserCdpTimeout(() => tab.view.webContents.capturePage(), 'Page.captureScreenshot', BROWSER_OBSERVE_TIMEOUT_MS + 3_000, operationSignal)
       throwIfBrowserOperationAborted(operationSignal)
+      if (image.isEmpty()) {
+        this.trace(browserSession, tab, 'screenshot', '截图为空，已拒绝返回无效图片', 'failed')
+        throw new Error('截图为空：浏览器页面尚未完成可捕获布局，请稍后重试或改用 BrowserObserve。')
+      }
+      const { width, height } = image.getSize()
+      if (width <= 0 || height <= 0) {
+        this.trace(browserSession, tab, 'screenshot', '截图尺寸无效，已拒绝返回无效图片', 'failed')
+        throw new Error('截图尺寸无效：浏览器页面尚未完成可捕获布局，请稍后重试或改用 BrowserObserve。')
+      }
       const buffer = image.toPNG()
+      if (!isValidImageBytes('image/png', buffer)) {
+        this.trace(browserSession, tab, 'screenshot', '截图 PNG 数据无效，已拒绝返回无效图片', 'failed')
+        throw new Error('截图 PNG 数据无效，请稍后重试或改用 BrowserObserve。')
+      }
       if (buffer.byteLength > MAX_SCREENSHOT_BYTES) throw new Error('截图过大，请缩小页面或改用 browser_observe。')
       this.trace(browserSession, tab, 'screenshot', '截取当前页面', 'verified')
       return { tabId: tab.tabId, url: tab.state.url, mimeType: 'image/png', base64: buffer.toString('base64') }

--- a/apps/electron/src/main/lib/image-content-validation.ts
+++ b/apps/electron/src/main/lib/image-content-validation.ts
@@ -1,0 +1,95 @@
+import type { ImageContent, TextContent } from '@earendil-works/pi-ai'
+
+function isPng(bytes: Buffer): boolean {
+  if (bytes.length < 45 || !bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return false
+  let offset = 8
+  let hasIhdr = false
+  while (offset + 12 <= bytes.length) {
+    const length = bytes.readUInt32BE(offset)
+    const type = bytes.subarray(offset + 4, offset + 8).toString('ascii')
+    const end = offset + 12 + length
+    if (end > bytes.length) return false
+    if (!hasIhdr) {
+      if (type !== 'IHDR' || length !== 13) return false
+      hasIhdr = true
+    }
+    if (type === 'IEND') return length === 0 && end === bytes.length
+    offset = end
+  }
+  return false
+}
+
+const IMAGE_SIGNATURES: Record<string, (bytes: Buffer) => boolean> = {
+  'image/png': isPng,
+  'image/jpeg': (bytes) => bytes.length >= 4
+    && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff
+    && bytes[bytes.length - 2] === 0xff && bytes[bytes.length - 1] === 0xd9,
+  'image/gif': (bytes) => bytes.length >= 14
+    && (bytes.subarray(0, 6).toString('ascii') === 'GIF87a' || bytes.subarray(0, 6).toString('ascii') === 'GIF89a')
+    && bytes[bytes.length - 1] === 0x3b,
+  'image/webp': (bytes) => bytes.length >= 16
+    && bytes.subarray(0, 4).toString('ascii') === 'RIFF'
+    && bytes.readUInt32LE(4) + 8 === bytes.length
+    && bytes.subarray(8, 12).toString('ascii') === 'WEBP',
+}
+
+function decodeBase64(data: string): Buffer | undefined {
+  const normalized = data.replace(/\s/g, '')
+  if (!normalized || normalized.length % 4 !== 0) return undefined
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)) return undefined
+  const paddingIndex = normalized.indexOf('=')
+  if (paddingIndex >= 0 && paddingIndex < normalized.length - (normalized.endsWith('==') ? 2 : 1)) return undefined
+
+  try {
+    return Buffer.from(normalized, 'base64')
+  } catch {
+    return undefined
+  }
+}
+
+/** Returns whether bytes match the declared image MIME type supported by Pi tool results. */
+export function isValidImageBytes(mimeType: string, bytes: Buffer): boolean {
+  const matchesSignature = IMAGE_SIGNATURES[mimeType.trim().toLowerCase()]
+  return bytes.length > 0 && Boolean(matchesSignature?.(bytes))
+}
+
+/** Reject empty, malformed, unsupported, or MIME-mismatched image content before Pi serializes it. */
+export function isValidImageContent(content: ImageContent): boolean {
+  if (typeof content.data !== 'string' || typeof content.mimeType !== 'string') return false
+  const bytes = decodeBase64(content.data)
+  return bytes !== undefined && isValidImageBytes(content.mimeType, bytes)
+}
+
+/**
+ * Removes invalid image blocks while retaining the surrounding textual tool output.
+ * The added text makes the failed visual result explicit without letting it poison
+ * the persisted Pi transcript or a later provider request.
+ */
+export function sanitizeToolResultImageContent(
+  content: Array<TextContent | ImageContent>,
+): Array<TextContent | ImageContent> {
+  const invalidImages = content.filter((block) => block.type === 'image' && !isValidImageContent(block)).length
+  if (invalidImages === 0) return content
+
+  const validContent = content.filter((block) => block.type !== 'image' || isValidImageContent(block))
+  validContent.push({
+    type: 'text',
+    text: `已忽略 ${invalidImages} 个无效图片工具结果，未将其发送给模型。`,
+  })
+  return validContent
+}
+
+/**
+ * Last-resort request boundary for Pi transcripts restored from disk. Fresh tool
+ * results are sanitized earlier, but an old persisted transcript can otherwise
+ * replay a bad image forever when the session is resumed.
+ */
+export function sanitizePiMessageImageContent<T extends { role?: unknown; content?: unknown }>(messages: T[]): T[] {
+  return messages.map((message) => {
+    if ((message.role !== 'user' && message.role !== 'toolResult') || !Array.isArray(message.content)) return message
+    const sanitizedContent = sanitizeToolResultImageContent(
+      message.content as Array<TextContent | ImageContent>,
+    )
+    return sanitizedContent === message.content ? message : { ...message, content: sanitizedContent }
+  })
+}


### PR DESCRIPTION
## Summary

- Validate browser screenshot bytes before returning image content.
- Filter invalid image blocks at Pi tool, MCP, renderer adaptation, and resumed-transcript request boundaries.

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)