### PR TITLE
perf(agent): remove history scroll scans

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -19,7 +19,6 @@ import { getModelLogo, resolveModelProvider } from '@/lib/model-logo'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { useShortcut } from '@/hooks/useShortcut'
 import { cn } from '@/lib/utils'
-import { measurePerformance } from '@/lib/performance-monitor'
 
 export interface MinimapItem {
   id: string
@@ -83,15 +82,23 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   /** 主区视口几何中心当前对应的消息 id —— 面板打开时作为列表居中锚点 */
   const [centerVisibleId, setCenterVisibleId] = React.useState<string | undefined>(undefined)
   const [canScroll, setCanScroll] = React.useState(false)
+  const [thumbHeightPct, setThumbHeightPct] = React.useState(100)
   const [searchQuery, setSearchQuery] = React.useState('')
   const [isDragging, setIsDragging] = React.useState(false)
-  const [scrollMetrics, setScrollMetrics] = React.useState({ scrollTop: 0, scrollHeight: 1, clientHeight: 1 })
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const fadeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const openTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const searchInputRef = React.useRef<HTMLInputElement>(null)
   const trackRef = React.useRef<HTMLDivElement>(null)
   const listRef = React.useRef<HTMLDivElement>(null)
+  const visibleIdsRef = React.useRef<Set<string>>(new Set())
+  const visibleElementsRef = React.useRef<Map<string, HTMLElement>>(new Map())
+  const hoveredRef = React.useRef(hovered)
+  hoveredRef.current = hovered
+  const updateCenterVisibleRef = React.useRef<(() => void) | null>(null)
+  const canScrollRef = React.useRef(false)
+  const thumbHeightPctRef = React.useRef(100)
+  const thumbRef = React.useRef<HTMLDivElement>(null)
 
   // ── 组件卸载时清理计时器 ──
 
@@ -103,58 +110,123 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     }
   }, [])
 
