### PR TITLE
feat(browser): open Agent links in managed browser

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.16",
+  "version": "0.17.17",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/browser-atoms.ts
+++ b/apps/electron/src/renderer/atoms/browser-atoms.ts
@@ -6,6 +6,8 @@ import { currentAgentSessionIdAtom } from './agent-atoms'
 /** 每个 Agent 会话的受管浏览器面板开关。主进程仍是状态权威。 */
 export const browserPanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 export const browserStateMapAtom = atom<Map<string, BrowserViewState>>(new Map())
+/** 首次风险确认完成后自动加载的 Agent 回复链接。 */
+export const browserPendingNavigationMapAtom = atom<Map<string, string>>(new Map())
 
 /** 用户手动恢复文件面板后，该会话再次打开浏览器时不再自动收起。 */
 export const browserFilePanelManualRestoreSessionIdsAtom = atomWithStorage<string[]>(

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -35,6 +35,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, buildTaskProgressDataForTurn, type MessageGroup } from './SDKMessageRenderer'
 import { buildLiveGroupSet } from './live-group-set'
 import { ContentBlock } from './ContentBlock'
+import { AgentBrowserLinkProvider } from '@/components/browser/AgentBrowserLinkProvider'
 import { parseThinkTagsFromText } from './thinking-tag-parser'
 import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
