### PR TITLE
fix(browser): allow unrestricted URL navigation

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.21",
+  "version": "0.17.22",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -899,8 +899,8 @@ function buildBrowserTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefiniti
     sdk.defineTool({
       name: 'BrowserNavigate',
       label: '在受管浏览器中打开网页',
-      description: 'Navigate the Agent working in-app browser tab to an HTTP/HTTPS URL. Localhost loopback addresses are allowed for local development; other private-network addresses, downloads, popups, and browser permissions are blocked.',
-      parameters: Type.Object({ url: Type.String({ description: 'A complete HTTP/HTTPS URL. Localhost loopback addresses are supported for local development.' }), tabId: Type.Optional(Type.String({ description: 'Optional tab id. Defaults to the Agent working tab, independent of the tab visible to the user.' })) }),
+      description: 'Navigate the Agent working in-app browser tab to a URL. The managed browser accepts any URL Chromium can load; downloads, popups, and browser permissions remain blocked.',
+      parameters: Type.Object({ url: Type.String({ description: 'A complete URL to navigate to. Protocol-relative and bare domain inputs are normalized to HTTPS.' }), tabId: Type.Optional(Type.String({ description: 'Optional tab id. Defaults to the Agent working tab, independent of the tab visible to the user.' })) }),
       async execute(_id, params, signal?: AbortSignal) {
         const args = params as Record<string, unknown>
         return jsonToolResult(await browserController.navigate(ctx.sessionId, typeof args.url === 'string' ? args.url : '', typeof args.tabId === 'string' ? args.tabId : undefined, signal))
@@ -1039,8 +1039,8 @@ function buildBrowserTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefiniti
     sdk.defineTool({
       name: 'BrowserNewTab',
       label: '新建浏览器标签',
-      description: 'Create a new Agent working tab and activate it in the visible in-app browser. Optionally navigate it to an HTTP/HTTPS URL, including localhost loopback for local development.',
-      parameters: Type.Object({ url: Type.Optional(Type.String({ description: 'Optional HTTP/HTTPS URL; localhost loopback is supported for local development.' })) }),
+      description: 'Create a new Agent working tab and activate it in the visible in-app browser. Optionally navigate it to any URL Chromium can load.',
+      parameters: Type.Object({ url: Type.Optional(Type.String({ description: 'Optional URL to navigate to.' })) }),
       async execute(_id, params) {
         const url = typeof (params as Record<string, unknown>).url === 'string' ? (params as Record<string, string>).url : undefined
         return jsonToolResult(await browserController.createNewTab(ctx.sessionId, url))

--- a/apps/electron/src/main/lib/browser-policy.ts
+++ b/apps/electron/src/main/lib/browser-policy.ts
@@ -1,7 +1,5 @@
-/** 受管浏览器的纯 URL 边界；保持无 Electron 依赖，便于在普通 Bun 测试中验证。 */
-import { lookup } from 'node:dns/promises'
+/** 受管浏览器的 URL 规范化与合法性校验；保持无 Electron 依赖，便于在普通 Bun 测试中验证。 */
 
-/** 仅允许本机 loopback 用于本地开发；局域网与其他私网仍须隔离。 */
 function isLoopbackAddress(hostname: string): boolean {
   const host = hostname.toLowerCase()
   if (host === 'localhost' || host.endsWith('.localhost')) return true
@@ -11,29 +9,15 @@ function isLoopbackAddress(hostname: string): boolean {
   return Number(match?.[1]) === 127
 }
 
-function isPrivateAddress(hostname: string): boolean {
-  const host = hostname.toLowerCase()
-  if (isLoopbackAddress(host)) return false
-  if (host.endsWith('.local')) return true
-  const ipv6 = host.replace(/^\[/, '').replace(/\]$/, '')
-  // IPv6 unspecified、IPv4-mapped、ULA、link-local 与 multicast 都不能作为
-  // 受管浏览器的网络目的地。IPv4-mapped 地址一律拒绝，避免映射后绕过 IPv4 私网段判断。
-  if (ipv6 === '::' || ipv6.startsWith('::ffff:') || ipv6.startsWith('fc') || ipv6.startsWith('fd') || ipv6.startsWith('fe8') || ipv6.startsWith('fe9') || ipv6.startsWith('fea') || ipv6.startsWith('feb') || ipv6.startsWith('ff')) return true
-  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
-  if (!match) return false
-  const a = Number(match[1] ?? 0)
-  const b = Number(match[2] ?? 0)
-  return a === 10 || (a === 169 && b === 254) || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168) || a === 0 || a >= 224
-}
-
 /**
  * 地址栏可直接输入域名或路径（例如 `example.com/docs`）；缺省协议时按 HTTPS 打开。
- * 显式协议仍按原安全策略校验，绝不把 `javascript:` / `//host` 等输入误当作域名。
+ * 受管浏览器不再按网络地址、协议或 URL 认证信息设置访问限制，具体协议支持由 Chromium 决定。
  */
 export function normalizeBrowserUrl(input: string): string {
   const value = input.trim()
   if (!value) throw new Error('浏览器地址不能为空。')
-  if (value.startsWith('//')) throw new Error('浏览器地址必须使用 HTTP 或 HTTPS 协议。')
+  // 协议相对 URL 按 HTTPS 处理，和无协议域名保持一致。
+  if (value.startsWith('//')) return `https:${value}`
   // `localhost:3000` 和 `example.com:8080` 是没有协议的常见地址栏输入，不能被误判为 scheme。
   if (/^[^/?#:\s]+:\d+(?:[/?#]|$)/.test(value)) {
     const localCandidate = new URL(`http://${value}`)
@@ -49,29 +33,20 @@ export function normalizeBrowserUrl(input: string): string {
   return `https://${value}`
 }
 
+/** 仅拒绝空值或无法被 URL 标准解析的输入；不限制目标网络、协议或认证信息。 */
 export function assertSafeBrowserUrl(input: string): string {
   const normalized = normalizeBrowserUrl(input)
-  let parsed: URL
-  try { parsed = new URL(normalized) } catch { throw new Error('浏览器地址无效。请输入公共域名或完整的 HTTP/HTTPS URL。') }
-  if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('受管浏览器不允许此 URL 协议。')
-  if (parsed.username || parsed.password || isPrivateAddress(parsed.hostname)) throw new Error('受管浏览器仅允许访问公网或本机 loopback 地址；私网及带认证信息的 URL 不受支持。')
-  return parsed.toString()
+  try {
+    return new URL(normalized).toString()
+  } catch {
+    throw new Error('浏览器地址无效。')
+  }
 }
 
 /**
- * 导航/请求开始前再次解析域名，并拒绝落到私网（本机 loopback 除外）的结果。
- * Chromium 仍是最终网络栈；完整 DNS-rebinding 防护需要后续接入受控 egress proxy，
- * 但这个 guard 可以阻断当前解析即指向局域网或其他私网的常见攻击路径。
+ * 保持现有调用接口，导航前不再进行 DNS 解析或地址类型过滤。
+ * Chromium 是实际加载 URL 的网络栈，并决定各协议是否可用。
  */
 export async function assertSafeBrowserDestination(input: string): Promise<string> {
-  const safeUrl = assertSafeBrowserUrl(input)
-  const hostname = new URL(safeUrl).hostname
-  // IPv6 字面量带方括号时，Node DNS lookup 不会将它当作地址；本机 loopback
-  // 已在同步 URL 校验阶段允许，无需经过 DNS，避免误解析到其他地址。
-  if (isLoopbackAddress(hostname)) return safeUrl
-  const addresses = await lookup(hostname, { all: true, verbatim: true })
-  if (addresses.length === 0 || addresses.some(({ address }) => isPrivateAddress(address))) {
-    throw new Error('受管浏览器拒绝访问解析到私网的地址（本机 loopback 除外）。')
-  }
-  return safeUrl
+  return assertSafeBrowserUrl(input)
 }


### PR DESCRIPTION
## Summary
- 移除受管浏览器对私网、Fake IP、URL 认证信息及非 HTTP(S) 协议的导航校验
- 取消导航前 DNS 地址段过滤，交由 Chromium 决定 URL 加载能力
- 更新 Agent 浏览器工具说明，并将 Electron 版本升级至 0.17.22

## Validation
- `bun build apps/electron/src/main/lib/browser-policy.ts --outdir /tmp/proma-browser-policy-build --target=node`
- 全量 typecheck / main build 受 worktree 的 `@proma/shared` 解析问题阻塞

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)