### PR TITLE
feat(settings): 新增浏览器面板自动展开开关【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -39,6 +39,7 @@ export function getSettings(): AppSettings {
       windowsShellPreference: 'auto',
       agentThinking: { type: 'adaptive' },
       gitAttributionEnabled: true,
+      browserAutoOpenPanelEnabled: true,
     }
   }
 
@@ -72,6 +73,7 @@ export function getSettings(): AppSettings {
       agentThinking: settings.agentThinking ?? { type: 'adaptive' },
       // 缺省 true：老配置文件未写该字段时保持推广默认开启
       gitAttributionEnabled: settings.gitAttributionEnabled ?? true,
+      browserAutoOpenPanelEnabled: settings.browserAutoOpenPanelEnabled ?? true,
       // 仅保留 macOS 原生 Island 开关；清理旧非原生 surface 的持久化残留字段。
       agentIsland: sanitizeAgentIslandSettings(data.agentIsland),
     }
@@ -91,6 +93,7 @@ export function getSettings(): AppSettings {
       windowsShellPreference: 'auto',
       agentThinking: { type: 'adaptive' },
       gitAttributionEnabled: true,
+      browserAutoOpenPanelEnabled: true,
     }
   }
 }

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -20,6 +20,9 @@ export const richTextRenderingEnabledAtom = atom<boolean>(false)
 /** 左侧会话列表悬浮预览迷你地图（默认关闭，需手动开启） */
 export const sessionHoverPreviewEnabledAtom = atom<boolean>(false)
 
+/** Agent 使用受管浏览器时是否自动展开浏览器面板（默认开启） */
+export const browserAutoOpenPanelEnabledAtom = atom<boolean>(true)
+
 // ===== 初始化 =====
 
 /**
@@ -29,7 +32,8 @@ export async function initializeUiPreferences(
   setStickyUserMessageEnabled: (enabled: boolean) => void,
   setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void,
   setRichTextRenderingEnabled?: (enabled: boolean) => void,
-  setSessionHoverPreviewEnabled?: (enabled: boolean) => void
+  setSessionHoverPreviewEnabled?: (enabled: boolean) => void,
+  setBrowserAutoOpenPanelEnabled?: (enabled: boolean) => void
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
@@ -37,6 +41,7 @@ export async function initializeUiPreferences(
     setLongTextPasteAsAttachmentEnabled?.(settings.longTextPasteAsAttachmentEnabled ?? false)
     setRichTextRenderingEnabled?.(settings.richTextRenderingEnabled ?? false)
     setSessionHoverPreviewEnabled?.(settings.sessionHoverPreviewEnabled ?? false)
+    setBrowserAutoOpenPanelEnabled?.(settings.browserAutoOpenPanelEnabled ?? true)
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
   }
@@ -85,5 +90,16 @@ export async function updateSessionHoverPreviewEnabled(enabled: boolean): Promis
     await window.electronAPI.updateSettings({ sessionHoverPreviewEnabled: enabled })
   } catch (error) {
     console.error('[UI偏好] 更新会话悬浮预览设置失败:', error)
+  }
+}
+
+/**
+ * 更新 Agent 浏览器自动展开面板开关并持久化
+ */
+export async function updateBrowserAutoOpenPanelEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ browserAutoOpenPanelEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新浏览器自动展开面板设置失败:', error)
   }
 }

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -23,6 +23,9 @@ export const sessionHoverPreviewEnabledAtom = atom<boolean>(false)
 /** Agent 使用受管浏览器时是否自动展开浏览器面板（默认开启） */
 export const browserAutoOpenPanelEnabledAtom = atom<boolean>(true)
 
