### PR TITLE
perf(renderer): virtualize sidebar chat lists

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -82,6 +82,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-symbols/icons": "^1.3.1",
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-virtual": "^3.14.9",
     "@tiptap/core": "^3.19.0",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",
     "@tiptap/extension-link": "^3.19.0",

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -63,15 +63,29 @@ export const streamingStatesAtom = atom<Map<string, ConversationStreamState>>(ne
 
 /**
  * 当前正在流式输出的对话 ID 集合（派生只读原子）
- * 用于侧边栏绿色呼吸点指示器
+ * 用于侧边栏绿色呼吸点指示器。
+ *
+ * 流式文本 chunk 会频繁替换 streamingStatesAtom，但通常不会改变正在运行的
+ * conversation ID。复用相同 Set 引用可避免订阅该 atom 的侧边栏按 token 重渲染。
  */
+let previousStreamingConversationIds = new Set<string>()
+let previousStreamingConversationIdsSignature = ''
+
 export const streamingConversationIdsAtom = atom<Set<string>>((get) => {
   const states = get(streamingStatesAtom)
-  const ids = new Set<string>()
+  const ids: string[] = []
   for (const [id, state] of states) {
-    if (state.streaming) ids.add(id)
+    if (state.streaming) ids.push(id)
   }
-  return ids
+  ids.sort()
+  const signature = ids.join('\u0000')
+  if (signature === previousStreamingConversationIdsSignature) {
+    return previousStreamingConversationIds
+  }
+
+  previousStreamingConversationIdsSignature = signature
+  previousStreamingConversationIds = new Set(ids)
+  return previousStreamingConversationIds
 })
 
 /**

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2035,7 +2035,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const externalSelectedModel = computedSelectedModel ?? stableSelectedModelRef.current
 
   /** 发送消息 */
-  const handleSend = React.useCallback(async (overrideText?: string): Promise<void> => {
+  const handleSend = React.useCallback(async (overrideText?: string, fromEditor = false): Promise<void> => {
     const text = (overrideText ?? inputContent).trim()
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
@@ -2081,7 +2081,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         id: 'agent-view-queued-message-hint',
         description: '如需立即处理，点击队列消息右侧的「立即发送」可打断当前执行（会终止正在运行的命令）。',
       })
-      if (overrideText === undefined) {
+      if (overrideText === undefined || fromEditor) {
         setInputContent('')
         setInputHtmlContent('')
       }
@@ -2110,7 +2110,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             additionalDirectories: attachmentContext.additionalDirectories,
           }
         : undefined)
-      if (overrideText === undefined) {
+      if (overrideText === undefined || fromEditor) {
         setInputContent('')
         setInputHtmlContent('')
       }
@@ -2245,10 +2245,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       ...(mentions.mentionedCalendarEventIds.length > 0 && { mentionedCalendarEventIds: mentions.mentionedCalendarEventIds }),
     }
 
-    // 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）
-    // 用 === undefined 与上方 `overrideText ?? inputContent` 的取值语义保持一致，
-    // 避免未来出现 handleSend('') 时两条路径行为割裂
-    if (overrideText === undefined) {
+    // 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）。
+    // Enter 路径会显式传入已刷新的编辑器内容，因此也应清空。
+    if (overrideText === undefined || fromEditor) {
       setInputContent('')
       setInputHtmlContent('')
     }

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -49,6 +49,7 @@ import {
   createSkillMentionSuggestion,
 } from '@/components/agent/mention-suggestions'
 import { shouldConvertClipboardTextToAttachment } from '@/lib/clipboard-text-attachment'
+import { measurePerformance } from '@/lib/performance-monitor'
 import {
   VOICE_DICTATION_CLEAR_PREVIEW_EVENT,
   VOICE_DICTATION_INSERT_EVENT,
@@ -125,8 +126,8 @@ interface RichTextInputProps {
   value: string
   /** 值变更回调 */
   onChange: (markdown: string) => void
-  /** 提交回调（Enter 键） */
-  onSubmit: () => void
+  /** 提交回调（Enter 键）；传入值可避免草稿同步尚未提交时发送旧内容。 */
+  onSubmit: (content?: string, fromEditor?: boolean) => void
   /** 粘贴文件回调（拦截粘贴的文件） */
   onPasteFiles?: (files: File[]) => void
   /** 粘贴超长文本回调（由调用方决定是否转换为附件） */
@@ -222,6 +223,8 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   const isExpandedRef = useRef(false)
   // 行数检查的 rAF 调度句柄（用 rAF 节流，一帧最多检查一次）
   const lineCheckHandleRef = useRef<number | null>(null)
+  // 草稿序列化与上层状态同步同样合并到每帧一次；TipTap 自己仍在输入事件内即时更新 DOM。
+  const draftSyncHandleRef = useRef<number | null>(null)
   // 跟踪编辑器自己设置的值，用于区分外部设置和内部更新
   const lastEditorValueRef = useRef<string>('')
   // 记录尚未由 props 确认的本地草稿。长文本连续编辑时，React 可能先提交较旧的
@@ -356,6 +359,63 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
     () => createSessionMentionSuggestion(currentSessionIdRef, mentionActiveRef, mentionItemCountRef),
     [],
   )
+  const syncEditorDraft = useCallback((ed: NonNullable<ReturnType<typeof useEditor>>): string => {
+    const html = ed.getHTML()
+    if (html === '<p></p>') {
+      lastEditorValueRef.current = ''
+      pendingLocalDraftEchoesRef.current = recordLocalDraftEcho(pendingLocalDraftEchoesRef.current, '')
+      onChange('')
+      onHtmlChangeRef.current?.('')
+      if (isExpandedRef.current) {
+        isExpandedRef.current = false
+        setIsExpanded(false)
+      }
+      setIsManuallyCollapsed(false)
+      return ''
+    }
+
+    // DOM → Markdown 遍历对长草稿较重；将多次连续输入收敛到一帧一次。
+    const markdown = measurePerformance('input.html-to-markdown', () => (
+      htmlToMarkdown(html, { skipMarkdownEscape: !richTextEnabled })
+    ))
+    lastEditorValueRef.current = markdown
+    pendingLocalDraftEchoesRef.current = recordLocalDraftEcho(pendingLocalDraftEchoesRef.current, markdown)
+    onChange(markdown)
+    onHtmlChangeRef.current?.(html)
+
+    if (lineCheckHandleRef.current !== null) {
+      cancelAnimationFrame(lineCheckHandleRef.current)
+    }
+    lineCheckHandleRef.current = requestAnimationFrame(() => {
+      lineCheckHandleRef.current = null
+      const nextExpanded = countEditorLines(ed) > 5
+      if (nextExpanded !== isExpandedRef.current) {
+        isExpandedRef.current = nextExpanded
+        setIsExpanded(nextExpanded)
+      }
+    })
+    return markdown
+  }, [onChange, richTextEnabled])
+
+  const syncEditorDraftRef = useRef(syncEditorDraft)
+  syncEditorDraftRef.current = syncEditorDraft
+
+  const flushPendingDraftSync = useCallback((ed: NonNullable<ReturnType<typeof useEditor>>): string => {
+    if (draftSyncHandleRef.current !== null) {
+      cancelAnimationFrame(draftSyncHandleRef.current)
+      draftSyncHandleRef.current = null
+    }
+    return syncEditorDraftRef.current(ed)
+  }, [])
+
+  const scheduleDraftSync = useCallback((ed: NonNullable<ReturnType<typeof useEditor>>): void => {
+    if (draftSyncHandleRef.current !== null) return
+    draftSyncHandleRef.current = requestAnimationFrame(() => {
+      draftSyncHandleRef.current = null
+      syncEditorDraftRef.current(ed)
+    })
+  }, [])
+
   const planningMentionSuggestions = useMemo(
     () => [
       createPlanningMentionSuggestion('~', currentSessionIdRef, mentionActiveRef, mentionItemCountRef),
@@ -696,7 +756,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
 
           if (isSend) {
             event.preventDefault()
-            onSubmitRef.current()
+            // Enter 可能紧跟最后一次输入；先同步当前编辑器，再把最新 Markdown
+            // 直接交给发送方，避免 rAF 批处理导致发送旧草稿。
+            onSubmitRef.current(editor ? flushPendingDraftSync(editor) : undefined, true)
             return true
           }
 
@@ -756,40 +818,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
       },
     },
     onUpdate: ({ editor: ed }) => {
-      const html = ed.getHTML()
-      if (html === '<p></p>') {
-        lastEditorValueRef.current = ''
-        pendingLocalDraftEchoesRef.current = recordLocalDraftEcho(pendingLocalDraftEchoesRef.current, '')
-        onChange('')
-        onHtmlChangeRef.current?.('')
-        if (isExpandedRef.current) {
-          isExpandedRef.current = false
-          setIsExpanded(false)
-        }
-        setIsManuallyCollapsed(false)
-      } else {
-        // 纯文本模式下跳过 markdown 特殊字符转义，保持用户所见即所得
-        // 纯文本模式下跳过 markdown 特殊字符转义，保持用户所见即所得
-        const markdown = htmlToMarkdown(html, { skipMarkdownEscape: !richTextEnabled })
-        lastEditorValueRef.current = markdown
-        pendingLocalDraftEchoesRef.current = recordLocalDraftEcho(pendingLocalDraftEchoesRef.current, markdown)
-        onChange(markdown)
-        onHtmlChangeRef.current?.(html)
-
-        // 行数检查用 rAF 节流：每键 doc.descendants 全文遍历 + setState 重渲染会让
-        // 输入热路径变重；延后到下一帧合并连续按键，对 UX 无影响。
-        if (lineCheckHandleRef.current !== null) {
-          cancelAnimationFrame(lineCheckHandleRef.current)
-        }
-        lineCheckHandleRef.current = requestAnimationFrame(() => {
-          lineCheckHandleRef.current = null
-          const nextExpanded = countEditorLines(ed) > 5
-          if (nextExpanded !== isExpandedRef.current) {
-            isExpandedRef.current = nextExpanded
-            setIsExpanded(nextExpanded)
-          }
-        })
-      }
+      scheduleDraftSync(ed)
     },
   }, [richTextEnabled])
 
@@ -799,6 +828,10 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
       if (lineCheckHandleRef.current !== null) {
         cancelAnimationFrame(lineCheckHandleRef.current)
         lineCheckHandleRef.current = null
+      }
+      if (draftSyncHandleRef.current !== null) {
+        cancelAnimationFrame(draftSyncHandleRef.current)
+        draftSyncHandleRef.current = null
       }
     }
   }, [])

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -19,6 +19,7 @@ import { getModelLogo, resolveModelProvider } from '@/lib/model-logo'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { useShortcut } from '@/hooks/useShortcut'
 import { cn } from '@/lib/utils'
