### PR TITLE
fix(agent): 恢复 AgentMessages memo，修复输入卡顿与丢焦点

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -136,6 +136,9 @@ import type { AgentQueuedAttachment, AgentQueuedMessage, QueueDropPlacement } fr
 
 /** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
 const EMPTY_SDK_MESSAGES: SDKMessage[] = []
+/** 稳定的空 string 数组引用，供无附件时的 attachedDirs/attachedFiles 回退复用，
+ * 避免 ?? [] 每次渲染新建数组，破坏下游 useMemo 链与 AgentMessages 的 memo。 */
+const EMPTY_STRING_ARRAY: string[] = []
 const LONG_TEXT_ATTACHMENT_THRESHOLD = 2000
 
 function endOfToday(): number {
@@ -514,15 +517,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const openSession = useOpenSession()
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
-  const attachedDirs = attachedDirsMap.get(sessionId) ?? []
+  const attachedDirs = attachedDirsMap.get(sessionId) ?? EMPTY_STRING_ARRAY
   const setAttachedFilesMap = useSetAtom(agentAttachedFilesMapAtom)
   const attachedFilesMap = useAtomValue(agentAttachedFilesMapAtom)
-  const attachedFiles = attachedFilesMap.get(sessionId) ?? []
+  const attachedFiles = attachedFilesMap.get(sessionId) ?? EMPTY_STRING_ARRAY
   const wsAttachedDirsMap = useAtomValue(workspaceAttachedDirectoriesMapAtom)
-  const wsAttachedDirs = currentWorkspaceId ? (wsAttachedDirsMap.get(currentWorkspaceId) ?? []) : []
+  const wsAttachedDirs = currentWorkspaceId ? (wsAttachedDirsMap.get(currentWorkspaceId) ?? EMPTY_STRING_ARRAY) : EMPTY_STRING_ARRAY
   const setWsAttachedFilesMap = useSetAtom(workspaceAttachedFilesMapAtom)
   const wsAttachedFilesMap = useAtomValue(workspaceAttachedFilesMapAtom)
-  const wsAttachedFiles = currentWorkspaceId ? (wsAttachedFilesMap.get(currentWorkspaceId) ?? []) : []
+  const wsAttachedFiles = currentWorkspaceId ? (wsAttachedFilesMap.get(currentWorkspaceId) ?? EMPTY_STRING_ARRAY) : EMPTY_STRING_ARRAY
 
   // 按 sessionId 切片订阅 drafts/draftHtml：仅本 session 草稿变化才让 AgentView 重渲染。
   // 输入框每次按键都会写整 Map atom，若直接订阅整 Map，AgentView 跟着每键重渲染。


### PR DESCRIPTION
## 问题

Agent 输入框输入卡顿、历史消息区与左侧会话列表卡顿，并经常伴随输入框丢失焦点。#1579 修复（AgentMessages 加 `React.memo`、autoFocus 守卫、行数检查 debounce、草稿 rAF 批处理）已在 main，用户反馈「比之前好一些但仍存在」。

## 根因

`AgentMessages` 虽已 `React.memo`，但传入的 `attachedDirs={allAttachedDirs}` prop 每次按键都换新引用，导致 memo 失效：

- 无附件会话（常见场景）下，`attachedDirs` / `attachedFiles` / `wsAttachedDirs` / `wsAttachedFiles` 用 `?? []` 回退，每次渲染新建空数组。
- 这些数组是 `allAttachedDirs`（及 `workspaceDirs`、mention paths 等）`useMemo` 的依赖 → `allAttachedDirs` 每次渲染得到新引用。
- 每敲一个字 → 草稿 atom 变化 → `AgentView` 重渲染 → `allAttachedDirs` 新引用 → `AgentMessages` memo 被击穿 → **整段消息历史每键重渲染**。

主线程被整段 transcript 重渲染占满：输入框卡顿、历史区卡顿、左侧列表交互卡顿（主线程竞争），并因同步重渲染 jank 间歇性丢焦点。

## 修复

复用已有的 `EMPTY_SDK_MESSAGES` 稳定引用模式，新增 `EMPTY_STRING_ARRAY`，作为四处空数组的稳定回退。无附件时引用保持稳定 → 下游 `useMemo` 链不再无谓重算 → `AgentMessages` memo 恢复生效 → transcript 不再随按键重渲染。

## 影响面

- 仅改 `AgentView.tsx` 顶部常量 + 4 行回退赋值，类型完全一致（`string[]`）。
- 有附件时行为不变（`map.get` 命中原引用）。

## 测试

- [x] `bun run --filter='@proma/electron' typecheck` 通过
- [ ] 本地在长历史会话中连续输入，确认输入/历史区/侧边栏不再卡顿、焦点不丢

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)