### PR TITLE
fix(agent): 后台会话自动续发排队消息【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2639,7 +2639,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     (allExitPlanRequests.get(sessionId)?.length ?? 0) > 0
   const hasBlockingRequests = hasBannerOverlay || (allPermissionRequests.get(sessionId)?.length ?? 0) > 0
   const canSendQueuedNow = messagesLoaded && (streaming || !messagesRefreshing) && !!agentChannelId && hasAvailableModel && !hasBlockingRequests && !isStopping
-  const autoSendingQueuedRef = React.useRef(false)
   const queuedSendInFlightRef = React.useRef(false)
   const sendingQueuedMessageIdsRef = React.useRef<Set<string>>(new Set())
 
@@ -2709,34 +2708,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   ): void => {
     setQueuedMessages((prev) => moveQueuedMessage(prev, sourceId, targetId, placement))
   }, [setQueuedMessages])
-
-  React.useEffect(() => {
-    if (autoSendingQueuedRef.current) return
-    if (queuedSendInFlightRef.current) return
-    if (queuedMessages.length === 0) return
-    if (messagesRefreshingRef.current) return
-    if (!canSendQueuedNow || streaming || stoppedByUser) return
-
-    const message = queuedMessages[0]
-    if (!message) return
-    if (sendingQueuedMessageIdsRef.current.has(message.id)) return
-
-    autoSendingQueuedRef.current = true
-    queuedSendInFlightRef.current = true
-    sendingQueuedMessageIdsRef.current.add(message.id)
-    setQueuedMessages((prev) => removeQueuedMessage(prev, message.id))
-    sendPlainTextAgentMessage(message)
-      .catch((error) => {
-        console.error('[AgentView] 自动发送队列消息失败:', error)
-        toast.error('自动发送队列消息失败', { description: String(error) })
-        setQueuedMessages((prev) => restoreQueuedMessageToFront(prev, message))
-      })
-      .finally(() => {
-        sendingQueuedMessageIdsRef.current.delete(message.id)
-        queuedSendInFlightRef.current = false
-        autoSendingQueuedRef.current = false
-      })
-  }, [canSendQueuedNow, queuedMessages, sendPlainTextAgentMessage, setQueuedMessages, stoppedByUser, streaming])
 
   // ===== 预览面板状态（toggle 快捷键，分屏布局在 MainArea） =====
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -13,6 +13,7 @@ import { useStore } from 'jotai'
 import {
   agentStreamingStatesAtom,
   agentStreamErrorsAtom,
+  agentSessionMessageQueueAtom,
   agentSessionsAtom,
   agentMessageRefreshAtom,
   allPendingPermissionRequestsAtom,
@@ -32,6 +33,7 @@ import {
   agentModelIdAtom,
   agentChannelIdAtom,
   agentPermissionModeMapAtom,
+  agentDefaultPermissionModeAtom,
   stoppedByUserSessionsAtom,
   agentPlanModeSessionsAtom,
   finalizeStreamingActivities,
@@ -65,7 +67,7 @@ import { channelsAtom } from '@/atoms/chat-atoms'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
-import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta, ProviderType } from '@proma/shared'
+import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta, ProviderType } from '@proma/shared'
 import { inferContextWindow } from '@proma/shared'
 import { buildExternalAgentRunActivation, shouldActivateExternalAgentRun } from '@/lib/external-agent-run'
 import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