+import { measurePerformance } from '@/lib/performance-monitor'
 
 export interface MinimapItem {
   id: string
@@ -108,38 +109,49 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     const el = scrollRef.current
     if (!el) return
 
+    let frame: number | null = null
     const update = (): void => {
-      const { scrollTop, scrollHeight, clientHeight } = el
-      setCanScroll(scrollHeight > clientHeight + 10)
-      setScrollMetrics({ scrollTop, scrollHeight, clientHeight })
-      if (scrollHeight <= 0) return
+      measurePerformance('history.minimap-scan', () => {
+        const { scrollTop, scrollHeight, clientHeight } = el
+        setCanScroll(scrollHeight > clientHeight + 10)
+        setScrollMetrics({ scrollTop, scrollHeight, clientHeight })
+        if (scrollHeight <= 0) return
 
-      const viewportCenter = scrollTop + clientHeight / 2
-      const nodes = el.querySelectorAll<HTMLElement>('[data-message-id]')
-      const ids = new Set<string>()
-      let centerId: string | undefined
-      for (const node of nodes) {
-        const top = getOffsetTopRelativeTo(node, el)
-        const bottom = top + node.offsetHeight
-        if (bottom > scrollTop && top < scrollTop + clientHeight) {
-          const id = node.getAttribute('data-message-id')
-          if (id) ids.add(id)
+        const viewportCenter = scrollTop + clientHeight / 2
+        const nodes = el.querySelectorAll<HTMLElement>('[data-message-id]')
+        const ids = new Set<string>()
+        let centerId: string | undefined
+        for (const node of nodes) {
+          const top = getOffsetTopRelativeTo(node, el)
+          const bottom = top + node.offsetHeight
+          if (bottom > scrollTop && top < scrollTop + clientHeight) {
+            const id = node.getAttribute('data-message-id')
+            if (id) ids.add(id)
+          }
+          if (centerId === undefined && top <= viewportCenter && bottom > viewportCenter) {
+            centerId = node.getAttribute('data-message-id') ?? undefined
+          }
         }
-        if (centerId === undefined && top <= viewportCenter && bottom > viewportCenter) {
-          centerId = node.getAttribute('data-message-id') ?? undefined
-        }
-      }
-      setVisibleIds(ids)
-      setCenterVisibleId(centerId)
+        setVisibleIds(ids)
+        setCenterVisibleId(centerId)
+      })
+    }
+    const scheduleUpdate = (): void => {
+      if (frame !== null) return
+      frame = requestAnimationFrame(() => {
+        frame = null
+        update()
+      })
     }
 
     update()
-    el.addEventListener('scroll', update, { passive: true })
-    const observer = new ResizeObserver(update)
+    el.addEventListener('scroll', scheduleUpdate, { passive: true })
+    const observer = new ResizeObserver(scheduleUpdate)
     observer.observe(el)
 
     return () => {
-      el.removeEventListener('scroll', update)
+      if (frame !== null) cancelAnimationFrame(frame)
+      el.removeEventListener('scroll', scheduleUpdate)
       observer.disconnect()
     }
   }, [scrollRef])

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -20,6 +20,7 @@ import { stickyUserMessageEnabledAtom } from '@/atoms/ui-preferences'
 import { MessageResponse, remarkMentions } from './message'
 import type { RemarkPluginFn } from './message'
 import { cn } from '@/lib/utils'