+/** 浏览器自动展开设置是否已从主进程加载完成。 */
+export const browserAutoOpenPanelReadyAtom = atom<boolean>(false)
+
 // ===== 初始化 =====
 
 /**
@@ -33,7 +36,8 @@ export async function initializeUiPreferences(
   setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void,
   setRichTextRenderingEnabled?: (enabled: boolean) => void,
   setSessionHoverPreviewEnabled?: (enabled: boolean) => void,
-  setBrowserAutoOpenPanelEnabled?: (enabled: boolean) => void
+  setBrowserAutoOpenPanelEnabled?: (enabled: boolean) => void,
+  setBrowserAutoOpenPanelReady?: (ready: boolean) => void
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
@@ -44,6 +48,8 @@ export async function initializeUiPreferences(
     setBrowserAutoOpenPanelEnabled?.(settings.browserAutoOpenPanelEnabled ?? true)
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
+  } finally {
+    setBrowserAutoOpenPanelReady?.(true)
   }
 }
 

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -42,10 +42,12 @@ import {
   richTextRenderingEnabledAtom,
   stickyUserMessageEnabledAtom,
   sessionHoverPreviewEnabledAtom,
+  browserAutoOpenPanelEnabledAtom,
   updateLongTextPasteAsAttachmentEnabled,
   updateRichTextRenderingEnabled,
   updateStickyUserMessageEnabled,
   updateSessionHoverPreviewEnabled,
+  updateBrowserAutoOpenPanelEnabled,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
 import { detectIsMac } from '@/lib/platform'
@@ -71,6 +73,7 @@ export function GeneralSettings(): React.ReactElement {
   const [longTextPasteAsAttachmentEnabled, setLongTextPasteAsAttachmentEnabled] = useAtom(longTextPasteAsAttachmentEnabledAtom)
   const [richTextRenderingEnabled, setRichTextRenderingEnabled] = useAtom(richTextRenderingEnabledAtom)
   const [sessionHoverPreviewEnabled, setSessionHoverPreviewEnabled] = useAtom(sessionHoverPreviewEnabledAtom)
+  const [browserAutoOpenPanelEnabled, setBrowserAutoOpenPanelEnabled] = useAtom(browserAutoOpenPanelEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -392,6 +395,15 @@ export function GeneralSettings(): React.ReactElement {
             onCheckedChange={(checked) => {
               setSessionHoverPreviewEnabled(checked)
               updateSessionHoverPreviewEnabled(checked)
+            }}
+          />
+          <SettingsToggle
+            label="浏览器自动展开面板"
+            description="Agent 使用受管浏览器访问网页时，自动展开右侧浏览器面板；关闭后需从会话工具栏手动打开"
+            checked={browserAutoOpenPanelEnabled}
+            onCheckedChange={(checked) => {
+              setBrowserAutoOpenPanelEnabled(checked)
+              updateBrowserAutoOpenPanelEnabled(checked)
             }}
           />
           {isMac && (

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -33,7 +33,7 @@ import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { cn } from '@/lib/utils'
 import { browserPanelOpenMapAtom, browserPendingNavigationMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
-import { browserAutoOpenPanelEnabledAtom } from '@/atoms/ui-preferences'
+import { browserAutoOpenPanelEnabledAtom, browserAutoOpenPanelReadyAtom } from '@/atoms/ui-preferences'
 import { BrowserPanel } from '@/components/browser/BrowserPanel'
 
 export function MainArea(): React.ReactElement {
@@ -59,6 +59,7 @@ export function MainArea(): React.ReactElement {
   const [browserOpenMap, setBrowserOpenMap] = useAtom(browserPanelOpenMapAtom)
   const [browserStateMap, setBrowserStateMap] = useAtom(browserStateMapAtom)
   const browserAutoOpenPanelEnabled = useAtomValue(browserAutoOpenPanelEnabledAtom)
+  const browserAutoOpenPanelReady = useAtomValue(browserAutoOpenPanelReadyAtom)
   const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
   const [splitRatio, setSplitRatio] = useAtom(previewSplitRatioAtom)
   const [rightWorkspaceRatio, setRightWorkspaceRatio] = useAtom(rightWorkspaceSplitRatioAtom)
@@ -70,10 +71,10 @@ export function MainArea(): React.ReactElement {
     setBrowserStateMap((previous) => { const next = new Map(previous); next.set(state.sessionId, state); return next })
     // 用户关闭“自动展开面板”后，仅同步状态数据，不再把浏览器面板强行拉起；
     // 面板的打开与否完全交给用户从工具栏手动控制。
-    if (browserAutoOpenPanelEnabled) {
+    if (browserAutoOpenPanelReady && browserAutoOpenPanelEnabled) {
       setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(state.sessionId, true); return next })
     }
-  }, [setBrowserOpenMap, setBrowserStateMap, browserAutoOpenPanelEnabled])
+  }, [setBrowserOpenMap, setBrowserStateMap, browserAutoOpenPanelEnabled, browserAutoOpenPanelReady])
 
   React.useEffect(() => {
     // Vite renderer 可在 preload 热重载前先更新；旧 bridge 时浏览器功能不可用，

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -33,6 +33,7 @@ import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { cn } from '@/lib/utils'
 import { browserPanelOpenMapAtom, browserPendingNavigationMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
+import { browserAutoOpenPanelEnabledAtom } from '@/atoms/ui-preferences'
 import { BrowserPanel } from '@/components/browser/BrowserPanel'
 
 export function MainArea(): React.ReactElement {
@@ -57,6 +58,7 @@ export function MainArea(): React.ReactElement {
   const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
   const [browserOpenMap, setBrowserOpenMap] = useAtom(browserPanelOpenMapAtom)
   const [browserStateMap, setBrowserStateMap] = useAtom(browserStateMapAtom)
+  const browserAutoOpenPanelEnabled = useAtomValue(browserAutoOpenPanelEnabledAtom)
   const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
   const [splitRatio, setSplitRatio] = useAtom(previewSplitRatioAtom)
   const [rightWorkspaceRatio, setRightWorkspaceRatio] = useAtom(rightWorkspaceSplitRatioAtom)
@@ -66,8 +68,12 @@ export function MainArea(): React.ReactElement {
 
   const publishBrowserState = React.useCallback((state: BrowserViewState) => {
     setBrowserStateMap((previous) => { const next = new Map(previous); next.set(state.sessionId, state); return next })
-    setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(state.sessionId, true); return next })
-  }, [setBrowserOpenMap, setBrowserStateMap])
+    // 用户关闭“自动展开面板”后，仅同步状态数据，不再把浏览器面板强行拉起；
+    // 面板的打开与否完全交给用户从工具栏手动控制。
+    if (browserAutoOpenPanelEnabled) {
+      setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(state.sessionId, true); return next })
+    }
+  }, [setBrowserOpenMap, setBrowserStateMap, browserAutoOpenPanelEnabled])
 
   React.useEffect(() => {
     // Vite renderer 可在 preload 热重载前先更新；旧 bridge 时浏览器功能不可用，

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -57,6 +57,7 @@ import {
   richTextRenderingEnabledAtom,
   sessionHoverPreviewEnabledAtom,
   browserAutoOpenPanelEnabledAtom,
+  browserAutoOpenPanelReadyAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -617,6 +618,7 @@ function UiPreferencesInitializer(): null {
   const setRichTextRenderingEnabled = useSetAtom(richTextRenderingEnabledAtom)
   const setSessionHoverPreviewEnabled = useSetAtom(sessionHoverPreviewEnabledAtom)
   const setBrowserAutoOpenPanelEnabled = useSetAtom(browserAutoOpenPanelEnabledAtom)
+  const setBrowserAutoOpenPanelReady = useSetAtom(browserAutoOpenPanelReadyAtom)
 
   useEffect(() => {
     initializeUiPreferences(
@@ -624,9 +626,10 @@ function UiPreferencesInitializer(): null {
       setLongTextPasteAsAttachmentEnabled,
       setRichTextRenderingEnabled,
       setSessionHoverPreviewEnabled,
-      setBrowserAutoOpenPanelEnabled
+      setBrowserAutoOpenPanelEnabled,
+      setBrowserAutoOpenPanelReady
     )
-  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled, setSessionHoverPreviewEnabled, setBrowserAutoOpenPanelEnabled])
+  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled, setSessionHoverPreviewEnabled, setBrowserAutoOpenPanelEnabled, setBrowserAutoOpenPanelReady])
 
   return null
 }

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -56,6 +56,7 @@ import {
   longTextPasteAsAttachmentEnabledAtom,
   richTextRenderingEnabledAtom,
   sessionHoverPreviewEnabledAtom,
+  browserAutoOpenPanelEnabledAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -615,15 +616,17 @@ function UiPreferencesInitializer(): null {
   const setLongTextPasteAsAttachmentEnabled = useSetAtom(longTextPasteAsAttachmentEnabledAtom)
   const setRichTextRenderingEnabled = useSetAtom(richTextRenderingEnabledAtom)
   const setSessionHoverPreviewEnabled = useSetAtom(sessionHoverPreviewEnabledAtom)
+  const setBrowserAutoOpenPanelEnabled = useSetAtom(browserAutoOpenPanelEnabledAtom)
 
   useEffect(() => {
     initializeUiPreferences(
       setStickyUserMessageEnabled,
       setLongTextPasteAsAttachmentEnabled,
       setRichTextRenderingEnabled,
-      setSessionHoverPreviewEnabled
+      setSessionHoverPreviewEnabled,
+      setBrowserAutoOpenPanelEnabled
     )
-  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled, setSessionHoverPreviewEnabled])
+  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled, setSessionHoverPreviewEnabled, setBrowserAutoOpenPanelEnabled])
 
   return null
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -361,6 +361,12 @@ export interface AppSettings {
    * 关闭后不注入任何 Proma 归因，并覆盖 Claude SDK 默认 Co-Authored-By。
    */
   gitAttributionEnabled?: boolean
