### PR TITLE
fix(agent): route OpenCode Go Vision Relay models

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.22",
+  "version": "0.17.23",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -24,6 +24,7 @@ import {
   getPromaUserAgent,
   normalizeAnthropicBaseUrlForSdk,
   normalizeOpenAIBaseUrlForSdk,
+  normalizeVersionedAnthropicBaseUrl,
   resolveAnthropicMessagesUrl,
 } from '@proma/core'
 import type { Api, KnownProvider, Model } from '@earendil-works/pi-ai/compat'
@@ -333,6 +334,8 @@ function candidatePiProviders(provider: ProviderType): KnownProvider[] {
       return ['moonshotai-cn', 'moonshotai']
     case 'kimi-coding':
       return ['kimi-coding', 'moonshotai-cn', 'moonshotai']
+    case 'opencode-go-openai':
+      return ['opencode-go']
     case 'zhipu':
       return ['zai']
     case 'zhipu-coding':
@@ -350,8 +353,9 @@ function candidatePiProviders(provider: ProviderType): KnownProvider[] {
 
 function findCatalogModelById(models: readonly PiCatalogModel[], modelId: string): PiCatalogModel | undefined {
   const normalized = modelId.toLowerCase()
-  return models.find((model) =>
-    model.id.toLowerCase() === normalized || model.name.toLowerCase() === normalized)
+  // ID 是渠道实际发送到上游的稳定标识；同名展示名称只能在没有 ID 命中时兜底。
+  return models.find((model) => model.id.toLowerCase() === normalized)
+    ?? models.find((model) => model.name.toLowerCase() === normalized)
 }
 
 /**
@@ -446,6 +450,52 @@ export async function resolvePiImageInputCapability(
   const catalogModel = await findPiCatalogModel(provider, resolvedModelId)
   if (!catalogModel) return 'unknown'
   return catalogModel.input.includes('image') ? 'supported' : 'unsupported'
+}
+
+/**
+ * Vision Relay 的实际请求路由。
+ *
+ * OpenCode Go 的同一渠道同时提供 OpenAI 和 Anthropic Messages 模型；因此必须以
+ * Pi catalog 中该模型声明的 API 与 Base URL 为准，不能只按渠道类型固定走 OpenAI。
+ */
+export interface PiVisionRelayRoute {
+  adapterProvider: ProviderType
+  baseUrl?: string
+}
+
+export async function resolvePiVisionRelayRoute(
+  provider: ProviderType,
+  modelId: string | undefined,
+): Promise<PiVisionRelayRoute | undefined> {
+  const resolvedModelId = stripLegacyAgentSdkContextSuffix(modelId)
+  if (!resolvedModelId) return undefined
+  const catalogModel = await findPiCatalogModel(provider, resolvedModelId)
+  if (!catalogModel?.input.includes('image')) return undefined
+
+  if (provider !== 'opencode-go-openai') {
+    return { adapterProvider: provider }
+  }
+
+  switch (catalogModel.api) {
+    case 'anthropic-messages':
+      return {
+        // Anthropic-compatible adapter 接收完整 messages 端点，避免误套 OpenAI 协议。
+        adapterProvider: 'anthropic-compatible',
+        baseUrl: `${normalizeVersionedAnthropicBaseUrl(catalogModel.baseUrl)}/messages`,
+      }
+    case 'openai-completions':
+      return {
+        adapterProvider: 'opencode-go-openai',
+        baseUrl: catalogModel.baseUrl,
+      }
+    case 'openai-responses':
+      return {
+        adapterProvider: 'openai-responses',
+        baseUrl: catalogModel.baseUrl,
+      }
+    default:
+      return undefined
+  }
 }
 
 /**

--- a/apps/electron/src/main/lib/vision-relay-service.ts
+++ b/apps/electron/src/main/lib/vision-relay-service.ts
@@ -14,7 +14,7 @@ import { getChannelById, resolveChannelRuntimeApiKey } from './channel-manager'
 import { getSettings } from './settings-service'
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
-import { resolvePiImageInputCapability } from './adapters/pi-model-registry'
+import { resolvePiVisionRelayRoute } from './adapters/pi-model-registry'
 
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024
 const MAX_RESULT_CHARS = 12_000
@@ -187,15 +187,15 @@ export async function inspectImageWithVisionRelay(input: InspectImageInput): Pro
     return failure('VISION_ROUTE_UNAVAILABLE', '配置的视觉渠道或模型已不可用，请重新配置视觉助手。')
   }
 
-  try {
-    getAdapter(channel.provider)
-  } catch {
-    return failure('VISION_ROUTE_UNAVAILABLE', '所选渠道不支持视觉助手请求，请选择 API 渠道而非订阅登录渠道。')
+  const route = await resolvePiVisionRelayRoute(channel.provider, configured.modelId)
+  if (!route) {
+    return failure('VISION_ROUTE_UNAVAILABLE', '所选模型未被确认支持图片输入或协议路由，请选择一个已知的视觉模型。')
   }
 
-  const capability = await resolvePiImageInputCapability(channel.provider, configured.modelId)
-  if (capability !== 'supported') {
-    return failure('VISION_ROUTE_UNAVAILABLE', '所选模型未被确认支持图片输入，请选择一个已知的视觉模型。')
+  try {
+    getAdapter(route.adapterProvider)
+  } catch {
+    return failure('VISION_ROUTE_UNAVAILABLE', '所选渠道不支持视觉助手请求，请选择 API 渠道而非订阅登录渠道。')
   }
 
   let apiKey: string
@@ -217,9 +217,9 @@ export async function inspectImageWithVisionRelay(input: InspectImageInput): Pro
       mediaType: image.mediaType,
       data: image.data.toString('base64'),
     }]
-    const adapter = getAdapter(channel.provider)
+    const adapter = getAdapter(route.adapterProvider)
     const request = adapter.buildStreamRequest({
-      baseUrl: channel.baseUrl,
+      baseUrl: route.baseUrl ?? channel.baseUrl,
       apiKey,
       modelId: configured.modelId,
       history: [],


### PR DESCRIPTION
## Summary

- fix(agent): route OpenCode Go Vision Relay models

## Test plan

- [x] `bun run typecheck`
- [x] `bun run --cwd apps/electron build:main`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)