### PR TITLE
fix(voice): 麦克风就绪后才进入听写【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.17",
+  "version": "0.17.18",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/voice-dictation-window.ts
+++ b/apps/electron/src/main/lib/voice-dictation-window.ts
@@ -23,7 +23,7 @@ const INDICATOR_BOTTOM_MARGIN = 28
 
 let voiceDictationActive = false
 let usesExternalIndicator = false
-let indicatorState: 'recording' | 'stopping' = 'recording'
+let indicatorState: 'preparing' | 'recording' | 'stopping' = 'preparing'
 let indicatorVolume = 0
 let indicatorTranscript = ''
 let activeOutputContextId: string | null = null
@@ -68,7 +68,7 @@ export function toggleVoiceDictationWindow(options: VoiceDictationToggleOptions 
   activeOutputContextId = outputContextId
   voiceDictationActive = true
   usesExternalIndicator = !targetIsProma
-  indicatorState = 'recording'
+  indicatorState = 'preparing'
   indicatorVolume = 0
   indicatorTranscript = ''
   if (usesExternalIndicator) showVoiceIndicator()
@@ -111,7 +111,8 @@ export function destroyVoiceDictationWindow(): void {
 
 /** 仅接收主窗口的采集结果，转发给外部应用的无焦点状态条。 */
 export function updateVoiceDictationIndicatorVolume(volume: number): void {
-  if (!usesExternalIndicator || indicatorState !== 'recording') return
+  if (!usesExternalIndicator || indicatorState === 'stopping') return
+  indicatorState = 'recording'
   indicatorVolume = Math.max(0, Math.min(1, Number.isFinite(volume) ? volume : 0))
   sendIndicatorState()
 }

--- a/apps/electron/src/renderer/components/ai-elements/speech-button.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/speech-button.tsx
@@ -47,8 +47,9 @@ export function SpeechButton({
 }: SpeechButtonProps): React.ReactElement {
   const [voiceStatus, setVoiceStatus] = useState<InlineVoiceStatus>(IDLE_VOICE_STATUS)
   const isRecording = voiceStatus.status === 'recording'
-  const isStopping = voiceStatus.status === 'connecting' || voiceStatus.status === 'stopping'
-  const isActive = isRecording || isStopping
+  const isPreparing = voiceStatus.status === 'connecting'
+  const isStopping = voiceStatus.status === 'stopping'
+  const isActive = isPreparing || isRecording || isStopping
 
   useEffect(() => {
     const handleStatus = (event: Event): void => {
@@ -106,7 +107,7 @@ export function SpeechButton({
             disabled={disabled}
             aria-label={isActive ? '停止语音输入' : '开始语音输入'}
           >
-            {isStopping ? (
+            {isPreparing || isStopping ? (
               <Loader2 className="size-4 animate-spin" />
             ) : isRecording ? (
               <span className="flex h-4 items-center gap-[2px]" aria-hidden="true">
@@ -124,7 +125,7 @@ export function SpeechButton({
           </Button>
           {isActive && (
             <span className="max-w-20 truncate text-xs text-primary" role="status">
-              {isStopping ? '收尾中' : '正在听写'}
+              {isPreparing ? '准备麦克风' : isStopping ? '收尾中' : '正在听写'}
             </span>
           )}
         </span>

--- a/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
+++ b/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
@@ -51,6 +51,7 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
   const previewTextRef = React.useRef('')
   const dictationIdRef = React.useRef<string | null>(null)
   const recordingAttemptRef = React.useRef(0)
+  const audioCaptureReadyRef = React.useRef(false)
   const lastReportedVolumeAtRef = React.useRef(0)
   /** 本次听写会话归属的输入框 ID，仅用于同步内嵌按钮状态。 */
   const dictationSourceRef = React.useRef<string | null>(null)
@@ -131,6 +132,7 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
       pendingAudioRef.current = []
       queuedAudioRef.current = []
       asrReadyRef.current = false
+      audioCaptureReadyRef.current = false
     }
     setVolume(0)
   }, [])
@@ -378,6 +380,11 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
 
     processor.onaudioprocess = (event) => {
       if (!sessionIdRef.current || stoppingRef.current) return
+      if (!audioCaptureReadyRef.current) {
+        audioCaptureReadyRef.current = true
+        setStatus('recording')
+        setMessage('正在听写')
+      }
       const input = event.inputBuffer.getChannelData(0)
       let peak = 0
       for (let i = 0; i < input.length; i += 1) {
@@ -438,6 +445,7 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
       commitTimerRef.current = null
     }
     asrReadyRef.current = false
+    audioCaptureReadyRef.current = false
     lastReportedVolumeAtRef.current = 0
     queuedAudioRef.current = []
     pendingAudioRef.current = []
@@ -450,8 +458,8 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
       currentSessionId: '',
     }
     setCommitResult(null)
-    setStatus('recording')
-    setMessage('请开始说话')
+    setStatus('connecting')
+    setMessage('准备麦克风...')
     const recordingAttempt = ++recordingAttemptRef.current
 
     const isCurrentAttempt = (): boolean => recordingAttempt === recordingAttemptRef.current
@@ -516,8 +524,6 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
           scheduleCommit(STOP_COMMIT_TIMEOUT_MS)
           return
         }
-        setStatus('recording')
-        setMessage('正在听写')
       })
       .catch((error) => {
         if (!isCurrentAttempt() || sessionIdRef.current !== nextSessionId || stoppingRef.current) return
@@ -583,8 +589,11 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
     const cleanupState = window.electronAPI.onVoiceDictationState((event: VoiceDictationStateEvent) => {
       if (event.sessionId && event.sessionId !== sessionIdRef.current) return
       if (stoppingRef.current && event.status === 'error') return
-      if (event.status === 'connecting') {
-        setStatus('recording')
+      if (event.status === 'connecting' || event.status === 'recording') {
+        if (!audioCaptureReadyRef.current) {
+          setStatus('connecting')
+          setMessage('准备麦克风...')
+        }
         return
       }
       if (event.status === 'idle' && event.message === 'asr_session_ended') {
@@ -737,7 +746,11 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
               <div className="whitespace-pre-wrap break-words overflow-hidden">
                 {transcript || (
                   <span className="text-muted-foreground/60">
-                    {status === 'idle' ? '等待 Ctrl+～ 唤起' : '请开始说话'}
+                    {status === 'idle'
+                      ? '等待 Ctrl+～ 唤起'
+                      : status === 'connecting'
+                        ? '准备麦克风...'
+                        : '请开始说话'}
                   </span>
                 )}
               </div>

--- a/apps/electron/src/renderer/components/voice-dictation/VoiceDictationIndicatorApp.tsx
+++ b/apps/electron/src/renderer/components/voice-dictation/VoiceDictationIndicatorApp.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { Loader2, Mic } from 'lucide-react'
 
 export function VoiceDictationIndicatorApp(): React.ReactElement {
-  const [state, setState] = React.useState<'recording' | 'stopping'>('recording')
+  const [state, setState] = React.useState<'preparing' | 'recording' | 'stopping'>('preparing')
   const [volume, setVolume] = React.useState(0)
   const [transcript, setTranscript] = React.useState('')
   const [typedTranscript, setTypedTranscript] = React.useState('')
@@ -31,6 +31,7 @@ export function VoiceDictationIndicatorApp(): React.ReactElement {
     return () => window.clearTimeout(timer)
   }, [transcript, typedTranscript])
 
+  const preparing = state === 'preparing'
   const stopping = state === 'stopping'
   const lines = getRecentTranscriptLines(typedTranscript)
 
@@ -38,7 +39,7 @@ export function VoiceDictationIndicatorApp(): React.ReactElement {
     <div className="flex h-screen w-screen flex-col overflow-hidden rounded-lg border border-border/70 bg-background/95 px-4 py-2.5 text-foreground shadow-lg backdrop-blur">
       <div className="flex shrink-0 items-center justify-center gap-2 text-xs font-medium">
         <span className="flex size-5 items-center justify-center text-primary" aria-hidden="true">
-          {stopping ? (
+          {preparing || stopping ? (
             <Loader2 className="size-4 animate-spin" />
           ) : (
             <span className="flex h-4 items-center gap-[2px]">
@@ -55,7 +56,7 @@ export function VoiceDictationIndicatorApp(): React.ReactElement {
             </span>
           )}
         </span>
-        <span>{stopping ? '正在整理语音' : '正在听写'}</span>
+        <span>{preparing ? '准备麦克风' : stopping ? '正在整理语音' : '正在听写'}</span>
         <Mic className="size-3.5 text-muted-foreground" aria-hidden="true" />
       </div>
 
@@ -73,7 +74,7 @@ export function VoiceDictationIndicatorApp(): React.ReactElement {
             ))}
           </div>
         ) : (
-          <p className="text-muted-foreground/60">请开始说话</p>
+          <p className="text-muted-foreground/60">{preparing ? '准备麦克风...' : '请开始说话'}</p>
         )}
       </div>
     </div>

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -115,7 +115,7 @@ export interface VoiceDictationShownEvent {
 
 /** 外部应用听写状态条的实时显示数据。 */
 export interface VoiceDictationIndicatorEvent {
-  state: 'recording' | 'stopping'
+  state: 'preparing' | 'recording' | 'stopping'
   /** 已归一化、平滑处理后的麦克风音量（0~1）。 */
   volume: number
   /** 尚未提交给第三方应用的实时转写文本。 */


### PR DESCRIPTION
## 概述

修复语音听写点击后立即显示“正在听写”，但麦克风尚未开始采样的问题。现在在设置、权限、音频上下文初始化期间明确显示“准备麦克风”，仅在收到首个真实音频帧后进入“正在听写”，避免用户被过早提示误导。

## 改动

- `apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx` — 新增采集就绪标记；初始化阶段保持 `connecting` 和“准备麦克风”，在首个 `onaudioprocess` 回调后才切换为 `recording`。同时拦截 ASR 先完成握手时发出的 `recording` 状态，避免覆盖实际麦克风就绪状态。
- `apps/electron/src/renderer/components/ai-elements/speech-button.tsx` — 输入框听写按钮区分“准备麦克风”“正在听写”“收尾中”三种反馈。
- `apps/electron/src/main/lib/voice-dictation-window.ts` — 外部应用的状态条从 `preparing` 开始，收到首个音量回调后再进入 `recording`。
- `apps/electron/src/renderer/components/voice-dictation/VoiceDictationIndicatorApp.tsx` — 渲染外部状态条的准备态和相应提示文案。
- `apps/electron/src/types/settings.ts` — 扩展外部状态条事件类型，加入 `preparing`。
- `apps/electron/package.json` — `@proma/electron` 版本递增至 `0.17.18`。

## 测试方法

1. 执行 `bun run typecheck`，确认所有 workspace package 的 TypeScript 检查通过。
2. 执行 `bun test apps/electron/src/renderer/components/voice-dictation/voice-transcript-merge.test.ts`，3 个既有语音转写测试全部通过。
3. 执行 `bun run build:main`、`bun run build:preload` 和 `bun run build:renderer`，主进程、preload 与渲染进程均构建成功。
4. 在桌面端点击输入框听写按钮：初始化期间应显示“准备麦克风”，收到首个音频帧后才显示“正在听写”和音量波形。

## 备注

- 该改动不改变 ASR 音频缓存或转写协议，只校正 UI 就绪状态与真实采样时刻的一致性。
- 已审核未提交 diff：6 个文件，+36/-20；未发现 Windows 路径、Shell、平台分支或打包兼容性风险。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)