### PR TITLE
perf(agent): compact live history rendering

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -39,6 +39,8 @@ interface AgentHistorySelection {
 interface AgentHistorySelectionLayerProps {
   sessionId: string
   rootRef: React.RefObject<HTMLDivElement>
+  /** 流式尾部预览与完整历史的文本偏移不同，运行中不允许创建不可恢复的历史引用。 */
+  disabled?: boolean
   /** 同一消息内的历史选区优先插入当前 Agent 富文本输入框。 */
   onAddToAgent?: (quote: QuotedSelection) => boolean
 }
@@ -82,6 +84,7 @@ function getMessageTurn(root: HTMLElement, messageElement: Element): number {
 export function AgentHistorySelectionLayer({
   sessionId,
   rootRef,
+  disabled = false,
   onAddToAgent,
 }: AgentHistorySelectionLayerProps): React.ReactElement {
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
@@ -99,9 +102,11 @@ export function AgentHistorySelectionLayer({
 
   const clearSelection = React.useCallback((): void => {
     setSelection(null)
+    window.getSelection()?.removeAllRanges()
   }, [])
 
-  const captureSelection = React.useCallback((): void => {
+    const captureSelection = React.useCallback((): void => {
+    if (disabled) return
     const root = rootRef.current
     if (!root) return
     const activeEl = document.activeElement
@@ -175,7 +180,7 @@ export function AgentHistorySelectionLayer({
         duration: 3000,
       })
     }
-  }, [clearSelection, rootRef, sessionId])
+  }, [clearSelection, disabled, rootRef, sessionId])
 
   const scheduleCaptureSelection = React.useCallback((): void => {
     if (captureTimerRef.current != null) {
@@ -188,6 +193,10 @@ export function AgentHistorySelectionLayer({
   }, [captureSelection])
 
   React.useEffect(() => {
+    if (disabled) {
+      clearSelection()
+      return
+    }
     const onSelectionChange = (): void => {
       if (pointerSelectingRef.current) return
       const sel = window.getSelection()
@@ -232,7 +241,7 @@ export function AgentHistorySelectionLayer({
       document.removeEventListener('pointercancel', onPointerCancel, true)
       document.removeEventListener('keyup', onKeyUp, true)
     }
-  }, [clearSelection, rootRef, scheduleCaptureSelection])
+  }, [clearSelection, disabled, rootRef, scheduleCaptureSelection])
 
   const handleAddToAgent = React.useCallback((): void => {
     if (!selection) return

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -44,6 +44,26 @@ import { getSDKCompactStatus } from '@proma/shared'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 
+const STREAMING_PREVIEW_MAX_CHARS = 600
+
+function getStreamingTextPreview(content: string): string {
+  if (!content.trim()) return ''
+  const tail = content.length > STREAMING_PREVIEW_MAX_CHARS
+    ? content.slice(-STREAMING_PREVIEW_MAX_CHARS)
+    : content
+  const preview = tail.trim()
+  return content.length > STREAMING_PREVIEW_MAX_CHARS ? `…${preview}` : preview
+}
+
+function StreamingTextPreview({ text }: { text: string }): React.ReactElement | null {
+  if (!text) return null
+  return (
+    <p className="line-clamp-4 whitespace-pre-wrap break-words text-[14px] leading-6 text-foreground/80">
+      {text}
+    </p>
+  )
+}
+
 function stableStringify(value: unknown): string {
   if (value == null || typeof value !== 'object') return JSON.stringify(value) ?? String(value)
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
@@ -715,11 +735,14 @@ export const AgentMessages = React.memo(function AgentMessages({
   // 会导致 fallback 气泡与持久化消息同时渲染一帧（重复内容闪烁）。
   // 用原始 streamingContent 作为守卫：内容已清空且不在流式中，立即归零。
   const smoothContent = (streaming || streamingContent) ? rawSmoothContent : ''
+  const streamingPreview = React.useMemo(
+    () => getStreamingTextPreview(smoothContent),
+    [smoothContent],
+  )
   const smoothContentBlocks = React.useMemo(() => {
-    if (!smoothContent) return []
+    if (streaming || !smoothContent) return []
     return parseThinkTagsFromText(smoothContent)
-  }, [smoothContent])
-  const hasSmoothTextContent = smoothContentBlocks.some((block) => block.type === 'text')
+  }, [smoothContent, streaming])
 
   /**
    * 流式完成过渡：streaming 结束到持久化消息加载完成之间，
@@ -957,22 +980,9 @@ export const AgentMessages = React.memo(function AgentMessages({
                   />
                   <MessageContent>
                     {retrying && <RetryingNotice retrying={retrying} />}
-                    {smoothContent ? (
+                    {streamingPreview ? (
                       <>
-                        <div className={cn('space-y-2')}>
-                          {smoothContentBlocks.map((block, index) => (
-                            <ContentBlock
-                              key={index}
-                              block={block}
-                              allMessages={allSDKMessages}
-                              basePath={sessionPath || undefined}
-                              basePaths={attachedDirs}
-                              index={index}
-                              dimmed={hasSmoothTextContent && block.type !== 'text'}
-                              isStreaming={streaming}
-                            />
-                          ))}
-                        </div>
+                        <StreamingTextPreview text={streamingPreview} />
                         {streaming && <AgentRunningIndicator startedAt={startedAt} />}
                       </>
                     ) : (
@@ -990,6 +1000,7 @@ export const AgentMessages = React.memo(function AgentMessages({
         <TaskProgressOverlay
           key={sessionId}
           activities={liveTaskActivities}
+          taskProgressInline={hasLiveAssistantContent}
           streaming={streaming}
           contextCompaction={contextCompaction}
         />
@@ -997,11 +1008,12 @@ export const AgentMessages = React.memo(function AgentMessages({
           <StickyUserMessage userMessages={allUserMessagesData} />
         )}
       </Conversation>
-      <AgentHistorySelectionLayer
-        sessionId={sessionId}
-        rootRef={historySelectionRootRef}
-        onAddToAgent={onAddHistoryQuote}
-      />
+        <AgentHistorySelectionLayer
+          sessionId={sessionId}
+          rootRef={historySelectionRootRef}
+          disabled={streaming}
+          onAddToAgent={onAddHistoryQuote}
+        />
     </div>
     </BasePathsProvider>
   )

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.test.ts
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { buildAssistantTurnRenderItems, buildProcessGroupToolNames } from './ProcessBlockGroup'
+import { buildAssistantTurnRenderItems, buildProcessGroupToolNames, getStreamingTurnPreview } from './ProcessBlockGroup'
 import type { SDKContentBlock } from '@proma/shared'
 
 const tool = (id: string, name = 'Read'): SDKContentBlock => ({
@@ -129,6 +129,30 @@ describe('Agent 过程块折叠分组', () => {
     if (items[0]?.type === 'process-group') {
       expect(items[0].items.map((item) => item.index)).toEqual([0, 1])
     }
+  })
+
+  test('given a long streaming text block when building a preview then keeps only its latest tail', () => {
+    const value = `${'a'.repeat(700)}tail`
+
+    const preview = getStreamingTurnPreview([text(value)])
+
+    expect(preview).toBe(`…${value.slice(-600)}`)
+    expect(preview.endsWith('tail')).toBe(true)
+  })
+
+  test('given process blocks followed by text when building a streaming preview then uses the latest non-empty text', () => {
+    const preview = getStreamingTurnPreview([
+      thinking(),
+      tool('tool-1'),
+      text(''),
+      text('最新输出'),
+    ])
+
+    expect(preview).toBe('最新输出')
+  })
+
+  test('given no text block when building a streaming preview then returns an empty preview', () => {
+    expect(getStreamingTurnPreview([thinking(), tool('tool-1')])).toBe('')
   })
 
   test('given repeated tools when building capability icons then returns unique tool names in order', () => {

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
@@ -133,6 +133,27 @@ export function buildAssistantTurnRenderItems(
   return items
 }
 
+const MAX_STREAMING_PREVIEW_CHARS = 600
+
+/**
+ * 流式阶段只保留最后一段文本尾部，避免完整 Markdown / 工具结果树在每次 SDK 更新时重建。
+ * 结束后仍由正常渲染路径恢复完整内容和现有过程折叠。
+ */
+export function getStreamingTurnPreview(blocks: SDKContentBlock[]): string {
+  for (let index = blocks.length - 1; index >= 0; index--) {
+    const block = blocks[index]
+    if (block?.type !== 'text' || !('text' in block)) continue
+    const text = (block as { text: string }).text
+    if (!text.trim()) continue
+    const tail = text.length > MAX_STREAMING_PREVIEW_CHARS
+      ? text.slice(-MAX_STREAMING_PREVIEW_CHARS)
+      : text
+    const preview = tail.trim()
+    return text.length > MAX_STREAMING_PREVIEW_CHARS ? `…${preview}` : preview
+  }
+  return ''
+}
+
 function buildProcessGroupSummary(blocks: SDKContentBlock[]): string {
   let toolCount = 0
   let messageCount = 0

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -19,7 +19,8 @@ import { ImageLightbox, type LightboxImage } from '@/components/ui/image-lightbo
 import { ContentBlock } from './ContentBlock'
 import { TurnFileChangesSummary, buildTurnFileNameMap } from './TurnFileChangesSummary'
 import { TurnSkillUsageSummary } from './TurnSkillUsageSummary'
-import { ProcessBlockGroup, buildAssistantTurnRenderItems, buildCompletedToolResultIds } from './ProcessBlockGroup'
+import { TaskProgressCard } from './TaskProgressCard'
+import { ProcessBlockGroup, buildAssistantTurnRenderItems, buildCompletedToolResultIds, getStreamingTurnPreview } from './ProcessBlockGroup'
 import { extractToolResultText, TASK_TOOL_NAMES } from './task-progress'
 import { normalizeThinkTagsInContentBlocks } from './thinking-tag-parser'
 // 会话转录的纯逻辑(Turn 分组 / 快照去重 / 预览)已下沉到 @proma/session-core 作为唯一真源。
@@ -366,7 +367,16 @@ export function buildTaskProgressDataForTurn(turn: AssistantTurn): { taskActivit
 }
 
 
-// ===== AssistantTurnRenderer — 渲染一个完整的 assistant turn =====
+function StreamingTurnPreview({ text }: { text: string }): React.ReactElement | null {
+  if (!text) return null
+
+  return (
+    <p className="line-clamp-4 whitespace-pre-wrap break-words text-[14px] leading-6 text-foreground/80">
+      {text}
+    </p>
+  )
+}
+
 
 export interface AssistantTurnRendererProps {
   turn: AssistantTurn
@@ -466,20 +476,26 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
     (b) => b.type === 'text' && 'text' in b && !!(b as { text: string }).text
   )
 
-  const completedToolResultIds = React.useMemo(() => {
-    return buildCompletedToolResultIds(turn.turnMessages)
-  }, [turn.turnMessages])
-  const renderItems = React.useMemo(() => {
-    return buildAssistantTurnRenderItems(topLevelBlocks, {
-      isStreaming,
-      completedToolResultIds,
-    })
-  }, [topLevelBlocks, isStreaming, completedToolResultIds])
+  const completedToolResultIds = React.useMemo(
+    () => isStreaming ? new Set<string>() : buildCompletedToolResultIds(turn.turnMessages),
+    [isStreaming, turn.turnMessages],
+  )
+  const renderItems = React.useMemo(
+    () => isStreaming
+      ? []
+      : buildAssistantTurnRenderItems(topLevelBlocks, { completedToolResultIds }),
+    [topLevelBlocks, isStreaming, completedToolResultIds],
+  )
 
-  // 本轮「文件名 → 绝对路径」映射：与 footer chips 同源，供正文内联文件引用补全裸文件名
+  // 本轮「文件名 → 绝对路径」映射只在完整输出渲染时需要。
   const turnFileMap = React.useMemo(
-    () => buildTurnFileNameMap(turn.turnMessages),
-    [turn.turnMessages]
+    () => isStreaming ? new Map<string, string>() : buildTurnFileNameMap(turn.turnMessages),
+    [isStreaming, turn.turnMessages],
+  )
+
+  const streamingTaskActivities = React.useMemo(
+    () => isStreaming ? buildTaskProgressDataForTurn(turn).taskActivities : [],
+    [isStreaming, turn],
   )
 
   // 如果只有错误消息
@@ -498,6 +514,40 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
 
   // 如果没有任何内容
   if (enrichedBlocks.length === 0 && !hasError) return null
+
+  const streamingPreview = getStreamingTurnPreview(topLevelBlocks)
+
+  if (isStreaming) {
+    return (
+      <Message from="assistant">
+        <MessageHeader
+          model={turn.model ? resolveModelDisplayName(turn.model, channels) : undefined}
+          time={turn.createdAt ? formatMessageTime(turn.createdAt) : undefined}
+          logo={<AssistantLogo model={turn.model} />}
+        />
+        <MessageContent>
+          <TaskProgressCard activities={streamingTaskActivities} animate />
+          <StreamingTurnPreview text={streamingPreview} />
+          {!streamingPreview && streamingTaskActivities.length === 0 && (
+            <div className="flex min-h-[28px] items-center gap-2 text-[13px] font-light text-muted-foreground/75">
+              <Loader2 className="size-3.5 animate-spin text-primary/75" />
+              <span>Agent Running</span>
+            </div>
+          )}
+          {hasError && errorContent && (
+            <AssistantErrorTail
+              message={errorContent}
+              onRetry={onRetry}
+              onRetryInNewSession={onRetryInNewSession}
+              onCompact={onCompact}
+              onRelinkProjectRoot={onRelinkProjectRoot}
+              onRestoreProjectRoot={onRestoreProjectRoot}
+            />
+          )}
+        </MessageContent>
+      </Message>
+    )
+  }
 
   const renderTopLevelBlock = (block: SDKContentBlock, i: number): React.ReactNode => {
     // 任务进度由底部浮层统一呈现，输出记录不再重复显示任务卡。

--- a/apps/electron/src/renderer/components/agent/TaskProgressOverlay.tsx
+++ b/apps/electron/src/renderer/components/agent/TaskProgressOverlay.tsx
@@ -32,6 +32,8 @@ export interface ContextCompactionProgress {
 interface TaskProgressOverlayProps {
   /** 仅当前 live turn 的任务工具活动，不传历史 turn。 */
   activities: ToolActivity[]
+  /** 是否在当前流式历史区内显示任务进度，避免与内联执行面板重复。 */
+  taskProgressInline?: boolean
   streaming: boolean
   /** 与 Agent 任务并列的系统级短时操作；当前用于上下文压缩。 */
   contextCompaction?: ContextCompactionProgress
@@ -88,7 +90,7 @@ function CompactionProgressDetails({ progress }: { progress: ContextCompactionPr
  * 取代单独的“回到最下方”按钮：任务进行时展示单行进度，点击展开完整任务卡；
  * 无任务时自动退化为原箭头按钮。
  */
-export function TaskProgressOverlay({ activities, streaming, contextCompaction }: TaskProgressOverlayProps): React.ReactElement | null {
+export function TaskProgressOverlay({ activities, taskProgressInline = false, streaming, contextCompaction }: TaskProgressOverlayProps): React.ReactElement | null {
   const { isAtBottom, scrollToBottom } = useStickToBottomContext()
   const liveItems = React.useMemo(
     () => aggregateTaskItems(activities, false),
@@ -108,12 +110,12 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
 
   // liveMessages 在收尾时会被清空；保留最后一份任务快照，才能完成 4 秒反馈。
   React.useEffect(() => {
-    if (!hasLiveTasks || liveSignature === retainedSignature) return
+    if (taskProgressInline || !hasLiveTasks || liveSignature === retainedSignature) return
     setRetainedActivities(activities)
     setRetainedSignature(liveSignature)
     setFading(false)
     setVisible(true)
-  }, [activities, hasLiveTasks, liveSignature, retainedSignature])
+  }, [activities, hasLiveTasks, liveSignature, retainedSignature, taskProgressInline])
 
   const liveCompactionSignature = contextCompaction ? compactionSignature(contextCompaction) : ''
   React.useEffect(() => {
@@ -139,11 +141,13 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
     setVisible(hasLiveTasks)
   }, [streaming, contextCompaction, retainedCompaction, hasLiveTasks])
 
-  const displayActivities = hasLiveTasks ? activities : retainedActivities
-  const displayItems = hasLiveTasks
-    ? liveItems
-    : aggregateTaskItems(retainedActivities, false)
-  const displaySignature = hasLiveTasks ? liveSignature : retainedSignature
+  const displayActivities = hasLiveTasks && taskProgressInline ? [] : hasLiveTasks ? activities : retainedActivities
+  const displayItems = hasLiveTasks && taskProgressInline
+    ? []
+    : hasLiveTasks
+      ? liveItems
+      : aggregateTaskItems(retainedActivities, false)
+  const displaySignature = hasLiveTasks && taskProgressInline ? '' : hasLiveTasks ? liveSignature : retainedSignature
   const displayCompaction = contextCompaction ?? retainedCompaction
   // 上游每次 liveMessages 更新都会重建 progress 对象；超时 effect 必须依赖稳定签名，不能依赖对象引用。
   const displayCompactionSignature = displayCompaction ? compactionSignature(displayCompaction) : ''


### PR DESCRIPTION
## Summary

- 流式 turn 期间将完整历史渲染收敛为任务进度面板和最新文本尾部预览
- 限制流式预览长度，避免持续解析完整 Markdown、代码高亮、工具结果树和思考块
- 纯工具阶段显示轻量运行状态，流式错误保留错误详情与重试入口
- 流式期间禁用历史选区引用，完成后恢复完整内容和历史引用

## Validation

- `bun run --filter @proma/electron typecheck`
- `bun test apps/electron/src/renderer/components/agent/ProcessBlockGroup.test.ts apps/electron/src/renderer/components/agent/AgentMessages.test.ts apps/electron/src/renderer/components/agent/SDKMessageRenderer.test.ts`
- `git diff --check`

## Dependency

基于已合并的 PR #1600（`perf(agent): remove history scroll scans`）。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)