+  /**
+   * Agent 使用受管浏览器时是否自动展开浏览器面板。
+   * 默认 true：Agent 导航/操作网页时自动打开右侧浏览器面板以便观察。
+   * 关闭后面板保持当前状态，需从工具栏按钮手动打开。
+   */
+  browserAutoOpenPanelEnabled?: boolean
   /** macOS 原生 Agent 灵动岛偏好。 */
   agentIsland?: AgentIslandSettings
   /** 主窗口状态（大小、位置、是否最大化） */


### PR DESCRIPTION
## 概述
在通用设置中新增「浏览器自动展开面板」全局开关，用于控制 Agent 通过内置浏览器工具访问网页时是否自动展开右侧浏览器面板。默认保持开启，兼容现有行为；关闭后，Agent 的浏览器状态仍会正常同步，但不会因为后台状态事件自动拉起面板，用户仍可通过会话工具栏手动打开浏览器。

本 PR 同时修复了应用启动阶段的初始化时序问题：在持久化设置加载完成前，浏览器状态事件只同步状态，不触发展开，避免用户已关闭自动展开时在启动恢复阶段被误打开。

## 改动
- `apps/electron/src/types/settings.ts` — 在 `AppSettings` 中新增 `browserAutoOpenPanelEnabled` 字段。
- `apps/electron/src/main/lib/settings-service.ts` — 为新设置补齐新配置、老配置和读取失败 fallback 的默认值 `true`，保持向后兼容。
- `apps/electron/src/renderer/atoms/ui-preferences.ts` — 新增自动展开设置 atom、初始化完成状态 atom，以及持久化更新函数。
- `apps/electron/src/renderer/main.tsx` — 接入 UI 偏好初始化流程；设置读取成功或失败后均标记初始化完成。
- `apps/electron/src/renderer/components/settings/GeneralSettings.tsx` — 在通用设置中新增「浏览器自动展开面板」Toggle。
- `apps/electron/src/renderer/components/tabs/MainArea.tsx` — 仅当设置已初始化且开关开启时，才允许浏览器状态事件自动打开面板；关闭时仍持续更新浏览器状态。

