### PR TITLE
fix: expanded agent island has no collapse/dismiss affordance in idle mode

### DIFF
--- a/apps/electron/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/electron/native/agent-island/macos-agent-island-helper.swift
@@ -534,6 +534,20 @@ struct ExpandedIslandView: View {
                 .font(.system(size: 15.5, weight: .bold)).foregroundStyle(.white.opacity(0.98))
             }
             Spacer()
+            // 显式的收起按钮：顶部空白手势太隐蔽，用户会以为展开态无法关闭。
+            Button(action: { action("set-expanded", ["expanded": false]) }) {
+              Image(systemName: "chevron.up")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.6))
+                .frame(width: 26, height: 26)
+            }.buttonStyle(IslandButtonStyle())
+            // 完全关闭（dismiss）：岛整体隐藏，直到出现新的 Agent 状态 / 计划提醒。
+            Button(action: { action("dismiss", [:]) }) {
+              Image(systemName: "xmark")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.6))
+                .frame(width: 26, height: 26)
+            }.buttonStyle(IslandButtonStyle())
             Button(action: { action("open-main", [:]) }) {
               HStack(spacing: 5) {
                 Text("打开 Proma")
@@ -550,8 +564,29 @@ struct ExpandedIslandView: View {
       } else {
         // The compact notch is a real physical exclusion zone. Keep planning
         // content below it and use that otherwise-empty band for Plan usage.
-        PlanQuotaCarousel(quotas: snapshot.planQuotas)
-          .frame(height: snapshot.planQuotas.isEmpty ? 56 : 108)
+        ZStack(alignment: .topTrailing) {
+          PlanQuotaCarousel(quotas: snapshot.planQuotas)
+            .frame(height: snapshot.planQuotas.isEmpty ? 56 : 108)
+          // 无 Agent 会话时（查余额 / 纯提醒），此前没有任何收起入口：
+          // 展开后无法关闭，一直占据视野。这里提供收起（折叠为 pill）
+          // 与关闭（dismiss，完全隐藏直到有新状态）两个按钮。
+          HStack(spacing: 6) {
+            Button(action: { action("set-expanded", ["expanded": false]) }) {
+              Image(systemName: "chevron.up")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.6))
+                .frame(width: 24, height: 24)
+            }.buttonStyle(IslandButtonStyle())
+            Button(action: { action("dismiss", [:]) }) {
+              Image(systemName: "xmark")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.6))
+                .frame(width: 24, height: 24)
+            }.buttonStyle(IslandButtonStyle())
+          }
+          .padding(.trailing, 10)
+          .padding(.top, 10)
+        }
       }
 
       if !displayedSessions.isEmpty {


### PR DESCRIPTION
## Summary

Follow-up to #1520 (already merged). The expanded Agent Island had **no collapse or dismiss affordance in idle dashboard mode** (no running Agent session) — e.g. the plan-quota / balance surface shown at the notch. The header (with the top-area collapse gesture and buttons) only rendered while Agent sessions existed, so with nothing running, expanding the island left the user unable to close it: it stayed on screen, blocking the view.

### Changes (Swift helper)

- Idle/planning content (no sessions): added **collapse** (chevron.up) and **dismiss** (xmark) buttons at the top-trailing corner.
  - collapse → folds back to the compact pill;
  - dismiss → hides the island entirely until a new Agent status / planning reminder appears (the main-process `dismiss` intent already existed and was fixed in #1520; the Swift side just never sent it).
- Session header (sessions exist): added an explicit collapse button next to the existing top-area tap gesture, plus a dismiss button for parity.

Validated with `swiftc -parse`. No TS changes needed — the main process already handles the `dismiss` intent.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