+import { measurePerformance } from '@/lib/performance-monitor'
 
 /** 悬浮条专用 remark 插件（仅 mention，不保留换行） */
 const STICKY_REMARK_PLUGINS: RemarkPluginFn[] = [remarkMentions]
@@ -68,31 +69,39 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
       return
     }
 
+    let frame: number | null = null
     const check = () => {
-      const containerRect = el.getBoundingClientRect()
-      const nodes = el.querySelectorAll<HTMLElement>('[data-message-role="user"]')
+      measurePerformance('history.sticky-user-scan', () => {
+        const containerRect = el.getBoundingClientRect()
+        const nodes = el.querySelectorAll<HTMLElement>('[data-message-role="user"]')
 
-      // 从后往前找第一个完全在视口上方的用户消息节点
-      let found: UserMessageData | null = null
-      for (let i = nodes.length - 1; i >= 0; i--) {
-        const node = nodes[i]!
-        const nodeRect = node.getBoundingClientRect()
-        if (nodeRect.bottom < containerRect.top) {
-          // 找到了视口上方最近的用户消息
-          const msgId = node.getAttribute('data-message-id')
-          if (msgId) {
-            found = messageMap.get(msgId) ?? null
+        // 从后往前找第一个完全在视口上方的用户消息节点
+        let found: UserMessageData | null = null
+        for (let i = nodes.length - 1; i >= 0; i--) {
+          const node = nodes[i]!
+          const nodeRect = node.getBoundingClientRect()
+          if (nodeRect.bottom < containerRect.top) {
+            // 找到了视口上方最近的用户消息
+            const msgId = node.getAttribute('data-message-id')
+            if (msgId) found = messageMap.get(msgId) ?? null
+            break
           }
-          break
         }
-      }
-      setStickyMessage(found)
+        setStickyMessage((previous) => previous?.id === found?.id ? previous : found)
+      })
+    }
+    const scheduleCheck = (): void => {
+      if (frame !== null) return
+      frame = requestAnimationFrame(() => {
+        frame = null
+        check()
+      })
     }
 
-    el.addEventListener('scroll', check, { passive: true })
+    el.addEventListener('scroll', scheduleCheck, { passive: true })
 
     // 监听容器尺寸变化
-    const resizeObserver = new ResizeObserver(check)
+    const resizeObserver = new ResizeObserver(scheduleCheck)
     resizeObserver.observe(el)
 
     // 监听内容区域 DOM 变化（流式输出、消息加载后及时检测）
@@ -105,7 +114,8 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
     const rafId = requestAnimationFrame(check)
 
     return () => {
-      el.removeEventListener('scroll', check)
+      if (frame !== null) cancelAnimationFrame(frame)
+      el.removeEventListener('scroll', scheduleCheck)
       resizeObserver.disconnect()
       cancelAnimationFrame(rafId)
     }

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -89,6 +89,7 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { sessionHoverPreviewEnabledAtom } from '@/atoms/ui-preferences'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
+import { VirtualSidebarList, type VirtualSidebarRow } from '@/components/ui/virtual-sidebar-list'
 import { LocalProjectBadge } from '@/components/agent/LocalProjectBadge'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
 import {
@@ -801,6 +802,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const store = useStore()
   const sidebarRootRef = React.useRef<HTMLDivElement>(null)
   const quickSwitchTargetsRef = React.useRef<QuickSwitchTarget[]>([])
+  // 快捷切换只会标注前 9 行；保留它们避免滚动时全量清理/重写所有列表行。
+  const quickSwitchHintRowsRef = React.useRef<HTMLElement[]>([])
+  const quickSwitchRefreshFrameRef = React.useRef<number | null>(null)
   const quickSwitchHintTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const processedQuickSwitchEventsRef = React.useRef<WeakSet<KeyboardEvent>>(new WeakSet())
   const [quickSwitchHintsVisible, setQuickSwitchHintsVisible] = React.useState(false)
@@ -825,14 +829,15 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     return () => window.clearInterval(id)
   }, [])
 
-  // 当 activeTabId 变化时，自动滚动侧边栏使选中项可见
+  // Chat 列表改由 virtualizer 按 index 定位；普通 Agent 项目列表当前仍是树状 DOM，
+  // 保留既有的原生定位行为，避免打开后台 Agent 会话后选中项不可见。
   React.useEffect(() => {
-    if (!activeTabId) return
+    if (!activeTabId || mode !== 'agent' || viewMode !== 'active') return
     requestAnimationFrame(() => {
-      const el = document.querySelector('.agent-session-item-active, .session-item-selected')
+      const el = document.querySelector('.agent-session-item-active')
       el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
     })
-  }, [activeTabId])
+  }, [activeTabId, mode, viewMode])
 
   // per-conversation/session Map atoms（删除时清理）
   const setConvModels = useSetAtom(conversationModelsAtom)
