### PR TITLE
fix(agent): remove queued message toast notification

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2078,12 +2078,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             }
           : undefined),
       ])
-      // 入队对用户是隐性的：不提示的话，用户会以为消息已发出但 Agent 没反应。
-      // 固定 toast id 避免多条排队消息反复弹出；提示里同时给出打断入口。
-      toast.info('消息已加入队列，将在当前执行结束后自动发送', {
-        id: 'agent-view-queued-message-hint',
-        description: '如需立即处理，点击队列消息右侧的「立即发送」可打断当前执行（会终止正在运行的命令）。',
-      })
+      // 入队后消息会出现在队列 UI 中，用户可见；不再弹 toast 打扰。
       if (overrideText === undefined || fromEditor) {
         setInputContent('')
         setInputHtmlContent('')


### PR DESCRIPTION
追加消息入队时不再弹 toast 提醒。消息本身已在聊天 UI 队列中可见，额外 toast 只是干扰。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)