### PR TITLE
feat(agent-island): Windows Agent 状态通知与托盘交互优化

### DIFF
--- a/apps/electron/src/main/agent-status-hover-bounds.test.ts
+++ b/apps/electron/src/main/agent-status-hover-bounds.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import { calculateHoverWindowBounds } from './agent-status-hover-bounds'
+import type { Rectangle, Display } from 'electron'
+
+const WINDOW_SIZE = { width: 320, height: 400 }
+
+function makeDisplay(workArea: Rectangle, bounds?: Rectangle): Display {
+  return { workArea, bounds: bounds ?? workArea } as Display
+}
+
+describe('calculateHoverWindowBounds', () => {
+  test('托盘在屏幕底部居中 → 窗口在托盘正上方居中', () => {
+    const trayBounds: Rectangle = { x: 940, y: 1040, width: 40, height: 40 }
+    const display = makeDisplay({ x: 0, y: 0, width: 1920, height: 1040 })
+
+    const result = calculateHoverWindowBounds(trayBounds, WINDOW_SIZE, display)
+
+    expect(result.x).toBe(800)
+    expect(result.y).toBe(640)
+    expect(result.width).toBe(320)
+    expect(result.height).toBe(400)
+  })
+
+  test('托盘在右下角 → 窗口水平 clamp 不出屏', () => {
+    const trayBounds: Rectangle = { x: 1880, y: 1040, width: 40, height: 40 }
+    const display = makeDisplay({ x: 0, y: 0, width: 1920, height: 1040 })
+
+    const result = calculateHoverWindowBounds(trayBounds, WINDOW_SIZE, display)
+
+    expect(result.x + result.width).toBeLessThanOrEqual(1920)
+    expect(result.x).toBe(1600)
+    expect(result.y).toBe(640)
+  })
+
+  test('窗口高度超过可用空间 → clamp 到 workArea 高度', () => {
+    const trayBounds: Rectangle = { x: 800, y: 500, width: 40, height: 40 }
+    const display = makeDisplay({ x: 0, y: 0, width: 1920, height: 600 })
+
+    const result = calculateHoverWindowBounds(trayBounds, { width: 320, height: 1000 }, display)
+
+    expect(result.height).toBe(600)
+    expect(result.y).toBeGreaterThanOrEqual(0)
+    expect(result.y + result.height).toBeLessThanOrEqual(600)
+  })
+
+  test('多显示器（display 有 offset）→ 坐标正确', () => {
+    const trayBounds: Rectangle = { x: 2000, y: 1040, width: 40, height: 40 }
+    const display = makeDisplay({ x: 1920, y: 0, width: 1920, height: 1040 })
+
+    const result = calculateHoverWindowBounds(trayBounds, WINDOW_SIZE, display)
+
+    expect(result.x).toBeGreaterThanOrEqual(1920)
+    expect(result.x + result.width).toBeLessThanOrEqual(1920 + 1920)
+    expect(result.y).toBe(640)
+  })
+
+  test('窗口在 workArea 左边界 clamp', () => {
+    const trayBounds: Rectangle = { x: 1900, y: 1040, width: 40, height: 40 }
+    const display = makeDisplay({ x: 1920, y: 0, width: 1920, height: 1040 })
+
+    const result = calculateHoverWindowBounds(trayBounds, WINDOW_SIZE, display)
+
+    expect(result.x).toBe(1920)
+  })
+})

--- a/apps/electron/src/main/agent-status-hover-bounds.ts
+++ b/apps/electron/src/main/agent-status-hover-bounds.ts
@@ -1,0 +1,24 @@
+import type { Rectangle, Display } from 'electron'
+
+export function calculateHoverWindowBounds(
+  trayBounds: Rectangle,
+  windowSize: { width: number; height: number },
+  display: Display,
+): Rectangle {
+  const { workArea } = display
+  const width = windowSize.width
+  const clampedHeight = Math.min(windowSize.height, workArea.height)
+
+  let x = Math.round(trayBounds.x + trayBounds.width / 2 - width / 2)
+  let y = Math.round(trayBounds.y - clampedHeight)
+
+  x = Math.max(workArea.x, Math.min(x, workArea.x + workArea.width - width))
+
+  if (y < workArea.y) {
+    y = trayBounds.y + trayBounds.height
+  }
+
+  y = Math.max(workArea.y, Math.min(y, workArea.y + workArea.height - clampedHeight))
+
+  return { x, y, width, height: clampedHeight }
+}

