### PR TITLE
Fix renderer input focus stealing and draft lag

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -584,7 +584,7 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
   )
 }
 
-export function AgentMessages({
+export const AgentMessages = React.memo(function AgentMessages({
   sessionId,
   sessionModelId,
   messagesLoaded,
@@ -1000,4 +1000,4 @@ export function AgentMessages({
     </div>
     </BasePathsProvider>
   )
-}
+})

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -601,6 +601,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setTodoGroupId('__none__')
     setTodoDialogOpen(true)
   }, [])
+  const handleOpenRestoreProjectRootDialog = React.useCallback(() => {
+    setRestoreProjectRootDialogOpen(true)
+  }, [])
 
   const handleCreateReplyTodo = React.useCallback(async (): Promise<void> => {
     setCreatingTodo(true)
@@ -2956,7 +2959,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onRetry={handleRetry}
           onRetryInNewSession={handleRetryInNewSession}
           onRelinkProjectRoot={handleRelinkProjectRoot}
-          onRestoreProjectRoot={() => setRestoreProjectRootDialogOpen(true)}
+          onRestoreProjectRoot={handleOpenRestoreProjectRootDialog}
           onFork={isLegacyTranscript ? undefined : handleFork}
           onRewind={isLegacyTranscript ? undefined : handleRewindRequest}
           onCreateTodo={handleOpenReplyTodoDialog}

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -221,8 +221,8 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   const [isManuallyCollapsed, setIsManuallyCollapsed] = useState(false)
   // 跟踪 isExpanded 最新值（对比后再 setState，避免每键无谓 setState 触发重渲染）
   const isExpandedRef = useRef(false)
-  // 行数检查的 rAF 调度句柄（用 rAF 节流，一帧最多检查一次）
-  const lineCheckHandleRef = useRef<number | null>(null)
+  // 行数检查会遍历整篇 ProseMirror 文档；在输入停顿后再计算，避免长草稿每帧重复扫描。
+  const lineCheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // 草稿序列化与上层状态同步同样合并到每帧一次；TipTap 自己仍在输入事件内即时更新 DOM。
   const draftSyncHandleRef = useRef<number | null>(null)
   // 跟踪编辑器自己设置的值，用于区分外部设置和内部更新
@@ -383,17 +383,17 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
     onChange(markdown)
     onHtmlChangeRef.current?.(html)
 
-    if (lineCheckHandleRef.current !== null) {
-      cancelAnimationFrame(lineCheckHandleRef.current)
+    if (lineCheckTimerRef.current !== null) {
+      clearTimeout(lineCheckTimerRef.current)
     }
-    lineCheckHandleRef.current = requestAnimationFrame(() => {
-      lineCheckHandleRef.current = null
+    lineCheckTimerRef.current = setTimeout(() => {
+      lineCheckTimerRef.current = null
       const nextExpanded = countEditorLines(ed) > 5
       if (nextExpanded !== isExpandedRef.current) {
         isExpandedRef.current = nextExpanded
         setIsExpanded(nextExpanded)
       }
-    })
+    }, 150)
     return markdown
   }, [onChange, richTextEnabled])
 
@@ -825,9 +825,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   // 卸载时取消未触发的 rAF 行数检查，避免泄漏 / 在卸载组件上 setState
   useEffect(() => {
     return () => {
-      if (lineCheckHandleRef.current !== null) {
-        cancelAnimationFrame(lineCheckHandleRef.current)
-        lineCheckHandleRef.current = null
+      if (lineCheckTimerRef.current !== null) {
+        clearTimeout(lineCheckTimerRef.current)
+        lineCheckTimerRef.current = null
       }
       if (draftSyncHandleRef.current !== null) {
         cancelAnimationFrame(draftSyncHandleRef.current)
@@ -917,14 +917,23 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
     }
   }, [editor, placeholder])
 
-  // 自动聚焦：组件挂载时 + autoFocusTrigger 变化时
+  // 自动聚焦仅属于「切换到另一会话」：同一输入框因 loading/streaming 等状态重建 editor
+  // 时，不应在 100ms 后把用户刚移走的焦点抢回来。
+  const lastAutoFocusTriggerRef = useRef<string | null | undefined>(undefined)
   useEffect(() => {
-    if (editor && !disabled) {
-      const timer = setTimeout(() => {
-        editor.commands.focus()
-      }, 100)
-      return () => clearTimeout(timer)
-    }
+    if (!editor || disabled) return
+
+    const triggerChanged = lastAutoFocusTriggerRef.current !== autoFocusTrigger
+    lastAutoFocusTriggerRef.current = autoFocusTrigger
+    if (!triggerChanged) return
+
+    const timer = setTimeout(() => {
+      // 延迟期间用户可能已点击另一个控件；只在页面尚未有可编辑目标时自动聚焦。
+      const activeElement = document.activeElement as HTMLElement | null
+      const activeEditable = activeElement?.matches('input, textarea, [contenteditable="true"]')
+      if (!activeEditable) editor.commands.focus()
+    }, 100)
+    return () => clearTimeout(timer)
   }, [editor, disabled, autoFocusTrigger])
 
   // 对外暴露命令接口：右侧文件面板拖入时，在光标处插入 @file 引用 mention。

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1478,6 +1478,11 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setCurrentWorkspaceId,
   ])
 
+  const handleConfigureProject = React.useCallback((workspaceId: string): void => {
+    handleSelectProject(workspaceId)
+    handleOpenMcpManagement()
+  }, [handleOpenMcpManagement, handleSelectProject])
+
   /** 展开某个项目时每次额外显示的会话数量 */
   const handleShowMoreSessions = React.useCallback((workspaceId: string): void => {
     setExpandedExtraCountMap((prev) => {
@@ -3190,10 +3195,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                     onDragLeave={handleProjectDragLeave}
                     onDrop={handleProjectDrop}
                     onDragEnd={handleProjectDragEnd}
-                    onConfigureProject={isAuto ? noopVoid : (workspaceId) => {
-                      handleSelectProject(workspaceId)
-                      handleOpenMcpManagement()
-                    }}
+                    onConfigureProject={isAuto ? noopVoid : handleConfigureProject}
                     onRenameWorkspace={isAuto ? noopAsync : handleWorkspaceRename}
                     onRelinkProjectRoot={isAuto ? noopAsync : handleRelinkProjectRoot}
                     onRequestRestoreProjectRoot={isAuto ? noopVoid : setPendingRestoreProjectRootId}

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -192,8 +192,12 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
       pendingContentRef.current = pendingContentEditorRef.current.getHTML()
     }
     const nextContent = pendingContentRef.current
-    if (contentRef.current !== nextContent) setContent(nextContent)
-  }, [setContent])
+    if (contentRef.current !== nextContent) {
+      // beforeunload 的同步落盘紧接着读取 atom；直接写入 Jotai store，避免等待 React state flush。
+      contentRef.current = nextContent
+      store.set(scratchPadContentAtom, nextContent)
+    }
+  }, [store])
 
   const scheduleContentSync = React.useCallback((editor: NonNullable<ReturnType<typeof useEditor>>): void => {
     pendingContentEditorRef.current = editor
@@ -207,9 +211,15 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
     })
   }, [setContent])
 
