### PR TITLE
fix(renderer): 修复 Windows Ctrl+B 快捷键冲突【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2720,7 +2720,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                 <PanelLeftOpen size={17} />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="right">展开侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+B'})</TooltipContent>
+            <TooltipContent side="right">展开侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+Shift+E'})</TooltipContent>
           </Tooltip>
         </div>
 
@@ -2963,7 +2963,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               <PanelLeftClose size={14} />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="right">收起侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+B'})</TooltipContent>
+          <TooltipContent side="right">收起侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+Shift+E'})</TooltipContent>
         </Tooltip>
       </div>
 

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -73,7 +73,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     name: '切换侧边栏',
     description: '显示或隐藏左侧边栏',
     defaultMac: 'Cmd+B',
-    defaultWin: 'Ctrl+B',
+    defaultWin: 'Ctrl+Shift+E',
     category: 'app',
   },
   // 由 Electron 原生菜单角色处理，展示但不允许在应用内修改。
@@ -147,13 +147,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'navigation',
   },
 
-  // 编辑级（输入框格式化，仅 macOS — Cmd+B/S 被全局快捷键占用）
+  // 编辑级（输入框格式化 — macOS 上 Cmd+B 被切换侧边栏占用，改用 Ctrl+B；Windows 上 Ctrl+B 直接加粗）
   {
     id: 'editor-bold',
     name: '加粗 / 取消加粗',
-    description: '输入框中切换文字加粗（因 Cmd+B 已用于切换侧边栏）',
+    description: '输入框中切换文字加粗',
     defaultMac: 'Ctrl+B',
-    defaultWin: '',
+    defaultWin: 'Ctrl+B',
     category: 'edit',
     readonly: true,
   },

--- a/apps/electron/src/renderer/lib/tips.ts
+++ b/apps/electron/src/renderer/lib/tips.ts
@@ -43,7 +43,7 @@ export const TIPS: Tip[] = [
   { id: 'win-shortcut-search', text: '按 Ctrl+Shift+F 搜索历史对话', platform: 'windows' },
   { id: 'win-shortcut-file-find', text: '按 Ctrl+F 可在对话中搜索消息，预览面板中则查找文件内容', platform: 'windows' },
   { id: 'win-shortcut-settings', text: '按 Ctrl+, 打开设置', platform: 'windows' },
-  { id: 'win-shortcut-sidebar', text: '按 Ctrl+B 切换侧边栏显示', platform: 'windows' },
+  { id: 'win-shortcut-sidebar', text: '按 Ctrl+Shift+E 切换侧边栏显示', platform: 'windows' },
   { id: 'win-shortcut-mode', text: '按 Ctrl+Shift+M 快速切换 Chat / Agent 模式', platform: 'windows' },
   { id: 'win-shortcut-focus', text: '按 Ctrl+L 快速跳转到输入框', platform: 'windows' },
   { id: 'win-shortcut-clear', text: '按 Ctrl+K 清除当前对话上下文', platform: 'windows' },


### PR DESCRIPTION
## 概述

修复 Windows 版本中 Ctrl+B 同时与侧边栏切换和编辑器加粗冲突的问题。Ctrl+B 现在保留给输入框加粗，侧边栏切换改用 Ctrl+Shift+E；macOS 默认快捷键保持不变。

## 改动

- `apps/electron/src/renderer/lib/shortcut-defaults.ts` — 将 Windows 侧边栏快捷键从 Ctrl+B 改为 Ctrl+Shift+E，并将 Windows 加粗快捷键明确声明为 Ctrl+B。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 更新展开和收起侧边栏 tooltip 中的 Windows 快捷键提示。
- `apps/electron/src/renderer/lib/tips.ts` — 更新 Windows 使用技巧中的侧边栏快捷键提示。

## 测试方法

1. 在 Windows 版本中聚焦富文本输入框，按 Ctrl+B，确认文字加粗状态切换且侧边栏不变化。
2. 按 Ctrl+Shift+E，确认侧边栏展开或收起。
3. 在 macOS 版本中确认 Cmd+B 仍切换侧边栏，Ctrl+B 仍切换加粗。
4. 已执行 `git diff --check`。
5. 已执行 `bun test apps/electron/src/renderer/lib/shortcut-defaults.test.ts`，测试通过。

## 备注

- 本次审核未发现 blocker 或中高风险缺陷。
- Electron typecheck 尚未执行成功，因为当前环境未安装依赖，`tsc` 不可用。
- 已在提交中加入 `Made-with: Proma` trailer。
