### PR TITLE
fix(voice): restore dictation after microphone permission

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.24",
+  "version": "0.17.25",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
+++ b/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
@@ -11,6 +11,7 @@ import { CHUNK_BYTES, concatAudioBuffers, floatTo16BitPcm, splitChunk } from './
 import { mergeVoiceDictationTranscript } from './voice-transcript-merge'
 import type { VoiceDictationTranscriptMergeState } from './voice-transcript-merge'
 import { useVoiceWindowLayout } from './use-voice-window-layout'
+import { resumeAudioContextForCapture } from './audio-context'
 import {
   VOICE_DICTATION_STATUS_EVENT,
   resolveVoiceDictationSessionInputIds,
@@ -416,16 +417,7 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
 
     source.connect(processor)
     processor.connect(audioContext.destination)
-    if (audioContext.state !== 'running') {
-      try {
-        await audioContext.resume()
-      } catch {
-        throw new Error('音频处理启动失败，请重新触发语音输入或检查系统音频权限')
-      }
-    }
-    if (audioContext.state !== 'running') {
-      throw new Error('音频处理未进入运行状态，请重新触发语音输入或检查系统音频权限')
-    }
+    await resumeAudioContextForCapture(audioContext)
     if (!stream.getAudioTracks().some((track) => track.readyState === 'live' && track.enabled)) {
       throw new Error('麦克风未就绪，请检查系统麦克风权限与设备连接')
     }
@@ -567,6 +559,7 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
         const textMessage = getMicrophoneErrorMessage(error)
         setStatus('error')
         setMessage(textMessage)
+        toast.error(textMessage)
         cleanupAudio()
       })
     })

--- a/apps/electron/src/renderer/components/voice-dictation/audio-context.ts
+++ b/apps/electron/src/renderer/components/voice-dictation/audio-context.ts
@@ -1,0 +1,26 @@
+/**
+ * Web Audio 在 macOS 权限弹窗关闭后可能短暂保持 interrupted/suspended。
+ * 这不代表麦克风轨道不可用，不能据此中止刚获授权的听写会话。
+ */
+
+interface ResumableAudioContext {
+  readonly state: AudioContextState
+  resume(): Promise<void>
+}
+
+/**
+ * 尝试恢复音频上下文；只有 resume 本身失败或上下文已关闭时才判定启动失败。
+ */
+export async function resumeAudioContextForCapture(audioContext: ResumableAudioContext): Promise<void> {
+  if (audioContext.state === 'running') return
+
+  try {
+    await audioContext.resume()
+  } catch {
+    throw new Error('音频处理启动失败，请重新触发语音输入或检查系统音频权限')
+  }
+
+  if (audioContext.state === 'closed') {
+    throw new Error('音频处理已关闭，请重新触发语音输入')
+  }
+}


### PR DESCRIPTION
## Summary

- 避免 macOS 麦克风授权弹窗关闭后，`AudioContext` 短暂处于 `interrupted` / `suspended` 时被误判为启动失败
- 仅在恢复调用失败或音频上下文已关闭时中止听写，已获取的 live 麦克风轨道可继续采集
- 启动失败时展示可见错误提示
- Electron 版本升级至 `0.17.25`

## Validation

- `bun run typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
