### PR TITLE
fix(agent): 对齐 Skill 调用 chip 高度【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/TurnSkillUsageSummary.tsx
+++ b/apps/electron/src/renderer/components/agent/TurnSkillUsageSummary.tsx
@@ -38,12 +38,12 @@ function SkillUsageChip({ activation }: { activation: SkillActivation }): React.
     }, { mode: 'split' })
   }, [activation.filePath, activation.workspaceSkillPath, activation.workspaceSlug, openPreview, sessionId])
   const chipClassName = cn(
-    'inline-flex max-w-[240px] items-center gap-1.5 rounded-md px-2.5 py-1',
-    'bg-[hsl(270_60%_60%/0.15)] text-[12px] font-medium text-[hsl(270_60%_50%)]',
+    'inline-flex max-w-[240px] items-center gap-[0.25em] rounded-md px-[0.35em] py-[0.15em] text-[0.875em] font-medium leading-none',
+    'bg-[hsl(270_60%_60%/0.15)] text-[hsl(270_60%_50%)]',
     canPreview && 'cursor-pointer transition-colors hover:bg-[hsl(270_60%_60%/0.24)]',
   )
   const chipContent = <>
-    <Sparkles className="size-3.5 shrink-0" />
+    <Sparkles className="size-3 shrink-0" />
     <span className="truncate">{activation.name}</span>
   </>
 


### PR DESCRIPTION
## 概述
调整 Agent 每轮结束后展示的 Skill 调用 chip，使其与下方文件 chip 使用一致的紧凑高度。此次改动只涉及渲染样式，不改变 Skill 记录、预览、IPC 或持久化逻辑。

## 改动
- `apps/electron/src/renderer/components/agent/TurnSkillUsageSummary.tsx` — 将 Skill chip 的内边距、字号和行高对齐文件 chip 的 `0.875em + 0.15em + leading-none` 尺寸规则。
- `apps/electron/src/renderer/components/agent/TurnSkillUsageSummary.tsx` — 将 Sparkles 图标从 14px 调整为 12px，使图标高度与文件 chip 图标一致。

## 测试方法
1. 运行 `bun run typecheck`，所有 6 个 package 通过。
2. 在 `apps/cli` 目录运行 `bun test`，12 项测试全部通过。
3. 运行 `git diff --check`，检查通过。
4. 完成 Windows 兼容性扫描，未发现新增路径、Shell、平台分支或打包问题。

## 备注
- 修改前的测试用单行注释已撤回。
- 当前改动经过 Proma Agent 独立审查，未发现 blocker 或 Warning。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)