-  // ── 可见消息 + 滚动指标追踪 ──
+  // 仅列表结构变化时重新绑定消息。滚动时由 IntersectionObserver 追踪可见项，
+  // 避免每帧查询整个历史 DOM 并读取所有消息的几何信息。
+  const itemIds = React.useMemo(() => items.map((item) => item.id).join('\u0000'), [items])
 
   React.useEffect(() => {
     const el = scrollRef.current
     if (!el) return
 
-    let frame: number | null = null
-    const update = (): void => {
-      measurePerformance('history.minimap-scan', () => {
-        const { scrollTop, scrollHeight, clientHeight } = el
-        setCanScroll(scrollHeight > clientHeight + 10)
-        setScrollMetrics({ scrollTop, scrollHeight, clientHeight })
-        if (scrollHeight <= 0) return
+    const updateVisibleIds = (next: Set<string>): void => {
+      const previous = visibleIdsRef.current
+      if (previous.size === next.size && [...previous].every((id) => next.has(id))) return
+      visibleIdsRef.current = next
+      setVisibleIds(next)
+    }
 
-        const viewportCenter = scrollTop + clientHeight / 2
-        const nodes = el.querySelectorAll<HTMLElement>('[data-message-id]')
-        const ids = new Set<string>()
-        let centerId: string | undefined
-        for (const node of nodes) {
-          const top = getOffsetTopRelativeTo(node, el)
-          const bottom = top + node.offsetHeight
-          if (bottom > scrollTop && top < scrollTop + clientHeight) {
-            const id = node.getAttribute('data-message-id')
-            if (id) ids.add(id)
-          }
-          if (centerId === undefined && top <= viewportCenter && bottom > viewportCenter) {
-            centerId = node.getAttribute('data-message-id') ?? undefined
-          }
+    const updateCenterVisible = (): void => {
+      const viewportCenter = el.getBoundingClientRect().top + el.clientHeight / 2
+      let closestId: string | undefined
+      let closestDistance = Number.POSITIVE_INFINITY
+      for (const [id, element] of visibleElementsRef.current) {
+        const rect = element.getBoundingClientRect()
+        const distance = viewportCenter < rect.top
+          ? rect.top - viewportCenter
+          : viewportCenter > rect.bottom
+            ? viewportCenter - rect.bottom
+            : 0
+        if (distance < closestDistance) {
+          closestDistance = distance
+          closestId = id
         }
-        setVisibleIds(ids)
-        setCenterVisibleId(centerId)
-      })
-    }
-    const scheduleUpdate = (): void => {
-      if (frame !== null) return
-      frame = requestAnimationFrame(() => {
-        frame = null
-        update()
-      })
+      }
+      setCenterVisibleId((previous) => previous === closestId ? previous : closestId)
     }
 
-    update()
-    el.addEventListener('scroll', scheduleUpdate, { passive: true })
-    const observer = new ResizeObserver(scheduleUpdate)
-    observer.observe(el)
+    const updateThumb = (): void => {
+      const { scrollTop, scrollHeight, clientHeight } = el
+      const scrollRange = scrollHeight - clientHeight
+      const nextCanScroll = scrollRange > 10
+      const nextThumbHeightPct = scrollHeight > 0
+        ? Math.max(10, Math.min((clientHeight / scrollHeight) * 100, 100))
+        : 100
+      const thumbTopPct = scrollRange > 0
+        ? (scrollTop / scrollRange) * (100 - nextThumbHeightPct)
+        : 0
+
+      if (nextCanScroll !== canScrollRef.current) {
+        canScrollRef.current = nextCanScroll
+        setCanScroll(nextCanScroll)
+      }
+      if (Math.abs(thumbHeightPctRef.current - nextThumbHeightPct) >= 0.01) {
+        thumbHeightPctRef.current = nextThumbHeightPct
+        setThumbHeightPct(nextThumbHeightPct)
+      }
+      if (thumbRef.current) thumbRef.current.style.top = `${thumbTopPct}%`
+    }
+
+    const visible = new Set<string>()
+    const observer = new IntersectionObserver((entries) => {
+      let changed = false
+      for (const entry of entries) {
+        const id = entry.target.getAttribute('data-message-id')
+        if (!id) continue
+        if (entry.isIntersecting) {
+          visibleElementsRef.current.set(id, entry.target as HTMLElement)
+          if (!visible.has(id)) {
+            visible.add(id)
+            changed = true
+          }
+        } else {
+          visibleElementsRef.current.delete(id)
+          if (visible.delete(id)) changed = true
+        }
+      }
+      if (changed) updateVisibleIds(new Set(visible))
+      if (hoveredRef.current) updateCenterVisible()
+    }, { root: el, threshold: 0 })
+
+    updateCenterVisibleRef.current = updateCenterVisible
+    for (const message of el.querySelectorAll<HTMLElement>('[data-message-id]')) observer.observe(message)
+    updateThumb()
+
+    const onScroll = (): void => {
+      updateThumb()
+      if (hoveredRef.current) updateCenterVisible()
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    const resizeObserver = new ResizeObserver(updateThumb)
+    resizeObserver.observe(el)
+    const content = el.firstElementChild
+    if (content) resizeObserver.observe(content)
 
     return () => {
-      if (frame !== null) cancelAnimationFrame(frame)
-      el.removeEventListener('scroll', scheduleUpdate)
+      el.removeEventListener('scroll', onScroll)
       observer.disconnect()
+      resizeObserver.disconnect()
+      updateCenterVisibleRef.current = null
+      visibleIdsRef.current = new Set()
+      visibleElementsRef.current.clear()
     }
-  }, [scrollRef])
+  }, [itemIds, scrollRef])
+
+  React.useEffect(() => {
+    if (hovered) updateCenterVisibleRef.current?.()
+  }, [hovered])
+
+  // 进度条首次从不可滚动状态挂载时，上一段 effect 中尚无 thumb DOM；
+  // 此处在绘制前补齐当前位置，保证恢复历史滚动位置后滑块也正确定位。
+  React.useLayoutEffect(() => {
+    const el = scrollRef.current
+    const thumb = thumbRef.current
+    if (!el || !thumb || !canScroll) return
+    const scrollRange = el.scrollHeight - el.clientHeight
+    const thumbTopPct = scrollRange > 0
+      ? (el.scrollTop / scrollRange) * (100 - thumbHeightPct)
+      : 0
+    thumb.style.top = `${thumbTopPct}%`
+  }, [canScroll, scrollRef, thumbHeightPct])
 
   // ── 面板打开时自动聚焦搜索框 ──
 
@@ -183,7 +255,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
       list.scrollTo({ top: Math.max(0, offset), behavior: 'auto' })
     }, 0)
     return () => clearTimeout(timer)
-  }, [hovered])
+  }, [centerVisibleId, hovered, visibleIds])
 
   // ── 面板关闭时清空搜索 ──
 