@@ -910,9 +911,8 @@ export function AgentMessages({
                 const isLastAssistantTurn = !streaming && stoppedByUser
                   && group.type === 'assistant-turn'
                   && idx === visibleGroups.findLastIndex((g) => g.type === 'assistant-turn')
-                return (
+                const renderer = (
                   <MessageGroupRenderer
-                    key={getGroupId(group)}
                     group={group}
                     allMessages={allSDKMessages}
                     basePath={sessionPath || undefined}
@@ -930,6 +930,9 @@ export function AgentMessages({
                     sessionModelId={sessionModelId}
                   />
                 )
+                return group.type === 'assistant-turn'
+                  ? <AgentBrowserLinkProvider key={getGroupId(group)} sessionId={sessionId}>{renderer}</AgentBrowserLinkProvider>
+                  : <React.Fragment key={getGroupId(group)}>{renderer}</React.Fragment>
               })}
 
               {/* 有实时助手内容时：显示运行指示器或占位（防止 streaming 结束到 Actions Bar 出现之间的高度跳动） */}
@@ -945,6 +948,7 @@ export function AgentMessages({
               {/* 无实时助手内容时：显示完整气泡（含头像/名称/时间） */}
               {/* 注意：工具活动已通过 SDK 渲染路径（liveGroups）展示 */}
               {!hasLiveAssistantContent && !suppressAgentRunning && (streaming || smoothContent || retrying) && (
+                <AgentBrowserLinkProvider sessionId={sessionId}>
                 <Message from="assistant">
                   <MessageHeader
                     model={agentStreamingModel}
@@ -976,6 +980,7 @@ export function AgentMessages({
                     )}
                   </MessageContent>
                 </Message>
+                </AgentBrowserLinkProvider>
               )}
 
             </>

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -40,6 +40,7 @@ import { CodeBlock, MermaidBlock } from '@proma/ui'
 import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isImageFilePath, isRelativeFilePath } from './file-path-chip'
 import { buildAgentHistoryQuoteLabel, parseAgentHistoryQuoteMention } from '@/lib/quoted-selection'
+import { useAgentBrowserLink } from '@/components/browser/AgentBrowserLinkProvider'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
@@ -531,6 +532,7 @@ const MarkdownLink = React.memo(function MarkdownLink({
   children: linkChildren,
   ...linkProps
 }: React.AnchorHTMLAttributes<HTMLAnchorElement>): React.ReactElement {
+  const agentBrowserLink = useAgentBrowserLink()
   // mention:// 协议 → 渲染为 MentionChip
   if (href) {
     const mentionMatch = MENTION_URL_RE.exec(href)
@@ -551,7 +553,8 @@ const MarkdownLink = React.memo(function MarkdownLink({
       onClick={(e) => {
         e.preventDefault()
         if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
-          window.electronAPI.openExternal(href)
+          if (agentBrowserLink) agentBrowserLink.openLink(href)
+          else void window.electronAPI.openExternal(href)
         }
       }}
       title={href}

--- a/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
+++ b/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import { useSetAtom } from 'jotai'
+import type { BrowserViewState } from '@proma/shared'
+import { BROWSER_RISK_DISCLAIMER_VERSION } from '@/types/settings'
+import {
+  browserPanelOpenMapAtom,
+  browserPendingNavigationMapAtom,
+  browserStateMapAtom,
+} from '@/atoms/browser-atoms'
+import { shouldReuseInitialBrowserTab } from './agent-browser-link-utils'
+
+interface AgentBrowserLinkContextValue {
+  openLink: (url: string) => void
+}
+
+const AgentBrowserLinkContext = React.createContext<AgentBrowserLinkContextValue | null>(null)
+
+/** Agent 回复内网页链接的打开目标；未提供时保留原有系统浏览器行为。 */
+export function useAgentBrowserLink(): AgentBrowserLinkContextValue | null {
+  return React.useContext(AgentBrowserLinkContext)
+}
+
+export function AgentBrowserLinkProvider({
+  sessionId,
+  children,
+}: {
+  sessionId: string
+  children: React.ReactNode
+}): React.ReactElement {
+  const setBrowserOpenMap = useSetAtom(browserPanelOpenMapAtom)
+  const setBrowserStateMap = useSetAtom(browserStateMapAtom)
+  const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
+
+  const publishBrowserState = React.useCallback((state: BrowserViewState) => {
+    setBrowserStateMap((previous) => {
+      const next = new Map(previous)
+      next.set(state.sessionId, state)
+      return next
+    })
+    setBrowserOpenMap((previous) => {
+      const next = new Map(previous)
+      next.set(state.sessionId, true)
+      return next
+    })
+  }, [setBrowserOpenMap, setBrowserStateMap])
+
+  const openLink = React.useCallback((url: string) => {
+    void (async () => {
+      const openBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).openAgentBrowser
+      if (typeof openBrowser !== 'function') {
+        await window.electronAPI.openExternal(url)
+        return
+      }
+
+      try {
+        const [settings, state] = await Promise.all([
+          window.electronAPI.getSettings(),
+          openBrowser(sessionId),
+        ])
+        publishBrowserState(state)
+
+        const riskAcknowledged = (settings.browserRiskDisclaimerVersion ?? 0) >= BROWSER_RISK_DISCLAIMER_VERSION
+        if (!riskAcknowledged) {
+          setPendingNavigationMap((previous) => {
+            const next = new Map(previous)
+            next.set(sessionId, url)
+            return next
+          })
+          return
+        }
+
+        const nextState = shouldReuseInitialBrowserTab(state)
+          ? await window.electronAPI.navigateAgentBrowser({ sessionId, url })
+          : await window.electronAPI.createAgentBrowserTab({ sessionId, url })
+        publishBrowserState(nextState)
+      } catch (error) {
+        console.error('[Agent 回复链接] 在受管浏览器中打开失败:', error)
+      }
+    })()
+  }, [publishBrowserState, sessionId, setPendingNavigationMap])
+
+  const value = React.useMemo(() => ({ openLink }), [openLink])
+  return <AgentBrowserLinkContext.Provider value={value}>{children}</AgentBrowserLinkContext.Provider>
+}

--- a/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
+++ b/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
@@ -15,6 +15,9 @@ interface AgentBrowserLinkContextValue {
 
 const AgentBrowserLinkContext = React.createContext<AgentBrowserLinkContextValue | null>(null)
 
+/** 同一会话的所有 Agent 回复共用队列，避免跨消息快速点击时覆盖首个导航。 */
+const navigationQueues = new Map<string, Promise<void>>()
+
 /** Agent 回复内网页链接的打开目标；未提供时保留原有系统浏览器行为。 */
 export function useAgentBrowserLink(): AgentBrowserLinkContextValue | null {
   return React.useContext(AgentBrowserLinkContext)
@@ -45,38 +48,44 @@ export function AgentBrowserLinkProvider({
   }, [setBrowserOpenMap, setBrowserStateMap])
 
   const openLink = React.useCallback((url: string) => {
-    void (async () => {
-      const openBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).openAgentBrowser
-      if (typeof openBrowser !== 'function') {
-        await window.electronAPI.openExternal(url)
-        return
-      }
+    const openBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).openAgentBrowser
+    if (typeof openBrowser !== 'function') {
+      void window.electronAPI.openExternal(url)
+      return
+    }
 
-      try {
-        const [settings, state] = await Promise.all([
-          window.electronAPI.getSettings(),
-          openBrowser(sessionId),
-        ])
-        publishBrowserState(state)
+    const nextNavigation = (navigationQueues.get(sessionId) ?? Promise.resolve())
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          const [settings, state] = await Promise.all([
+            window.electronAPI.getSettings(),
+            openBrowser(sessionId),
+          ])
+          publishBrowserState(state)
 
-        const riskAcknowledged = (settings.browserRiskDisclaimerVersion ?? 0) >= BROWSER_RISK_DISCLAIMER_VERSION
-        if (!riskAcknowledged) {
-          setPendingNavigationMap((previous) => {
-            const next = new Map(previous)
-            next.set(sessionId, url)
-            return next
-          })
-          return
+          const riskAcknowledged = (settings.browserRiskDisclaimerVersion ?? 0) >= BROWSER_RISK_DISCLAIMER_VERSION
+          if (!riskAcknowledged) {
+            setPendingNavigationMap((previous) => {
+              const next = new Map(previous)
+              next.set(sessionId, url)
+              return next
+            })
+            return
+          }
+
+          const nextState = shouldReuseInitialBrowserTab(state)
+            ? await window.electronAPI.navigateAgentBrowser({ sessionId, url })
+            : await window.electronAPI.createAgentBrowserTab({ sessionId, url })
+          publishBrowserState(nextState)
+        } catch (error) {
+          console.error('[Agent 回复链接] 在受管浏览器中打开失败:', error)
         }
-
-        const nextState = shouldReuseInitialBrowserTab(state)
-          ? await window.electronAPI.navigateAgentBrowser({ sessionId, url })
-          : await window.electronAPI.createAgentBrowserTab({ sessionId, url })
-        publishBrowserState(nextState)
-      } catch (error) {
-        console.error('[Agent 回复链接] 在受管浏览器中打开失败:', error)
-      }
-    })()
+      })
+    navigationQueues.set(sessionId, nextNavigation)
+    void nextNavigation.finally(() => {
+      if (navigationQueues.get(sessionId) === nextNavigation) navigationQueues.delete(sessionId)
+    })
   }, [publishBrowserState, sessionId, setPendingNavigationMap])
 
   const value = React.useMemo(() => ({ openLink }), [openLink])

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
 import type { BrowserViewState } from '@proma/shared'
-import { ArrowLeft, ArrowRight, Globe2, LoaderCircle, Plus, RefreshCw, ShieldAlert, Square, X } from 'lucide-react'
+import { ArrowLeft, ArrowRight, ExternalLink, Globe2, LoaderCircle, Plus, RefreshCw, ShieldAlert, Square, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -16,6 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { BROWSER_RISK_DISCLAIMER_VERSION } from '@/types/settings'
 import { detectIsWindows, getWindowControlsPaddingClass } from '@/lib/platform'
 import { cn } from '@/lib/utils'
+import { browserPendingNavigationMapAtom } from '@/atoms/browser-atoms'
 import { BrowserSlot } from './BrowserSlot'
 
 interface BrowserPanelProps {
@@ -28,6 +30,8 @@ export function BrowserPanel({ sessionId, state, onClose }: BrowserPanelProps): 
   const [url, setUrl] = React.useState(state?.url ?? '')
   const [riskAcknowledged, setRiskAcknowledged] = React.useState<boolean | null>(null)
   const [savingRiskAcknowledgement, setSavingRiskAcknowledgement] = React.useState(false)
+  const pendingNavigationUrl = useAtomValue(browserPendingNavigationMapAtom).get(sessionId)
+  const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
 
   React.useEffect(() => setUrl(state?.url ?? ''), [state?.url])
   React.useEffect(() => {
@@ -50,6 +54,11 @@ export function BrowserPanel({ sessionId, state, onClose }: BrowserPanelProps): 
     try { await navigateBrowser({ sessionId, url: value }) } catch (error) { console.error('[受管浏览器] 导航失败:', error) }
   }, [sessionId, url])
 
+  const openInDefaultBrowser = React.useCallback(() => {
+    const value = url.trim()
+    if (value.startsWith('http://') || value.startsWith('https://')) void window.electronAPI.openExternal(value)
+  }, [url])
+
   const close = React.useCallback(async () => {
     const closeBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).closeAgentBrowser
     if (typeof closeBrowser !== 'function') { onClose(); return }
@@ -66,12 +75,25 @@ export function BrowserPanel({ sessionId, state, onClose }: BrowserPanelProps): 
     try {
       await window.electronAPI.updateSettings({ browserRiskDisclaimerVersion: BROWSER_RISK_DISCLAIMER_VERSION })
       setRiskAcknowledged(true)
+      if (pendingNavigationUrl) {
+        try {
+          await window.electronAPI.navigateAgentBrowser({ sessionId, url: pendingNavigationUrl })
+        } catch (error) {
+          console.error('[受管浏览器] 打开待处理链接失败:', error)
+        } finally {
+          setPendingNavigationMap((previous) => {
+            const next = new Map(previous)
+            next.delete(sessionId)
+            return next
+          })
+        }
+      }
     } catch (error) {
       console.error('[受管浏览器] 保存风险告知确认失败:', error)
     } finally {
       setSavingRiskAcknowledgement(false)
     }
-  }, [])
+  }, [pendingNavigationUrl, sessionId, setPendingNavigationMap])
 
   const stopBackgroundRun = React.useCallback(async () => {
     if (state?.executionSource === 'user') return
@@ -124,6 +146,7 @@ export function BrowserPanel({ sessionId, state, onClose }: BrowserPanelProps): 
         <form className="flex-1 min-w-0" onSubmit={(event) => { event.preventDefault(); if (!riskBlocked) void navigate() }}>
           <Input disabled={riskBlocked} value={url} onChange={(event) => setUrl(event.target.value)} placeholder="输入域名或 URL（默认 HTTPS，仅公共网站）" className="h-7 text-xs bg-background/70" aria-label="浏览器地址" />
         </form>
+        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" disabled={!url.startsWith('http://') && !url.startsWith('https://')} onClick={openInDefaultBrowser} aria-label="在系统默认浏览器中打开当前网页"><ExternalLink className="size-3.5" /></Button></TooltipTrigger><TooltipContent>在系统默认浏览器中打开</TooltipContent></Tooltip>
         {state?.loading && <LoaderCircle className="size-3.5 text-muted-foreground animate-spin" />}
         {isBackgroundRun && (
           <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7 text-amber-600 hover:text-amber-700" onClick={() => void stopBackgroundRun()} aria-label="停止当前后台 Agent"><Square className="size-3.5 fill-current" /></Button></TooltipTrigger><TooltipContent>停止当前{state?.executionSource === 'automation' ? '自动任务' : '委派'}运行</TooltipContent></Tooltip>
@@ -156,11 +179,6 @@ export function BrowserPanel({ sessionId, state, onClose }: BrowserPanelProps): 
           </button>
         ))}
         <Tooltip><TooltipTrigger asChild><Button type="button" variant="ghost" size="icon" className="size-6 shrink-0" disabled={riskBlocked} onClick={() => void createTab()} aria-label="新建浏览器标签"><Plus className="size-3.5" /></Button></TooltipTrigger><TooltipContent>新建标签</TooltipContent></Tooltip>
-      </div>
-      <div className="flex items-center h-7 px-3 gap-2 border-b border-border/25 text-[11px] text-muted-foreground">
-        <span className="truncate">{title}</span>
-        {isBackgroundRun && <span className="shrink-0 text-amber-600">{state?.executionSource === 'automation' ? '自动任务' : '委派'}来源 · 可停止当前运行</span>}
-        <span className="ml-auto shrink-0">Proma 仅本地存储登录状态</span>
       </div>
       {activity && (
         <div className="flex min-h-7 items-center gap-2 border-b border-border/25 bg-primary/[0.04] px-3 py-1 text-[11px]" role="status" aria-live="polite">

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -19,6 +19,7 @@ import { detectIsWindows, getWindowControlsPaddingClass } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import { browserPendingNavigationMapAtom } from '@/atoms/browser-atoms'
 import { BrowserSlot } from './BrowserSlot'
+import { shouldReuseInitialBrowserTab } from './agent-browser-link-utils'
 
 interface BrowserPanelProps {
   sessionId: string
@@ -77,7 +78,13 @@ export function BrowserPanel({ sessionId, state, onClose }: BrowserPanelProps): 
       setRiskAcknowledged(true)
       if (pendingNavigationUrl) {
         try {
-          await window.electronAPI.navigateAgentBrowser({ sessionId, url: pendingNavigationUrl })
+          const currentState = await window.electronAPI.getAgentBrowserState(sessionId)
+          if (!currentState) throw new Error('受管浏览器会话不存在。')
+          if (shouldReuseInitialBrowserTab(currentState)) {
+            await window.electronAPI.navigateAgentBrowser({ sessionId, url: pendingNavigationUrl })
+          } else {
+            await window.electronAPI.createAgentBrowserTab({ sessionId, url: pendingNavigationUrl })
+          }
         } catch (error) {
           console.error('[受管浏览器] 打开待处理链接失败:', error)
         } finally {

--- a/apps/electron/src/renderer/components/browser/agent-browser-link-utils.ts
+++ b/apps/electron/src/renderer/components/browser/agent-browser-link-utils.ts
@@ -1,0 +1,8 @@
+import type { BrowserViewState } from '@proma/shared'
+
+/** 新会话仅有空白初始标签时，复用它而非额外创建无用标签。 */
+export function shouldReuseInitialBrowserTab(state: BrowserViewState): boolean {
+  return state.tabs.length === 1
+    && state.activeTabId === state.tabs[0]?.tabId
+    && (state.url === '' || state.url === 'about:blank')
+}

--- a/apps/electron/src/renderer/components/browser/agent-browser-link-utils.ts
+++ b/apps/electron/src/renderer/components/browser/agent-browser-link-utils.ts
@@ -1,8 +1,11 @@
 import type { BrowserViewState } from '@proma/shared'
 
-/** 新会话仅有空白初始标签时，复用它而非额外创建无用标签。 */
+/** 仅复用用户的空白初始标签，绝不导航 Agent 的工作标签。 */
 export function shouldReuseInitialBrowserTab(state: BrowserViewState): boolean {
+  const activeTab = state.tabs[0]
   return state.tabs.length === 1
-    && state.activeTabId === state.tabs[0]?.tabId
+    && state.activeTabId === activeTab?.tabId
+    && state.agentTabId !== activeTab?.tabId
+    && !activeTab?.openedByAgent
     && (state.url === '' || state.url === 'about:blank')
 }

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -32,7 +32,7 @@ import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { cn } from '@/lib/utils'
-import { browserPanelOpenMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
+import { browserPanelOpenMapAtom, browserPendingNavigationMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
 import { BrowserPanel } from '@/components/browser/BrowserPanel'
 
 export function MainArea(): React.ReactElement {
@@ -57,6 +57,7 @@ export function MainArea(): React.ReactElement {
   const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
   const [browserOpenMap, setBrowserOpenMap] = useAtom(browserPanelOpenMapAtom)
   const [browserStateMap, setBrowserStateMap] = useAtom(browserStateMapAtom)
+  const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
   const [splitRatio, setSplitRatio] = useAtom(previewSplitRatioAtom)
   const [rightWorkspaceRatio, setRightWorkspaceRatio] = useAtom(rightWorkspaceSplitRatioAtom)
   const previewDragging = React.useRef(false)
@@ -307,6 +308,7 @@ export function MainArea(): React.ReactElement {
                       onClose={() => {
                         setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(browserSessionId, false); return next })
                         setBrowserStateMap((previous) => { const next = new Map(previous); next.delete(browserSessionId); return next })
+                        setPendingNavigationMap((previous) => { const next = new Map(previous); next.delete(browserSessionId); return next })
                       }}
                     />
                   </div>


### PR DESCRIPTION
## Summary
- Open HTTP(S) links in Agent replies in the managed browser by default, reusing a blank tab or creating a new tab.
- Preserve first-use risk acknowledgement and navigate automatically after acknowledgement.
- Add a toolbar action to open the current page in the system default browser.
- Remove the redundant browser status line.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)