-  React.useEffect(() => () => {
-    // 卸载时不能丢弃最后一笔输入（例如快速切出 Scratch Pad）。
-    flushContentSync()
+  React.useEffect(() => {
+    // Electron 的 beforeunload 会先由全局持久化器同步读取 atom；用 capture 阶段先 flush
+    // 当前 TipTap 文档，避免 rAF 尚未执行就退出时丢最后一笔输入。
+    window.addEventListener('beforeunload', flushContentSync, { capture: true })
+    return () => {
+      window.removeEventListener('beforeunload', flushContentSync, { capture: true })
+      // 卸载时不能丢弃最后一笔输入（例如快速切出 Scratch Pad）。
+      flushContentSync()
+    }
   }, [flushContentSync])
 
   const persistScrollPosition = React.useCallback((element?: HTMLElement | null): void => {

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -176,6 +176,41 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
   // 用 ref 追踪最新内容，避免在 useEffect deps 里包含 content 导致循环
   const contentRef = React.useRef(content)
   contentRef.current = content
+  // TipTap 的 transaction 可以比屏幕刷新更密集；只在下一帧向全局 atom 发布一次
+  // 完整 HTML，避免每键驱动整个 Scratch Pad 容器及持久化监听器更新。
+  const pendingContentRef = React.useRef(content)
+  const pendingContentEditorRef = React.useRef<NonNullable<ReturnType<typeof useEditor>> | null>(null)
+  const contentSyncFrameRef = React.useRef<number | null>(null)
+
+  const flushContentSync = React.useCallback((): void => {
+    if (contentSyncFrameRef.current !== null) {
+      cancelAnimationFrame(contentSyncFrameRef.current)
+      contentSyncFrameRef.current = null
+    }
+    // 连续输入期间不在每个 transaction 中序列化完整文档；离开页面时再强制拿最新值。
+    if (pendingContentEditorRef.current) {
+      pendingContentRef.current = pendingContentEditorRef.current.getHTML()
+    }
+    const nextContent = pendingContentRef.current
+    if (contentRef.current !== nextContent) setContent(nextContent)
+  }, [setContent])
+
+  const scheduleContentSync = React.useCallback((editor: NonNullable<ReturnType<typeof useEditor>>): void => {
+    pendingContentEditorRef.current = editor
+    if (contentSyncFrameRef.current !== null) return
+    contentSyncFrameRef.current = requestAnimationFrame(() => {
+      contentSyncFrameRef.current = null
+      const pendingEditor = pendingContentEditorRef.current
+      if (pendingEditor) pendingContentRef.current = pendingEditor.getHTML()
+      const nextContent = pendingContentRef.current
+      if (contentRef.current !== nextContent) setContent(nextContent)
+    })
+  }, [setContent])
+
+  React.useEffect(() => () => {
+    // 卸载时不能丢弃最后一笔输入（例如快速切出 Scratch Pad）。
+    flushContentSync()
+  }, [flushContentSync])
 
   const persistScrollPosition = React.useCallback((element?: HTMLElement | null): void => {
     const scrollContainer = element ?? scrollContainerRef.current
@@ -292,7 +327,7 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
       },
     },
     onUpdate: ({ editor }) => {
-      setContent(editor.getHTML())
+      scheduleContentSync(editor)
     },
     immediatelyRender: false,
   })


### PR DESCRIPTION
## Summary
- prevent same-session RichTextInput remounts from reclaiming user focus
- memoize Agent history rendering and stabilize sidebar callbacks
- coalesce Scratch Pad draft serialization and debounce input line counting

## Validation
- `bun run typecheck`
- `bun test ./apps/electron/src/renderer/lib/markdown-rich-text.test.ts`
- `bun run --filter='@proma/electron' build:renderer`
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)