@@ -77,6 +79,8 @@ import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/a
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
 import { detectIsWindows } from '@/lib/platform'
 import { getSessionFileChangeKind, arePathsEqual, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
+import { buildQueuedMessageSendPayload, removeQueuedMessage, restoreQueuedMessageToFront, shouldAutoDispatchQueuedMessage } from '@/lib/agent-message-queue'
+import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -464,6 +468,209 @@ export function useGlobalAgentListeners(): void {
     const autoActivatedChangeTurns = new Map<string, string>()
     /** 正在执行的 git 突变 Bash 命令：toolUseId → sessionId（完成后触发 diff 刷新） */
     const pendingGitMutateTools = new Map<string, string>()
+
+    const queuedDispatchInFlight = new Set<string>()
+    const queuedDispatchScheduled = new Set<string>()
+    // IPC 拒绝后保留失败的队首，直到用户调整队列，避免订阅回调触发自动重试风暴。
+    const queuedDispatchSuppressedMessageIds = new Map<string, string>()
+
+    const dispatchQueuedMessage = (sessionId: string): void => {
+      if (queuedDispatchInFlight.has(sessionId)) return
+
+      const queuedMessages = store.get(agentSessionMessageQueueAtom).get(sessionId) ?? []
+      if (queuedDispatchSuppressedMessageIds.get(sessionId) === queuedMessages[0]?.id) return
+      queuedDispatchSuppressedMessageIds.delete(sessionId)
+      const streamState = store.get(agentStreamingStatesAtom).get(sessionId)
+      const session = store.get(agentSessionsAtom).find((item) => item.id === sessionId)
+      if (session?.legacyTranscript?.continuationRequired) return
+
+      const channelId = session?.channelId
+        ?? store.get(agentSessionChannelMapAtom).get(sessionId)
+        ?? store.get(agentChannelIdAtom)
+      const modelId = session?.modelId
+        ?? store.get(agentSessionModelMapAtom).get(sessionId)
+        ?? store.get(agentModelIdAtom)
+      const channels = store.get(channelsAtom)
+      const hasAvailableModel = channels.some((channel) => (
+        channel.enabled && channel.models.some((model) => model.enabled)
+      ))
+      const hasBlockingRequests =
+        (store.get(allPendingPermissionRequestsAtom).get(sessionId)?.length ?? 0) > 0 ||
+        (store.get(allPendingAskUserRequestsAtom).get(sessionId)?.length ?? 0) > 0 ||
+        (store.get(allPendingExitPlanRequestsAtom).get(sessionId)?.length ?? 0) > 0
+
+      if (!shouldAutoDispatchQueuedMessage({
+        queueLength: queuedMessages.length,
+        running: streamState?.running ?? false,
+        backgroundWaiting: streamState?.backgroundWaiting ?? false,
+        stoppedByUser: store.get(stoppedByUserSessionsAtom).has(sessionId),
+        hasBlockingRequests,
+        hasChannel: Boolean(channelId),
+        hasAvailableModel,
+      })) {
+        return
+      }
+
+      const message = queuedMessages[0]
+      if (!message || !channelId) return
+
+      const streamStartedAt = Date.now()
+      const quotedSelectionBlock = message.quotedSelection
+        ? buildQuotedSelectionBlock(message.quotedSelection)
+        : ''
+      const payload = buildQueuedMessageSendPayload(message, quotedSelectionBlock)
+      let dequeued = false
+      queuedDispatchInFlight.add(sessionId)
+      store.set(agentSessionMessageQueueAtom, (prev) => {
+        const current = prev.get(sessionId) ?? []
+        if (current[0]?.id !== message.id) return prev
+        const map = new Map(prev)
+        const next = removeQueuedMessage(current, message.id)
+        if (next.length === 0) map.delete(sessionId)
+        else map.set(sessionId, next)
+        dequeued = true
+        return map
+      })
+      if (!dequeued) {
+        queuedDispatchInFlight.delete(sessionId)
+        return
+      }
+
+      const optimisticMessageUuid = `queued-${message.id}`
+      const optimisticMessage: SDKMessage = {
+        type: 'user',
+        uuid: optimisticMessageUuid,
+        message: { content: [{ type: 'text', text: payload.rawText }] },
+        parent_tool_use_id: null,
+        _createdAt: streamStartedAt,
+      } as unknown as SDKMessage
+      store.set(liveMessagesMapAtom, (prev) => {
+        const map = new Map(prev)
+        map.set(sessionId, [...(map.get(sessionId) ?? []), optimisticMessage])
+        return map
+      })
+      store.set(agentStreamErrorsAtom, (prev) => {
+        if (!prev.has(sessionId)) return prev
+        const map = new Map(prev)
+        map.delete(sessionId)
+        return map
+      })
+      store.set(agentStreamingStatesAtom, (prev) => {
+        const map = new Map(prev)
+        map.set(sessionId, {
+          running: true,
+          content: '',
+          toolActivities: [],
+          model: modelId || undefined,
+          startedAt: streamStartedAt,
+          inputTokens: prev.get(sessionId)?.inputTokens,
+          contextWindow: prev.get(sessionId)?.contextWindow,
+        })
+        return map
+      })
+
+      const rollbackFailedDispatch = (): void => {
+        queuedDispatchSuppressedMessageIds.set(sessionId, message.id)
+        store.set(agentSessionMessageQueueAtom, (prev) => {
+          const map = new Map(prev)
+          map.set(sessionId, restoreQueuedMessageToFront(map.get(sessionId) ?? [], message))
+          return map
+        })
+        store.set(liveMessagesMapAtom, (prev) => {
+          const current = prev.get(sessionId) ?? []
+          const next = current.filter((item) => (item as unknown as { uuid?: string }).uuid !== optimisticMessageUuid)
+          if (next.length === current.length) return prev
+          const map = new Map(prev)
+          if (next.length === 0) map.delete(sessionId)
+          else map.set(sessionId, next)
+          return map
+        })
+        store.set(agentStreamingStatesAtom, (prev) => {
+          const current = prev.get(sessionId)
+          if (!current || current.startedAt !== streamStartedAt) return prev
+          const map = new Map(prev)
+          map.set(sessionId, { ...current, running: false })
+          return map
+        })
+      }
+
+      const queuedAdditionalDirectories = message.additionalDirectories ?? []
+      const workspaceId = session?.workspaceId ?? store.get(currentAgentWorkspaceIdAtom) ?? undefined
+      const attachedDirectories = store.get(agentAttachedDirectoriesMapAtom).get(sessionId)
+        ?? session?.attachedDirectories
+        ?? []
+      const attachedFiles = store.get(agentAttachedFilesMapAtom).get(sessionId)
+        ?? session?.attachedFiles
+        ?? []
+      const workspaceAttachedFiles = workspaceId
+        ? (store.get(workspaceAttachedFilesMapAtom).get(workspaceId) ?? [])
+        : []
+      const additionalDirectories = Array.from(new Set([
+        ...attachedDirectories,
+        ...[...attachedFiles, ...workspaceAttachedFiles].map(getParentDir).filter(Boolean),
+        ...queuedAdditionalDirectories,
+      ]))
+      const permissionMode = store.get(agentPermissionModeMapAtom).get(sessionId)
+        ?? session?.permissionMode
+        ?? store.get(agentDefaultPermissionModeAtom)
+
+      try {
+        const sendPromise = window.electronAPI.sendAgentMessage({
+          sessionId,
+          userMessage: payload.sdkText,
+          rawUserMessage: payload.rawText,
+          channelId,
+          modelId: modelId || undefined,
+          workspaceId,
+          startedAt: streamStartedAt,
+          permissionModeOverride: permissionMode,
+          ...(additionalDirectories.length > 0 && { additionalDirectories }),
+          ...(payload.mentions.mentionedSkills.length > 0 && { mentionedSkills: payload.mentions.mentionedSkills }),
+          ...(payload.mentions.mentionedMcpServers.length > 0 && { mentionedMcpServers: payload.mentions.mentionedMcpServers }),
+          ...(payload.mentions.mentionedSessionIds.length > 0 && { mentionedSessionIds: payload.mentions.mentionedSessionIds }),
+          ...(payload.mentions.mentionedTodoIds.length > 0 && { mentionedTodoIds: payload.mentions.mentionedTodoIds }),
+          ...(payload.mentions.mentionedCalendarEventIds.length > 0 && { mentionedCalendarEventIds: payload.mentions.mentionedCalendarEventIds }),
+        })
+        queuedDispatchInFlight.delete(sessionId)
+        void sendPromise.catch((error) => {
+          console.error('[GlobalAgentListeners] 自动发送队列消息失败:', error)
+          rollbackFailedDispatch()
+          toast.error('自动发送队列消息失败', { description: String(error) })
+        })
+      } catch (error) {
+        queuedDispatchInFlight.delete(sessionId)
+        console.error('[GlobalAgentListeners] 自动发送队列消息初始化失败:', error)
+        rollbackFailedDispatch()
+        toast.error('自动发送队列消息失败', { description: String(error) })
+      }
+    }
+
+    const scheduleQueuedMessageDispatch = (sessionId: string): void => {
+      if (queuedDispatchScheduled.has(sessionId)) return
+      queuedDispatchScheduled.add(sessionId)
+      queueMicrotask(() => {
+        queuedDispatchScheduled.delete(sessionId)
+        dispatchQueuedMessage(sessionId)
+      })
+    }
+
+    const scheduleAllQueuedMessageDispatches = (): void => {
+      for (const sessionId of store.get(agentSessionMessageQueueAtom).keys()) {
+        scheduleQueuedMessageDispatch(sessionId)
+      }
+    }
+
+    const queuedDispatchUnsubscribers = [
+      store.sub(agentSessionMessageQueueAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(agentStreamingStatesAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(agentSessionsAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(agentSessionChannelMapAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(agentChannelIdAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(allPendingPermissionRequestsAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(allPendingAskUserRequestsAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(allPendingExitPlanRequestsAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(channelsAtom, scheduleAllQueuedMessageDispatches),
+    ]
 
     /** 构建导航到指定会话的回调 */
     const makeNavigateToSession = (sessionId: string, sessionTitle: string) => () => {
@@ -1327,6 +1534,10 @@ export function useGlobalAgentListeners(): void {
           return prev
         })
 
+        if (!backgroundTasksPending) {
+          scheduleQueuedMessageDispatch(data.sessionId)
+        }
+
         // 非正常结束时显示截断提示
         if (data.resultSubtype && data.resultSubtype !== 'success' && !data.stoppedByUser) {
           const messages: Record<string, string> = {
@@ -1574,6 +1785,7 @@ export function useGlobalAgentListeners(): void {
       cleanupTodoAgentSessionReady()
       cleanupTitleUpdated()
       cleanupWatchedFileChanges()
+      queuedDispatchUnsubscribers.forEach((unsubscribe) => unsubscribe())
       clearInterval(pruneTimer)
       window.removeEventListener('focus', onWindowFocus)
     }

--- a/apps/electron/src/renderer/lib/agent-message-queue.test.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { buildQueuedMessageSendPayload, getQueuedMessageDisplayParts, parseQueuedMessageMentions } from './agent-message-queue'
+import {
+  buildQueuedMessageSendPayload,
+  getQueuedMessageDisplayParts,
+  parseQueuedMessageMentions,
+} from './agent-message-queue'
 
 describe('queued message @file mention path decoding (Agent 侧真实路径)', () => {
   test('decodes percent-encoded @file path back to the real path with spaces', () => {

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -24,6 +24,28 @@ export interface AgentQueuedMessage {
   additionalDirectories?: string[]
 }
 
+/**
+ * 队列的自动消费必须由常驻调度器执行，不能依赖某个 AgentView 是否仍挂载。
+ * 保留停止、后台等待和交互阻塞状态，避免在不安全的时机意外开启新一轮 run。
+ */
+export function shouldAutoDispatchQueuedMessage(options: {
+  queueLength: number
+  running: boolean
+  backgroundWaiting: boolean
+  stoppedByUser: boolean
+  hasBlockingRequests: boolean
+  hasChannel: boolean
+  hasAvailableModel: boolean
+}): boolean {
+  return options.queueLength > 0 &&
+    !options.running &&
+    !options.backgroundWaiting &&
+    !options.stoppedByUser &&
+    !options.hasBlockingRequests &&
+    options.hasChannel &&
+    options.hasAvailableModel
+}
+
 export function createAgentQueuedMessage(
   text: string,
   id: string,


### PR DESCRIPTION
## 概述
将 Agent 排队消息的自动消费从 `AgentView` 的挂载生命周期迁移到全局 IPC listener。后台会话在当前轮结束后可自动启动队首消息，无需用户切回该会话。

## 改动
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` — 在常驻 listener 中实现按会话串行的队列调度；监听完成、流状态、交互阻塞、channel 和会话配置变化；补齐引用、附件目录、工作区与权限模式参数，并在 IPC 失败时回滚队列及实时消息。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 移除依赖视图挂载的旧自动发送 effect，保留手动“立即发送”等交互。
- `apps/electron/src/renderer/lib/agent-message-queue.ts` — 提取自动派发前置条件，明确停止、后台等待和交互阻塞时不得开启新 run。
- `apps/electron/src/renderer/lib/agent-message-queue.test.ts` — 保留既有队列引用解析测试并适配导入变更。

## 测试方法
1. 运行 `bun run typecheck`，确认 monorepo 所有 package 类型检查通过。
2. 运行 `bun test apps/electron/src/renderer/lib/agent-message-queue.test.ts`，确认 5 个既有队列引用解析测试通过。
3. 运行 `git diff --check origin/main..HEAD`，确认差异无空白错误。
4. 手动验证：在后台会话排入一条或多条消息，当前轮完成后不切回会话，确认队首自动续发；再验证权限、AskUser 或 Plan 阻塞解除后可恢复续发。

## 备注
- PR 基于 `origin/main` 的 `751d25ce` 创建。
- upstream 未授予当前账号直推权限，分支已推送至 `Andreaseszhang/Proma`。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)