### PR TITLE
fix: repair Qwen, browser, and updater regressions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@ It is not just another chat box. Proma is meant to become a long-lived Agent wor
 
 ![Proma Poster](https://img.erlich.fun/personal-blog/uPic/pb.png)
 
-[中文 README](./README.md) | [Beginner Tutorial](./tutorial/tutorial.md) | [Open-Source Release](https://github.com/ErlichLiu/Proma/releases) | [Commercial Version](https://proma.cool/download)
+[中文 README](./README.md) | [Beginner Tutorial](./tutorial/tutorial.md) | [Open-Source Release](https://github.com/proma-ai/Proma/releases) | [Commercial Version](https://proma.cool/download)
 
 ## What Proma Can Do
 
@@ -24,7 +24,7 @@ It is not just another chat box. Proma is meant to become a long-lived Agent wor
 
 ### Download
 
-Download the open-source version from [GitHub Releases](https://github.com/ErlichLiu/Proma/releases), with builds for macOS Apple Silicon, macOS Intel, and Windows.
+Download the open-source version from [GitHub Releases](https://github.com/proma-ai/Proma/releases), with builds for macOS Apple Silicon, macOS Intel, and Windows.
 
 The open-source version can be used independently with self-configured AI provider channels. If you prefer Proma-provided built-in model channels and subscription options, you can optionally explore the [Proma commercial version](https://proma.cool/download). The two versions support different preferences, and you are free to choose the one that best fits your workflow.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Proma 是一个本地优先的 AI 桌面应用，把多模型 Chat、通用 Agen
   <source src="https://img.erlich.fun/personal-blog/uPic/%E7%AE%80%E5%8D%95%E4%BB%8B%E7%BB%8D%20Proma.mp4" type="video/mp4">
 </video>
 
-[English README](./README.en.md) | [新手教程](./tutorial/tutorial.md) | [下载开源版](https://github.com/ErlichLiu/Proma/releases) | [下载商业版](https://proma.cool/download)
+[English README](./README.en.md) | [新手教程](./tutorial/tutorial.md) | [下载开源版](https://github.com/proma-ai/Proma/releases) | [下载商业版](https://proma.cool/download)
 
 > **最新思考 ｜ 2026 Q2–Q3**：[勇敢地解决真实的问题 — Proactive · 个人注意力 · 团队协作](./proma-thinking/proma-2026-q2-q3-thinking.md) ｜ 往期思考：[2026 Q1](./proma-thinking/proma-2026-q1-thinking.md)
 
@@ -30,7 +30,7 @@ Proma 是一个本地优先的 AI 桌面应用，把多模型 Chat、通用 Agen
 
 ### 下载安装
 
-从 [GitHub Releases](https://github.com/ErlichLiu/Proma/releases) 下载开源版本，提供 macOS Apple Silicon、macOS Intel 和 Windows 安装包。
+从 [GitHub Releases](https://github.com/proma-ai/Proma/releases) 下载开源版本，提供 macOS Apple Silicon、macOS Intel 和 Windows 安装包。
 
 开源版可独立使用，并支持自行配置 AI 供应商渠道。如果你更希望使用 Proma 提供的内置模型渠道和订阅方案，也可以按需了解 [Proma 商业版](https://proma.cool/download)。两个版本面向不同的使用偏好，你可以自由选择适合自己的版本。
 

--- a/apps/electron/default-skills/automation/SKILL.md
+++ b/apps/electron/default-skills/automation/SKILL.md
@@ -128,8 +128,8 @@ Proma 已提供内置 `automation` MCP 工具。你必须通过这些工具操�
 
 一个 monthly 月度报告任务的 prompt 范本（创建任务时按这个结构写，跨运行记忆段落直接照搬）：
 
-    目标：汇总本月 ErlichLiu/Proma 仓库合入的 PR，按类别归类并标注影响。
-    范围：读取 ErlichLiu/Proma 的 closed PR 列表，筛选本月合入的。
+    目标：汇总本月 proma-ai/Proma 仓库合入的 PR，按类别归类并标注影响。
+    范围：读取 proma-ai/Proma 的 closed PR 列表，筛选本月合入的。
     判断标准：每个 PR 是否引入破坏性变更、是否影响用户配置、是否需要更新文档。
     输出格式：Markdown 报告，分「重大变更」「新功能」「修复」「文档」四组。
 

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -153,5 +153,5 @@ nsis:
 # ============================================
 publish:
   provider: github
-  owner: ErlichLiu
+  owner: proma-ai
   repo: Proma

--- a/apps/electron/src/main/lib/adapters/pi-provider-compat.ts
+++ b/apps/electron/src/main/lib/adapters/pi-provider-compat.ts
@@ -8,5 +8,5 @@ import type { ProviderType } from '@proma/shared'
  * system 角色。原生 OpenAI 渠道仍可使用 developer。
  */
 export function supportsPiDeveloperRole(provider: ProviderType): boolean {
-  return provider !== 'doubao' && provider !== 'custom'
+  return provider !== 'doubao' && provider !== 'qwen' && provider !== 'custom'
 }

--- a/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react'
+import { nextBrowserLayoutRevision } from './browser-layout-revision'
 
 // 每次 publish（包括卸载隐藏）分配全局单调 revision。旧 slot 的 IPC 即使晚到，
 // 主进程也不会覆盖随后已挂载 tab 的可见性和边界。
-let nextBrowserLayoutRevision = 0
-
-function nextLayoutRevision(): number {
-  nextBrowserLayoutRevision += 1
-  return nextBrowserLayoutRevision
-}
 
 /**
  * WebContentsView 是原生子视图，天然盖在 renderer DOM 之上；CSS z-index 无法反转。
@@ -67,7 +62,7 @@ export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: st
         void setLayout({
           sessionId,
           tabId,
-          revision: nextLayoutRevision(),
+          revision: nextBrowserLayoutRevision(),
           visible: visible && rect.width > 4 && rect.height > 4,
           bounds: {
             x: Math.round(rect.x), y: Math.round(rect.y),
@@ -96,7 +91,7 @@ export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: st
       overlayObserver.disconnect()
       window.removeEventListener('resize', publishBounded)
       if (frame) cancelAnimationFrame(frame)
-      void setLayout({ sessionId, tabId, revision: nextLayoutRevision(), visible: false, bounds: { x: 0, y: 0, width: 0, height: 0 } })
+      void setLayout({ sessionId, tabId, revision: nextBrowserLayoutRevision(), visible: false, bounds: { x: 0, y: 0, width: 0, height: 0 } })
     }
   }, [sessionId, tabId])
 

--- a/apps/electron/src/renderer/components/browser/browser-layout-revision.ts
+++ b/apps/electron/src/renderer/components/browser/browser-layout-revision.ts
@@ -1,0 +1,12 @@
+/**
+ * Use a time-based epoch with sub-millisecond sequence numbers rather than a
+ * module-local counter starting at zero. The main process outlives renderer
+ * reloads, so a fresh renderer must always publish revisions newer than the
+ * revisions from its predecessor.
+ */
+let nextRevision = Date.now() * 1_000
+
+export function nextBrowserLayoutRevision(): number {
+  nextRevision += 1
+  return nextRevision
+}

--- a/apps/electron/src/renderer/components/settings/AboutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AboutSettings.tsx
@@ -27,7 +27,7 @@ import { VersionHistory } from './VersionHistory'
 declare const __APP_VERSION__: string
 const APP_VERSION = __APP_VERSION__
 
-const GITHUB_RELEASES_URL = 'https://github.com/ErlichLiu/Proma/releases'
+const GITHUB_RELEASES_URL = 'https://github.com/proma-ai/Proma/releases'
 
 /** 更新状态卡片 */
 function UpdateCard(): React.ReactElement | null {
@@ -511,12 +511,12 @@ export function AboutSettings(): React.ReactElement {
         </SettingsRow>
         <SettingsRow label="项目地址">
           <a
-            href="https://github.com/ErlichLiu/Proma.git"
+            href="https://github.com/proma-ai/Proma.git"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-primary hover:underline"
           >
-            github.com/ErlichLiu/Proma
+            github.com/proma-ai/Proma
           </a>
         </SettingsRow>
       </SettingsCard>


### PR DESCRIPTION
## Summary
- Send Pi Agent Qwen system prompts with the compatible `system` role.
- Keep browser layout revisions newer after renderer reloads.
- Point updater, release links, and documentation to the canonical `proma-ai/Proma` repository.

## Validation
- `bun run --filter @proma/electron build:renderer`
- `bun run --filter @proma/electron typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