## 行为边界
- 默认开启：Agent 使用 `BrowserNavigate`、`BrowserClick` 等内置浏览器工具时，行为与现有版本一致，面板自动展开。
- 关闭后：Agent 后台浏览器状态不会自动拉起右侧面板；用户点击会话工具栏浏览器按钮后仍可手动打开。
- 用户主动点击 Agent 回复中的网页链接仍会打开内置浏览器。这是明确的用户操作，不属于需要抑制的 unwanted popup，因此该路径保持原有行为。
- 设置加载失败时采用默认开启，避免因初始化异常导致浏览器功能永久不自动展示。

## 测试方法
1. 运行 `bun run --filter @proma/electron typecheck`，确认 Electron 包类型检查通过。
2. 运行 `git diff --check`，确认无空白字符错误。
3. 手动验证通用设置开关默认开启、关闭后 Agent 后台浏览器操作不再自动展开。
4. 手动验证关闭开关后，从会话工具栏仍可手动打开浏览器面板。
5. 手动验证点击 Agent 回复中的网页链接仍会打开内置浏览器。
6. 手动验证老版本未包含该字段的 `settings.json` 仍默认开启。

## 备注
- 本 PR 未修改主进程浏览器控制器，也未改变浏览器工具的执行和状态同步协议。
- 当前改动已完成本地 code review，并修复了设置初始化期间的自动展开竞态。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