@@ -359,14 +431,6 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
 
   const barCount = Math.min(items.length, MAX_BARS)
 
-  // ── 滚动条滑块尺寸计算 ──
-
-  const { scrollTop, scrollHeight, clientHeight } = scrollMetrics
-  const scrollRange = scrollHeight - clientHeight
-  const thumbRatio = scrollHeight > 0 ? Math.min(clientHeight / scrollHeight, 1) : 1
-  const thumbHeightPct = Math.max(10, thumbRatio * 100)
-  const thumbTopPct = scrollRange > 0 ? (scrollTop / scrollRange) * (100 - thumbHeightPct) : 0
-
   return (
     <div className="absolute right-1 top-0 bottom-0 z-30 flex pointer-events-none">
       {/* ── 迷你地图悬停区域（面板 + 横杠） ── */}
@@ -480,6 +544,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
           onMouseDown={handleTrackMouseDown}
         >
           <div
+            ref={thumbRef}
             className={cn(
               'absolute left-0 right-0 rounded-full transition-colors duration-100 scroll-progress-thumb',
               isDragging
@@ -488,7 +553,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
             )}
             style={{
               height: `${thumbHeightPct}%`,
-              top: `${thumbTopPct}%`,
+              top: '0%',
             }}
             onMouseDown={handleThumbMouseDown}
           />

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -20,7 +20,6 @@ import { stickyUserMessageEnabledAtom } from '@/atoms/ui-preferences'
 import { MessageResponse, remarkMentions } from './message'
 import type { RemarkPluginFn } from './message'
 import { cn } from '@/lib/utils'
-import { measurePerformance } from '@/lib/performance-monitor'
 
 /** 悬浮条专用 remark 插件（仅 mention，不保留换行） */
 const STICKY_REMARK_PLUGINS: RemarkPluginFn[] = [remarkMentions]
@@ -45,6 +44,11 @@ interface StickyUserMessageProps {
   userMessages: UserMessageData[]
 }
 
+interface UserMessagePosition {
+  id: string
+  bottom: number
+}
+
 export function StickyUserMessage({ userMessages }: StickyUserMessageProps): React.ReactElement {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const userProfile = useAtomValue(userProfileAtom)
@@ -52,74 +56,111 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
 
   // 当前悬浮展示的消息
   const [stickyMessage, setStickyMessage] = React.useState<UserMessageData | null>(null)
+  const positionsRef = React.useRef<UserMessagePosition[]>([])
 
-  // 构建 id → data 查找表
+  const userMessageSignature = React.useMemo(
+    () => userMessages.map((message) => message.id ?? '').join('\u0000'),
+    [userMessages],
+  )
+
+  // 构建 id → data 查找表；流式 assistant 更新会重建上游数组，但用户消息未变时
+  // 保持 map 引用稳定，避免重新绑定观察器和测量全部历史消息。
   const messageMap = React.useMemo(() => {
     const map = new Map<string, UserMessageData>()
     for (const msg of userMessages) {
       if (msg.id) map.set(msg.id, msg)
     }
     return map
-  }, [userMessages])
+  }, [userMessageSignature])
 
   React.useEffect(() => {
     const el = scrollRef.current
     if (!el || userMessages.length === 0 || !stickyEnabled) {
+      positionsRef.current = []
       setStickyMessage(null)
       return
     }
 
-    let frame: number | null = null
-    const check = () => {
-      measurePerformance('history.sticky-user-scan', () => {
-        const containerRect = el.getBoundingClientRect()
-        const nodes = el.querySelectorAll<HTMLElement>('[data-message-role="user"]')
+    let scrollFrame: number | null = null
+    let measureFrame: number | null = null
+    let containerWidth = el.clientWidth
 
-        // 从后往前找第一个完全在视口上方的用户消息节点
-        let found: UserMessageData | null = null
-        for (let i = nodes.length - 1; i >= 0; i--) {
-          const node = nodes[i]!
-          const nodeRect = node.getBoundingClientRect()
-          if (nodeRect.bottom < containerRect.top) {
-            // 找到了视口上方最近的用户消息
-            const msgId = node.getAttribute('data-message-id')
-            if (msgId) found = messageMap.get(msgId) ?? null
-            break
-          }
+    const updateStickyMessage = (): void => {
+      const scrollTop = el.scrollTop
+      const positions = positionsRef.current
+      let low = 0
+      let high = positions.length - 1
+      let match: UserMessagePosition | undefined
+      while (low <= high) {
+        const middle = Math.floor((low + high) / 2)
+        const candidate = positions[middle]!
+        if (candidate.bottom < scrollTop) {
+          match = candidate
+          low = middle + 1
+        } else {
+          high = middle - 1
         }
-        setStickyMessage((previous) => previous?.id === found?.id ? previous : found)
+      }
+      const found = match ? messageMap.get(match.id) ?? null : null
+      setStickyMessage((previous) => previous?.id === found?.id ? previous : found)
+    }
+
+    const measurePositions = (): void => {
+      const containerRect = el.getBoundingClientRect()
+      const positions: UserMessagePosition[] = []
+      for (const node of el.querySelectorAll<HTMLElement>('[data-message-role="user"]')) {
+        const id = node.getAttribute('data-message-id')
+        if (!id) continue
+        const rect = node.getBoundingClientRect()
+        positions.push({ id, bottom: rect.bottom - containerRect.top + el.scrollTop })
+      }
+      positionsRef.current = positions
+      updateStickyMessage()
+    }
+
+    const scheduleMeasure = (): void => {
+      if (measureFrame !== null) return
+      measureFrame = requestAnimationFrame(() => {
+        measureFrame = null
+        measurePositions()
       })
     }
-    const scheduleCheck = (): void => {
-      if (frame !== null) return
-      frame = requestAnimationFrame(() => {
-        frame = null
-        check()
+    const scheduleScrollUpdate = (): void => {
+      if (scrollFrame !== null) return
+      scrollFrame = requestAnimationFrame(() => {
+        scrollFrame = null
+        updateStickyMessage()
       })
     }
 
-    el.addEventListener('scroll', scheduleCheck, { passive: true })
-
-    // 监听容器尺寸变化
-    const resizeObserver = new ResizeObserver(scheduleCheck)
-    resizeObserver.observe(el)
-
-    // 监听内容区域 DOM 变化（流式输出、消息加载后及时检测）
-    const contentEl = el.firstElementChild as HTMLElement | null
-    if (contentEl) {
-      resizeObserver.observe(contentEl)
+    el.addEventListener('scroll', scheduleScrollUpdate, { passive: true })
+    const resizeObserver = new ResizeObserver((entries) => {
+      const containerEntry = entries.find((entry) => entry.target === el)
+      if (containerEntry && Math.abs(containerEntry.contentRect.width - containerWidth) >= 1) {
+        containerWidth = containerEntry.contentRect.width
+        scheduleMeasure()
+        return
+      }
+      if (entries.some((entry) => entry.target !== el)) scheduleMeasure()
+    })
+    // 只有最后一条用户消息及其之前的内容会改变用户消息的绝对位置。
+    // 当前流式 assistant 位于它之后，不纳入观察，避免每个流式高度更新重测整段历史。
+    const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+    const lastUserMessageIndex = messageElements.findLastIndex(
+      (message) => message.dataset.messageRole === 'user',
+    )
+    for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
+      resizeObserver.observe(message)
     }
-
-    // 延迟一帧执行初始检查，确保 DOM 已完成渲染
-    const rafId = requestAnimationFrame(check)
+    scheduleMeasure()
 
     return () => {
-      if (frame !== null) cancelAnimationFrame(frame)
-      el.removeEventListener('scroll', scheduleCheck)
+      if (scrollFrame !== null) cancelAnimationFrame(scrollFrame)
+      if (measureFrame !== null) cancelAnimationFrame(measureFrame)
+      el.removeEventListener('scroll', scheduleScrollUpdate)
       resizeObserver.disconnect()
-      cancelAnimationFrame(rafId)
     }
-  }, [scrollRef, userMessages, messageMap, stickyEnabled])
+  }, [scrollRef, userMessageSignature, messageMap, stickyEnabled])
 
   // 点击回滚到原始消息
   const scrollToOriginal = React.useCallback(() => {


### PR DESCRIPTION
## Summary

- remove per-frame full-history DOM scans from the Agent minimap
- track visible messages with IntersectionObserver
- cache sticky user-message positions and use binary search during scrolling
- update the scroll thumb directly during scroll events to avoid unnecessary React rerenders

This PR contains only the history scrolling optimization from commit `4da1fe7d`. The separate live-history rendering optimization is intentionally not included.

## Validation

- bun run --filter @proma/electron typecheck
- bun run --filter @proma/electron build:renderer
- 22 related Agent tests passed
- git diff --check

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)