### PR TITLE
Fix queued agent history collapse

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.21",
+  "version": "0.17.22",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -829,8 +829,9 @@ export const AgentMessages = React.memo(function AgentMessages({
       allGroups,
       liveMessages,
       streaming,
+      activeRunStartedAt: streamState?.startedAt,
     })
-  }, [allGroups, liveMessages, streaming])
+  }, [allGroups, liveMessages, streaming, streamState?.startedAt])
 
   // 迷你地图数据 — 直接使用统一的 allGroups（无需去重）
   const minimapItems: MinimapItem[] = React.useMemo(

--- a/apps/electron/src/renderer/components/agent/live-group-set.ts
+++ b/apps/electron/src/renderer/components/agent/live-group-set.ts
@@ -5,6 +5,12 @@ interface BuildLiveGroupSetOptions {
   allGroups: MessageGroup[]
   liveMessages?: readonly SDKMessage[] | null
   streaming: boolean
+  /** 当前运行的起始时间，用于从跨队列残留的实时消息中识别本轮。 */
+  activeRunStartedAt?: number
+}
+
+type RunScopedLiveMessage = SDKMessage & {
+  _promaLiveRunStartedAt?: number
 }
 
 const EMPTY_LIVE_GROUPS: ReadonlySet<MessageGroup> = new Set<MessageGroup>()
@@ -17,10 +23,19 @@ export function buildLiveGroupSet({
   allGroups,
   liveMessages,
   streaming,
+  activeRunStartedAt,
 }: BuildLiveGroupSetOptions): ReadonlySet<MessageGroup> {
   if (!streaming || !liveMessages || liveMessages.length === 0) return EMPTY_LIVE_GROUPS
 
-  const liveSet = new Set<SDKMessage>(liveMessages)
+  // 自动派发下一条队列消息时，上一轮的实时消息会保留到落盘刷新完成。
+  // 新旧 run 之间若没有可见的 `streaming=false` 渲染，旧过程组将一直维持展开态。
+  // 以运行起始时间限定 live 集合，令上一轮立即进入完成态并执行自动折叠。
+  const activeLiveMessages = activeRunStartedAt == null
+    ? liveMessages
+    : liveMessages.filter((message) => (
+      (message as RunScopedLiveMessage)._promaLiveRunStartedAt === activeRunStartedAt
+    ))
+  const liveSet = new Set<SDKMessage>(activeLiveMessages)
   const result = new Set<MessageGroup>()
 
   for (const group of allGroups) {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -543,6 +543,7 @@ export function useGlobalAgentListeners(): void {
         message: { content: [{ type: 'text', text: payload.rawText }] },
         parent_tool_use_id: null,
         _createdAt: streamStartedAt,
+        _promaLiveRunStartedAt: streamStartedAt,
       } as unknown as SDKMessage
       store.set(liveMessagesMapAtom, (prev) => {
         const map = new Map(prev)
@@ -1027,6 +1028,13 @@ export function useGlobalAgentListeners(): void {
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
             if (typeof msgRecord._createdAt !== 'number') {
               msgRecord._createdAt = Date.now()
+            }
+
+            // 队列自动派发会在上一轮实时消息尚未落盘刷新时开始下一轮。
+            // 标记每条实时消息所属 run，渲染层即可把上一轮立即视为完成并自动收起过程块。
+            const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+            if (activeRunStartedAt != null) {
+              msgRecord._promaLiveRunStartedAt = activeRunStartedAt
             }
 
             // 为 assistant 消息注入渠道信息，确保流式期间就绑定正确模型与 Agent SDK 窗口


### PR DESCRIPTION
## Summary
- scope live Agent messages to their active queued run
- allow prior process groups to enter their existing auto-collapse flow

## Validation
- `bun run typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)