### PR TITLE
fix(automation): validate schedule transitions

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -224,6 +224,7 @@ import {
   listAutomations,
   getAutomation,
   createAutomation,
+  getEffectiveAutomationScheduleFields,
   updateAutomation,
   deleteAutomation,
 } from './lib/automation-manager'
@@ -5215,51 +5216,33 @@ export function registerIpcHandlers(): void {
     input: Partial<CreateAutomationInput | UpdateAutomationInput>,
     existing?: Automation,
   ): void => {
-    const scheduleType = input.scheduleType ?? existing?.scheduleType
-    if (scheduleType === 'interval') {
-      const intervalMinutes = input.intervalMinutes ?? existing?.intervalMinutes
-      if (!isFiniteInt(intervalMinutes) || intervalMinutes < 1) throw new Error('scheduleType=interval 时 intervalMinutes 必填')
+    const effective = getEffectiveAutomationScheduleFields(input, existing)
+    if (effective.scheduleType === 'interval') {
+      if (!isFiniteInt(effective.intervalMinutes) || effective.intervalMinutes < 1) throw new Error('scheduleType=interval 时 intervalMinutes 必填')
     }
-    const activeWindowStart = input.activeWindowStart !== undefined
-      ? input.activeWindowStart ?? undefined
-      : existing?.activeWindowStart
-    const activeWindowEnd = input.activeWindowEnd !== undefined
-      ? input.activeWindowEnd ?? undefined
-      : existing?.activeWindowEnd
-    if ((activeWindowStart === undefined) !== (activeWindowEnd === undefined)) {
+    if ((effective.activeWindowStart === undefined) !== (effective.activeWindowEnd === undefined)) {
       throw new Error('activeWindowStart 与 activeWindowEnd 必须同时设置或同时清除')
     }
-    const activeWeekdays = input.activeWeekdays !== undefined
-      ? input.activeWeekdays ?? undefined
-      : existing?.activeWeekdays
-    if (activeWeekdays !== undefined && activeWeekdays.length === 0) {
-      // 空数组明确表示每天，不需要额外约束。
-    } else if (activeWeekdays !== undefined && scheduleType !== 'interval') {
+    if (effective.activeWeekdays !== undefined && effective.activeWeekdays.length > 0 && effective.scheduleType !== 'interval') {
       throw new Error('周内运行日限制仅支持 scheduleType=interval')
     }
-    if (activeWindowStart !== undefined && activeWindowEnd !== undefined) {
-      if (scheduleType !== 'interval') throw new Error('每日执行窗口仅支持 scheduleType=interval')
-      if (!validTimeOfDay(activeWindowStart) || !validTimeOfDay(activeWindowEnd) || activeWindowStart >= activeWindowEnd) {
+    if (effective.activeWindowStart !== undefined && effective.activeWindowEnd !== undefined) {
+      if (effective.scheduleType !== 'interval') throw new Error('每日执行窗口仅支持 scheduleType=interval')
+      if (!validTimeOfDay(effective.activeWindowStart) || !validTimeOfDay(effective.activeWindowEnd) || effective.activeWindowStart >= effective.activeWindowEnd) {
         throw new Error('每日执行窗口必须是同一天内有效的 HH:MM 范围，且开始早于结束')
       }
     }
-    if (scheduleType === 'daily' || scheduleType === 'weekly' || scheduleType === 'monthly') {
-      const timeOfDay = input.timeOfDay ?? existing?.timeOfDay
-      if (!validTimeOfDay(timeOfDay)) throw new Error('scheduleType=daily/weekly/monthly 时 timeOfDay 必填')
+    if (effective.scheduleType === 'daily' || effective.scheduleType === 'weekly' || effective.scheduleType === 'monthly') {
+      if (!validTimeOfDay(effective.timeOfDay)) throw new Error('scheduleType=daily/weekly/monthly 时 timeOfDay 必填')
     }
-    if (scheduleType === 'weekly') {
-      const dayOfWeek = input.dayOfWeek ?? existing?.dayOfWeek
-      if (!isFiniteInt(dayOfWeek)) throw new Error('scheduleType=weekly 时 dayOfWeek 必填')
+    if (effective.scheduleType === 'weekly' && !isFiniteInt(effective.dayOfWeek)) {
+      throw new Error('scheduleType=weekly 时 dayOfWeek 必填')
     }
-    if (scheduleType === 'monthly') {
-      const dayOfMonth = input.dayOfMonth ?? existing?.dayOfMonth
-      if (!isFiniteInt(dayOfMonth)) throw new Error('scheduleType=monthly 时 dayOfMonth 必填')
+    if (effective.scheduleType === 'monthly' && !isFiniteInt(effective.dayOfMonth)) {
+      throw new Error('scheduleType=monthly 时 dayOfMonth 必填')
     }
-    if (scheduleType === 'once') {
-      const scheduledAt = input.scheduledAt ?? existing?.scheduledAt
-      if (typeof scheduledAt !== 'number' || !Number.isFinite(scheduledAt) || scheduledAt <= 0) {
-        throw new Error('scheduleType=once 时 scheduledAt 必填')
-      }
+    if (effective.scheduleType === 'once' && (typeof effective.scheduledAt !== 'number' || !Number.isFinite(effective.scheduledAt) || effective.scheduledAt <= 0)) {
+      throw new Error('scheduleType=once 时 scheduledAt 必填')
     }
   }
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -225,6 +225,7 @@ import {
   getAutomation,
   createAutomation,
   getEffectiveAutomationScheduleFields,
+  validateExplicitAutomationScheduleFields,
   updateAutomation,
   deleteAutomation,
 } from './lib/automation-manager'
@@ -5216,6 +5217,9 @@ export function registerIpcHandlers(): void {
     input: Partial<CreateAutomationInput | UpdateAutomationInput>,
     existing?: Automation,
   ): void => {
+    const scheduleType = input.scheduleType ?? existing?.scheduleType
+    if (!scheduleType) throw new Error('scheduleType 必填')
+    validateExplicitAutomationScheduleFields(input, scheduleType)
     const effective = getEffectiveAutomationScheduleFields(input, existing)
     if (effective.scheduleType === 'interval') {
       if (!isFiniteInt(effective.intervalMinutes) || effective.intervalMinutes < 1) throw new Error('scheduleType=interval 时 intervalMinutes 必填')

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -20,6 +20,7 @@ import {
   deleteAutomation,
   getAutomation,
   getEffectiveAutomationScheduleFields,
+  validateExplicitAutomationScheduleFields,
   listAutomations,
   updateAutomation,
 } from '../automation-manager'
@@ -391,6 +392,7 @@ function buildAutomationTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefin
           active: (args.active as boolean) ?? true,
         }
         validateScheduleFields(input)
+        validateExplicitAutomationScheduleFields(input, input.scheduleType)
         if (input.scheduleType === 'interval' && args.intervalMinutes === undefined) {
           throw new Error('scheduleType=interval 时 intervalMinutes 必填')
         }
@@ -478,6 +480,8 @@ function buildAutomationTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefin
         validateScheduleFields(input)
         const existing = getAutomation(id)
         if (!existing) throw new Error(`定时任务不存在: ${id}`)
+        const scheduleType = input.scheduleType ?? existing.scheduleType
+        validateExplicitAutomationScheduleFields(input, scheduleType)
         const effective = getEffectiveAutomationScheduleFields(input, existing)
         if (effective.scheduleType === 'interval' && (!isFiniteInt(effective.intervalMinutes) || effective.intervalMinutes < 1)) {
           throw new Error('scheduleType=interval 时 intervalMinutes 必填')

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -19,6 +19,7 @@ import {
   createAutomation,
   deleteAutomation,
   getAutomation,
+  getEffectiveAutomationScheduleFields,
   listAutomations,
   updateAutomation,
 } from '../automation-manager'
@@ -476,29 +477,31 @@ function buildAutomationTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefin
         if (input.prompt !== undefined) assertNonBlank(input.prompt, 'prompt')
         validateScheduleFields(input)
         const existing = getAutomation(id)
-        if (input.scheduleType === 'once' && input.scheduledAt === undefined) {
-          if (!existing?.scheduledAt) {
-            throw new Error('scheduleType 改为 once 时必须提供 scheduledAt')
-          }
+        if (!existing) throw new Error(`定时任务不存在: ${id}`)
+        const effective = getEffectiveAutomationScheduleFields(input, existing)
+        if (effective.scheduleType === 'interval' && (!isFiniteInt(effective.intervalMinutes) || effective.intervalMinutes < 1)) {
+          throw new Error('scheduleType=interval 时 intervalMinutes 必填')
         }
-        const activeWindowStart = input.activeWindowStart !== undefined
-          ? input.activeWindowStart ?? undefined
-          : existing?.activeWindowStart
-        const activeWindowEnd = input.activeWindowEnd !== undefined
-          ? input.activeWindowEnd ?? undefined
-          : existing?.activeWindowEnd
-        const effectiveScheduleType = input.scheduleType ?? existing?.scheduleType
-        if ((activeWindowStart === undefined) !== (activeWindowEnd === undefined)) {
+        if ((effective.activeWindowStart === undefined) !== (effective.activeWindowEnd === undefined)) {
           throw new Error('activeWindowStart 与 activeWindowEnd 必须同时设置或同时清除')
         }
-        const effectiveWeekdays = input.activeWeekdays !== undefined
-          ? input.activeWeekdays ?? undefined
-          : existing?.activeWeekdays
-        if (effectiveWeekdays && effectiveWeekdays.length > 0 && effectiveScheduleType !== 'interval') {
+        if (effective.activeWeekdays && effective.activeWeekdays.length > 0 && effective.scheduleType !== 'interval') {
           throw new Error('周内运行日限制仅支持 interval')
         }
-        if (activeWindowStart && activeWindowEnd && (effectiveScheduleType !== 'interval' || activeWindowStart >= activeWindowEnd)) {
+        if (effective.activeWindowStart && effective.activeWindowEnd && (effective.scheduleType !== 'interval' || effective.activeWindowStart >= effective.activeWindowEnd)) {
           throw new Error('每日执行窗口仅支持 interval，且开始时间必须早于结束时间')
+        }
+        if ((effective.scheduleType === 'daily' || effective.scheduleType === 'weekly' || effective.scheduleType === 'monthly') && !effective.timeOfDay) {
+          throw new Error('scheduleType=daily/weekly/monthly 时 timeOfDay 必填')
+        }
+        if (effective.scheduleType === 'weekly' && effective.dayOfWeek === undefined) {
+          throw new Error('scheduleType=weekly 时 dayOfWeek 必填')
+        }
+        if (effective.scheduleType === 'monthly' && effective.dayOfMonth === undefined) {
+          throw new Error('scheduleType=monthly 时 dayOfMonth 必填')
+        }
+        if (effective.scheduleType === 'once' && effective.scheduledAt === undefined) {
+          throw new Error('scheduleType 改为 once 时必须提供 scheduledAt')
         }
         const automation = updateAutomation(input)
         if (!automation) throw new Error(`定时任务不存在: ${id}`)

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -351,6 +351,14 @@ function shouldAutoComplete(a: Pick<Automation, 'scheduleType' | 'maxRuns' | 'ru
  * 按调度模式清理不适用字段。
  * 更新接口只需声明目标 scheduleType，避免调用方必须手动清空旧模式字段。
  */
+type AutomationScheduleFields = Omit<
+  Pick<
+    Automation,
+    'scheduleType' | 'intervalMinutes' | 'activeWindowStart' | 'activeWindowEnd' | 'activeWeekdays' | 'timeOfDay' | 'dayOfWeek' | 'dayOfMonth' | 'scheduledAt'
+  >,
+  'intervalMinutes'
+> & { intervalMinutes?: number }
+
 export function normalizeAutomationScheduleFields(
   target: Pick<Automation, 'scheduleType' | 'activeWindowStart' | 'activeWindowEnd' | 'activeWeekdays' | 'timeOfDay' | 'dayOfWeek' | 'dayOfMonth' | 'scheduledAt'>,
 ): void {
@@ -365,6 +373,33 @@ export function normalizeAutomationScheduleFields(
   if (target.scheduleType !== 'weekly') target.dayOfWeek = undefined
   if (target.scheduleType !== 'monthly') target.dayOfMonth = undefined
   if (target.scheduleType !== 'once') target.scheduledAt = undefined
+}
+
+/**
+ * 合并更新输入与已有任务，并按目标 scheduleType 清理旧模式字段后供边界层校验。
+ * 切换模式时，旧模式的字段不能参与新模式的完整性校验；否则归一化尚未执行就会被拒绝。
+ */
+export function getEffectiveAutomationScheduleFields(
+  input: Partial<CreateAutomationInput | UpdateAutomationInput>,
+  existing?: Automation,
+): AutomationScheduleFields {
+  const scheduleType = input.scheduleType ?? existing?.scheduleType ?? 'interval'
+  const useExisting = <K extends keyof AutomationScheduleFields>(field: K): AutomationScheduleFields[K] | undefined =>
+    input[field] !== undefined ? input[field] as AutomationScheduleFields[K] : existing?.[field]
+
+  const effective: AutomationScheduleFields = {
+    scheduleType,
+    intervalMinutes: useExisting('intervalMinutes'),
+    activeWindowStart: useExisting('activeWindowStart') ?? undefined,
+    activeWindowEnd: useExisting('activeWindowEnd') ?? undefined,
+    activeWeekdays: useExisting('activeWeekdays') ?? undefined,
+    timeOfDay: useExisting('timeOfDay') ?? undefined,
+    dayOfWeek: useExisting('dayOfWeek'),
+    dayOfMonth: useExisting('dayOfMonth'),
+    scheduledAt: useExisting('scheduledAt'),
+  }
+  normalizeAutomationScheduleFields(effective)
+  return effective
 }
 
 export function createAutomation(input: CreateAutomationInput): Automation {

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -387,6 +387,8 @@ export function validateExplicitAutomationScheduleFields(
 ): void {
   const hasValue = (value: unknown): boolean => value !== undefined && value !== null
 
+  // intervalMinutes 是所有 Automation 持久化记录及 CreateAutomationInput 的必填兼容字段；
+  // 非 interval 模式会保留它作为闲置值，不能在此按模式拒绝。
   if (scheduleType !== 'interval') {
     if (input.activeWeekdays !== undefined && input.activeWeekdays !== null) {
       throw new Error('周内运行日限制仅支持 scheduleType=interval')

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -376,6 +376,40 @@ export function normalizeAutomationScheduleFields(
 }
 
 /**
+ * 拒绝调用方显式提交的、与目标 scheduleType 不兼容的字段。
+ *
+ * 此检查必须发生在 getEffectiveAutomationScheduleFields() 归一化之前：后者只用于
+ * 忽略已有任务继承的旧模式字段，不能将本次请求明确提供的非法字段静默丢弃。
+ */
+export function validateExplicitAutomationScheduleFields(
+  input: Partial<CreateAutomationInput | UpdateAutomationInput>,
+  scheduleType: Automation['scheduleType'],
+): void {
+  const hasValue = (value: unknown): boolean => value !== undefined && value !== null
+
+  if (scheduleType !== 'interval') {
+    if (input.activeWeekdays !== undefined && input.activeWeekdays !== null && input.activeWeekdays.length > 0) {
+      throw new Error('周内运行日限制仅支持 scheduleType=interval')
+    }
+    if (hasValue(input.activeWindowStart) || hasValue(input.activeWindowEnd)) {
+      throw new Error('每日执行窗口仅支持 scheduleType=interval')
+    }
+  }
+  if (scheduleType !== 'daily' && scheduleType !== 'weekly' && scheduleType !== 'monthly' && input.timeOfDay !== undefined) {
+    throw new Error('timeOfDay 仅支持 scheduleType=daily/weekly/monthly')
+  }
+  if (scheduleType !== 'weekly' && input.dayOfWeek !== undefined) {
+    throw new Error('dayOfWeek 仅支持 scheduleType=weekly')
+  }
+  if (scheduleType !== 'monthly' && input.dayOfMonth !== undefined) {
+    throw new Error('dayOfMonth 仅支持 scheduleType=monthly')
+  }
+  if (scheduleType !== 'once' && input.scheduledAt !== undefined) {
+    throw new Error('scheduledAt 仅支持 scheduleType=once')
+  }
+}
+
+/**
  * 合并更新输入与已有任务，并按目标 scheduleType 清理旧模式字段后供边界层校验。
  * 切换模式时，旧模式的字段不能参与新模式的完整性校验；否则归一化尚未执行就会被拒绝。
  */

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -388,7 +388,7 @@ export function validateExplicitAutomationScheduleFields(
   const hasValue = (value: unknown): boolean => value !== undefined && value !== null
 
   if (scheduleType !== 'interval') {
-    if (input.activeWeekdays !== undefined && input.activeWeekdays !== null && input.activeWeekdays.length > 0) {
+    if (input.activeWeekdays !== undefined && input.activeWeekdays !== null) {
       throw new Error('周内运行日限制仅支持 scheduleType=interval')
     }
     if (hasValue(input.activeWindowStart) || hasValue(input.activeWindowEnd)) {

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -768,6 +768,7 @@ export function AutomationFormView({ standalone = false }: { standalone?: boolea
                 if (next === 'interval') {
                   update({
                     scheduleType: next,
+                    intervalMinutes: form.intervalMinutes ?? 10,
                     timeOfDay: undefined,
                     dayOfWeek: undefined,
                     dayOfMonth: undefined,

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -758,8 +758,14 @@ export function AutomationFormView({ standalone = false }: { standalone?: boolea
               value={form.scheduleType}
               onValueChange={(v) => {
                 const next = v as AutomationDraft['scheduleType']
-                // 切到 once 且尚无触发时间时，默认填入 1 小时后，避免空值导致自动保存失败
-                if (next === 'once' && !form.scheduledAt) {
+                // 默认值必须写入 draft：展示层 fallback 不会进入自动保存请求。
+                if (next === 'daily') {
+                  update({ scheduleType: next, timeOfDay: form.timeOfDay ?? '09:00' })
+                } else if (next === 'weekly') {
+                  update({ scheduleType: next, timeOfDay: form.timeOfDay ?? '09:00', dayOfWeek: form.dayOfWeek ?? 1 })
+                } else if (next === 'monthly') {
+                  update({ scheduleType: next, timeOfDay: form.timeOfDay ?? '09:00', dayOfMonth: form.dayOfMonth ?? 1 })
+                } else if (next === 'once' && !form.scheduledAt) {
                   update({ scheduleType: next, scheduledAt: Date.now() + 60 * 60 * 1000 })
                 } else {
                   update({ scheduleType: next })

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -759,16 +759,56 @@ export function AutomationFormView({ standalone = false }: { standalone?: boolea
               onValueChange={(v) => {
                 const next = v as AutomationDraft['scheduleType']
                 // 默认值必须写入 draft：展示层 fallback 不会进入自动保存请求。
-                if (next === 'daily') {
-                  update({ scheduleType: next, timeOfDay: form.timeOfDay ?? '09:00' })
+                // 同时立即清除不适用字段，避免后端归一化后旧配置仍滞留本地并在切回时复活。
+                const clearIntervalFields = {
+                  activeWindowStart: undefined,
+                  activeWindowEnd: undefined,
+                  activeWeekdays: undefined,
+                }
+                if (next === 'interval') {
+                  update({
+                    scheduleType: next,
+                    timeOfDay: undefined,
+                    dayOfWeek: undefined,
+                    dayOfMonth: undefined,
+                    scheduledAt: undefined,
+                  })
+                } else if (next === 'daily') {
+                  update({
+                    scheduleType: next,
+                    ...clearIntervalFields,
+                    timeOfDay: form.timeOfDay ?? '09:00',
+                    dayOfWeek: undefined,
+                    dayOfMonth: undefined,
+                    scheduledAt: undefined,
+                  })
                 } else if (next === 'weekly') {
-                  update({ scheduleType: next, timeOfDay: form.timeOfDay ?? '09:00', dayOfWeek: form.dayOfWeek ?? 1 })
+                  update({
+                    scheduleType: next,
+                    ...clearIntervalFields,
+                    timeOfDay: form.timeOfDay ?? '09:00',
+                    dayOfWeek: form.dayOfWeek ?? 1,
+                    dayOfMonth: undefined,
+                    scheduledAt: undefined,
+                  })
                 } else if (next === 'monthly') {
-                  update({ scheduleType: next, timeOfDay: form.timeOfDay ?? '09:00', dayOfMonth: form.dayOfMonth ?? 1 })
-                } else if (next === 'once' && !form.scheduledAt) {
-                  update({ scheduleType: next, scheduledAt: Date.now() + 60 * 60 * 1000 })
+                  update({
+                    scheduleType: next,
+                    ...clearIntervalFields,
+                    timeOfDay: form.timeOfDay ?? '09:00',
+                    dayOfWeek: undefined,
+                    dayOfMonth: form.dayOfMonth ?? 1,
+                    scheduledAt: undefined,
+                  })
                 } else {
-                  update({ scheduleType: next })
+                  update({
+                    scheduleType: next,
+                    ...clearIntervalFields,
+                    timeOfDay: undefined,
+                    dayOfWeek: undefined,
+                    dayOfMonth: undefined,
+                    scheduledAt: form.scheduledAt ?? Date.now() + 60 * 60 * 1000,
+                  })
                 }
               }}
             >


### PR DESCRIPTION
## Summary
- Validate schedule changes from a normalized effective configuration, so stale interval fields do not reject a switch to another mode.
- Materialize daily, weekly, and monthly defaults in the form draft before automatic saving.

## Validation
- `bun run typecheck`
- focused schedule-transition assertions
- `bun test` *(528 passed; 4 existing Electron/runtime-environment failures)*

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)