### PR TITLE
fix(markdown): 修复 Mermaid 富文本编辑预览【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -1815,6 +1815,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                   onChange={updateMarkdownDraft}
                   onSave={() => void saveMarkdownEdit()}
                   onCancel={exitMarkdownEdit}
+                  renderMermaidInEditor
                   disabled={markdownSaving || Boolean(readOnly)}
                   fileAccess={markdownFileAccess}
                   shikiTheme={theme === 'dark' ? 'github-dark' : 'github-light'}

--- a/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
+++ b/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
@@ -32,6 +32,8 @@ interface MarkdownRichEditorProps {
   onSave: () => void
   onCancel: () => void
   onRequestEdit?: () => void
+  /** 由外层源码编辑器接管 Mermaid 源码编辑时，富文本态持续显示图表预览。 */
+  renderMermaidInEditor?: boolean
   disabled?: boolean
   fileAccess?: FileAccessOptions
   shikiTheme?: string
@@ -48,6 +50,7 @@ export function MarkdownRichEditor({
   onSave,
   onCancel,
   onRequestEdit,
+  renderMermaidInEditor = false,
   disabled,
   fileAccess,
   shikiTheme = 'github-dark',
@@ -57,6 +60,7 @@ export function MarkdownRichEditor({
   onSelectionChange,
 }: MarkdownRichEditorProps): React.ReactElement {
   const isEditable = editing && !disabled
+  const showMermaidPreview = !isEditable || renderMermaidInEditor
   const markdownRendererVersion = MARKDOWN_RENDERER_VERSION
   const onChangeRef = React.useRef(onChange)
   const onSaveRef = React.useRef(onSave)
@@ -334,9 +338,8 @@ export function MarkdownRichEditor({
         }}
         className={cn(
           editing ? 'min-h-0 flex-1 overflow-auto scrollbar-thin' : 'h-full min-h-full flex-1',
-          isEditable
-            ? '[&_.proma-mermaid-preview]:hidden [&_.proma-code-source-body]:block'
-            : [
+          showMermaidPreview
+            ? [
                 '[&_.proma-code-block--mermaid]:overflow-visible',
                 '[&_.proma-code-block--mermaid]:rounded-none',
                 '[&_.proma-code-block--mermaid]:border-0',
@@ -344,7 +347,8 @@ export function MarkdownRichEditor({
                 '[&_.proma-code-block--mermaid_.proma-code-header]:hidden',
                 '[&_.proma-code-block--mermaid_.proma-mermaid-preview]:block',
                 '[&_.proma-code-block--mermaid_.proma-code-source-body]:hidden',
-              ],
+              ]
+            : '[&_.proma-mermaid-preview]:hidden [&_.proma-code-source-body]:block',
         )}
       />
       {editing && editor && <TableBubbleMenu editor={editor} />}

--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -703,7 +703,7 @@ function createMathView(initialNode: ProseMirrorNode, displayMode: boolean) {
   })
 }
 
-function createShikiCodeBlockView(initialNode: ProseMirrorNode, view: EditorView) {
+function createShikiCodeBlockView(initialNode: ProseMirrorNode) {
   const dom = document.createElement('div')
   setClass(dom, 'not-prose my-3 overflow-hidden rounded-md border border-border/40 bg-muted/30')
   dom.dataset.promaCodeBlock = 'true'
@@ -771,7 +771,7 @@ function createShikiCodeBlockView(initialNode: ProseMirrorNode, view: EditorView
     currentCode = node.textContent
     label.textContent = language === 'text' ? 'Code' : getDisplayName(language)
     const className = language === 'text' ? undefined : `language-${language}`
-    const shouldRenderMermaid = !view.editable && shouldRenderMermaidCodeBlock(className, currentCode)
+    const shouldRenderMermaid = shouldRenderMermaidCodeBlock(className, currentCode)
     dom.classList.toggle('proma-code-block--mermaid', shouldRenderMermaid)
     scheduleMermaidRender(shouldRenderMermaid ? currentCode : null)
   }
@@ -1146,7 +1146,7 @@ export function createShikiCodeBlock(themeRef: ThemeRef): Node {
     },
 
     addNodeView() {
-      return ({ node, view }) => createShikiCodeBlockView(node, view)
+      return ({ node }) => createShikiCodeBlockView(node)
     },
 
     addProseMirrorPlugins() {

--- a/apps/electron/src/renderer/lib/mermaid-detection.test.ts
+++ b/apps/electron/src/renderer/lib/mermaid-detection.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { shouldRenderMermaidCodeBlock } from './mermaid-detection'
+
+describe('Mermaid code block detection', () => {
+  test('recognizes a Gantt block without a language class', () => {
+    expect(shouldRenderMermaidCodeBlock(undefined, [
+      'gantt',
+      '  title Delivery plan',
+      '  section Build',
+      '  API :done, api, 2026-08-13, 2d',
+    ].join('\n'))).toBe(true)
+  })
+
+  test('recognizes other Mermaid diagram types after rich editor round trips', () => {
+    expect(shouldRenderMermaidCodeBlock('language-mermaid', 'sequenceDiagram\n  A->>B: Hello')).toBe(true)
+    expect(shouldRenderMermaidCodeBlock('language-mmd', 'flowchart TD\n  A-->B')).toBe(true)
+  })
+
+  test('does not classify ordinary text code as Mermaid', () => {
+    expect(shouldRenderMermaidCodeBlock('language-javascript', 'const graph = []')).toBe(false)
+    expect(shouldRenderMermaidCodeBlock(undefined, 'graph of results')).toBe(false)
+  })
+})


### PR DESCRIPTION
## 概述
修复 Markdown 文档中的 Mermaid 图表，尤其是未标注语言的 Gantt 图，在预览切入富文本编辑后退化为源码的问题。Diff 文档的富文本编辑态继续展示 Mermaid SVG；用户切换源码编辑时仍通过独立 textarea 修改原始 Markdown。同时将该展示行为限定在具备源码模式的 Diff 编辑路径，避免自动化 Prompt 等通用富文本编辑器失去代码块源码编辑能力。

## 改动
- `apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx` — Mermaid code block 的 NodeView 不再依据 `view.editable` 停止挂载 `MermaidBlock`，使其在 Diff 富文本编辑态保持 SVG 渲染。
- `apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx` — 新增默认关闭的 `renderMermaidInEditor` 开关；只有外层接管 Mermaid 源码编辑时才在富文本态隐藏源码层。
- `apps/electron/src/renderer/components/diff/DiffTabContent.tsx` — 为带独立源码 textarea 的 Markdown Diff 编辑流程显式开启 Mermaid 富文本预览。
- `apps/electron/src/renderer/lib/mermaid-detection.test.ts` — 覆盖未标语言 Gantt、`language-mermaid`、`language-mmd` 以及普通代码不误判的场景。

## 测试方法
1. 运行 `bun test ./apps/electron/src/renderer/lib/mermaid-detection.test.ts ./apps/electron/src/renderer/lib/markdown-rich-text.test.ts`，确认 25 个测试通过。
2. 运行 `bun run --filter @proma/electron typecheck`，确认 Electron 包类型检查通过。
3. 运行 `bun run --filter @proma/electron build:renderer`，确认 renderer 构建通过。
4. 手动验证 Markdown Diff：富文本编辑态显示 Mermaid SVG，切换源码编辑后可编辑原始 fenced Markdown；普通代码块仍显示可编辑源码。

## 备注
- 已完成 Windows 兼容性静态扫描：本次无新增路径、Shell、平台分支、快捷键、打包脚本或依赖变更。
- Mermaid NodeView 和 `MermaidBlock` 的既有异步渲染/销毁防竞态逻辑未改动。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)