### PR TITLE
fix: keep skills list stable when toggling

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
+++ b/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
@@ -2,8 +2,9 @@
  * useAgentSkillsData — Agent 技能视图的数据层
  *
  * 封装当前工作区 Skills / MCP 的加载与增删改逻辑（IPC 调用），
- * 供「Agent 技能」全屏视图复用。所有写操作后会 bump
- * workspaceCapabilitiesVersionAtom，通知侧边栏等订阅方刷新。
+ * 供「Agent 技能」全屏视图复用。当前 Skills 页面挂载期间固定初始快照，
+ * 避免文件监听导致的重排和整页跳动；开关仅更新对应卡片的 enabled 字段。
+ * 离开后下次进入或切换工作区时再重新读取完整能力列表。
  */
 
 import * as React from 'react'
@@ -41,7 +42,6 @@ export function useAgentSkillsData(): AgentSkillsData {
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const bumpCapabilitiesVersion = useSetAtom(workspaceCapabilitiesVersionAtom)
-  const capabilitiesVersion = useAtomValue(workspaceCapabilitiesVersionAtom)
 
   const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
   const workspaceSlug = currentWorkspace?.slug ?? ''
@@ -85,22 +85,22 @@ export function useAgentSkillsData(): AgentSkillsData {
     }
   }, [workspaceSlug])
 
-  // workspaceSlug 或外部能力版本变化时重新拉取
+  // 只在进入页面或切换工作区时读取。文件监听会在切换开关后异步推送能力变化，
+  // 这里刻意不订阅 capabilitiesVersion，防止扫描 active/inactive 目录后重排当前列表。
   React.useEffect(() => {
     setLoading(true)
     void loadData()
-  }, [loadData, capabilitiesVersion])
+  }, [loadData])
 
   const toggleSkill = React.useCallback(async (slug: string, enabled: boolean) => {
     try {
       await window.electronAPI.toggleWorkspaceSkill(workspaceSlug, slug, enabled)
       setSkills((prev) => prev.map((s) => (s.slug === slug ? { ...s, enabled } : s)))
-      bumpCapabilitiesVersion((v) => v + 1)
     } catch (error) {
       console.error('[Agent 技能] 切换 Skill 状态失败:', error)
       toast.error('切换 Skill 状态失败')
     }
-  }, [workspaceSlug, bumpCapabilitiesVersion])
+  }, [workspaceSlug])
 
   const deleteSkill = React.useCallback(async (slug: string, name: string): Promise<boolean> => {
     try {


### PR DESCRIPTION
## Summary
- Keep the Skills list snapshot stable while its view remains open.
- Apply a toggle by updating only the matching Skill's enabled state.
- Defer capability rescan and ordering until the view is reopened or the workspace changes.

## Test plan
- `bun run typecheck`
- Manually toggle a Skill on and off: the current list should retain its order, group expansion, and scroll position without a loading refresh.
- Leave and reopen the Skills view: it should reload the latest Skill list and ordering.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
