### PR TITLE
fix(markdown): 修复标签式加粗标记渲染【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.17",
+  "version": "0.17.18",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -26,6 +26,7 @@ import { CalendarDays, ChevronDown, ChevronUp, Paperclip, FileText, ListTodo, Sp
 import { cn } from '@/lib/utils'
 import { shouldInspectMermaidCodeBlock, shouldRenderMermaidCodeBlock } from '@/lib/mermaid-detection'
 import { normalizeLatexDelimiters } from '@/lib/normalize-latex'
+import { normalizeMalformedStrongDelimiters } from '@/lib/markdown-emphasis'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { Button } from '@/components/ui/button'
 import { ImageLightbox, type LightboxImage } from '@/components/ui/image-lightbox'
@@ -721,7 +722,7 @@ export const MessageResponse = React.memo(
           urlTransform={mentionUrlTransform}
           components={components}
         >
-          {normalizeLatexDelimiters(renderedMarkdown)}
+          {normalizeLatexDelimiters(normalizeMalformedStrongDelimiters(renderedMarkdown))}
         </Markdown>
       </div>
     )

--- a/apps/electron/src/renderer/lib/markdown-emphasis.ts
+++ b/apps/electron/src/renderer/lib/markdown-emphasis.ts
@@ -1,0 +1,70 @@
+/**
+ * Repairs a narrow class of malformed strong delimiters commonly emitted by
+ * models: `**Label:**value` and the escaped text left behind after rich-text
+ * editing, `\*\*Label: \*\*value`.
+ *
+ * CommonMark treats a closing delimiter as invalid when it is directly
+ * followed by a letter or number. The recovery is limited to label or sentence
+ * endings so intentional literal asterisks retain their original meaning.
+ */
+
+const DIRECT_STRONG_RE = /(?<!\\)\*\*([^*\r\n]*?[,:;!?\u3002\uFF01\uFF1F\uFF1A\uFF1B\u3001\uFF09)\]\u3011}])\s*\*\*(?=[\p{L}\p{N}])/gu
+const ESCAPED_STRONG_RE = /\\\*\\\*([^*\r\n]*?[,:;!?\u3002\uFF01\uFF1F\uFF1A\uFF1B\u3001\uFF09)\]\u3011}])\s*\\\*\\\*(?=[\p{L}\p{N}])/gu
+
+function normalizeText(text: string): string {
+  return text
+    .replace(ESCAPED_STRONG_RE, (_match, content: string) => `**${content}** `)
+    .replace(DIRECT_STRONG_RE, (_match, content: string) => `**${content}** `)
+}
+
+function normalizeInlineText(line: string): string {
+  let normalized = ''
+  let cursor = 0
+  // Protect code, raw HTML tags, and Markdown link/image destinations. The
+  // visible link label remains eligible for correction; only its destination
+  // must retain byte-for-byte semantics.
+  const protectedInline = /(`+)(.*?)\1|<\/?[A-Za-z][^>\r\n]*>|(!?\[[^\]\r\n]*\]\()((?:\\.|[^)\r\n])*)(\))/g
+
+  for (const match of line.matchAll(protectedInline)) {
+    const start = match.index ?? 0
+    normalized += normalizeText(line.slice(cursor, start))
+
+    if (match[3] !== undefined) {
+      normalized += normalizeText(match[3]) + (match[4] ?? '') + (match[5] ?? '')
+    } else {
+      normalized += match[0]
+    }
+
+    cursor = start + match[0].length
+  }
+
+  return normalized + normalizeText(line.slice(cursor))
+}
+
+/**
+ * Normalizes high-confidence malformed `**...**` sequences outside fenced,
+ * indented, and inline code. Markdown preview and chat messages use this
+ * function before parsing.
+ */
+export function normalizeMalformedStrongDelimiters(markdown: string): string {
+  if (!markdown.includes('**') && !markdown.includes('\\*')) return markdown
+
+  let inFence: { marker: '`' | '~'; length: number } | null = null
+
+  return markdown.split('\n').map((line) => {
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/)
+    const isCode = Boolean(inFence || fenceMatch || /^(?: {4}|\t)/.test(line))
+
+    if (fenceMatch) {
+      const markerText = fenceMatch[1] ?? ''
+      const marker = markerText[0] as '`' | '~'
+      if (!inFence) {
+        inFence = { marker, length: markerText.length }
+      } else if (marker === inFence.marker && markerText.length >= inFence.length) {
+        inFence = null
+      }
+    }
+
+    return isCode ? line : normalizeInlineText(line)
+  }).join('\n')
+}

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from 'markdown-it'
+import { normalizeMalformedStrongDelimiters } from './markdown-emphasis'
 
 const VIDEO_EXT_RE = /\.(mp4|webm|ogg|ogv|mov|m4v)(?:[?#].*)?$/i
 const PREVIEW_BLOCK_RE = /^<div\s+[^>]*data-type=(["'])(?:raw-html-block|math-block)\1/i
@@ -6,7 +7,7 @@ const DETAILS_BLOCK_RE = /<details(\s[^>]*)?>\s*<summary>([\s\S]*?)<\/summary>([
 const STANDALONE_HTML_MEDIA_RE = /^\s*<(?:img|video)\b[^>]*(?:\/?>|>.*?<\/video>)\s*$/i
 const LEADING_FRONTMATTER_RE = /^(?:\ufeff)?---[ \t]*\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)[ \t]*(?=\r?\n|$)/
 
-export const MARKDOWN_RENDERER_VERSION = 4
+export const MARKDOWN_RENDERER_VERSION = 5
 
 const EMOJI_SHORTCODES: Record<string, string> = {
   '+1': '👍',
@@ -332,7 +333,9 @@ function preprocessMarkdown(markdown: string): string {
   return splitMarkdownCodeRegions(wrapLeadingFrontmatterBlock(markdown))
     .map((chunk) => chunk.code
       ? chunk.text
-      : wrapMarkdownDetailsBlocks(separateStandaloneHtmlMediaBlocks(normalizeMarkdownLinePrefixes(chunk.text))))
+      : wrapMarkdownDetailsBlocks(separateStandaloneHtmlMediaBlocks(
+        normalizeMarkdownLinePrefixes(normalizeMalformedStrongDelimiters(chunk.text))
+      )))
     .join('')
 }
 


### PR DESCRIPTION
## 概述
修复模型常见的标签式 Markdown 强调写法在中文标签后紧接日期、英文或数字时，被 CommonMark 识别为普通文本并露出 `**` 的问题。修复同时覆盖 Markdown 文件预览/富文本编辑器与 Agent、Chat 主对话的渲染入口；并把 Electron patch 版本升级到 `0.17.18`。

## 改动
- `apps/electron/src/renderer/lib/markdown-emphasis.ts` — 新增保守的强调标记规范化器，将 `**调研日期：**2026` 等高频模型输出修复为合法的 `**调研日期：** 2026`；同时恢复 Tiptap 富文本编辑把无效强调标记序列化为 `\\*\\*...\\*\\*` 后的显示问题。
- `apps/electron/src/renderer/lib/markdown-rich-text.ts` — 在 Markdown 文件预览和富文本编辑器进入 `markdown-it` 前接入该规范化器，并升级渲染器版本以刷新已挂载编辑器内容。
- `apps/electron/src/renderer/components/ai-elements/message.tsx` — 在 `react-markdown` 解析前接入相同规范化器，保持 Agent/Chat 主对话与文件预览一致。
- `apps/electron/package.json` — Electron 包版本从 `0.17.17` 升至 `0.17.18`。

## 明确的产品取舍
- 保留对 `\\*\\*标签：\\*\\*值` 的恢复：这在严格 Markdown 语义中可能是用户刻意展示字面星号，但在 Proma 的真实路径中更常见的是模型先生成无效 `**标签：**值`，随后被 Tiptap 为保护普通文本而转义并写回文件。为优先修复文件预览与 Agent 输出中高频、明显错误的加粗展示，接受这个极低概率的字面文本取舍。
- 规范化器已显式跳过行内代码、围栏代码、缩进代码、raw HTML tag/属性，以及 Markdown 链接和图片的 destination，避免修改代码字面量、HTML 属性或 URL 数据。链接可见正文仍可被修复。

## 测试方法
1. 运行 `bun test apps/electron/src/renderer/lib/markdown-rich-text.test.ts`，确认现有 Markdown 预览、代码区域与序列化测试全部通过。
2. 运行 `bun run --filter='@proma/electron' typecheck`，确认 Electron renderer 类型检查通过。
3. 手动在 DEF Agent 中创建含 `**调研日期：**2026-08-13` 和 `\\*\\*调研日期： \\*\\*2026-08-13` 的 Markdown 文件，确认文件预览和 Agent 主对话均显示加粗，行内代码与围栏代码继续显示字面标记。

## 备注
- 未引入依赖、IPC、存储格式或跨平台路径变更。
- 本次没有新增测试文件或测试用例，避免为这一小型展示修复增加额外测试维护面；验证以既有定向测试、类型检查和实际 DEF Agent 双路径手工回归完成。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
