### PR TITLE
fix(browser): 修复关闭标签后的状态异常【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -207,6 +207,10 @@ export class BrowserController {
 
   private emit(browserSession: BrowserSessionRecord): void {
     if (!this.owner || this.owner.isDestroyed()) return
+    // WebContents 的关闭/导航事件可能晚于 disposeTab 到达；已移除的 session
+    // 不再发布状态，避免把正常的生命周期竞态升级为主进程未捕获异常。
+    if (this.sessions.get(browserSession.sessionId) !== browserSession) return
+    if (browserSession.tabs.size === 0 || !browserSession.tabs.has(browserSession.activeTabId)) return
     this.owner.webContents.send(AGENT_IPC_CHANNELS.BROWSER_STATE_CHANGED, this.buildState(browserSession))
   }
 
@@ -291,16 +295,20 @@ export class BrowserController {
   }
 
   private updateNavigationState(browserSession: BrowserSessionRecord, tab: BrowserTabRecord): void {
+    // Navigation callbacks can arrive after the tab was closed or its session removed.
+    if (this.sessions.get(browserSession.sessionId) !== browserSession) return
+    if (browserSession.tabs.get(tab.tabId) !== tab || tab.view.webContents.isDestroyed()) return
+
     const contents = tab.view.webContents
-    tab.state.url = contents.getURL()
-    tab.state.title = contents.getTitle() || '未命名页面'
-    tab.state.loading = contents.isLoading()
     try {
+      tab.state.url = contents.getURL()
+      tab.state.title = contents.getTitle() || '未命名页面'
+      tab.state.loading = contents.isLoading()
       tab.state.canGoBack = contents.canGoBack()
       tab.state.canGoForward = contents.canGoForward()
     } catch {
-      tab.state.canGoBack = false
-      tab.state.canGoForward = false
+      // The WebContents may be destroyed between the lifecycle check and the read.
+      return
     }
     this.emit(browserSession)
   }


### PR DESCRIPTION
## 概述
修复受管浏览器关闭最后一个标签页后，迟到的 WebContents 导航事件仍尝试发布浏览器状态，进而导致主进程抛出“受管浏览器没有有效标签”错误弹窗的问题。

## 改动
- `apps/electron/src/main/lib/browser-controller.ts` — 在状态发布前确认 session 仍由 controller 管理，且 active tab 仍有效；已移除 session 或空标签状态不再进入 `buildState()`。
- `apps/electron/src/main/lib/browser-controller.ts` — 在导航状态更新前确认回调所属的 session 与 tab 仍然有效，并处理检查后 WebContents 被销毁的竞态，避免关闭标签后的迟到事件向主进程冒泡。

## 测试方法
1. 运行 `bun run typecheck`，确认全部 workspace package 通过 TypeScript 检查。
2. 运行 `bun run --filter='@proma/electron' build:main`，确认 Electron 主进程可构建。
3. 在开发版中反复执行“打开受管浏览器 -> 导航到 https://example.com -> 关闭唯一标签 -> 新建标签”，确认不再出现 `A JavaScript error occurred in the main process` 弹窗。
4. 运行 `bun test`：503/507 通过；4 个失败均位于未改动的 Electron/Bun 测试环境依赖用例，与本 PR 无关。

## 备注
- 保留 `buildState()` 对真正内部状态不变量的错误保护；仅对已关闭 tab 或已移除 session 的正常异步竞态静默跳过。
- 不涉及路径、Shell、平台分支、原生二进制或打包配置，Windows 兼容性 diff 扫描无新增风险。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