--- a/apps/electron/src/main/agent-status-hover-window.ts
+++ b/apps/electron/src/main/agent-status-hover-window.ts
@@ -1,0 +1,230 @@
+import { app, BrowserWindow, screen } from 'electron'
+import { join } from 'node:path'
+import { WINDOWS_AGENT_ISLAND_IPC_CHANNELS } from '../types'
+import type { NativeAgentIslandSnapshot } from '@proma/shared'
+import { calculateHoverWindowBounds } from './agent-status-hover-bounds'
+
+const HOVER_WINDOW_WIDTH = 320
+
+const SHOW_DELAY_MS = 300
+const TRAY_LEAVE_GRACE_MS = 1500
+const HOVER_LEAVE_HIDE_MS = 300
+
+const HEADER_HEIGHT = 50
+const ROW_HEIGHT = 72
+const EMPTY_HEIGHT = 80
+const MAX_HEIGHT = 600
+const MAX_VISIBLE_SESSIONS = 10
+
+function calculateHeight(sessionCount: number): number {
+  if (sessionCount === 0) return EMPTY_HEIGHT
+  const visible = Math.min(sessionCount, MAX_VISIBLE_SESSIONS)
+  return Math.min(MAX_HEIGHT, HEADER_HEIGHT + visible * ROW_HEIGHT)
+}
+
+export class AgentStatusHoverWindow {
+  private win: BrowserWindow | null = null
+  private showTimer: ReturnType<typeof setTimeout> | null = null
+  private hideTimer: ReturnType<typeof setTimeout> | null = null
+  private latestSnapshot: NativeAgentIslandSnapshot | null = null
+  private currentHeight = EMPTY_HEIGHT
+  private hoverActive = false
+  private lastTrayBounds: Electron.Rectangle | null = null
+
+  ensureCreated(): void {
+    if (this.win && !this.win.isDestroyed()) return
+
+    this.win = new BrowserWindow({
+      width: HOVER_WINDOW_WIDTH,
+      height: this.currentHeight,
+      frame: false,
+      transparent: true,
+      backgroundColor: '#00000000',
+      skipTaskbar: true,
+      alwaysOnTop: true,
+      focusable: true,
+      resizable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      show: false,
+      hasShadow: false,
+      webPreferences: {
+        preload: join(__dirname, 'preload.cjs'),
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    })
+
+    this.win.on('closed', () => {
+      this.win = null
+    })
+
+    this.win.on('blur', () => {
+      this.scheduleHide()
+    })
+
+    if (app.isPackaged) {
+      this.win.loadFile(join(__dirname, 'renderer', 'index.html'), {
+        query: { window: 'agent-status-hover' },
+      })
+    } else {
+      this.win.loadURL('http://127.0.0.1:5173?window=agent-status-hover')
+    }
+  }
+
+  onTrayMouseEnter(bounds: Electron.Rectangle): void {
+    this.clearHideTimer()
+
+    if (this.win && !this.win.isDestroyed() && this.win.isVisible()) {
+      this.pushSnapshot()
+      return
+    }
+
+    this.clearShowTimer()
+    this.showTimer = setTimeout(() => {
+      this.showTimer = null
+      this.show(bounds)
+    }, SHOW_DELAY_MS)
+  }
+
+  onTrayMouseMove(bounds: Electron.Rectangle): void {
+    this.clearHideTimer()
+
+    if (this.win && !this.win.isDestroyed() && this.win.isVisible()) {
+      return
+    }
+
+    if (!this.showTimer) {
+      this.showTimer = setTimeout(() => {
+        this.showTimer = null
+        this.show(bounds)
+      }, SHOW_DELAY_MS)
+    }
+  }
+
+  onTrayMouseLeave(): void {
+    if (this.hoverActive) return
+    this.clearShowTimer()
+    this.scheduleHide(TRAY_LEAVE_GRACE_MS)
+  }
+
+  onHoverMouseEnter(): void {
+    this.hoverActive = true
+    this.clearHideTimer()
+  }
+
+  onHoverMouseLeave(): void {
+    this.hoverActive = false
+    this.scheduleHide()
+  }
+
+  updateSnapshot(snapshot: NativeAgentIslandSnapshot): void {
+    this.latestSnapshot = snapshot
+    if (this.win && !this.win.isDestroyed() && this.win.isVisible()) {
+      if (snapshot.state.sessions.length === 0) {
+        this.hide()
+        return
+      }
+      this.resizeToFit(snapshot.state.sessions.length)
+      this.win.webContents.send(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.PUSH_SNAPSHOT, snapshot)
+    }
+  }
+
+  dispose(): void {
+    this.clearShowTimer()
+    this.clearHideTimer()
+    if (this.win && !this.win.isDestroyed()) {
+      this.win.destroy()
+    }
+    this.win = null
+  }
+
+  private show(bounds: Electron.Rectangle): void {
+    if (!this.latestSnapshot || this.latestSnapshot.state.sessions.length === 0) return
+    if (!this.win || this.win.isDestroyed()) return
+
+    this.lastTrayBounds = bounds
+    this.resizeToFit(this.latestSnapshot.state.sessions.length)
+    const display = screen.getDisplayNearestPoint({ x: bounds.x, y: bounds.y })
+    const rect = calculateHoverWindowBounds(
+      bounds,
+      { width: HOVER_WINDOW_WIDTH, height: this.currentHeight },
+      display,
+    )
+    this.win.setBounds(rect)
+    this.win.showInactive()
+    this.pushSnapshot()
+  }
+
+  private hide(): void {
+    this.hoverActive = false
+    if (this.win && !this.win.isDestroyed()) {
+      this.win.hide()
+    }
+  }
+
+  private scheduleHide(delay = HOVER_LEAVE_HIDE_MS): void {
+    if (this.hideTimer) clearTimeout(this.hideTimer)
+    this.hideTimer = setTimeout(() => {
+      this.hideTimer = null
+      this.hide()
+    }, delay)
+  }
+
+  private resizeToFit(sessionCount: number): void {
+    const newHeight = calculateHeight(sessionCount)
+    if (newHeight === this.currentHeight) return
+    this.currentHeight = newHeight
+    if (this.win && !this.win.isDestroyed() && this.win.isVisible() && this.lastTrayBounds) {
+      const display = screen.getDisplayNearestPoint({
+        x: this.lastTrayBounds.x,
+        y: this.lastTrayBounds.y,
+      })
+      const rect = calculateHoverWindowBounds(
+        this.lastTrayBounds,
+        { width: HOVER_WINDOW_WIDTH, height: newHeight },
+        display,
+      )
+      this.win.setBounds(rect)
+    }
+  }
+
+  private pushSnapshot(): void {
+    if (!this.win || this.win.isDestroyed() || !this.latestSnapshot) return
+    if (this.win.webContents.isLoading()) {
+      this.win.webContents.once('did-finish-load', () => {
+        if (this.latestSnapshot) this.pushSnapshot()
+      })
+      return
+    }
+    this.win.webContents.send(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.PUSH_SNAPSHOT, this.latestSnapshot)
+  }
+
+  private clearShowTimer(): void {
+    if (this.showTimer) {
+      clearTimeout(this.showTimer)
+      this.showTimer = null
+    }
+  }
+
+  private clearHideTimer(): void {
+    if (this.hideTimer) {
+      clearTimeout(this.hideTimer)
+      this.hideTimer = null
+    }
+  }
+}
+
+let hoverWindow: AgentStatusHoverWindow | null = null
+
+export function getAgentStatusHoverWindow(): AgentStatusHoverWindow {
+  if (!hoverWindow) hoverWindow = new AgentStatusHoverWindow()
+  return hoverWindow
+}
+
+export function destroyAgentStatusHoverWindow(): void {
+  hoverWindow?.dispose()
+  hoverWindow = null
+}

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -79,7 +79,7 @@ for (const key of Object.keys(process.env)) {
 
 import { createApplicationMenu } from './menu'
 import { registerIpcHandlers } from './ipc'
-import { createTray, destroyTray, getTray } from './tray'
+import { createTray, destroyTray, getTray, setTrayFlash } from './tray'
 import { initializeRuntime } from './lib/runtime-init'
 import { seedDefaultSkills } from './lib/config-paths'
 import { upgradeDefaultSkillsInWorkspaces } from './lib/agent-workspace-manager'
@@ -112,12 +112,14 @@ import { getDingTalkMultiBotConfig } from './lib/dingtalk-config'
 import { wechatBridge } from './lib/wechat-bridge'
 import { getWeChatConfig } from './lib/wechat-config'
 import { createQuickTaskWindow, toggleQuickTaskWindow, destroyQuickTaskWindow } from './lib/quick-task-window'
+import { getAgentStatusHoverWindow, destroyAgentStatusHoverWindow } from './agent-status-hover-window'
 import { destroyPlanningWindow, showPlanningWindow } from './lib/planning-window'
 import { configurePlanningQuickEntries } from './lib/planning-quick-entry'
 import { hasOpenPlanningArgument } from './lib/planning-quick-entry-model'
 import { handleNativeAgentIslandEvent, initAgentIslandService, disposeAgentIslandService, publishAgentIslandNow } from './lib/agent-island-service'
 import { disposeMacAgentIslandNativeHost, startMacAgentIslandNativeHost, isMacAgentIslandNativeHostReady } from './lib/mac-agent-island-native-host'
-import { isAgentIslandSupported } from './lib/macos-version'
+import { isAgentIslandServiceSupported, isMacAgentIslandSurfaceSupported } from './lib/macos-version'
+import { getWindowsAgentIslandSurface, processNotification, type SurfaceDeps } from './lib/windows-agent-island-surface'
 import {
   createVoiceDictationWindow,
   toggleVoiceDictationWindow,
@@ -126,11 +128,11 @@ import {
 } from './lib/voice-dictation-window'
 import { registerGlobalShortcut, unregisterAllGlobalShortcuts } from './lib/global-shortcut-service'
 import { setPromaVersion } from '@proma/core'
-import { TRAY_IPC_CHANNELS } from '../types'
+import { TRAY_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS } from '../types'
 
 /** macOS 26+ 使用 Swift/AppKit NSPanel；其他平台不创建 Agent Island surface。 */
 function startAgentIslandSurface(): void {
-  if (!isAgentIslandSupported()) {
+  if (!isMacAgentIslandSurfaceSupported()) {
     console.info('[agent-island] 当前平台或 macOS 版本不支持，已禁用')
     return
   }
@@ -650,6 +652,9 @@ async function bootstrap(): Promise<void> {
   if (hasOpenPlanningArgument(process.argv)) showPlanningWindow()
 
   // Create system tray icon
+  const hoverWin = process.platform === 'win32' ? getAgentStatusHoverWindow() : null
+  if (hoverWin) safeRun('ensureHoverWindow', () => hoverWin.ensureCreated())
+
   createTray({
     showMainWindow: showAndFocusMainWindow,
     showPlanningWindow,
@@ -662,7 +667,29 @@ async function bootstrap(): Promise<void> {
     createAgentSession: () => {
       sendToMainWindow(TRAY_IPC_CHANNELS.CREATE_SESSION, { mode: 'agent' })
     },
+    onTrayMouseEnter: hoverWin ? (bounds) => hoverWin.onTrayMouseEnter(bounds) : undefined,
+    onTrayMouseMove: hoverWin ? (bounds) => hoverWin.onTrayMouseMove(bounds) : undefined,
+    onTrayMouseLeave: hoverWin ? () => hoverWin.onTrayMouseLeave() : undefined,
   })
+
+  // Windows: 将 Agent Island surface 的 pill 状态接入托盘图标 + tooltip + 通知
+  if (process.platform === 'win32') {
+    const surface = getWindowsAgentIslandSurface()
+    surface.onTrayFlash = (flashing) => setTrayFlash(flashing)
+
+    const notificationDeps: SurfaceDeps = {
+      sendPlaySound: (type) => {
+        const win = getMainWindow()
+        if (win) win.webContents.send(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.PLAY_SOUND, { type })
+      },
+      soundEnabled: () => getSettings().notificationSoundEnabled ?? true,
+    }
+    surface.onNotification = (transition) => processNotification(transition, notificationDeps)
+
+    if (hoverWin) {
+      surface.onHoverWindowUpdate = (snapshot) => hoverWin.updateSnapshot(snapshot)
+    }
+  }
 
   // 启动工作区文件监听（Agent MCP/Skills + 文件浏览器自动刷新）
   if (mainWindow) {
@@ -684,8 +711,8 @@ async function bootstrap(): Promise<void> {
     safeRun('createVoiceDictationWindow', createVoiceDictationWindow)
   }
 
-  // Agent Island 仅在 macOS 26+ 原生 surface 上初始化；Windows/Linux 不注册服务、窗口或事件监听。
-  if (isAgentIslandSupported()) {
+  // Agent Island 状态机在 macOS 和 Windows 都初始化；Swift surface 仅 macOS 26+。
+  if (isAgentIslandServiceSupported()) {
     safeRun('initAgentIslandService', () => {
       initAgentIslandService({
         showAndFocusMainWindow,
@@ -693,9 +720,12 @@ async function bootstrap(): Promise<void> {
           sendToMainWindow(TRAY_IPC_CHANNELS.OPEN_AGENT_SESSION, { sessionId, title })
         },
         openPlanning: showPlanningWindow,
-        enabled: () => isMacAgentIslandNativeHostReady() && getSettings().agentIsland?.enabled !== false,
+        enabled: () => getSettings().agentIsland?.enabled !== false,
       })
     })
+  }
+
+  if (isMacAgentIslandSurfaceSupported()) {
     safeRun('startAgentIslandSurface', startAgentIslandSurface)
   }
 
@@ -829,6 +859,7 @@ app.on('before-quit', () => {
   destroyQuickTaskWindow()
   destroyPlanningWindow()
   destroyVoiceDictationWindow()
+  destroyAgentStatusHoverWindow()
   // 销毁原生 macOS 灵动岛服务（其他平台从未创建 surface）
   disposeMacAgentIslandNativeHost()
   disposeAgentIslandService()

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -10,7 +10,7 @@ import { existsSync, realpathSync, readFileSync, writeFileSync, mkdirSync, statS
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
   VoiceDictationAudioChunkInput,
@@ -205,7 +205,8 @@ import { extractTextFromAttachment } from './lib/document-parser'
 import { getTutorialContent, createWelcomeConversation } from './lib/tutorial-service'
 import { getUserProfile, updateUserProfile } from './lib/user-profile-service'
 import { getSettings, updateSettings } from './lib/settings-service'
-import { refreshAgentIslandConfiguration } from './lib/agent-island-service'
+import { refreshAgentIslandConfiguration, markAgentIslandSessionViewed } from './lib/agent-island-service'
+import { getAgentStatusHoverWindow } from './agent-status-hover-window'
 import { setBuiltinMcpUserEnabled } from './lib/builtin-mcp/settings'
 import { setDockBadgeCount } from './lib/dock-badge-service'
 
@@ -5327,4 +5328,31 @@ export function registerIpcHandlers(): void {
       await runAutomationNow(id)
     }
   )
+
+  // ===== Windows Agent Island =====
+
+  ipcMain.handle(
+    WINDOWS_AGENT_ISLAND_IPC_CHANNELS.OPEN_SESSION,
+    async (_, sessionId: unknown, title: unknown): Promise<void> => {
+      if (!isNonEmptyString(sessionId)) return
+      markAgentIslandSessionViewed(sessionId)
+      const { getMainWindow } = await import('./index')
+      const mainWindow = getMainWindow()
+      if (!mainWindow) return
+      mainWindow.webContents.send(TRAY_IPC_CHANNELS.OPEN_AGENT_SESSION, {
+        sessionId,
+        title: typeof title === 'string' ? title : '',
+      })
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.show()
+      mainWindow.focus()
+    }
+  )
+
+  ipcMain.on(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.MOUSE_ENTER, () => {
+    getAgentStatusHoverWindow().onHoverMouseEnter()
+  })
+  ipcMain.on(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.MOUSE_LEAVE, () => {
+    getAgentStatusHoverWindow().onHoverMouseLeave()
+  })
 }

--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -34,6 +34,7 @@ import { selectAgentIslandCompactPlanQuota } from './agent-island-plan-quota'
 import { getAgentIslandPhasePriority } from './agent-island-priority'
 import { buildVisibilityKey } from './agent-island-visibility'
 import { shouldRetainAgentIslandSession } from './agent-island-session-visibility'
+import { getWindowsAgentIslandSurface } from './windows-agent-island-surface'
 import { listCalendarEvents, listTodos } from './planning-manager'
 import { onPlanningChanged } from './planning-events'
 import { getChannelPlanQuota, listChannels } from './channel-manager'
@@ -633,9 +634,19 @@ function pushState(): void {
   if (json === lastStateJson) return
   lastStateJson = json
 
-  // macOS 原生 helper 是唯一的 Island surface；helper 不可用时直接停止投影。
-  if (!isMacAgentIslandNativeHostReady()) return
-  publishMacAgentIslandSnapshot(buildNativeSnapshot(state, planning))
+  const snapshot = buildNativeSnapshot(state, planning)
+
+  if (isMacAgentIslandNativeHostReady()) {
+    publishMacAgentIslandSnapshot(snapshot)
+  }
+
+  if (process.platform === 'win32') {
+    publishWindowsAgentIslandSnapshot(snapshot)
+  }
+}
+
+function publishWindowsAgentIslandSnapshot(snapshot: NativeAgentIslandSnapshot): void {
+  getWindowsAgentIslandSurface().onSnapshot(snapshot)
 }
 
 /**
@@ -791,7 +802,6 @@ export function initAgentIslandService(deps: AgentIslandServiceDeps): void {
 
   // 订阅 Agent 事件流
   disposeEventBus = agentEventBus.on((sessionId, payload) => {
-    if (deps.enabled?.() === false) return
     handleAgentEvent(sessionId, payload)
     schedulePush(requiresImmediateAgentIslandPush(payload) ? PUSH_THROTTLE_MS : AGENT_STREAM_PUSH_THROTTLE_MS)
   })
@@ -807,7 +817,7 @@ export function initAgentIslandService(deps: AgentIslandServiceDeps): void {
  * 完成和异常态的未读由主进程管理；主应用确认用户已经看过后，在此统一清除。
  * 待接手会话仍保持 attention，直到用户实际完成权限确认、回答或计划审批。
  */
-function markAgentIslandSessionViewed(sessionId: string): void {
+export function markAgentIslandSessionViewed(sessionId: string): void {
   const session = sessions.get(sessionId)
   if (!session || (session.phase !== 'completed' && session.phase !== 'error')) return
   if (session.phase === 'completed' && !session.unread) return

--- a/apps/electron/src/main/lib/macos-version.test.ts
+++ b/apps/electron/src/main/lib/macos-version.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  isAgentIslandServiceSupported,
+  isMacAgentIslandSurfaceSupported,
+  isAgentIslandSupported,
+} from './macos-version'
+
+const DARWIN_25 = '25.0.0'
+const DARWIN_24 = '24.0.0'
+
+describe('isAgentIslandServiceSupported', () => {
+  test('Given macOS When checking Then returns true regardless of version', () => {
+    expect(isAgentIslandServiceSupported('darwin')).toBe(true)
+    expect(isAgentIslandServiceSupported('darwin')).toBe(true)
+  })
+
+  test('Given Windows When checking Then returns true', () => {
+    expect(isAgentIslandServiceSupported('win32')).toBe(true)
+  })
+
+  test('Given Linux When checking Then returns false', () => {
+    expect(isAgentIslandServiceSupported('linux')).toBe(false)
+  })
+})
+
+describe('isMacAgentIslandSurfaceSupported', () => {
+  test('Given macOS Darwin 25 (macOS 26) When checking Then returns true', () => {
+    expect(isMacAgentIslandSurfaceSupported('darwin', DARWIN_25)).toBe(true)
+  })
+
+  test('Given macOS Darwin 24 (macOS 15) When checking Then returns false', () => {
+    expect(isMacAgentIslandSurfaceSupported('darwin', DARWIN_24)).toBe(false)
+  })
+
+  test('Given Windows When checking Then returns false', () => {
+    expect(isMacAgentIslandSurfaceSupported('win32', DARWIN_25)).toBe(false)
+  })
+
+  test('Given Linux When checking Then returns false', () => {
+    expect(isMacAgentIslandSurfaceSupported('linux', DARWIN_25)).toBe(false)
+  })
+})
+
+describe('isAgentIslandSupported (deprecated alias)', () => {
+  test('Given macOS Darwin 25 When checking Then delegates to surface supported', () => {
+    expect(isAgentIslandSupported('darwin', DARWIN_25)).toBe(true)
+  })
+
+  test('Given Windows When checking Then returns false (surface is Mac-only)', () => {
+    expect(isAgentIslandSupported('win32', DARWIN_25)).toBe(false)
+  })
+})

--- a/apps/electron/src/main/lib/macos-version.ts
+++ b/apps/electron/src/main/lib/macos-version.ts
@@ -8,7 +8,17 @@ export function isMacOS26OrLater(darwinRelease = release()): boolean {
   return Number.isFinite(darwinMajor) && darwinMajor >= MACOS_26_DARWIN_MAJOR
 }
 
-/** Agent Island 仅在 macOS 26+ 使用原生 Swift/AppKit surface。 */
-export function isAgentIslandSupported(platform = process.platform, darwinRelease = release()): boolean {
+/** 状态机支持的平台：macOS 和 Windows 都初始化 AgentIslandService。Linux 暂不支持。 */
+export function isAgentIslandServiceSupported(platform = process.platform): boolean {
+  return platform === 'darwin' || platform === 'win32'
+}
+
+/** macOS Swift/AppKit surface 仅在 macOS 26+ 启动。 */
+export function isMacAgentIslandSurfaceSupported(platform = process.platform, darwinRelease = release()): boolean {
   return platform === 'darwin' && isMacOS26OrLater(darwinRelease)
+}
+
+/** @deprecated 改用 isMacAgentIslandSurfaceSupported() */
+export function isAgentIslandSupported(platform = process.platform, darwinRelease = release()): boolean {
+  return isMacAgentIslandSurfaceSupported(platform, darwinRelease)
 }

--- a/apps/electron/src/main/lib/windows-agent-island-surface.test.ts
+++ b/apps/electron/src/main/lib/windows-agent-island-surface.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  detectPhaseTransitions,
+  WindowsAgentIslandSurface,
+  mapTransitionToSoundType,
+  processNotification,
+  type PhaseTransition,
+  type SurfaceDeps,
+} from './windows-agent-island-surface'
+import type { AgentIslandPhase, AgentIslandInteractionKind, NativeAgentIslandSnapshot } from '@proma/shared'
+
+function makeSnapshot(
+  sessions: Array<{
+    sessionId: string
+    phase: AgentIslandPhase
+    detail?: string
+    title?: string
+    attention?: boolean
+  }>,
+): NativeAgentIslandSnapshot {
+  return {
+    type: 'snapshot',
+    protocol: 1,
+    revision: 1,
+    state: {
+      visible: true,
+      presentation: 'compact',
+      hovered: false,
+      expanded: false,
+      pill: {
+        priorityStatus: 'idle',
+        sessionCount: sessions.length,
+        activeSessionCount: 0,
+        pendingInteractionCount: 0,
+        unreadCompletedCount: 0,
+      },
+      sessions: sessions.map((s) => ({
+        sessionId: s.sessionId,
+        title: s.title ?? s.sessionId,
+        phase: s.phase,
+        detail: s.detail ?? '',
+        activityLines: [],
+        attention: s.attention ?? false,
+        startedAt: 0,
+        lastActivityAt: 0,
+      })),
+      recentSessions: [],
+      idleDashboard: false,
+      totalCount: sessions.length,
+      updatedAt: 0,
+    },
+    planning: { dayStart: 0, dayEnd: 0, todos: [], events: [], overdueTodoCount: 0 },
+    planQuotas: [],
+  }
+}
+
+function makePhases(entries: Record<string, AgentIslandPhase>): Map<string, AgentIslandPhase> {
+  return new Map(Object.entries(entries))
+}
+
+describe('detectPhaseTransitions', () => {
+  test('running → completed 产生 1 个 transition', () => {
+    const prev = makePhases({ s1: 'running' })
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'completed' }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.from).toBe('running')
+    expect(result[0]!.to).toBe('completed')
+  })
+
+  test('running → needs-interaction 产生 1 个 transition', () => {
+    const prev = makePhases({ s1: 'running' })
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'needs-interaction' }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.to).toBe('needs-interaction')
+  })
+
+  test('running → error 产生 1 个 transition', () => {
+    const prev = makePhases({ s1: 'running' })
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'error', attention: true }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.to).toBe('error')
+  })
+
+  test('running → running（detail 变化）不产生 transition', () => {
+    const prev = makePhases({ s1: 'running' })
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'running', detail: '新内容' }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(0)
+  })
+
+  test('needs-interaction → running 不产生 transition', () => {
+    const prev = makePhases({ s1: 'needs-interaction' })
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'running' }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(0)
+  })
+
+  test('新会话直接 completed 产生 transition', () => {
+    const prev = makePhases({})
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'completed' }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.from).toBe('idle')
+    expect(result[0]!.to).toBe('completed')
+  })
+
+  test('新会话直接 running 不产生 transition', () => {
+    const prev = makePhases({})
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'running' }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(0)
+  })
+
+  test('多会话各自独立检测（A 完成 + B 报错 → 2 个 transition）', () => {
+    const prev = makePhases({ A: 'running', B: 'running' })
+    const curr = makeSnapshot([
+      { sessionId: 'A', phase: 'completed' },
+      { sessionId: 'B', phase: 'error', attention: true },
+    ])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(2)
+  })
+
+  test('会话从 snapshot 消失不产生 transition', () => {
+    const prev = makePhases({ s1: 'running', s2: 'running' })
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'completed' }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.sessionId).toBe('s1')
+  })
+
+  test('空 snapshot → 有会话的 snapshot：running 不通知，其余通知', () => {
+    const prev = makePhases({})
+    const curr = makeSnapshot([
+      { sessionId: 'a', phase: 'running' },
+      { sessionId: 'b', phase: 'needs-interaction' },
+      { sessionId: 'c', phase: 'completed' },
+      { sessionId: 'd', phase: 'error', attention: true },
+    ])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(3)
+    expect(result.map((t) => t.sessionId).sort()).toEqual(['b', 'c', 'd'])
+  })
+
+  test('相同 snapshot 重复传入不产生 transition', () => {
+    const prev = makePhases({ s1: 'running', s2: 'needs-interaction' })
+    const curr = makeSnapshot([
+      { sessionId: 's1', phase: 'running' },
+      { sessionId: 's2', phase: 'needs-interaction' },
+    ])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(0)
+  })
+
+  test('error attention=false 不产生 transition', () => {
+    const prev = makePhases({ s1: 'running' })
+    const curr = makeSnapshot([{ sessionId: 's1', phase: 'error', attention: false }])
+    const result = detectPhaseTransitions(prev, curr)
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('WindowsAgentIslandSurface', () => {
+  test('onSnapshot 首次传入 tracking running，完成时产生 transition', () => {
+    const surface = new WindowsAgentIslandSurface(() => true)
+    const notified: PhaseTransition[] = []
+    surface.onNotification = (t) => notified.push(t)
+
+    surface.onSnapshot(makeSnapshot([{ sessionId: 's1', phase: 'running' }]))
+    expect(notified).toHaveLength(0)
+
+    surface.onSnapshot(makeSnapshot([{ sessionId: 's1', phase: 'completed' }]))
+    expect(notified).toHaveLength(1)
+    expect(notified[0]!.to).toBe('completed')
+  })
+
+  test('onTrayFlash 反映是否存在 attention 会话', () => {
+    const surface = new WindowsAgentIslandSurface(() => true)
+    const flashes: boolean[] = []
+    surface.onTrayFlash = (f) => flashes.push(f)
+
+    surface.onSnapshot(makeSnapshot([{ sessionId: 's1', phase: 'running' }]))
+    surface.onSnapshot(makeSnapshot([{ sessionId: 's1', phase: 'running', attention: true }]))
+    surface.onSnapshot(makeSnapshot([{ sessionId: 's1', phase: 'running' }]))
+    expect(flashes).toEqual([false, true, false])
+  })
+
+  test('onHoverWindowUpdate 每次调用时收到 snapshot', () => {
+    const surface = new WindowsAgentIslandSurface(() => true)
+    const received: NativeAgentIslandSnapshot[] = []
+    surface.onHoverWindowUpdate = (s) => received.push(s)
+
+    const snap = makeSnapshot([{ sessionId: 's1', phase: 'running' }])
+    surface.onSnapshot(snap)
+    expect(received).toHaveLength(1)
+    expect(received[0]).toBe(snap)
+  })
+
+  test('回调未设置时安全执行（no-op）', () => {
+    const surface = new WindowsAgentIslandSurface(() => true)
+    expect(() => surface.onSnapshot(makeSnapshot([{ sessionId: 's1', phase: 'completed' }]))).not.toThrow()
+  })
+
+  test('禁用分支调用 onTrayFlash(false) 且不产生 hover 更新', () => {
+    const surface = new WindowsAgentIslandSurface(() => false)
+    const flashes: boolean[] = []
+    const hoverUpdates: NativeAgentIslandSnapshot[] = []
+    surface.onTrayFlash = (f) => flashes.push(f)
+    surface.onHoverWindowUpdate = (s) => hoverUpdates.push(s)
+
+    surface.onSnapshot(makeSnapshot([{ sessionId: 's1', phase: 'running' }]))
+    expect(flashes).toEqual([false])
+    expect(hoverUpdates).toHaveLength(0)
+  })
+})
+
+function makeTransition(
+  to: AgentIslandPhase,
+  opts?: { interactionKind?: AgentIslandInteractionKind; title?: string; detail?: string },
+): PhaseTransition {
+  return {
+    sessionId: 's1',
+    from: 'running',
+    to,
+    title: opts?.title ?? 'Test Session',
+    detail: opts?.detail ?? 'some detail',
+    interactionKind: opts?.interactionKind,
+  }
+}
+
+function makeMockDeps(overrides?: Partial<SurfaceDeps>): SurfaceDeps & {
+  calls: { sendPlaySound: string[] }
+} {
+  const calls = {
+    sendPlaySound: [] as string[],
+  }
+  return {
+    soundEnabled: overrides?.soundEnabled ?? (() => true),
+    sendPlaySound: (type) => calls.sendPlaySound.push(type),
+    calls,
+  }
+}
+
+describe('mapTransitionToSoundType', () => {
+  test('needs-interaction + permission → permissionRequest', () => {
+    expect(mapTransitionToSoundType(makeTransition('needs-interaction', { interactionKind: 'permission' }))).toBe('permissionRequest')
+  })
+
+  test('needs-interaction + ask_user_question → permissionRequest', () => {
+    expect(mapTransitionToSoundType(makeTransition('needs-interaction', { interactionKind: 'ask_user_question' }))).toBe('permissionRequest')
+  })
+
+  test('needs-interaction + plan_review → exitPlanMode', () => {
+    expect(mapTransitionToSoundType(makeTransition('needs-interaction', { interactionKind: 'plan_review' }))).toBe('exitPlanMode')
+  })
+
+  test('completed → taskComplete', () => {
+    expect(mapTransitionToSoundType(makeTransition('completed'))).toBe('taskComplete')
+  })
+
+  test('error → taskComplete', () => {
+    expect(mapTransitionToSoundType(makeTransition('error'))).toBe('taskComplete')
+  })
+})
+
+describe('processNotification', () => {
+  test('soundEnabled=false 不播放提示音', () => {
+    const deps = makeMockDeps({ soundEnabled: () => false })
+    processNotification(makeTransition('needs-interaction', { interactionKind: 'permission' }), deps)
+    expect(deps.calls.sendPlaySound).toHaveLength(0)
+  })
+
+  test('soundEnabled=true 播放 needs-interaction 对应提示音', () => {
+    const deps = makeMockDeps()
+    processNotification(makeTransition('needs-interaction', { interactionKind: 'permission' }), deps)
+    expect(deps.calls.sendPlaySound).toEqual(['permissionRequest'])
+  })
+
+  test('soundEnabled=true 播放 completed 对应提示音', () => {
+    const deps = makeMockDeps()
+    processNotification(makeTransition('completed'), deps)
+    expect(deps.calls.sendPlaySound).toEqual(['taskComplete'])
+  })
+})

--- a/apps/electron/src/main/lib/windows-agent-island-surface.ts
+++ b/apps/electron/src/main/lib/windows-agent-island-surface.ts
@@ -1,0 +1,115 @@
+import type {
+  AgentIslandInteractionKind,
+  AgentIslandPhase,
+  NativeAgentIslandSnapshot,
+} from '@proma/shared'
+import type { NotificationSoundType } from '../../types'
+import { getSettings } from './settings-service'
+
+export interface PhaseTransition {
+  sessionId: string
+  from: AgentIslandPhase
+  to: AgentIslandPhase
+  title: string
+  detail: string
+  interactionKind?: AgentIslandInteractionKind
+}
+
+function shouldNotifyTransition(
+  from: AgentIslandPhase | undefined,
+  to: AgentIslandPhase,
+  attention: boolean,
+): boolean {
+  if (from === to) return false
+  if (from === undefined) {
+    return to === 'needs-interaction' || to === 'completed' || (to === 'error' && attention)
+  }
+  if (to === 'error' && attention) return true
+  if (from === 'running' && (to === 'needs-interaction' || to === 'completed')) return true
+  return false
+}
+
+export function detectPhaseTransitions(
+  prevPhases: Map<string, AgentIslandPhase>,
+  curr: NativeAgentIslandSnapshot,
+): PhaseTransition[] {
+  const transitions: PhaseTransition[] = []
+  for (const session of curr.state.sessions) {
+    const prevPhase = prevPhases.get(session.sessionId)
+    if (shouldNotifyTransition(prevPhase, session.phase, session.attention)) {
+      transitions.push({
+        sessionId: session.sessionId,
+        from: prevPhase ?? 'idle',
+        to: session.phase,
+        title: session.title,
+        detail: session.detail,
+        interactionKind: session.interactionKind,
+      })
+    }
+  }
+  return transitions
+}
+
+export class WindowsAgentIslandSurface {
+  private prevPhases = new Map<string, AgentIslandPhase>()
+  private isEnabled: () => boolean
+
+  constructor(isEnabled?: () => boolean) {
+    this.isEnabled = isEnabled ?? (() => getSettings().agentIsland?.enabled !== false && getSettings().notificationsEnabled !== false)
+  }
+
+  onTrayFlash?(flashing: boolean): void
+  onNotification?(transition: PhaseTransition): void
+  onHoverWindowUpdate?(snapshot: NativeAgentIslandSnapshot): void
+
+  onSnapshot(snapshot: NativeAgentIslandSnapshot): void {
+    if (!this.isEnabled()) {
+      this.onTrayFlash?.(false)
+      this.prevPhases.clear()
+      return
+    }
+
+    const transitions = detectPhaseTransitions(this.prevPhases, snapshot)
+    this.prevPhases = new Map(snapshot.state.sessions.map((s) => [s.sessionId, s.phase]))
+
+    if (transitions.length > 0) {
+      console.log(
+        '[windows-agent-island] phase transitions:',
+        transitions.map((t) => `${t.sessionId.slice(0, 8)} ${t.from}→${t.to}`).join(', '),
+      )
+    }
+
+    this.onTrayFlash?.(snapshot.state.sessions.some((s) => s.attention))
+    for (const t of transitions) {
+      this.onNotification?.(t)
+    }
+    this.onHoverWindowUpdate?.(snapshot)
+  }
+}
+
+let windowsSurface: WindowsAgentIslandSurface | null = null
+
+export function getWindowsAgentIslandSurface(): WindowsAgentIslandSurface {
+  if (!windowsSurface) windowsSurface = new WindowsAgentIslandSurface()
+  return windowsSurface
+}
+
+// ===== 通知逻辑（纯函数 + 依赖注入） =====
+
+export interface SurfaceDeps {
+  sendPlaySound: (type: NotificationSoundType) => void
+  soundEnabled: () => boolean
+}
+
+export function mapTransitionToSoundType(transition: PhaseTransition): NotificationSoundType {
+  if (transition.to === 'needs-interaction') {
+    if (transition.interactionKind === 'plan_review') return 'exitPlanMode'
+    return 'permissionRequest'
+  }
+  return 'taskComplete'
+}
+
+export function processNotification(transition: PhaseTransition, deps: SurfaceDeps): void {
+  if (!deps.soundEnabled()) return
+  deps.sendPlaySound(mapTransitionToSoundType(transition))
+}

--- a/apps/electron/src/main/tray.ts
+++ b/apps/electron/src/main/tray.ts
@@ -14,11 +14,23 @@ export interface TrayActions {
   openAgentSession: (sessionId: string, title: string) => void
   createChatSession: () => void
   createAgentSession: () => void
+  onTrayMouseEnter?: (bounds: Electron.Rectangle) => void
+  onTrayMouseMove?: (bounds: Electron.Rectangle) => void
+  onTrayMouseLeave?: () => void
+}
+
+let flashTimer: ReturnType<typeof setInterval> | null = null
+
+function clearTrayFlashTimer(): void {
+  if (flashTimer) {
+    clearInterval(flashTimer)
+    flashTimer = null
+  }
 }
 
 /**
  * 获取托盘图标路径
- * 所有平台统一使用 Template 图标
+ * 所有平台统一使用 Template 图标（PNG）
  */
 function getTrayIconPath(): string {
   // dev: __dirname/resources（build:resources 拷贝产物）
@@ -136,31 +148,31 @@ function updateTrayMenu(actions: TrayActions): Menu | null {
 export function createTray(actionsInput?: Partial<TrayActions>): Tray | null {
   const iconPath = getTrayIconPath()
   const actions = { ...getDefaultTrayActions(), ...actionsInput }
+  const hasIcon = existsSync(iconPath)
 
-  if (!existsSync(iconPath)) {
+  if (!hasIcon && process.platform !== 'win32') {
     console.warn('Tray icon not found at:', iconPath)
     return null
   }
 
   try {
-    const image = nativeImage.createFromPath(iconPath)
+    const image = hasIcon ? nativeImage.createFromPath(iconPath) : nativeImage.createEmpty()
 
-    // macOS: 标记为 Template 图像
-    // Template 图像必须是单色的，使用 alpha 通道定义形状
-    // 系统会自动根据菜单栏主题填充颜色
     if (process.platform === 'darwin') {
       image.setTemplateImage(true)
     }
 
     tray = new Tray(image)
 
-    // 设置 tooltip
-    tray.setToolTip('Proma')
+    tray.setToolTip(process.platform === 'win32' ? '' : 'Proma')
 
     updateTrayMenu(actions)
 
-    // 点击行为：始终弹出菜单（与右键一致）
     tray.on('click', () => {
+      if (process.platform === 'win32') {
+        actions.showMainWindow()
+        return
+      }
       const contextMenu = updateTrayMenu(actions)
       if (contextMenu) {
         tray?.popUpContextMenu(contextMenu)
@@ -170,6 +182,20 @@ export function createTray(actionsInput?: Partial<TrayActions>): Tray | null {
     tray.on('right-click', () => {
       updateTrayMenu(actions)
     })
+
+    if (process.platform === 'win32') {
+      tray.on('mouse-enter', () => {
+        if (!tray) return
+        actions.onTrayMouseEnter?.(tray.getBounds())
+      })
+      tray.on('mouse-move', () => {
+        if (!tray) return
+        actions.onTrayMouseMove?.(tray.getBounds())
+      })
+      tray.on('mouse-leave', () => {
+        actions.onTrayMouseLeave?.()
+      })
+    }
 
     console.log('System tray created')
     return tray
@@ -183,6 +209,7 @@ export function createTray(actionsInput?: Partial<TrayActions>): Tray | null {
  * 销毁系统托盘
  */
 export function destroyTray(): void {
+  clearTrayFlashTimer()
   if (tray) {
     tray.destroy()
     tray = null
@@ -194,4 +221,23 @@ export function destroyTray(): void {
  */
 export function getTray(): Tray | null {
   return tray
+}
+
+/**
+ * 切换托盘图标闪烁（仅 Windows）
+ */
+export function setTrayFlash(on: boolean): void {
+  if (process.platform !== 'win32') return
+  clearTrayFlashTimer()
+  const baseIcon = nativeImage.createFromPath(getTrayIconPath())
+  if (!on) {
+    tray?.setImage(baseIcon)
+    return
+  }
+  if (!tray) return
+  let showIdle = true
+  flashTimer = setInterval(() => {
+    showIdle = !showIdle
+    tray?.setImage(showIdle ? baseIcon : nativeImage.createEmpty())
+  }, 500)
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -111,6 +111,7 @@ import type {
   WeChatBridgeState,
   AgentQueueMessageInput,
   PendingRequestsSnapshot,
+  NativeAgentIslandSnapshot,
   Automation,
   CreateAutomationInput,
   UpdateAutomationInput,
@@ -171,8 +172,9 @@ import type {
   MicPermissionResult,
   TrayCreateSessionData,
   TrayOpenAgentSessionData,
+  NotificationSoundType,
 } from '../types'
-import { QUICK_TASK_IPC_CHANNELS, TRAY_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS } from '../types'
+import { QUICK_TASK_IPC_CHANNELS, TRAY_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS } from '../types'
 
 /**
  * 暴露给渲染进程的 API 接口定义
@@ -1237,6 +1239,18 @@ export interface ElectronAPI {
   agentIsland: {
     markSessionViewed: (sessionId: string) => Promise<void>
   }
+
+  // ===== Windows Agent Island =====
+
+  /** Windows: 主进程委托渲染进程播放提示音 */
+  onWindowsAgentIslandPlaySound: (callback: (data: { type: NotificationSoundType }) => void) => () => void
+  /** Windows: 主进程推送全量 snapshot 到悬停窗（Step 5 接入） */
+  onWindowsAgentIslandPushSnapshot: (callback: (snapshot: NativeAgentIslandSnapshot) => void) => () => void
+  /** Windows: 悬停窗点击跳转到指定会话 */
+  openAgentIslandSession: (sessionId: string, title: string) => Promise<void>
+  /** Windows: 悬停窗鼠标进入/离开通知主进程 */
+  hoverMouseEnter: () => void
+  hoverMouseLeave: () => void
 }
 
 /**
@@ -2797,6 +2811,23 @@ const electronAPI: ElectronAPI = {
     markSessionViewed: (sessionId: string) =>
       ipcRenderer.invoke(AGENT_ISLAND_IPC_CHANNELS.MARK_SESSION_VIEWED, sessionId),
   },
+
+  // ===== Windows Agent Island =====
+  onWindowsAgentIslandPlaySound: (callback: (data: { type: NotificationSoundType }) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, data: { type: NotificationSoundType }): void => callback(data)
+    ipcRenderer.on(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.PLAY_SOUND, listener)
+    return () => { ipcRenderer.removeListener(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.PLAY_SOUND, listener) }
+  },
+  onWindowsAgentIslandPushSnapshot: (callback: (snapshot: NativeAgentIslandSnapshot) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, snapshot: NativeAgentIslandSnapshot): void => callback(snapshot)
+    ipcRenderer.on(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.PUSH_SNAPSHOT, listener)
+    return () => { ipcRenderer.removeListener(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.PUSH_SNAPSHOT, listener) }
+  },
+  openAgentIslandSession: (sessionId: string, title: string) => {
+    return ipcRenderer.invoke(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.OPEN_SESSION, sessionId, title)
+  },
+  hoverMouseEnter: () => { ipcRenderer.send(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.MOUSE_ENTER) },
+  hoverMouseLeave: () => { ipcRenderer.send(WINDOWS_AGENT_ISLAND_IPC_CHANNELS.MOUSE_LEAVE) },
 }
 
 // 将 API 暴露到渲染进程的 window 对象上

--- a/apps/electron/src/renderer/atoms/notifications.ts
+++ b/apps/electron/src/renderer/atoms/notifications.ts
@@ -8,6 +8,7 @@
 
 import { atom } from 'jotai'
 import type { NotificationSoundId, NotificationSoundType, NotificationSoundSettings } from '@/types/settings'
+import { detectIsWindows } from '@/lib/platform'
 
 // ===== 音频资源导入 =====
 import soundDing from '@/assets/sound/ding.mp3'
@@ -316,6 +317,9 @@ export function sendDesktopNotification(
 
     if (!enabled) return
     if (!options?.force && document.hasFocus()) return
+
+    // Windows 上系统通知由主进程统一发送，渲染进程跳过 Web Notification
+    if (detectIsWindows()) return
 
     const notification = new Notification(title, { body, silent: true })
     notification.onclick = () => {

--- a/apps/electron/src/renderer/components/agent-status-hover/HoverPanel.tsx
+++ b/apps/electron/src/renderer/components/agent-status-hover/HoverPanel.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react'
+import type {
+  NativeAgentIslandSnapshot,
+  AgentIslandSessionSnapshot,
+  AgentIslandPhase,
+  AgentIslandInteractionKind,
+} from '@proma/shared'
+import { Lock, HelpCircle, ClipboardList } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const PHASE_DOT_CLASS: Record<AgentIslandPhase, string> = {
+  idle: 'bg-transparent',
+  running: 'bg-blue-500',
+  'needs-interaction': 'bg-orange-500',
+  error: 'bg-red-500',
+  completed: 'bg-green-500',
+}
+
+const PHASE_LABEL: Record<AgentIslandPhase, string> = {
+  idle: '空闲',
+  running: '执行中',
+  'needs-interaction': '待处理',
+  error: '需关注',
+  completed: '已完成',
+}
+
+const INTERACTION_ICON: Partial<Record<AgentIslandInteractionKind, React.ComponentType<{ className?: string }>>> = {
+  permission: Lock,
+  ask_user_question: HelpCircle,
+  plan_review: ClipboardList,
+}
+
+function SessionIndicator({ session }: { session: AgentIslandSessionSnapshot }): React.ReactElement {
+  if (session.phase === 'needs-interaction' && session.interactionKind) {
+    const Icon = INTERACTION_ICON[session.interactionKind]
+    if (Icon) return <Icon className="mt-0.5 size-3.5 shrink-0 text-orange-500" />
+  }
+  return <span className={cn('mt-1 size-2 shrink-0 rounded-full', PHASE_DOT_CLASS[session.phase])} />
+}
+
+export function HoverPanel(): React.ReactElement {
+  const [snapshot, setSnapshot] = React.useState<NativeAgentIslandSnapshot | null>(null)
+
+  React.useEffect(() => {
+    document.body.style.background = 'transparent'
+    return window.electronAPI.onWindowsAgentIslandPushSnapshot(setSnapshot)
+  }, [])
+
+  const sessions = snapshot?.state.sessions ?? []
+  const pill = snapshot?.state.pill
+
+  const handleSessionClick = (session: AgentIslandSessionSnapshot): void => {
+    window.electronAPI.openAgentIslandSession(session.sessionId, session.title)
+  }
+
+  const headerLabel = pill
+    ? pill.activeSessionCount > 0
+      ? `${PHASE_LABEL[pill.priorityStatus]} · ${pill.activeSessionCount} 个会话`
+      : pill.unreadCompletedCount > 0
+        ? `${pill.unreadCompletedCount} 个已完成`
+        : '空闲'
+    : ''
+
+  return (
+    <div
+      className="flex h-screen w-screen flex-col overflow-hidden rounded-xl border border-border/80 bg-popover p-3 text-popover-foreground shadow-2xl"
+      onMouseEnter={() => window.electronAPI.hoverMouseEnter()}
+      onMouseLeave={() => window.electronAPI.hoverMouseLeave()}
+    >
+      <div className="mb-2 flex shrink-0 items-center gap-2">
+        {pill && (
+          <span
+            className={cn('size-2.5 shrink-0 rounded-full', PHASE_DOT_CLASS[pill.priorityStatus])}
+          />
+        )}
+        <span className="text-xs font-semibold">{headerLabel}</span>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
+        {sessions.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center py-6">
+            <span className="text-xs text-muted-foreground">暂无活跃 Agent</span>
+          </div>
+        ) : (
+          sessions.map((session) => (
+            <button
+              key={session.sessionId}
+              type="button"
+              onClick={() => handleSessionClick(session)}
+              className="flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+            >
+              <SessionIndicator session={session} />
+              <div className="min-w-0 flex-1">
+                <div className="text-[11px] font-medium text-muted-foreground">
+                  {PHASE_LABEL[session.phase]}
+                </div>
+                <p className="line-clamp-2 text-xs font-medium leading-snug">
+                  {session.title || '未命名会话'}
+                </p>
+                {session.detail ? (
+                  <p className="mt-0.5 line-clamp-1 text-[11px] leading-snug text-muted-foreground">
+                    {session.detail}
+                  </p>
+                ) : null}
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -48,7 +48,7 @@ import {
   updateSessionHoverPreviewEnabled,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
-import { detectIsMac } from '@/lib/platform'
+import { detectIsMac, detectIsWindows } from '@/lib/platform'
 import { Button } from '../ui/button'
 import type { NotificationSoundId, NotificationSoundType, NotificationSoundSettings } from '@/types/settings'
 
@@ -79,6 +79,7 @@ export function GeneralSettings(): React.ReactElement {
   const [gitAttributionEnabled, setGitAttributionEnabled] = React.useState(true)
   const [agentIslandEnabled, setAgentIslandEnabled] = React.useState(true)
   const isMac = React.useMemo(() => detectIsMac(), [])
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
   // 加载归档天数与 Git/PR 标识设置
@@ -341,6 +342,17 @@ export function GeneralSettings(): React.ReactElement {
               setNotificationSounds(newSounds)
             }}
           />
+          {isWindows && (
+            <SettingsToggle
+              label="Agent 状态通知"
+              description="在任务栏托盘显示 Agent 运行状态，悬停查看会话详情"
+              checked={agentIslandEnabled}
+              disabled={!notificationsEnabled}
+              onCheckedChange={(checked) => {
+                void handleAgentIslandChange(checked)
+              }}
+            />
+          )}
           <SettingsRow
             label="自动归档"
             description="超过指定天数未更新的对话将自动归档（置顶对话除外）"

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -58,6 +58,7 @@ import {
   notificationSoundEnabledAtom,
   notificationSoundsAtom,
   sendDesktopNotification,
+  playNotificationSoundForType,
 } from '@/atoms/notifications'
 import { appModeAtom } from '@/atoms/app-mode'
 import { tabsAtom, activeTabIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
@@ -1690,6 +1691,12 @@ export function useGlobalAgentListeners(): void {
         .catch(console.error)
     })
 
+    // ===== 6. Windows Agent Island 提示音委托 =====
+    const cleanupPlaySound = window.electronAPI.onWindowsAgentIslandPlaySound(({ type }) => {
+      const sounds = store.get(notificationSoundsAtom)
+      void playNotificationSoundForType(type, sounds)
+    })
+
     // 定期清理 60s 前的「最近修改」标记，避免 atom 无限增长
     const pruneTimer = setInterval(() => {
       const cutoff = Date.now() - RECENTLY_MODIFIED_TTL_MS
@@ -1784,6 +1791,7 @@ export function useGlobalAgentListeners(): void {
       cleanupError()
       cleanupTodoAgentSessionReady()
       cleanupTitleUpdated()
+      cleanupPlaySound()
       cleanupWatchedFileChanges()
       queuedDispatchUnsubscribers.forEach((unsubscribe) => unsubscribe())
       clearInterval(pruneTimer)

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -94,7 +94,8 @@ const isVoiceDictationIndicatorWindow = new URLSearchParams(window.location.sear
 const isDetachedPreviewWindow = new URLSearchParams(window.location.search).get('window') === 'detached-preview'
 const isPlanningWindow = new URLSearchParams(window.location.search).get('window') === 'planning'
 const isWorkspaceMemoryWindow = new URLSearchParams(window.location.search).get('window') === 'workspace-memory'
-const isMainWindow = !isQuickTaskWindow && !isVoiceDictationIndicatorWindow && !isDetachedPreviewWindow && !isPlanningWindow && !isWorkspaceMemoryWindow
+const isAgentStatusHoverWindow = new URLSearchParams(window.location.search).get('window') === 'agent-status-hover'
+const isMainWindow = !isQuickTaskWindow && !isVoiceDictationIndicatorWindow && !isDetachedPreviewWindow && !isPlanningWindow && !isWorkspaceMemoryWindow && !isAgentStatusHoverWindow
 
 initializePerformanceMonitor()
 
@@ -1111,6 +1112,15 @@ if (isQuickTaskWindow) {
         <ThemeInitializer />
         <WorkspaceMemoryWindowApp />
         <Toaster position="bottom-right" />
+      </React.StrictMode>
+    )
+  })
+} else if (isAgentStatusHoverWindow) {
+  import('./components/agent-status-hover/HoverPanel').then(({ HoverPanel }) => {
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+      <React.StrictMode>
+        <ThemeInitializer />
+        <HoverPanel />
       </React.StrictMode>
     )
   })

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -550,6 +550,20 @@ export const TRAY_IPC_CHANNELS = {
   CREATE_SESSION: 'tray:create-session',
 } as const
 
+/** Windows Agent Island IPC 通道（主进程 ↔ 渲染进程） */
+export const WINDOWS_AGENT_ISLAND_IPC_CHANNELS = {
+  /** 主进程 → 渲染进程：委托播放提示音 */
+  PLAY_SOUND: 'windows-agent-island:play-sound',
+  /** 渲染进程（悬停窗）→ 主进程：点击跳转到会话 */
+  OPEN_SESSION: 'windows-agent-island:open-session',
+  /** 主进程 → 渲染进程（悬停窗）：推送全量 snapshot */
+  PUSH_SNAPSHOT: 'windows-agent-island:push-snapshot',
+  /** 渲染进程（悬停窗）→ 主进程：鼠标进入气泡区域 */
+  MOUSE_ENTER: 'windows-agent-island:mouse-enter',
+  /** 渲染进程（悬停窗）→ 主进程：鼠标离开气泡区域 */
+  MOUSE_LEAVE: 'windows-agent-island:mouse-leave',
+} as const
+
 /** 存储管理 IPC 通道 */
 export const STORAGE_IPC_CHANNELS = {
   /** 计算各目录存储统计 */


### PR DESCRIPTION
## 概述

macOS 有灵动岛（Agent Island）实时展示 Agent 运行状态，Windows 上此前完全没有对应能力。本 PR 为 Windows 补齐 Agent 状态通知体系，并修复了一个托盘交互问题。

## 改动内容

### 1. Windows Agent 状态通知

复用 macOS 的 `AgentIslandService` 状态机（事件折叠、优先级聚合、推送节流），新增 Windows surface 层：

- **托盘图标闪烁**：Agent 进入 `needs-interaction`（权限请求 / 提问 / 计划审批）时托盘图标闪烁，用户响应后停止
- **悬停气泡**：鼠标悬停托盘 300ms 后弹出气泡窗，展示会话列表（状态色点 + 标题 + 详情摘要 + 交互类型图标），点击可跳转到对应会话
- **提示音**：phase 转移（running→needs-interaction / running→completed）时播放对应提示音
- **通知统一**：Windows 上渲染层不再发送 Web Notification，由主进程统一管理通知逻辑
- **设置项**：GeneralSettings 新增「Agent 状态通知」开关（仅 Windows 显示）

### 2. 修复：Windows 托盘左键行为

原行为：左键点击托盘弹出右键菜单（与右键完全一致）。
修复后：左键点击 → 显示并聚焦主窗口；右键 → 弹出菜单。

### 技术实现

- **门禁拆分**：`isAgentIslandSupported()` 拆为 `isAgentIslandServiceSupported()`（macOS + Windows 都初始化状态机）和 `isMacAgentIslandSurfaceSupported()`（macOS 26+ 启动 Swift surface）
- **pushState 分流**：`pushState()` 末尾从 macOS 单出口改为按平台分流（macOS→Swift helper，Windows→surface）
- **macOS 零改动**：所有新增逻辑均以 `process.platform === "win32"` 精确限定，不影响 macOS 现有行为

## 测试

以下测试文件覆盖核心逻辑：

| 文件 | 覆盖内容 |
|------|----------|
| `apps/electron/src/main/agent-status-hover-bounds.test.ts` | 悬停窗定位计算（边界裁剪、上方空间不足翻转到下方） |
| `apps/electron/src/main/lib/macos-version.test.ts` | 平台门禁拆分（service supported / mac surface supported） |
| `apps/electron/src/main/lib/windows-agent-island-surface.test.ts` | phase 转移检测 + 通知触发条件 + 提示音映射 |

```bash
bun test apps/electron/src/main/agent-status-hover-bounds.test.ts \
         apps/electron/src/main/lib/macos-version.test.ts \
         apps/electron/src/main/lib/windows-agent-island-surface.test.ts
```