@@ -1702,23 +1707,29 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     })
   }, [openSession, setActiveView, setUnviewedCompleted])
 
-  const refreshQuickSwitchTargets = React.useCallback((): QuickSwitchTarget[] => {
-    const root = sidebarRootRef.current
-    if (!root) {
-      quickSwitchTargetsRef.current = []
-      return []
-    }
-
-    const rows = Array.from(root.querySelectorAll<HTMLElement>('.session-quick-switch-row'))
-    for (const row of rows) {
+  const clearQuickSwitchHints = React.useCallback((): void => {
+    for (const row of quickSwitchHintRowsRef.current) {
       delete row.dataset.quickSwitchLabel
       delete row.dataset.quickSwitchIndex
       row.querySelector<HTMLElement>('.session-quick-switch-modifier')?.replaceChildren()
       row.querySelector<HTMLElement>('.session-quick-switch-number')?.replaceChildren()
     }
+    quickSwitchHintRowsRef.current = []
+    quickSwitchTargetsRef.current = []
+  }, [])
 
+  const refreshQuickSwitchTargets = React.useCallback((): QuickSwitchTarget[] => {
+    const root = sidebarRootRef.current
+    if (!root) {
+      clearQuickSwitchHints()
+      return []
+    }
+
+    // 先完成所有布局读取，再只写入上次/本次涉及的最多 9 行，避免 write→read
+    // 交错造成的 forced reflow。
+    const rows = Array.from(root.querySelectorAll<HTMLElement>('.session-quick-switch-row'))
+    const selectedRows: HTMLElement[] = []
     const targets: QuickSwitchTarget[] = []
-    const modifierLabel = getPrimaryModifierLabel(isMac)
     for (const row of rows) {
       if (targets.length >= SESSION_QUICK_SWITCH_LIMIT) break
       if (!isQuickSwitchRowVisible(row, root)) continue
@@ -1728,56 +1739,71 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         !sessionSwitchId
         || !sessionSwitchTitle
         || (sessionSwitchType !== 'chat' && sessionSwitchType !== 'agent')
-      ) {
-        continue
-      }
+      ) continue
 
-      const index = targets.length + 1
-      row.dataset.quickSwitchIndex = String(index)
-      row.dataset.quickSwitchLabel = `${modifierLabel}${index}`
+      selectedRows.push(row)
+      targets.push({ id: sessionSwitchId, title: sessionSwitchTitle, type: sessionSwitchType })
+    }
+
+    const modifierLabel = getPrimaryModifierLabel(isMac)
+    const nextRows = new Set(selectedRows)
+    for (const row of quickSwitchHintRowsRef.current) {
+      if (nextRows.has(row)) continue
+      delete row.dataset.quickSwitchLabel
+      delete row.dataset.quickSwitchIndex
+      row.querySelector<HTMLElement>('.session-quick-switch-modifier')?.replaceChildren()
+      row.querySelector<HTMLElement>('.session-quick-switch-number')?.replaceChildren()
+    }
+    selectedRows.forEach((row, index) => {
+      const position = String(index + 1)
+      if (row.dataset.quickSwitchIndex === position) return
+      row.dataset.quickSwitchIndex = position
+      row.dataset.quickSwitchLabel = `${modifierLabel}${position}`
       const modifier = row.querySelector<HTMLElement>('.session-quick-switch-modifier')
       const number = row.querySelector<HTMLElement>('.session-quick-switch-number')
       if (modifier) modifier.textContent = modifierLabel
-      if (number) number.textContent = String(index)
-      targets.push({
-        id: sessionSwitchId,
-        title: sessionSwitchTitle,
-        type: sessionSwitchType,
-      })
-    }
+      if (number) number.textContent = position
+    })
 
+    quickSwitchHintRowsRef.current = selectedRows
     quickSwitchTargetsRef.current = targets
     return targets
-  }, [isMac])
+  }, [clearQuickSwitchHints, isMac])
 
   React.useEffect(() => {
     const root = sidebarRootRef.current
     if (!root) return
 
     if (!quickSwitchHintsVisible) {
-      const rows = Array.from(root.querySelectorAll<HTMLElement>('.session-quick-switch-row'))
-      for (const row of rows) {
-        delete row.dataset.quickSwitchLabel
-        delete row.dataset.quickSwitchIndex
-        row.querySelector<HTMLElement>('.session-quick-switch-modifier')?.replaceChildren()
-        row.querySelector<HTMLElement>('.session-quick-switch-number')?.replaceChildren()
+      if (quickSwitchRefreshFrameRef.current !== null) {
+        cancelAnimationFrame(quickSwitchRefreshFrameRef.current)
+        quickSwitchRefreshFrameRef.current = null
       }
-      quickSwitchTargetsRef.current = []
+      clearQuickSwitchHints()
       return
     }
 
     const refresh = (): void => {
-      refreshQuickSwitchTargets()
+      if (quickSwitchRefreshFrameRef.current !== null) return
+      quickSwitchRefreshFrameRef.current = requestAnimationFrame(() => {
+        quickSwitchRefreshFrameRef.current = null
+        refreshQuickSwitchTargets()
+      })
     }
     refresh()
     root.addEventListener('scroll', refresh, true)
     window.addEventListener('resize', refresh)
     return () => {
+      if (quickSwitchRefreshFrameRef.current !== null) {
+        cancelAnimationFrame(quickSwitchRefreshFrameRef.current)
+        quickSwitchRefreshFrameRef.current = null
+      }
       root.removeEventListener('scroll', refresh, true)
       window.removeEventListener('resize', refresh)
     }
   }, [
     quickSwitchHintsVisible,
+    clearQuickSwitchHints,
     refreshQuickSwitchTargets,
     sidebarCollapsed,
     mode,
@@ -2448,6 +2474,212 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     />
   )
 
+  // Chat 历史展平为固定行：日期标题、置顶标题和每个会话各占一行，供虚拟列表
+  // 按需挂载。不要把整个日期组作为一行，否则大量会话仍会同时留在 DOM。
+  const chatActiveVirtualRows = React.useMemo<VirtualSidebarRow[]>(() => {
+    const rows: VirtualSidebarRow[] = []
+    if (pinnedConversations.length > 0) {
+      rows.push({
+        id: 'chat-pinned-heading',
+        estimateSize: 30,
+        content: <div className="pl-[18px] pr-3.5 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">置顶</div>,
+      })
+      for (const conv of pinnedConversations) {
+        rows.push({
+          id: `chat-pinned-${conv.id}`,
+          estimateSize: 34,
+          content: (
+            <div className="px-2">
+              <div className="ml-4">
+                <ConversationItem
+                  conversation={conv}
+                  active={conv.id === activeSessionId}
+                  streaming={streamingIds.has(conv.id)}
+                  showPinIcon={false}
+                  relativeTimeNow={relativeTimeNow}
+                  onSelect={handleSelectConversation}
+                  onRequestDelete={handleRequestDelete}
+                  onRename={handleRename}
+                  onTogglePin={handleTogglePin}
+                  onToggleArchive={handleToggleArchive}
+                />
+              </div>
+            </div>
+          ),
+        })
+      }
+    }
+
+    rows.push({
+      id: 'chat-history-heading',
+      estimateSize: 34,
+      content: (
+        <div className="group/chat-section relative flex items-center px-2 pt-2 pb-1">
+          <span className="ml-[4px] px-1.5 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">对话</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="新建对话"
+                onClick={() => { void createChat() }}
+                className="absolute right-2 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 titlebar-no-drag"
+              >
+                <Plus size={13} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {`新建对话${newChatShortcutLabel ? ` (${newChatShortcutLabel})` : ''}`}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      ),
+    })
+
+    for (const group of conversationGroups) {
+      rows.push({
+        id: `chat-date-${group.label}`,
+        estimateSize: 30,
+        content: <div className="ml-[4px] px-3.5 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">{group.label}</div>,
+      })
+      for (const conv of group.items) {
+        rows.push({
+          id: `chat-${conv.id}`,
+          estimateSize: 34,
+          content: (
+            <div className="px-2">
+              <ConversationItem
+                conversation={conv}
+                active={conv.id === activeSessionId}
+                streaming={streamingIds.has(conv.id)}
+                showPinIcon={!!conv.pinned}
+                relativeTimeNow={relativeTimeNow}
+                onSelect={handleSelectConversation}
+                onRequestDelete={handleRequestDelete}
+                onRename={handleRename}
+                onTogglePin={handleTogglePin}
+                onToggleArchive={handleToggleArchive}
+              />
+            </div>
+          ),
+        })
+      }
+    }
+    return rows
+  }, [activeSessionId, conversationGroups, createChat, handleRename, handleRequestDelete, handleSelectConversation, handleToggleArchive, handleTogglePin, newChatShortcutLabel, pinnedConversations, relativeTimeNow, streamingIds])
+
+  const chatArchivedVirtualRows = React.useMemo<VirtualSidebarRow[]>(() => {
+    const rows: VirtualSidebarRow[] = []
+    for (const group of conversationGroups) {
+      rows.push({
+        id: `chat-archived-date-${group.label}`,
+        estimateSize: 30,
+        content: <div className="px-3 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">{group.label}</div>,
+      })
+      for (const conv of group.items) {
+        rows.push({
+          id: `chat-archived-${conv.id}`,
+          estimateSize: 34,
+          content: (
+            <div className="px-3">
+              <ConversationItem
+                conversation={conv}
+                active={conv.id === activeSessionId}
+                streaming={streamingIds.has(conv.id)}
+                showPinIcon={!!conv.pinned}
+                relativeTimeNow={relativeTimeNow}
+                onSelect={handleSelectConversation}
+                onRequestDelete={handleRequestDelete}
+                onRename={handleRename}
+                onTogglePin={handleTogglePin}
+                onToggleArchive={handleToggleArchive}
+              />
+            </div>
+          ),
+        })
+      }
+    }
+    return rows
+  }, [activeSessionId, conversationGroups, handleRename, handleRequestDelete, handleSelectConversation, handleToggleArchive, handleTogglePin, relativeTimeNow, streamingIds])
+
+  const agentArchivedVirtualRows = React.useMemo<VirtualSidebarRow[]>(() => {
+    const rows: VirtualSidebarRow[] = []
+    for (const group of archivedAgentSessionTrees) {
+      rows.push({
+        id: `agent-archived-date-${group.label}`,
+        estimateSize: 30,
+        content: <div className="px-3 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">{group.label}</div>,
+      })
+      for (const item of group.items) {
+        const childCount = item.childSessions.length
+        const rowStatus = getSessionTreeStatus(item, agentIndicatorMap)
+        const treeActive = treeContainsSessionId(item, activeSessionId)
+        const activeChildVisible = item.childSessions.some((child) => child.id === activeSessionId)
+        const expandedChildren = expandedDelegationParentIds.has(item.session.id)
+          || (activeChildVisible && !collapsedDelegationParentIds.has(item.session.id))
+        rows.push({
+          id: `agent-archived-${item.session.id}`,
+          estimateSize: 34,
+          content: (
+            <div className="px-3">
+              <AgentSessionItem
+                session={item.session}
+                active={treeActive}
+                indicatorStatus={rowStatus}
+                showPinIcon={!!item.session.pinned}
+                disableMiniMap={!sessionHoverPreviewEnabled}
+                delegationSummary={childCount > 0
+                  ? {
+                    total: childCount,
+                    completed: countCompletedDelegatedChildren(item.childSessions),
+                    expanded: expandedChildren,
+                    onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
+                  }
+                  : undefined}
+                leftAccent={getSessionLeftAccent(rowStatus)}
+                workspaceName={item.session.workspaceId ? workspaceNameMap.get(item.session.workspaceId) : undefined}
+                relativeTimeNow={relativeTimeNow}
+                onSelect={handleSelectAgentSession}
+                onRequestDelete={handleRequestDelete}
+                onRequestMove={handleRequestMove}
+                onRename={handleAgentRename}
+                onTogglePin={handleTogglePinAgent}
+                onToggleStar={handleToggleStarAgent}
+                onToggleArchive={handleToggleArchiveAgent}
+              />
+            </div>
+          ),
+        })
+        if (expandedChildren) {
+          for (const childSession of item.childSessions) {
+            rows.push({
+              id: `agent-archived-child-${childSession.id}`,
+              estimateSize: 34,
+              content: (
+                <div className="ml-6 border-l border-foreground/10 pl-2 pr-3">
+                  <DelegatedChildSessionItem
+                    session={childSession}
+                    activeSessionId={activeSessionId}
+                    agentIndicatorMap={agentIndicatorMap}
+                    relativeTimeNow={relativeTimeNow}
+                    workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
+                    onSelect={handleSelectAgentSession}
+                    onRequestDelete={handleRequestDelete}
+                    onRequestMove={handleRequestMove}
+                    onRename={handleAgentRename}
+                    onTogglePin={handleTogglePinAgent}
+                    onToggleStar={handleToggleStarAgent}
+                    onToggleArchive={handleToggleArchiveAgent}
+                  />
+                </div>
+              ),
+            })
+          }
+        }
+      }
+    }
+    return rows
+  }, [activeSessionId, agentIndicatorMap, archivedAgentSessionTrees, collapsedDelegationParentIds, expandedDelegationParentIds, handleAgentRename, handleRequestDelete, handleRequestMove, handleSelectAgentSession, handleToggleArchiveAgent, handleToggleDelegationParent, handleTogglePinAgent, handleToggleStarAgent, relativeTimeNow, sessionHoverPreviewEnabled, workspaceNameMap])
+
   // ===== 折叠状态：精简图标视图 =====
   if (sidebarCollapsed) {
     return (
@@ -2793,82 +3025,12 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
       {/* Chat 模式 active 视图：置顶 + 对话历史，结构与 Agent active 视图保持一致 */}
       {mode === 'chat' && viewMode === 'active' ? (
-        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin titlebar-no-drag">
-          {pinnedConversations.length > 0 && (
-            <div className="pt-2 pb-1 flex-shrink-0 titlebar-no-drag">
-              <div className="pl-[18px] pr-3.5 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
-                置顶
-              </div>
-              <div>
-                <div className="px-2">
-                  <div className="ml-4 flex flex-col gap-0.5">
-                    {pinnedConversations.map((conv) => (
-                      <ConversationItem
-                        key={`pinned-${conv.id}`}
-                        conversation={conv}
-                        active={conv.id === activeSessionId}
-                        streaming={streamingIds.has(conv.id)}
-                        showPinIcon={false}
-                        relativeTimeNow={relativeTimeNow}
-                        onSelect={handleSelectConversation}
-                        onRequestDelete={handleRequestDelete}
-                        onRename={handleRename}
-                        onTogglePin={handleTogglePin}
-                        onToggleArchive={handleToggleArchive}
-                      />
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          <div className="group/chat-section relative flex items-center px-2 pt-2 pb-1 flex-shrink-0">
-            <span className="ml-[4px] px-1.5 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">对话</span>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label="新建对话"
-                  onClick={() => { void createChat() }}
-                  className="absolute right-2 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 titlebar-no-drag"
-                >
-                  <Plus size={13} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                {`新建对话${newChatShortcutLabel ? ` (${newChatShortcutLabel})` : ''}`}
-              </TooltipContent>
-            </Tooltip>
-          </div>
-
-          <div className="px-2 pb-3">
-            {conversationGroups.map((group) => (
-              <div key={group.label} className="mb-1">
-                <div className="ml-[4px] px-1.5 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
-                  {group.label}
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  {group.items.map((conv) => (
-                    <ConversationItem
-                      key={conv.id}
-                      conversation={conv}
-                      active={conv.id === activeSessionId}
-                      streaming={streamingIds.has(conv.id)}
-                      showPinIcon={!!conv.pinned}
-                      relativeTimeNow={relativeTimeNow}
-                      onSelect={handleSelectConversation}
-                      onRequestDelete={handleRequestDelete}
-                      onRename={handleRename}
-                      onTogglePin={handleTogglePin}
-                      onToggleArchive={handleToggleArchive}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+        <VirtualSidebarList
+          key="chat-active-list"
+          className="flex-1"
+          rows={chatActiveVirtualRows}
+          activeRowId={activeSessionId ? `chat-${activeSessionId}` : null}
+        />
       ) : mode === 'agent' && viewMode === 'active' ? (
         <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin titlebar-no-drag">
           {pinnedAgentSessions.length > 0 && (
@@ -3063,106 +3225,21 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           )}
 
           {/* 归档视图：单列表布局 */}
-          <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-thin titlebar-no-drag">
-            {mode === 'chat' ? (
-              /* Chat 归档：对话按日期分组 */
-              conversationGroups.map((group) => (
-                <div key={group.label} className="mb-1">
-                  <div className="px-3 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
-                    {group.label}
-                  </div>
-                  <div className="flex flex-col gap-0.5">
-                    {group.items.map((conv) => (
-                      <ConversationItem
-                        key={conv.id}
-                        conversation={conv}
-                        active={conv.id === activeSessionId}
-                        streaming={streamingIds.has(conv.id)}
-                        showPinIcon={!!conv.pinned}
-                        relativeTimeNow={relativeTimeNow}
-                        onSelect={handleSelectConversation}
-                        onRequestDelete={handleRequestDelete}
-                        onRename={handleRename}
-                        onTogglePin={handleTogglePin}
-                        onToggleArchive={handleToggleArchive}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))
-            ) : (
-              /* Agent 模式归档：Agent 会话按日期分组，含委派树 */
-              archivedAgentSessionTrees.map((group) => (
-                <div key={group.label} className="mb-1">
-                  <div className="px-3 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
-                    {group.label}
-                  </div>
-                  <div className="flex flex-col gap-0.5">
-                    {group.items.map((item) => {
-                      const childCount = item.childSessions.length
-                      const rowStatus = getSessionTreeStatus(item, agentIndicatorMap)
-                      const treeActive = treeContainsSessionId(item, activeSessionId)
-                      const activeChildVisible = item.childSessions.some((child) => child.id === activeSessionId)
-                      const expandedChildren = expandedDelegationParentIds.has(item.session.id)
-                        || (activeChildVisible && !collapsedDelegationParentIds.has(item.session.id))
-
-                      return (
-                        <div key={item.session.id} className="flex flex-col gap-0.5">
-                          <AgentSessionItem
-                            session={item.session}
-                            active={treeActive}
-                            indicatorStatus={rowStatus}
-                            showPinIcon={!!item.session.pinned}
-                            disableMiniMap={!sessionHoverPreviewEnabled}
-                            delegationSummary={childCount > 0
-                              ? {
-                                total: childCount,
-                                completed: countCompletedDelegatedChildren(item.childSessions),
-                                expanded: expandedChildren,
-                                onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
-                              }
-                              : undefined}
-                            leftAccent={getSessionLeftAccent(rowStatus)}
-                            workspaceName={item.session.workspaceId ? workspaceNameMap.get(item.session.workspaceId) : undefined}
-                            relativeTimeNow={relativeTimeNow}
-                            onSelect={handleSelectAgentSession}
-                            onRequestDelete={handleRequestDelete}
-                            onRequestMove={handleRequestMove}
-                            onRename={handleAgentRename}
-                            onTogglePin={handleTogglePinAgent}
-                            onToggleStar={handleToggleStarAgent}
-                            onToggleArchive={handleToggleArchiveAgent}
-                          />
-
-                          {childCount > 0 && expandedChildren && (
-                            <div className="ml-3 border-l border-foreground/10 pl-2 flex flex-col gap-0.5">
-                              {item.childSessions.map((childSession) => (
-                                <DelegatedChildSessionItem
-                                  key={childSession.id}
-                                  session={childSession}
-                                  activeSessionId={activeSessionId}
-                                  agentIndicatorMap={agentIndicatorMap}
-                                  relativeTimeNow={relativeTimeNow}
-                                  workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
-                                  onSelect={handleSelectAgentSession}
-                                  onRequestDelete={handleRequestDelete}
-                                  onRequestMove={handleRequestMove}
-                                  onRename={handleAgentRename}
-                                  onTogglePin={handleTogglePinAgent}
-                                  onToggleStar={handleToggleStarAgent}
-                                  onToggleArchive={handleToggleArchiveAgent}
-                                />
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
+          {mode === 'chat' ? (
+            <VirtualSidebarList
+              key="chat-archived-list"
+              className="flex-1 px-3 pt-2 pb-3"
+              rows={chatArchivedVirtualRows}
+              activeRowId={activeSessionId ? `chat-archived-${activeSessionId}` : null}
+            />
+          ) : (
+            <VirtualSidebarList
+              key="agent-archived-list"
+              className="flex-1 px-3 pt-2 pb-3"
+              rows={agentArchivedVirtualRows}
+              activeRowId={activeSessionId ? `agent-archived-${activeSessionId}` : null}
+            />
+          )}
         </>
       )}
 

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -269,17 +269,21 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   }, [setPendingAttachments])
 
   /** 发送消息 */
-  const handleSend = React.useCallback((): void => {
-    if (!canSend) return
+  const handleSend = React.useCallback((contentOverride?: string): void => {
+    const contentToSend = contentOverride ?? content
+    const canSendCurrentContent = (contentToSend.trim().length > 0 || pendingAttachments.length > 0)
+      && selectedModel !== null
+      && !streaming
+    if (!canSendCurrentContent) return
     // 发送前检查网络状态：离线时立即反馈，避免消息发出后静默失败
     if (!navigator.onLine) {
       toast.error('当前无网络连接，请检查网络后重试')
       return
     }
-    onSend(content.trim())
+    onSend(contentToSend.trim())
     setContent('')
     // 附件清理由 ChatView 的 handleSend 负责
-  }, [canSend, content, onSend])
+  }, [content, onSend, pendingAttachments.length, selectedModel, streaming])
 
   /** 粘贴文件回调 */
   const handlePasteFiles = React.useCallback((files: File[]): void => {
@@ -408,7 +412,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
       className={cn(
         canSend ? inputToolbarSendButtonClass : inputToolbarDisabledButtonClass
       )}
-      onClick={handleSend}
+      onClick={() => handleSend()}
       disabled={!canSend}
     >
       <CornerDownLeft className="size-[22px]" />

--- a/apps/electron/src/renderer/components/ui/virtual-sidebar-list.tsx
+++ b/apps/electron/src/renderer/components/ui/virtual-sidebar-list.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { cn } from '@/lib/utils'
+
+export interface VirtualSidebarRow {
+  id: string
+  /** 预估高度只影响首帧；实际挂载后由 measureElement 自动校正。 */
+  estimateSize: number
+  content: React.ReactNode
+}
+
+interface VirtualSidebarListProps {
+  rows: VirtualSidebarRow[]
+  className?: string
+  /** 选中行离开挂载范围时，自动定位后再挂载，保持原侧栏的选中项可见行为。 */
+  activeRowId?: string | null
+  /** 额外提前挂载的行数，保证触控板快速滚动时不会露白。 */
+  overscan?: number
+}
+
+/**
+ * 左侧栏统一虚拟列表容器。
+ *
+ * 保持原生 overflow 滚动、可变行高和 DOM 测量；仅让视口附近行挂载，避免会话
+ * 数量增长后 ContextMenu、Tooltip、hover hook 等交互树长期占据 DOM。
+ */
+export function VirtualSidebarList({
+  rows,
+  className,
+  activeRowId,
+  overscan = 10,
+}: VirtualSidebarListProps): React.ReactElement {
+  const parentRef = React.useRef<HTMLDivElement>(null)
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (index) => rows[index]?.estimateSize ?? 34,
+    getItemKey: (index) => rows[index]?.id ?? index,
+    overscan,
+  })
+  const items = virtualizer.getVirtualItems()
+
+  React.useEffect(() => {
+    if (!activeRowId) return
+    const index = rows.findIndex((row) => row.id === activeRowId)
+    if (index >= 0) virtualizer.scrollToIndex(index, { align: 'auto', behavior: 'smooth' })
+  }, [activeRowId, rows, virtualizer])
+
+  return (
+    <div ref={parentRef} className={cn('min-h-0 overflow-y-auto scrollbar-thin titlebar-no-drag', className)}>
+      <div
+        className="relative w-full"
+        style={{ height: virtualizer.getTotalSize() }}
+      >
+        {items.map((item) => {
+          const row = rows[item.index]
+          if (!row) return null
+          return (
+            <div
+              key={item.key}
+              ref={virtualizer.measureElement}
+              data-index={item.index}
+              className="absolute left-0 top-0 w-full"
+              style={{ transform: `translateY(${item.start}px)` }}
+            >
+              {row.content}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/lib/performance-monitor.ts
+++ b/apps/electron/src/renderer/lib/performance-monitor.ts
@@ -1,0 +1,100 @@
+/**
+ * Lightweight renderer performance diagnostics.
+ *
+ * Disabled by default. Enable with `?perf=1` or localStorage:
+ * `localStorage.setItem('proma-performance-debug', '1')`.
+ * When enabled, `window.__promaPerformance.snapshot()` exposes aggregate metrics
+ * without leaving a high-frequency trace in normal production sessions.
+ */
+
+export interface PerformanceMetric {
+  count: number
+  totalMs: number
+  maxMs: number
+  lastMs: number
+}
+
+export interface PerformanceSnapshot {
+  enabled: boolean
+  metrics: Record<string, PerformanceMetric>
+  longTasks: number
+  lastLongTaskMs: number
+}
+
+type PerformanceMetrics = Map<string, PerformanceMetric>
+
+const metrics: PerformanceMetrics = new Map()
+let initialized = false
+let longTasks = 0
+let lastLongTaskMs = 0
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof performance !== 'undefined'
+}
+
+export function isPerformanceMonitoringEnabled(): boolean {
+  if (!isBrowser()) return false
+  return new URLSearchParams(window.location.search).get('perf') === '1'
+    || window.localStorage.getItem('proma-performance-debug') === '1'
+}
+
+export function recordPerformanceSample(name: string, durationMs: number): void {
+  if (!isPerformanceMonitoringEnabled() || !Number.isFinite(durationMs)) return
+
+  const metric = metrics.get(name) ?? { count: 0, totalMs: 0, maxMs: 0, lastMs: 0 }
+  metric.count += 1
+  metric.totalMs += durationMs
+  metric.maxMs = Math.max(metric.maxMs, durationMs)
+  metric.lastMs = durationMs
+  metrics.set(name, metric)
+}
+
+export function measurePerformance<T>(name: string, operation: () => T): T {
+  if (!isPerformanceMonitoringEnabled()) return operation()
+  const start = performance.now()
+  try {
+    return operation()
+  } finally {
+    recordPerformanceSample(name, performance.now() - start)
+  }
+}
+
+export function getPerformanceSnapshot(): PerformanceSnapshot {
+  return {
+    enabled: isPerformanceMonitoringEnabled(),
+    metrics: Object.fromEntries(metrics.entries()),
+    longTasks,
+    lastLongTaskMs,
+  }
+}
+
+export function clearPerformanceMetrics(): void {
+  metrics.clear()
+  longTasks = 0
+  lastLongTaskMs = 0
+}
+
+export function initializePerformanceMonitor(): void {
+  if (!isBrowser() || initialized || !isPerformanceMonitoringEnabled()) return
+  initialized = true
+
+  window.__promaPerformance = {
+    snapshot: getPerformanceSnapshot,
+    clear: clearPerformanceMetrics,
+  }
+
+  // Chromium/Electron supports Long Task entries. Keep the observer optional so
+  // diagnostics never affect startup on runtimes that omit this entry type.
+  try {
+    const observer = new PerformanceObserver((entries) => {
+      for (const entry of entries.getEntries()) {
+        longTasks += 1
+        lastLongTaskMs = entry.duration
+        recordPerformanceSample('renderer.long-task', entry.duration)
+      }
+    })
+    observer.observe({ type: 'longtask', buffered: true })
+  } catch {
+    // Unsupported browsers simply expose the synchronous metrics above.
+  }
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -84,6 +84,7 @@ import { TabSwitcher } from './components/tabs/TabSwitcher'
 import { htmlToMarkdown, markdownToHtml } from './lib/markdown-rich-text'
 import { PromaLogo } from './lib/model-logo'
 import { initShortcutRegistry, updateShortcutOverrides } from './lib/shortcut-registry'
+import { initializePerformanceMonitor } from './lib/performance-monitor'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
 
@@ -94,6 +95,8 @@ const isDetachedPreviewWindow = new URLSearchParams(window.location.search).get(
 const isPlanningWindow = new URLSearchParams(window.location.search).get('window') === 'planning'
 const isWorkspaceMemoryWindow = new URLSearchParams(window.location.search).get('window') === 'workspace-memory'
 const isMainWindow = !isQuickTaskWindow && !isVoiceDictationIndicatorWindow && !isDetachedPreviewWindow && !isPlanningWindow && !isWorkspaceMemoryWindow
+
+initializePerformanceMonitor()
 
 // 主窗口和独立规划窗口均由内部面板管理滚动，避免页面本身出现第二层滚动。
 if (isMainWindow || isPlanningWindow || isWorkspaceMemoryWindow) {

--- a/apps/electron/src/renderer/vite-env.d.ts
+++ b/apps/electron/src/renderer/vite-env.d.ts
@@ -37,8 +37,15 @@ interface UpdaterAPI {
   cancelIdleInstall: () => Promise<void>
 }
 
+interface PromaPerformanceDiagnostics {
+  snapshot: () => import('./lib/performance-monitor').PerformanceSnapshot
+  clear: () => void
+}
+
 // 附件临时 base64 缓存（用于发送前暂存数据）
 interface Window {
   __pendingAttachmentData?: Map<string, string>
   __pendingAgentFileData?: Map<string, string>
+  /** 仅在 ?perf=1 或 proma-performance-debug=1 时安装的性能诊断接口。 */
+  __promaPerformance?: PromaPerformanceDiagnostics
 }

--- a/bun.lock
+++ b/bun.lock
@@ -79,6 +79,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-symbols/icons": "^1.3.1",
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-virtual": "^3.14.9",
         "@tiptap/core": "^3.19.0",
         "@tiptap/extension-code-block-lowlight": "^3.19.0",
         "@tiptap/extension-link": "^3.19.0",
@@ -776,6 +777,10 @@
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.20", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders" } }, "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.9", "", { "dependencies": { "@tanstack/virtual-core": "3.17.7" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.7", "", {}, "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA=="],
 
     "@tiptap/core": ["@tiptap/core@3.29.2", "", { "peerDependencies": { "@tiptap/pm": "3.29.2" } }, "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw=="],
 


### PR DESCRIPTION
## Summary

- 将输入草稿同步、滚动扫描和快捷切换 DOM 写入收敛到每帧一次，降低渲染热路径开销。
- 为 Chat 活跃/归档和归档 Agent 会话接入可变高度虚拟列表，仅挂载视口附近行。
- 添加默认关闭的性能诊断，可通过 `?perf=1` 或 localStorage 开关读取快照。

## Test plan

- [x] `bun run typecheck`
- [x] `bun run --filter='@proma/electron' build:renderer`
- [x] `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)