### PR TITLE
fix: disable orphan data cleanup by default

### DIFF
--- a/apps/electron/src/main/lib/storage-service.ts
+++ b/apps/electron/src/main/lib/storage-service.ts
@@ -1,7 +1,8 @@
 /**
  * 存储管理服务
  *
- * 提供磁盘用量统计、孤儿数据检测和清理功能。
+ * 提供磁盘用量统计和临时文件清理功能。
+ * 孤儿数据清理因可能误伤用户工作资料而默认关闭。
  * 由设置面板"磁盘管理"Tab 和启动时自动清理逻辑调用。
  */
 
@@ -81,6 +82,9 @@ const SKIP_DIRS = new Set([
 // 单次扫描最大文件数上限，防止超大工作区导致无限递归
 const MAX_FILE_SCAN = 100_000
 const MAX_ORPHAN_ITEM_PREVIEW = 80
+
+// 孤儿目录无法可靠区分用户仍需保留的会话工作资料，默认不展示也不允许删除。
+const ORPHAN_DATA_CLEANUP_ENABLED = false
 
 const WORKSPACE_METADATA_DIRS = new Set([
   'workspace-files',
@@ -235,7 +239,7 @@ async function calcAgentSessionsCategory(): Promise<StorageCategory> {
           const id = basename(file, '.jsonl')
           bytes += stat.size
           count++
-          if (!activeIds.has(id)) {
+          if (ORPHAN_DATA_CLEANUP_ENABLED && !activeIds.has(id)) {
             orphanBytes += stat.size
             orphanCount++
             orphanItemsTruncated = addOrphanItem(orphanItems, {
@@ -337,7 +341,7 @@ async function calcWorkspacesCategory(): Promise<StorageCategory> {
               bytes += sub.bytes
               count += sub.count
               // session 目录的 ID 不在活跃列表中 → 孤儿
-              if (!activeIds.has(entry) && !activeSlugs.has(entry)) {
+              if (ORPHAN_DATA_CLEANUP_ENABLED && !activeIds.has(entry) && !activeSlugs.has(entry)) {
                 const cleanable = await getDirSize(entryPath, { skipTopLevelDirs: PRESERVED_ORPHAN_SESSION_ENTRIES })
                 if (cleanable.count > 0) {
                   orphanBytes += cleanable.bytes
@@ -548,6 +552,14 @@ function cleanupArchivedSessions(beforeDays: number): CleanupResult {
 }
 
 export async function cleanupStorage(options: CleanupOptions): Promise<CleanupResult> {
+  if (options.orphansOnly && !ORPHAN_DATA_CLEANUP_ENABLED) {
+    return {
+      freedBytes: 0,
+      deletedCount: 0,
+      errors: ['孤儿数据清理功能已默认关闭，未删除任何数据'],
+    }
+  }
+
   let totalFreed = 0, totalDeleted = 0
   const allErrors: string[] = []
 

--- a/apps/electron/src/renderer/components/settings/StorageSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/StorageSettings.tsx
@@ -1,11 +1,11 @@
 /**
  * StorageSettings — 磁盘管理设置面板
  *
- * 展示各数据类别的磁盘占用、孤儿数据检测、手动/自动清理。
+ * 展示各数据类别的磁盘占用，以及可安全自动清理的临时文件。
  */
 
 import * as React from 'react'
-import { HardDrive, Trash2, RefreshCw, AlertTriangle } from 'lucide-react'
+import { Trash2, RefreshCw } from 'lucide-react'
 import {
   SettingsSection,
   SettingsCard,
@@ -20,35 +20,13 @@ import {
   SelectValue,
 } from '../ui/select'
 import { Button } from '../ui/button'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '../ui/alert-dialog'
 import { cn } from '@/lib/utils'
-
-interface StorageOrphanItem {
-  kind: 'file' | 'directory'
-  path: string
-  bytes: number
-  count: number
-}
 
 interface StorageCategory {
   label: string
   key: string
   bytes: number
   count: number
-  hasOrphans: boolean
-  orphanBytes: number
-  orphanCount: number
-  orphanItems: StorageOrphanItem[]
-  orphanItemsTruncated: boolean
 }
 
 interface StorageStats {
@@ -61,12 +39,6 @@ interface CleanupResult {
   freedBytes: number
   deletedCount: number
   errors: string[]
-}
-
-interface PendingCleanup {
-  label: string
-  cleaningKey: string
-  categories: string[]
 }
 
 function formatBytes(bytes: number): string {
@@ -115,7 +87,6 @@ export function StorageSettings(): React.ReactElement {
   const [lastResult, setLastResult] = React.useState<CleanupResult | null>(null)
   const [autoCleanupTemp, setAutoCleanupTemp] = React.useState(true)
   const [autoCleanupDays, setAutoCleanupDays] = React.useState(0)
-  const [pendingCleanup, setPendingCleanup] = React.useState<PendingCleanup | null>(null)
 
   const loadStats = React.useCallback(async () => {
     setLoading(true)
@@ -137,24 +108,6 @@ export function StorageSettings(): React.ReactElement {
     }).catch(console.error)
   }, [loadStats])
 
-  const handleCleanOrphans = async (target: PendingCleanup): Promise<void> => {
-    setCleaningKey(target.cleaningKey)
-    setLastResult(null)
-    try {
-      const result = await window.electronAPI.cleanupStorage({
-        categories: target.categories,
-        orphansOnly: true,
-        archivedBeforeDays: 0,
-      }) as CleanupResult
-      setLastResult(result)
-      await loadStats()
-    } catch (e) {
-      console.error('[存储管理] 清理失败:', e)
-    } finally {
-      setCleaningKey(null)
-    }
-  }
-
   const handleCleanTemp = async (): Promise<void> => {
     setCleaningKey('temp-files')
     setLastResult(null)
@@ -167,22 +120,6 @@ export function StorageSettings(): React.ReactElement {
     } finally {
       setCleaningKey(null)
     }
-  }
-
-  const requestCleanCategory = (category: StorageCategory): void => {
-    setPendingCleanup({
-      label: category.label,
-      cleaningKey: category.key,
-      categories: [category.key],
-    })
-  }
-
-  const requestCleanAllOrphans = (): void => {
-    setPendingCleanup({
-      label: '全部孤儿数据',
-      cleaningKey: 'all-orphans',
-      categories: ['agent-sessions', 'sdk-config', 'workspaces'],
-    })
   }
 
   const handleAutoCleanupTempChange = async (enabled: boolean): Promise<void> => {
@@ -203,18 +140,6 @@ export function StorageSettings(): React.ReactElement {
       console.error('[存储管理] 更新自动清理天数失败:', e)
     }
   }
-
-  const totalOrphanBytes = stats?.categories.reduce((sum, c) => sum + c.orphanBytes, 0) ?? 0
-  const hasOrphans = totalOrphanBytes > 0
-  const pendingCategories = React.useMemo(() => {
-    if (!pendingCleanup || !stats) return []
-    const keys = new Set(pendingCleanup.categories)
-    return stats.categories.filter((category) => keys.has(category.key) && category.hasOrphans)
-  }, [pendingCleanup, stats])
-  const pendingOrphanItems = pendingCategories.flatMap((category) => category.orphanItems)
-  const pendingOrphanBytes = pendingCategories.reduce((sum, category) => sum + category.orphanBytes, 0)
-  const pendingOrphanCount = pendingCategories.reduce((sum, category) => sum + category.orphanCount, 0)
-  const pendingOrphanItemsTruncated = pendingCategories.some((category) => category.orphanItemsTruncated)
 
   return (
     <div className="space-y-6">
@@ -251,12 +176,6 @@ export function StorageSettings(): React.ReactElement {
                   <span className="text-sm text-muted-foreground tabular-nums">
                     {formatBytes(cat.bytes)}
                   </span>
-                  {cat.hasOrphans && (
-                    <span className="flex items-center gap-1 text-xs text-amber-500">
-                      <AlertTriangle size={12} />
-                      孤儿 {formatBytes(cat.orphanBytes)}
-                    </span>
-                  )}
                 </div>
                 {cat.key === 'temp-files' ? (
                   <Button
@@ -268,17 +187,6 @@ export function StorageSettings(): React.ReactElement {
                   >
                     <Trash2 size={12} />
                     {cleaningKey === 'temp-files' ? '清理中...' : '清理'}
-                  </Button>
-                ) : cat.hasOrphans ? (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => requestCleanCategory(cat)}
-                    disabled={cleaningKey !== null}
-                    className="h-7 gap-1 text-xs"
-                  >
-                    <Trash2 size={12} />
-                    {cleaningKey === cat.key ? '清理中...' : '清理孤儿'}
                   </Button>
                 ) : null}
               </div>
@@ -315,38 +223,6 @@ export function StorageSettings(): React.ReactElement {
         </SettingsCard>
       </SettingsSection>
 
-      {/* 深度清理 */}
-      <SettingsSection
-        title="深度清理"
-        description="检测并清理已删除会话遗留的孤儿数据"
-      >
-        <SettingsCard>
-          <SettingsRow
-            label="孤儿数据"
-            description="删除会话后残留的消息文件、SDK 缓存和工作目录"
-          >
-            <div className="flex items-center gap-3">
-              {hasOrphans && (
-                <span className="flex items-center gap-1 text-sm text-amber-500">
-                  <AlertTriangle size={14} />
-                  {formatBytes(totalOrphanBytes)}
-                </span>
-              )}
-              <Button
-                variant={hasOrphans ? 'default' : 'ghost'}
-                size="sm"
-                onClick={requestCleanAllOrphans}
-                disabled={cleaningKey !== null || !hasOrphans}
-                className="gap-1.5"
-              >
-                <HardDrive size={14} />
-                {cleaningKey === 'all-orphans' ? '清理中...' : hasOrphans ? '一键清理' : '无孤儿数据'}
-              </Button>
-            </div>
-          </SettingsRow>
-        </SettingsCard>
-      </SettingsSection>
-
       {/* 操作结果提示 */}
       {lastResult && (
         <div className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm">
@@ -364,55 +240,6 @@ export function StorageSettings(): React.ReactElement {
           )}
         </div>
       )}
-
-      <AlertDialog
-        open={pendingCleanup !== null}
-        onOpenChange={(open) => { if (!open) setPendingCleanup(null) }}
-      >
-        <AlertDialogContent className="max-w-2xl">
-          <AlertDialogHeader>
-            <AlertDialogTitle>确认清理{pendingCleanup?.label}？</AlertDialogTitle>
-            <AlertDialogDescription>
-              将删除 {pendingOrphanCount} 项孤儿数据，预计释放 {formatBytes(pendingOrphanBytes)}。请确认下面的路径都不再需要。
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <div className="max-h-72 overflow-auto rounded-md bg-muted/50 p-2">
-            {pendingOrphanItems.length > 0 ? (
-              <div className="space-y-1">
-                {pendingOrphanItems.map((item) => (
-                  <div key={`${item.kind}:${item.path}`} className="flex items-start justify-between gap-3 rounded-sm px-2 py-1.5 text-xs">
-                    <div className="min-w-0">
-                      <div className="break-all font-mono text-foreground">{item.path}</div>
-                      <div className="mt-0.5 text-muted-foreground">
-                        {item.kind === 'directory' ? '目录' : '文件'} · {item.count} 个文件
-                      </div>
-                    </div>
-                    <span className="shrink-0 tabular-nums text-muted-foreground">{formatBytes(item.bytes)}</span>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="px-2 py-6 text-center text-sm text-muted-foreground">没有可展示的孤儿路径</div>
-            )}
-          </div>
-          {pendingOrphanItemsTruncated && (
-            <div className="text-xs text-amber-500">列表较长，仅展示前 80 项；确认后会清理当前分类下全部孤儿数据。</div>
-          )}
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setPendingCleanup(null)}>取消</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/92"
-              onClick={() => {
-                const target = pendingCleanup
-                setPendingCleanup(null)
-                if (target) void handleCleanOrphans(target)
-              }}
-            >
-              确认清理
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 移除设置页中的「深度清理」和各分类的「清理孤儿」入口。
- 主进程拒绝所有 `orphansOnly` 清理请求，阻止旧界面或其他调用路径绕过 UI 删除用户资料。
- 保留临时文件清理及用户主动启用的已归档会话清理。

## Validation
- `bun run typecheck`
- `bun run build:main`
- `bun run build:preload`
- `bun run build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
