### PR TITLE
perf(agent): isolate input and history rendering

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.23",
+  "version": "0.17.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3866,6 +3866,20 @@ export function registerIpcHandlers(): void {
   )
 
   // 搜索工作区文件（用于 @ 引用，递归扫描，支持附加目录）
+  type WorkspaceFileSearchEntry = {
+    name: string
+    path: string
+    type: 'file' | 'dir'
+    source: 'session' | 'workspace'
+  }
+  const workspaceFileSearchIndexCache = new Map<string, {
+    expiresAt: number
+    rootEntries: WorkspaceFileSearchEntry[]
+    workspaceEntries: WorkspaceFileSearchEntry[]
+  }>()
+  const WORKSPACE_FILE_INDEX_CACHE_TTL_MS = 3_000
+  const WORKSPACE_FILE_INDEX_CACHE_MAX_ENTRIES = 20
+
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES,
     async (_, rootPath: string, query: string, limit = 20, additionalPaths?: string[], sessionPaths?: string[]): Promise<FileSearchResult> => {
@@ -3873,15 +3887,18 @@ export function registerIpcHandlers(): void {
       const { resolve, relative, basename } = await import('node:path')
 
       const safeRoot = resolve(rootPath)
+      const resolvedAdditionalPaths = (additionalPaths ?? []).map((entry) => resolve(entry))
+      const resolvedSessionPaths = (sessionPaths ?? []).map((entry) => resolve(entry))
       const ignoreDirs = new Set(['node_modules', '.git', 'dist', '.next', '__pycache__', '.venv', 'build', '.cache'])
       const ignoreFiles = new Set(['.DS_Store', '.Spotlight-V100', '.Trashes', 'Thumbs.db', 'desktop.ini'])
       const BROWSE_LIMIT_PER_GROUP = 2000
       const BROWSE_TOTAL_CAP = 3000
+      const INDEX_ENTRY_CAP_PER_GROUP = 10_000
 
       // 按来源分组收集文件
-      type Entry = { name: string; path: string; type: 'file' | 'dir'; source: 'session' | 'workspace' }
-      const rootEntries: Entry[] = []
-      const workspaceEntries: Entry[] = []
+      type Entry = WorkspaceFileSearchEntry
+      let rootEntries: Entry[] = []
+      let workspaceEntries: Entry[] = []
 
       function scan(
         dir: string,
@@ -3891,10 +3908,11 @@ export function registerIpcHandlers(): void {
         useAbsPath: boolean,
         source: 'session' | 'workspace',
       ): void {
-        if (depth > 10) return
+        if (depth > 10 || target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
         try {
           const items = readdirSync(dir, { withFileTypes: true })
           for (const item of items) {
+            if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) break
             if (ignoreFiles.has(item.name)) continue
             if (item.isDirectory() && ignoreDirs.has(item.name)) continue
 
@@ -3917,6 +3935,7 @@ export function registerIpcHandlers(): void {
       }
 
       function addAttachedPath(pathValue: string, target: Entry[], source: 'session' | 'workspace'): void {
+        if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
         try {
           const attachedPath = resolve(pathValue)
           const name = basename(attachedPath)
@@ -3924,6 +3943,7 @@ export function registerIpcHandlers(): void {
 
           const stats = statSync(attachedPath)
           if (stats.isFile()) {
+            if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
             target.push({
               name,
               path: attachedPath,
@@ -3936,6 +3956,7 @@ export function registerIpcHandlers(): void {
           if (!stats.isDirectory()) return
           if (ignoreDirs.has(name)) return
 
+          if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
           target.push({
             name: name === 'workspace-files' ? '项目文件' : name,
             path: attachedPath,
@@ -3948,21 +3969,40 @@ export function registerIpcHandlers(): void {
         }
       }
 
-      // session 目录：相对路径
-      scan(safeRoot, 0, safeRoot, rootEntries, false, 'session')
+      const cacheKey = JSON.stringify([safeRoot, resolvedAdditionalPaths, resolvedSessionPaths])
+      const now = Date.now()
+      const cachedIndex = workspaceFileSearchIndexCache.get(cacheKey)
+      if (cachedIndex && cachedIndex.expiresAt > now) {
+        // 查询排序会原地修改数组；每次从缓存复制外壳，索引条目本身保持只读复用。
+        rootEntries = [...cachedIndex.rootEntries]
+        workspaceEntries = [...cachedIndex.workspaceEntries]
+      } else {
+        // session 目录：相对路径
+        scan(safeRoot, 0, safeRoot, rootEntries, false, 'session')
 
-      // 会话级附加路径：绝对路径，标记为 session（归入会话文件分组）
-      if (sessionPaths && sessionPaths.length > 0) {
-        for (const sp of sessionPaths) {
-          addAttachedPath(sp, rootEntries, 'session')
+        // 会话级附加路径：绝对路径，标记为 session（归入会话文件分组）
+        for (const sessionPath of resolvedSessionPaths) {
+          addAttachedPath(sessionPath, rootEntries, 'session')
         }
-      }
 
-      // 工作区文件 + 工作区级附加路径：绝对路径，标记为 workspace
-      if (additionalPaths && additionalPaths.length > 0) {
-        for (const addPath of additionalPaths) {
-          addAttachedPath(addPath, workspaceEntries, 'workspace')
+        // 工作区文件 + 工作区级附加路径：绝对路径，标记为 workspace
+        for (const additionalPath of resolvedAdditionalPaths) {
+          addAttachedPath(additionalPath, workspaceEntries, 'workspace')
         }
+
+        for (const [key, cached] of workspaceFileSearchIndexCache) {
+          if (cached.expiresAt <= now) workspaceFileSearchIndexCache.delete(key)
+        }
+        while (workspaceFileSearchIndexCache.size >= WORKSPACE_FILE_INDEX_CACHE_MAX_ENTRIES) {
+          const oldestKey = workspaceFileSearchIndexCache.keys().next().value
+          if (typeof oldestKey !== 'string') break
+          workspaceFileSearchIndexCache.delete(oldestKey)
+        }
+        workspaceFileSearchIndexCache.set(cacheKey, {
+          expiresAt: now + WORKSPACE_FILE_INDEX_CACHE_TTL_MS,
+          rootEntries: [...rootEntries],
+          workspaceEntries: [...workspaceEntries],
+        })
       }
 
       // 连续排序：来源仅用于解析与 badge，不作为结果分组依据。

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -6,7 +6,7 @@
  */
 
 import { atom } from 'jotai'
-import { atomFamily, atomWithStorage } from 'jotai/utils'
+import { atomFamily, atomWithStorage, selectAtom } from 'jotai/utils'
 import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, SDKMessage, UnstagedChangesResult } from '@proma/shared'
 import { PROMA_DEFAULT_PERMISSION_MODE } from '@proma/shared'
 import { calculateDockBadgeCount, countPendingRequests } from '@/lib/dock-badge-count'
@@ -300,6 +300,49 @@ export const agentSessionStreamingStateAtomFamily = atomFamily((sessionId: strin
   atom((get) => get(agentStreamingStatesAtom).get(sessionId)),
 )
 
+/** AgentView 输入区/工具栏需要的低频流状态；排除逐 token 变化的 content/toolActivities。 */
+export type AgentViewStreamState = Pick<
+  AgentStreamState,
+  | 'running'
+  | 'backgroundWaiting'
+  | 'inputTokens'
+  | 'outputTokens'
+  | 'cacheReadTokens'
+  | 'cacheCreationTokens'
+  | 'contextWindow'
+  | 'contextUsageIsEstimated'
+  | 'isCompacting'
+>
+
+const EMPTY_AGENT_VIEW_STREAM_STATE: AgentViewStreamState = { running: false }
+
+export function areAgentViewStreamStatesEqual(
+  previous: AgentViewStreamState,
+  next: AgentViewStreamState,
+): boolean {
+  return previous.running === next.running
+    && previous.backgroundWaiting === next.backgroundWaiting
+    && previous.inputTokens === next.inputTokens
+    && previous.outputTokens === next.outputTokens
+    && previous.cacheReadTokens === next.cacheReadTokens
+    && previous.cacheCreationTokens === next.cacheCreationTokens
+    && previous.contextWindow === next.contextWindow
+    && previous.contextUsageIsEstimated === next.contextUsageIsEstimated
+    && previous.isCompacting === next.isCompacting
+}
+
+/**
+ * AgentView 不订阅逐 token content；完整状态只由 AgentMessages 消费。
+ * selectAtom 的 equalityFn 保证纯文本流式更新不会重渲染输入框和工具栏。
+ */
+export const agentSessionViewStreamStateAtomFamily = atomFamily((sessionId: string) =>
+  selectAtom(
+    agentSessionStreamingStateAtomFamily(sessionId),
+    (state): AgentViewStreamState => state ?? EMPTY_AGENT_VIEW_STREAM_STATE,
+    areAgentViewStreamStatesEqual,
+  ),
+)
+
 /**
  * 实时 SDKMessage 累积 Map — Phase 2 新增
  *
@@ -307,6 +350,13 @@ export const agentSessionStreamingStateAtomFamily = atomFamily((sessionId: strin
  * 流式完成后清空（持久化消息从 JSONL 加载）。
  */
 export const liveMessagesMapAtom = atom<Map<string, SDKMessage[]>>(new Map())
+
+const EMPTY_LIVE_SDK_MESSAGES: SDKMessage[] = []
+
+/** 单个 session 的实时消息切片；其他 session 流式更新不唤醒当前历史区。 */
+export const agentLiveMessagesAtomFamily = atomFamily((sessionId: string) =>
+  atom((get) => get(liveMessagesMapAtom).get(sessionId) ?? EMPTY_LIVE_SDK_MESSAGES),
+)
 
 export const agentPendingPromptAtom = atom<AgentPendingPrompt | null>(null)
 

--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -98,7 +98,7 @@ export function AgentHistorySelectionLayer({
   const openChatPendingRef = React.useRef(false)
 
   const clearSelection = React.useCallback((): void => {
-    setSelection(null)
+    setSelection((current) => current === null ? current : null)
   }, [])
 
   const captureSelection = React.useCallback((): void => {
@@ -123,7 +123,13 @@ export function AgentHistorySelectionLayer({
 
     const startMessageEl = startEl.closest('[data-message-id]')
     const endMessageEl = endEl.closest('[data-message-id]')
-    if (!startMessageEl || !endMessageEl) {
+    if (
+      !startMessageEl
+      || !endMessageEl
+      || startMessageEl.getAttribute('data-agent-live') === 'true'
+      || endMessageEl.getAttribute('data-agent-live') === 'true'
+    ) {
+      // 流式尾部只渲染有界预览，文本偏移与完成后的完整消息不同，不能生成不可恢复引用。
       clearSelection()
       return
     }
@@ -190,6 +196,10 @@ export function AgentHistorySelectionLayer({
   React.useEffect(() => {
     const onSelectionChange = (): void => {
       if (pointerSelectingRef.current) return
+      // contenteditable 的光标移动会在每次输入时触发 selectionchange。
+      // 历史选区已在 pointerdown 时清理，此处不要读取或改写编辑器选区热路径。
+      const activeElement = document.activeElement
+      if (activeElement?.closest?.('.ProseMirror, [data-input-mode]')) return
       const sel = window.getSelection()
       if (!sel || sel.isCollapsed) clearSelection()
     }

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -39,10 +39,13 @@ import { AgentBrowserLinkProvider } from '@/components/browser/AgentBrowserLinkP
 import { parseThinkTagsFromText } from './thinking-tag-parser'
 import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
+import { createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
 import type { AgentEventUsage, RetryAttempt, SDKMessage, SDKSystemMessage } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
-import type { AgentStreamState } from '@/atoms/agent-atoms'
+import { agentLiveMessagesAtomFamily, agentSessionStreamingStateAtomFamily, type AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
+
+const EMPTY_SDK_MESSAGES: SDKMessage[] = []
 
 function stableStringify(value: unknown): string {
   if (value == null || typeof value !== 'object') return JSON.stringify(value) ?? String(value)
@@ -193,10 +196,6 @@ interface AgentMessagesProps {
   messagesLoaded?: boolean
   /** Phase 4: 持久化的 SDKMessage（新格式） */
   persistedSDKMessages?: SDKMessage[]
-  streaming: boolean
-  streamState?: AgentStreamState
-  /** Phase 2: 实时 SDKMessage 列表（流式期间累积） */
-  liveMessages?: SDKMessage[]
   /** 当前会话工作目录，用于解析相对文件路径 */
   sessionPath?: string | null
   /** 附加目录列表（与 sessionPath 一并用作相对路径解析候选） */
@@ -590,9 +589,6 @@ export const AgentMessages = React.memo(function AgentMessages({
   sessionModelId,
   messagesLoaded,
   persistedSDKMessages,
-  streaming,
-  streamState,
-  liveMessages,
   sessionPath,
   attachedDirs,
   stoppedByUser,
@@ -608,6 +604,10 @@ export const AgentMessages = React.memo(function AgentMessages({
   onAgentHistoryQuoteClick,
   historyQuoteNavigation,
 }: AgentMessagesProps): React.ReactElement {
+  // 高频 token/live message 状态在历史区内闭环，避免唤醒 AgentView 输入框和工具栏。
+  const streamState = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))
+  const liveMessages = useAtomValue(agentLiveMessagesAtomFamily(sessionId))
+  const streaming = streamState?.running ?? false
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
@@ -753,7 +753,7 @@ export const AgentMessages = React.memo(function AgentMessages({
 
   const transitioning = needsInstant || transitioningCooldown
 
-  // 合并持久化 + 实时 SDKMessage（供 ContentBlock 内查找工具结果）
+  // 合并持久化 + 实时 SDKMessage；历史 group 后续仅接收本 turn 消息，避免全历史依赖扩散。
   const allSDKMessages = React.useMemo(() => {
     const persisted = persistedSDKMessages ?? []
     const live = liveMessages ?? []
@@ -794,6 +794,14 @@ export const AgentMessages = React.memo(function AgentMessages({
     ]
   }, [persistedSDKMessages, liveMessages, streaming])
   const hasContent = allSDKMessages.length > 0
+  // 跨 turn task_notification 是历史 Task 卡片唯一需要追踪的外部元数据。
+  // 普通 token/live snapshot 不改变此签名，MessageGroupRenderer comparator 因而可忽略全消息数组新引用。
+  const taskNotificationSignature = React.useMemo(() => (
+    allSDKMessages
+      .filter((message) => message.type === 'system' && message.subtype === 'task_notification')
+      .map((message) => getSDKMessageStableKey(message))
+      .join('\u0000')
+  ), [allSDKMessages])
 
   // 仅扫描当前 live turn；不从持久化历史恢复任务，避免跨 turn 显示旧进度。
   const liveTaskActivities = React.useMemo(() => {
@@ -813,10 +821,19 @@ export const AgentMessages = React.memo(function AgentMessages({
   const suppressAgentRunning = streamState?.isCompacting
     || (streamState?.compactInFlight && contextCompaction != null)
 
-  // 统一分组：将持久化 + 实时消息合并后再分组，确保 system 消息（如压缩分割线）出现在正确位置
+  // 流式更新只重新分组当前 turn；已完成历史复用 group 引用，使 memoized renderer
+  // 跳过历史 Markdown/代码高亮/工具结果树。非流式刷新仍保持完整 groupIntoTurns 语义。
+  const messageGroupCacheRef = React.useRef(createMessageGroupRenderCache())
   const allGroups = React.useMemo(() => {
-    return groupIntoTurns(allSDKMessages, sessionModelId)
-  }, [allSDKMessages, sessionModelId])
+    const result = groupMessagesForRendering(
+      allSDKMessages,
+      sessionModelId,
+      streaming,
+      messageGroupCacheRef.current,
+    )
+    messageGroupCacheRef.current = result.cache
+    return result.groups
+  }, [allSDKMessages, sessionModelId, streaming])
   // 压缩过程由底部 Progress Overlay 独立承载，不占用对话历史、迷你地图或用户锚点。
   const visibleGroups = React.useMemo(
     () => allGroups.filter((group) => !isCompactionControlHistoryGroup(group)),
@@ -888,14 +905,15 @@ export const AgentMessages = React.memo(function AgentMessages({
 
   return (
     <BasePathsProvider basePaths={messageBasePaths}>
-    <div ref={historySelectionRootRef} className="relative flex min-h-0 flex-1 flex-col">
+      <AgentBrowserLinkProvider sessionId={sessionId}>
+        <div ref={historySelectionRootRef} className="relative flex min-h-0 flex-1 flex-col">
       <style>{`
         ::highlight(${AGENT_HISTORY_QUOTE_HIGHLIGHT_NAME}) {
           background-color: hsl(var(--primary) / 0.28);
           color: inherit;
         }
       `}</style>
-      <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
+          <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
         <ScrollPositionManager id={sessionId} ready={ready} />
         <ConversationContent>
           {!hasContent && !streaming ? (
@@ -915,7 +933,8 @@ export const AgentMessages = React.memo(function AgentMessages({
                 const renderer = (
                   <MessageGroupRenderer
                     group={group}
-                    allMessages={allSDKMessages}
+                    allMessages={group.type === 'assistant-turn' ? allSDKMessages : EMPTY_SDK_MESSAGES}
+                    externalMetadataSignature={group.type === 'assistant-turn' ? taskNotificationSignature : ''}
                     basePath={sessionPath || undefined}
                     onFork={shouldDisableActions ? undefined : onFork}
                     onRewind={shouldDisableActions ? undefined : onRewind}
@@ -931,9 +950,7 @@ export const AgentMessages = React.memo(function AgentMessages({
                     sessionModelId={sessionModelId}
                   />
                 )
-                return group.type === 'assistant-turn'
-                  ? <AgentBrowserLinkProvider key={getGroupId(group)} sessionId={sessionId}>{renderer}</AgentBrowserLinkProvider>
-                  : <React.Fragment key={getGroupId(group)}>{renderer}</React.Fragment>
+                return <React.Fragment key={getGroupId(group)}>{renderer}</React.Fragment>
               })}
 
               {/* 有实时助手内容时：显示运行指示器或占位（防止 streaming 结束到 Actions Bar 出现之间的高度跳动） */}
@@ -949,7 +966,6 @@ export const AgentMessages = React.memo(function AgentMessages({
               {/* 无实时助手内容时：显示完整气泡（含头像/名称/时间） */}
               {/* 注意：工具活动已通过 SDK 渲染路径（liveGroups）展示 */}
               {!hasLiveAssistantContent && !suppressAgentRunning && (streaming || smoothContent || retrying) && (
-                <AgentBrowserLinkProvider sessionId={sessionId}>
                 <Message from="assistant">
                   <MessageHeader
                     model={agentStreamingModel}
@@ -981,7 +997,6 @@ export const AgentMessages = React.memo(function AgentMessages({
                     )}
                   </MessageContent>
                 </Message>
-                </AgentBrowserLinkProvider>
               )}
 
             </>
@@ -997,13 +1012,14 @@ export const AgentMessages = React.memo(function AgentMessages({
         {allUserMessagesData.length > 0 && (
           <StickyUserMessage userMessages={allUserMessagesData} />
         )}
-      </Conversation>
-      <AgentHistorySelectionLayer
-        sessionId={sessionId}
-        rootRef={historySelectionRootRef}
-        onAddToAgent={onAddHistoryQuote}
-      />
-    </div>
+          </Conversation>
+          <AgentHistorySelectionLayer
+            sessionId={sessionId}
+            rootRef={historySelectionRootRef}
+            onAddToAgent={onAddHistoryQuote}
+          />
+        </div>
+      </AgentBrowserLinkProvider>
     </BasePathsProvider>
   )
 })

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -65,7 +65,7 @@ import { previewPanelOpenMapAtom, quotedSelectionMapAtom, currentQuotedSelection
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
-  agentSessionStreamingStateAtomFamily,
+  agentSessionViewStreamStateAtomFamily,
   agentChannelIdAtom,
   agentModelIdAtom,
   agentSessionChannelMapAtom,
@@ -134,8 +134,6 @@ import {
 } from '@/lib/agent-message-queue'
 import type { AgentQueuedAttachment, AgentQueuedMessage, QueueDropPlacement } from '@/lib/agent-message-queue'
 
-/** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
-const EMPTY_SDK_MESSAGES: SDKMessage[] = []
 /** 稳定的空 string 数组引用，避免无附件会话的 memo 链每次渲染失效。 */
 const EMPTY_STRING_ARRAY: string[] = []
 const LONG_TEXT_ATTACHMENT_THRESHOLD = 2000
@@ -155,6 +153,67 @@ interface PreparedAgentAttachment {
   attachments: AgentQueuedAttachment[]
   additionalDirectories: string[]
 }
+
+type AgentScopedRichTextInputProps = Omit<
+  React.ComponentProps<typeof RichTextInput>,
+  'value' | 'onChange' | 'draftScopeKey' | 'draftSyncVersion' | 'htmlValue' | 'onHtmlChange' | 'sessionId'
+> & {
+  sessionId: string
+}
+
+/**
+ * 将高频草稿订阅限制在编辑器边界内。
+ *
+ * TipTap 停顿同步 Markdown/HTML 时只重渲染这个轻量包装器，避免 3000 行 AgentView
+ * 连同消息历史和输入工具栏一起重新执行。外部清空/队列回填仍通过版本号强制覆盖编辑器。
+ */
+const AgentScopedRichTextInput = React.forwardRef<RichTextInputHandle, AgentScopedRichTextInputProps>(
+  function AgentScopedRichTextInput({ sessionId, ...props }, ref): React.ReactElement {
+    const value = useAtomValue(agentSessionDraftAtomFamily(sessionId))
+    const htmlValue = useAtomValue(agentSessionDraftHtmlAtomFamily(sessionId))
+    const draftSyncVersion = useAtomValue(agentSessionDraftSyncVersionAtomFamily(sessionId))
+    const setDraftsMap = useSetAtom(agentSessionDraftsAtom)
+    const setDraftHtmlMap = useSetAtom(agentSessionDraftHtmlAtom)
+
+    const handleChange = React.useCallback((nextValue: string): void => {
+      setDraftsMap((previous) => {
+        const currentValue = previous.get(sessionId) ?? ''
+        const normalizedValue = nextValue.trim() === '' ? '' : nextValue
+        if (currentValue === normalizedValue) return previous
+        const next = new Map(previous)
+        if (normalizedValue === '') next.delete(sessionId)
+        else next.set(sessionId, normalizedValue)
+        return next
+      })
+    }, [sessionId, setDraftsMap])
+
+    const handleHtmlChange = React.useCallback((nextHtml: string): void => {
+      setDraftHtmlMap((previous) => {
+        const normalizedHtml = !nextHtml || nextHtml === '<p></p>' ? '' : nextHtml
+        const currentHtml = previous.get(sessionId) ?? ''
+        if (currentHtml === normalizedHtml) return previous
+        const next = new Map(previous)
+        if (normalizedHtml === '') next.delete(sessionId)
+        else next.set(sessionId, normalizedHtml)
+        return next
+      })
+    }, [sessionId, setDraftHtmlMap])
+
+    return (
+      <RichTextInput
+        {...props}
+        ref={ref}
+        value={value}
+        onChange={handleChange}
+        draftScopeKey={sessionId}
+        draftSyncVersion={draftSyncVersion}
+        htmlValue={htmlValue}
+        onHtmlChange={handleHtmlChange}
+        sessionId={sessionId}
+      />
+    )
+  },
+)
 
 function createUserSDKMessage(text: string, uuid?: string, createdAt = Date.now()): SDKMessage {
   const message: OptimisticSDKUserMessage = {
@@ -367,14 +426,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const persistedSDKMessagesRef = React.useRef<SDKMessage[]>([])
   persistedSDKMessagesRef.current = persistedSDKMessages
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
-  // 按 sessionId 切片订阅：仅本 session 的 streaming state 变化才让 AgentView 重渲染。
-  // 流式期间其他 session 的高频更新（每 token 一次）通过 base map atom 传播但派生
-  // atom 输出引用未变，订阅者跳过通知。
-  const streamState = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))
-  const streaming = streamState?.running ?? false
+  // 只订阅输入区/工具栏需要的低频流状态。逐 token content/toolActivities 由
+  // AgentMessages 独立消费，不能让 3000 行 AgentView 和输入框跟随每个 token 重渲染。
+  const streamViewState = useAtomValue(agentSessionViewStreamStateAtomFamily(sessionId))
+  const streaming = streamViewState.running
   // 软空闲态：本轮主体已结束、UI 可输入，但 SDK 通道仍开着等后台任务唤醒。
   // 此时服务端 activeSessions 仍保留，新消息须走注入通道而非新建 run。
-  const backgroundWaiting = streamState?.backgroundWaiting ?? false
+  const backgroundWaiting = streamViewState.backgroundWaiting ?? false
   const stoppedByUserSessions = useAtomValue(stoppedByUserSessionsAtom)
   // 点击停止后，底层 Pi query 仍需一个很短的收尾窗口。该窗口内不可发起/排队新消息，
   // 否则旧 run 与新 run 会交错，导致同一用户消息被重复展示或持久化。
@@ -382,10 +440,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
   const longTextPasteAsAttachmentEnabled = useAtomValue(longTextPasteAsAttachmentEnabledAtom)
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
-  const liveMessagesMap = useAtomValue(liveMessagesMapAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
-  // 稳定化空数组引用，避免 ?? [] 每次创建新引用导致下游 useMemo 链不必要重算
-  const liveMessages = liveMessagesMap.get(sessionId) ?? EMPTY_SDK_MESSAGES
   // Per-session 渠道/模型配置（优先读 session map，回退到全局默认值）
   const sessionChannelMap = useAtomValue(agentSessionChannelMapAtom)
   const sessionModelMap = useAtomValue(agentSessionModelMapAtom)
@@ -465,10 +520,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [sessionId, sessionMetaChannelId, sessionMetaModelId, hasSessionMeta, defaultChannelId, defaultModelId, setSessionChannelMap, setSessionModelMap])
 
   const contextStatus: AgentContextStatus = {
-    isCompacting: streamState?.isCompacting ?? false,
-    inputTokens: streamState?.inputTokens,
-    contextWindow: streamState?.contextWindow,
-    contextUsageIsEstimated: streamState?.contextUsageIsEstimated,
+    isCompacting: streamViewState.isCompacting ?? false,
+    inputTokens: streamViewState.inputTokens,
+    outputTokens: streamViewState.outputTokens,
+    cacheReadTokens: streamViewState.cacheReadTokens,
+    cacheCreationTokens: streamViewState.cacheCreationTokens,
+    contextWindow: streamViewState.contextWindow,
+    contextUsageIsEstimated: streamViewState.contextUsageIsEstimated,
   }
   const setAgentStreamErrors = useSetAtom(agentStreamErrorsAtom)
   const streamErrors = useAtomValue(agentStreamErrorsAtom)
@@ -530,43 +588,36 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     ? (wsAttachedFilesMap.get(currentWorkspaceId) ?? EMPTY_STRING_ARRAY)
     : EMPTY_STRING_ARRAY
 
-  // 按 sessionId 切片订阅 drafts/draftHtml：仅本 session 草稿变化才让 AgentView 重渲染。
-  // 输入框每次按键都会写整 Map atom，若直接订阅整 Map，AgentView 跟着每键重渲染。
-  const inputContent = useAtomValue(agentSessionDraftAtomFamily(sessionId))
-  const draftSyncVersion = useAtomValue(agentSessionDraftSyncVersionAtomFamily(sessionId))
+  // AgentView 只保留低频外部草稿写入；编辑器本地同步由 AgentScopedRichTextInput 订阅，
+  // 避免每次停顿保存草稿时重渲染整个 Agent 页面。
   const setDraftsMap = useSetAtom(agentSessionDraftsAtom)
   const setDraftSyncVersions = useSetAtom(agentSessionDraftSyncVersionsAtom)
-  const setInputContentFromEditor = React.useCallback((value: string) => {
-    setDraftsMap((prev) => {
-      const map = new Map(prev)
-      if (value.trim() === '') {
-        map.delete(sessionId)
-      } else {
-        map.set(sessionId, value)
-      }
-      return map
-    })
-  }, [sessionId, setDraftsMap])
-  // 仅非编辑器自身的写入才要求 RichTextInput 用受控内容覆盖文档。
-  const setInputContent = React.useCallback((value: string) => {
-    setDraftSyncVersions((prev) => {
-      const map = new Map(prev)
-      map.set(sessionId, (map.get(sessionId) ?? 0) + 1)
-      return map
-    })
-    setInputContentFromEditor(value)
-  }, [sessionId, setDraftSyncVersions, setInputContentFromEditor])
-  const inputHtmlContent = useAtomValue(agentSessionDraftHtmlAtomFamily(sessionId))
   const setDraftHtmlMap = useSetAtom(agentSessionDraftHtmlAtom)
+  const setInputContent = React.useCallback((value: string) => {
+    setDraftSyncVersions((previous) => {
+      const next = new Map(previous)
+      next.set(sessionId, (next.get(sessionId) ?? 0) + 1)
+      return next
+    })
+    setDraftsMap((previous) => {
+      const currentValue = previous.get(sessionId) ?? ''
+      const normalizedValue = value.trim() === '' ? '' : value
+      if (currentValue === normalizedValue) return previous
+      const next = new Map(previous)
+      if (normalizedValue === '') next.delete(sessionId)
+      else next.set(sessionId, normalizedValue)
+      return next
+    })
+  }, [sessionId, setDraftSyncVersions, setDraftsMap])
   const setInputHtmlContent = React.useCallback((html: string) => {
-    setDraftHtmlMap((prev) => {
-      const map = new Map(prev)
-      if (!html || html === '<p></p>') {
-        map.delete(sessionId)
-      } else {
-        map.set(sessionId, html)
-      }
-      return map
+    setDraftHtmlMap((previous) => {
+      const normalizedHtml = !html || html === '<p></p>' ? '' : html
+      const currentHtml = previous.get(sessionId) ?? ''
+      if (currentHtml === normalizedHtml) return previous
+      const next = new Map(previous)
+      if (normalizedHtml === '') next.delete(sessionId)
+      else next.set(sessionId, normalizedHtml)
+      return next
     })
   }, [sessionId, setDraftHtmlMap])
 
@@ -2045,7 +2096,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   /** 发送消息 */
   const handleSend = React.useCallback(async (overrideText?: string, fromEditor = false): Promise<void> => {
-    const text = (overrideText ?? inputContent).trim()
+    const currentDraft = store.get(agentSessionDraftsAtom).get(sessionId) ?? ''
+    const text = (overrideText ?? currentDraft).trim()
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
     const pendingFilesSnapshot = pendingFilesRef.current
@@ -2266,7 +2318,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage, isLegacyTranscript, isStopping])
+  }, [createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage, isLegacyTranscript, isStopping])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -2680,23 +2732,25 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
     restoreQueuedAttachmentsToPending(message.attachments)
 
-    const hasDraft = inputContent.trim().length > 0
+    const currentDraft = store.get(agentSessionDraftsAtom).get(sessionId) ?? ''
+    const currentDraftHtml = store.get(agentSessionDraftHtmlAtom).get(sessionId) ?? ''
+    const hasDraft = currentDraft.trim().length > 0
     const nextDraft = hasDraft
-      ? `${inputContent.trimEnd()}\n\n${message.text}`
+      ? `${currentDraft.trimEnd()}\n\n${message.text}`
       : message.text
     setInputContent(nextDraft)
 
     // 已有草稿时，用「原草稿 HTML + 队列文本段落 HTML」合并，保留原草稿的 mention 等富文本节点；
     // 空草稿时留空 HTML，交给编辑器按纯文本重建（与正常输入渲染一致）。
     if (hasDraft) {
-      const draftHtml = inputHtmlContent.trim().length > 0
-        ? inputHtmlContent
-        : queuedTextToParagraphHtml(inputContent)
+      const draftHtml = currentDraftHtml.trim().length > 0
+        ? currentDraftHtml
+        : queuedTextToParagraphHtml(currentDraft)
       setInputHtmlContent(`${draftHtml}${queuedTextToParagraphHtml(message.text)}`)
     } else {
       setInputHtmlContent('')
     }
-  }, [inputContent, inputHtmlContent, queuedMessages, restoreQueuedAttachmentsToPending, sessionId, setInputContent, setInputHtmlContent, setQueuedMessages, setQuotedSelectionMap])
+  }, [queuedMessages, restoreQueuedAttachmentsToPending, sessionId, setInputContent, setInputHtmlContent, setQueuedMessages, setQuotedSelectionMap, store])
 
   const handleRemoveQueuedMessage = React.useCallback((messageId: string): void => {
     setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
@@ -2726,7 +2780,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     return registerShortcut('toggle-preview-panel', togglePreviewPanel)
   }, [togglePreviewPanel])
 
-  const [inputHasContent, setInputHasContent] = React.useState(false)
+  const [inputHasContent, setInputHasContent] = React.useState(
+    () => (store.get(agentSessionDraftsAtom).get(sessionId) ?? '').trim().length > 0,
+  )
   const inputHasContentRef = React.useRef(inputHasContent)
   inputHasContentRef.current = inputHasContent
   const handleInputActivity = React.useCallback((hasContent: boolean): void => {
@@ -2933,9 +2989,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           sessionModelId={agentModelId || undefined}
           messagesLoaded={messagesLoaded}
           persistedSDKMessages={persistedSDKMessages}
-          streaming={streaming}
-          streamState={streamState}
-          liveMessages={liveMessages}
           sessionPath={sessionPath}
           attachedDirs={allAttachedDirs}
           stoppedByUser={stoppedByUser}
@@ -3063,12 +3116,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               </div>
             )}
 
-            <RichTextInput
+            <AgentScopedRichTextInput
               ref={richTextInputRef}
-              value={inputContent}
-              onChange={setInputContentFromEditor}
+              sessionId={sessionId}
               onInputActivity={handleInputActivity}
-              draftSyncDelayMs={120}
+              draftSyncDelayMs={300}
               onSubmit={handleSend}
               onPasteFiles={handlePasteFiles}
               onPasteLongText={handlePasteLongText}
@@ -3085,17 +3137,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               }
               disabled={isLegacyTranscript || !agentChannelId || !hasAvailableModel}
               autoFocusTrigger={sessionId}
-              draftScopeKey={sessionId}
-              draftSyncVersion={draftSyncVersion}
               collapsible
               enableMentions
               workspacePath={sessionPath}
               workspaceSlug={workspaceSlug}
-              sessionId={sessionId}
               attachedDirs={workspaceMentionPaths}
               sessionAttachedDirs={sessionMentionPaths}
-              htmlValue={inputHtmlContent}
-              onHtmlChange={setInputHtmlContent}
               sendWithCmdEnter={sendWithCmdEnter}
               onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
             />

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -366,8 +366,6 @@ export function buildTaskProgressDataForTurn(turn: AssistantTurn): { taskActivit
 }
 
 
-// ===== AssistantTurnRenderer — 渲染一个完整的 assistant turn =====
-
 export interface AssistantTurnRendererProps {
   turn: AssistantTurn
   /** 所有消息（全局，供工具结果查找跨 turn 的结果） */
@@ -1383,6 +1381,8 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact, onReli
 export interface MessageGroupRendererProps {
   group: MessageGroup
   allMessages: SDKMessage[]
+  /** 仅跨 turn 工具元数据变化时更新历史 assistant；普通 live 数组新引用不触发重渲染。 */
+  externalMetadataSignature?: string
   basePath?: string
   onFork?: (upToMessageUuid: string) => void
   onRewind?: (assistantMessageUuid: string) => void
@@ -1452,7 +1452,7 @@ export function getGroupId(group: MessageGroup): string {
 
 // getGroupPreview 已迁移至 @proma/session-core（本文件从该包 import 并 re-export）
 
-export function MessageGroupRenderer({ group, allMessages, basePath, onFork, onRewind, onAgentHistoryQuoteClick, onCreateTodo, onRetry, onRetryInNewSession, onCompact, onRelinkProjectRoot, onRestoreProjectRoot, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
+export const MessageGroupRenderer = React.memo(function MessageGroupRenderer({ group, allMessages, basePath, onFork, onRewind, onAgentHistoryQuoteClick, onCreateTodo, onRetry, onRetryInNewSession, onCompact, onRelinkProjectRoot, onRestoreProjectRoot, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
   const groupId = getGroupId(group)
 
   if (group.type === 'user') {
@@ -1472,7 +1472,11 @@ export function MessageGroupRenderer({ group, allMessages, basePath, onFork, onR
 
   // assistant-turn
   return (
-    <div data-message-id={groupId} data-message-role="assistant">
+    <div
+      data-message-id={groupId}
+      data-message-role="assistant"
+      data-agent-live={isStreaming ? 'true' : undefined}
+    >
       <AssistantTurnRenderer
         turn={group}
         allMessages={allMessages}
@@ -1491,4 +1495,20 @@ export function MessageGroupRenderer({ group, allMessages, basePath, onFork, onR
       />
     </div>
   )
-}
+}, (previous, next) => (
+  previous.group === next.group
+  && previous.basePath === next.basePath
+  && previous.onFork === next.onFork
+  && previous.onRewind === next.onRewind
+  && previous.onAgentHistoryQuoteClick === next.onAgentHistoryQuoteClick
+  && previous.onCreateTodo === next.onCreateTodo
+  && previous.onRetry === next.onRetry
+  && previous.onRetryInNewSession === next.onRetryInNewSession
+  && previous.onCompact === next.onCompact
+  && previous.onRelinkProjectRoot === next.onRelinkProjectRoot
+  && previous.onRestoreProjectRoot === next.onRestoreProjectRoot
+  && previous.isStreaming === next.isStreaming
+  && previous.stoppedByUser === next.stoppedByUser
+  && previous.sessionModelId === next.sessionModelId
+  && previous.externalMetadataSignature === next.externalMetadataSignature
+))

--- a/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
+++ b/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
@@ -85,7 +85,14 @@ export function shouldClearEscSuppressionOnExit(
  * TipTap 会并发等待每次 items() 的异步结果。请求编号在发起时递增，因此旧请求即使
  * 最后返回，也无法覆盖当前触发符或当前 query 的弹窗。
  */
-export function createLatestSuggestionRequestGuard<T>() {
+export interface LatestSuggestionRequestGuard<T> {
+  startRequest: () => number
+  attachResult: (requestId: number, items: T[]) => T[]
+  isLatest: (items: T[]) => boolean
+  isStale: (items: T[]) => boolean
+}
+
+export function createLatestSuggestionRequestGuard<T>(): LatestSuggestionRequestGuard<T> {
   let latestRequestId = 0
   const requestIds = new WeakMap<T[], number>()
 
@@ -106,6 +113,50 @@ export function createLatestSuggestionRequestGuard<T>() {
       return requestId !== undefined && requestId !== latestRequestId
     },
   }
+}
+
+/**
+ * 合并连续 mention 查询。被新查询替代的 Promise 会立即以“已过期空结果”完成，
+ * 既不悬挂 TipTap 生命周期，也不会让旧空列表覆盖最新弹窗。
+ */
+export function createDebouncedSuggestionLoader<T>(
+  requestGuard: LatestSuggestionRequestGuard<T>,
+  delayMs = 80,
+): { load: (loader: () => Promise<T[]>) => Promise<T[]>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let pendingRequestId: number | null = null
+  let settlePending: ((items: T[]) => void) | null = null
+
+  const cancel = (): void => {
+    if (timer !== null) clearTimeout(timer)
+    timer = null
+    if (settlePending && pendingRequestId !== null) {
+      settlePending(requestGuard.attachResult(pendingRequestId, []))
+    }
+    pendingRequestId = null
+    settlePending = null
+  }
+
+  const load = (loader: () => Promise<T[]>): Promise<T[]> => {
+    const requestId = requestGuard.startRequest()
+    cancel()
+    return new Promise((resolve) => {
+      pendingRequestId = requestId
+      settlePending = resolve
+      timer = setTimeout(async () => {
+        timer = null
+        pendingRequestId = null
+        settlePending = null
+        try {
+          resolve(requestGuard.attachResult(requestId, await loader()))
+        } catch {
+          resolve(requestGuard.attachResult(requestId, []))
+        }
+      }, delayMs)
+    })
+  }
+
+  return { load, cancel }
 }
 
 /** 创建弹窗容器并挂载到 body */

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -11,7 +11,7 @@ import type { SuggestionOptions } from '@tiptap/suggestion'
 import { CalendarDays, ListTodo, MessageSquareText, Sparkles, Server } from 'lucide-react'
 import { MentionList } from './MentionList'
 import type { MentionListRef } from './MentionList'
-import { createLatestSuggestionRequestGuard, createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from './mention-popup-utils'
+import { createDebouncedSuggestionLoader, createLatestSuggestionRequestGuard, createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from './mention-popup-utils'
 import type { AgentSessionReferenceSearchResult } from '@proma/shared'
 import { shouldAllowMentionTrigger, shouldShowMentionSuggestion } from '@/components/ai-elements/mention-utils'
 import {
@@ -56,6 +56,7 @@ function createMentionSuggestion<T>(
   // 用文本而非位置判断：删除触发符前的字符导致位置移动时，片段仍延续，继续抑制。
   let suppressedTrigger: EscSuppressedTrigger | null = null
   const requestGuard = createLatestSuggestionRequestGuard<T>()
+  const queryLoader = createDebouncedSuggestionLoader(requestGuard)
 
   return {
     char: config.char,
@@ -81,19 +82,11 @@ function createMentionSuggestion<T>(
       })
     },
 
-    items: async ({ query }): Promise<T[]> => {
-      const requestId = requestGuard.startRequest()
+    items: ({ query }): Promise<T[]> => queryLoader.load(async () => {
       const slug = workspaceSlugRef.current
-      if (config.requiresContext !== false && !slug) return requestGuard.attachResult(requestId, [])
-      try {
-        return requestGuard.attachResult(
-          requestId,
-          await config.fetchItems(slug ?? '', (query ?? '').toLowerCase()),
-        )
-      } catch {
-        return requestGuard.attachResult(requestId, [])
-      }
-    },
+      if (config.requiresContext !== false && !slug) return []
+      return config.fetchItems(slug ?? '', (query ?? '').toLowerCase())
+    }),
 
     render: () => {
       let renderer: ReactRenderer<MentionListRef> | null = null
@@ -102,6 +95,7 @@ function createMentionSuggestion<T>(
       let editorDom: HTMLElement | null = null
 
       function cleanup() {
+        queryLoader.cancel()
         if (blurHandler && editorDom) {
           editorDom.removeEventListener('blur', blurHandler, true)
           blurHandler = null

--- a/apps/electron/src/renderer/components/agent/message-group-rendering.ts
+++ b/apps/electron/src/renderer/components/agent/message-group-rendering.ts
@@ -1,0 +1,125 @@
+import type { SDKMessage, SDKUserMessage } from '@proma/shared'
+import { groupIntoTurns, isUserInputMessage, type MessageGroup } from '@proma/session-core'
+
+export interface MessageGroupRenderCache {
+  prefixLength: number
+  prefixMessages: SDKMessage[]
+  sessionModelId?: string
+  prefixGroups: MessageGroup[]
+  previousGroups: MessageGroup[]
+}
+
+export function createMessageGroupRenderCache(): MessageGroupRenderCache {
+  return {
+    prefixLength: 0,
+    prefixMessages: [],
+    prefixGroups: [],
+    previousGroups: [],
+  }
+}
+
+function arraysShareItems<T>(previous: T[], next: T[]): boolean {
+  if (previous.length !== next.length) return false
+  return previous.every((item, index) => item === next[index])
+}
+
+function canReuseMessageGroup(previous: MessageGroup, next: MessageGroup): boolean {
+  if (previous.type !== next.type) return false
+
+  if (previous.type === 'user' && next.type === 'user') {
+    return previous.message === next.message
+  }
+  if (previous.type === 'system' && next.type === 'system') {
+    return previous.message === next.message && previous.identityMessage === next.identityMessage
+  }
+  if (previous.type !== 'assistant-turn' || next.type !== 'assistant-turn') return false
+
+  return previous.inputMessage === next.inputMessage
+    && previous.model === next.model
+    && previous.createdAt === next.createdAt
+    && previous.startsAfterWake === next.startsAfterWake
+    && arraysShareItems(previous.assistantMessages, next.assistantMessages)
+    && arraysShareItems(previous.turnMessages, next.turnMessages)
+}
+
+/**
+ * groupIntoTurns 每次都会创建新的 group/数组。复用内容未变的历史 group 引用，
+ * 让 React.memo 可以跳过已完成回合的 Markdown、代码高亮和工具结果渲染。
+ */
+export function stabilizeMessageGroups(previous: MessageGroup[], next: MessageGroup[]): MessageGroup[] {
+  let changed = previous.length !== next.length
+  const stable = next.map((group, index) => {
+    const prior = previous[index]
+    if (prior && canReuseMessageGroup(prior, group)) return prior
+    changed = true
+    return group
+  })
+  return changed ? stable : previous
+}
+
+function findActiveTurnBoundary(messages: SDKMessage[]): number {
+  return messages.findLastIndex((message) => (
+    message.type === 'user' && isUserInputMessage(message as SDKUserMessage)
+  ))
+}
+
+/**
+ * 流式时只重新分组当前 turn，历史前缀按 O(1) 身份检查复用。
+ * 边界从最后一条真实用户输入开始，因此与完整 groupIntoTurns 的分组语义一致。
+ */
+export function groupMessagesForRendering(
+  messages: SDKMessage[],
+  sessionModelId: string | undefined,
+  streaming: boolean,
+  cache: MessageGroupRenderCache,
+): { groups: MessageGroup[]; cache: MessageGroupRenderCache } {
+  if (!streaming) {
+    const groups = stabilizeMessageGroups(cache.previousGroups, groupIntoTurns(messages, sessionModelId))
+    return {
+      groups,
+      cache: {
+        prefixLength: 0,
+        prefixMessages: [],
+        prefixGroups: [],
+        previousGroups: groups,
+        sessionModelId,
+      },
+    }
+  }
+
+  const boundary = findActiveTurnBoundary(messages)
+  if (boundary <= 0) {
+    const groups = stabilizeMessageGroups(cache.previousGroups, groupIntoTurns(messages, sessionModelId))
+    return {
+      groups,
+      cache: {
+        prefixLength: 0,
+        prefixMessages: [],
+        prefixGroups: [],
+        previousGroups: groups,
+        sessionModelId,
+      },
+    }
+  }
+
+  const canReusePrefix = cache.prefixLength === boundary
+    && cache.sessionModelId === sessionModelId
+    && cache.prefixMessages.every((message, index) => messages[index] === message)
+  const prefixMessages = canReusePrefix ? cache.prefixMessages : messages.slice(0, boundary)
+  const prefixGroups = canReusePrefix
+    ? cache.prefixGroups
+    : groupIntoTurns(prefixMessages, sessionModelId)
+  const activeGroups = groupIntoTurns(messages.slice(boundary), sessionModelId)
+  const groups = stabilizeMessageGroups(cache.previousGroups, [...prefixGroups, ...activeGroups])
+
+  return {
+    groups,
+    cache: {
+      prefixLength: boundary,
+      prefixMessages,
+      sessionModelId,
+      prefixGroups,
+      previousGroups: groups,
+    },
+  }
+}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -56,6 +56,8 @@ import {
   liveMessagesMapAtom,
   agentSessionPendingFilesAtom,
   agentSessionStreamingStateAtomFamily,
+  agentSessionViewStreamStateAtomFamily,
+  agentLiveMessagesAtomFamily,
   agentSessionDraftAtomFamily,
   agentSessionDraftHtmlAtomFamily,
   agentPendingFilesAtomFamily,
@@ -919,6 +921,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     // atomFamily 内部缓存（Jotai 对 string key 强引用 Map，不显式 remove 永不释放）。
     // 删除/归档是会话的终态，连同草稿一起清理，无需像关闭 Tab 那样保留可恢复输入。
     agentSessionStreamingStateAtomFamily.remove(id)
+    agentSessionViewStreamStateAtomFamily.remove(id)
+    agentLiveMessagesAtomFamily.remove(id)
     agentSessionDraftAtomFamily.remove(id)
     agentSessionDraftHtmlAtomFamily.remove(id)
     agentPendingFilesAtomFamily.remove(id)
@@ -3922,6 +3926,10 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
           onClick={() => onSelect(session.id, session.title)}
           onMouseEnter={() => { setRowHovered(true); preview.handleMouseEnter() }}
           onMouseLeave={() => { setRowHovered(false); preview.handleMouseLeave() }}
+          style={active ? undefined : {
+            contentVisibility: 'auto',
+            containIntrinsicSize: 'auto 30px',
+          }}
           className={cn(
             'session-quick-switch-row group relative w-full flex items-center gap-1.5 rounded-md py-1.5 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -13,7 +13,7 @@ import { toast } from 'sonner'
 import { FileMentionList } from './FileMentionList'
 import type { FileMentionRef } from './FileMentionList'
 import type { FileIndexEntry } from '@proma/shared'
-import { createLatestSuggestionRequestGuard, createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from '@/components/agent/mention-popup-utils'
+import { createDebouncedSuggestionLoader, createLatestSuggestionRequestGuard, createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from '@/components/agent/mention-popup-utils'
 import { shouldAllowMentionTrigger, shouldShowMentionSuggestion } from '@/components/ai-elements/mention-utils'
 import { resolveFileMentionPath } from './file-mention-path'
 
@@ -34,6 +34,7 @@ export function createFileMentionSuggestion(
   // 用文本而非位置判断：删除触发符前的字符导致位置移动时，片段仍延续，继续抑制。
   let suppressedTrigger: EscSuppressedTrigger | null = null
   const requestGuard = createLatestSuggestionRequestGuard<FileIndexEntry>()
+  const queryLoader = createDebouncedSuggestionLoader(requestGuard)
 
   return {
     char: '@',
@@ -56,8 +57,7 @@ export function createFileMentionSuggestion(
       })
     },
 
-    items: async ({ query }): Promise<FileIndexEntry[]> => {
-      const requestId = requestGuard.startRequest()
+    items: ({ query }): Promise<FileIndexEntry[]> => queryLoader.load(async () => {
       const wsPath = workspacePathRef.current
       if (!wsPath) {
         console.warn('[FileMention] workspacePath is null, mention disabled')
@@ -67,14 +67,13 @@ export function createFileMentionSuggestion(
           })
           missingWorkspaceToastShown = true
         }
-        return requestGuard.attachResult(requestId, [])
+        return []
       }
       missingWorkspaceToastShown = false
 
       try {
         const additionalPaths = attachedDirsRef?.current ?? []
         const sessionPaths = sessionAttachedDirsRef?.current ?? []
-
         const result = await window.electronAPI.searchWorkspaceFiles(
           wsPath,
           query ?? '',
@@ -82,12 +81,12 @@ export function createFileMentionSuggestion(
           additionalPaths.length > 0 ? additionalPaths : undefined,
           sessionPaths.length > 0 ? sessionPaths : undefined,
         )
-        return requestGuard.attachResult(requestId, result.entries)
-      } catch(e) {
-        console.error('[FileMention] search failed:', e)
-        return requestGuard.attachResult(requestId, [])
+        return result.entries
+      } catch (error) {
+        console.error('[FileMention] search failed:', error)
+        return []
       }
-    },
+    }),
 
     render: () => {
       let renderer: ReactRenderer<FileMentionRef> | null = null
@@ -128,6 +127,7 @@ export function createFileMentionSuggestion(
       }
 
       function cleanup() {
+        queryLoader.cancel()
         if (blurHandler && editorRef) {
           editorRef.view.dom.removeEventListener('blur', blurHandler, true)
           blurHandler = null


### PR DESCRIPTION
## Summary
- isolate draft and session stream subscriptions from the heavy AgentView tree
- retain stable completed history groups so live updates skip unrelated message rendering
- debounce mention search and cache bounded file indexes
- skip offscreen Agent session-row painting in the sidebar

## Validation
- `bun run typecheck`
- `bun test` (528 passed; 4 existing Electron/native-environment failures)

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)