### PR TITLE
perf(agent): optimize history selection references

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -23,6 +23,12 @@ import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 
 const MAX_AGENT_HISTORY_QUOTED_CHARS = 2000
+const SELECTION_CAPTURE_DEBOUNCE_MS = 80
+const SELECTION_NAVIGATION_KEYS = new Set([
+  'Shift', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown',
+])
+
+type AgentHistoryMessageRole = 'user' | 'assistant' | 'system'
 
 interface AgentHistorySelection {
   text: string
@@ -30,7 +36,7 @@ interface AgentHistorySelection {
   y: number
   sourceLabel: string
   messageId?: string
-  messageRole?: 'user' | 'assistant' | 'system'
+  messageRole?: AgentHistoryMessageRole
   selectionStart?: number
   selectionEnd?: number
   turn?: number
@@ -59,31 +65,146 @@ function getRoleLabel(role?: string): string {
   return 'Agent 历史'
 }
 
+function isAgentHistoryMessageRole(role: string | null): role is AgentHistoryMessageRole {
+  return role === 'user' || role === 'assistant' || role === 'system'
+}
+
+function isInsideExcludedSubtree(node: Node, root: HTMLElement): boolean {
+  let element = getElementFromNode(node)
+  while (element) {
+    if (
+      element.hasAttribute('hidden')
+      || element.getAttribute('aria-hidden') === 'true'
+      || element.getAttribute('data-agent-history-selection-excluded') === 'true'
+    ) {
+      return true
+    }
+    if (element === root) break
+    element = element.parentElement
+  }
+  return false
+}
+
+function isVisibleRange(range: Range, root: HTMLElement): DOMRect | null {
+  const rect = range.getBoundingClientRect()
+  const anchorRect = rect.width > 0 || rect.height > 0 ? rect : range.getClientRects()[0]
+  if (!anchorRect) return null
+
+  const rootRect = root.getBoundingClientRect()
+  if (
+    anchorRect.bottom <= rootRect.top
+    || anchorRect.top >= rootRect.bottom
+    || anchorRect.right <= rootRect.left
+    || anchorRect.left >= rootRect.right
+  ) {
+    return null
+  }
+  return anchorRect
+}
+
 function getTextOffsetWithin(messageElement: Element, container: Node, offset: number): number | undefined {
   try {
-    const range = document.createRange()
-    range.selectNodeContents(messageElement)
-    range.setEnd(container, offset)
-    return range.toString().length
+    const boundary = document.createRange()
+    boundary.selectNodeContents(messageElement)
+    boundary.setEnd(container, offset)
+
+    const walker = document.createTreeWalker(messageElement, NodeFilter.SHOW_TEXT)
+    let textOffset = 0
+    let node = walker.nextNode()
+    while (node) {
+      const length = node.textContent?.length ?? 0
+      if (node === container) return textOffset + Math.min(offset, length)
+
+      const nodeRange = document.createRange()
+      nodeRange.selectNodeContents(node)
+      if (nodeRange.compareBoundaryPoints(Range.END_TO_END, boundary) <= 0) {
+        textOffset += length
+        node = walker.nextNode()
+        continue
+      }
+      return textOffset
+    }
+    return textOffset
   } catch {
     return undefined
   }
 }
 
-function getMessageTurn(root: HTMLElement, messageElement: Element): number {
-  let turn = 0
-  for (const element of root.querySelectorAll<HTMLElement>('[data-message-id][data-message-role]')) {
-    if (element.dataset.messageRole === 'user') turn += 1
-    if (element === messageElement) return Math.max(turn, 1)
+function getFirstTextNodeInRange(range: Range, root: HTMLElement): Text | null {
+  if (range.startContainer.nodeType === Node.TEXT_NODE) return range.startContainer as Text
+
+  const startElement = getElementFromNode(range.startContainer)
+  if (!startElement) return null
+  const child = range.startContainer.childNodes[range.startOffset] ?? null
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+
+  if (child) {
+    if (child.nodeType === Node.TEXT_NODE) return child as Text
+    walker.currentNode = child
+    const descendant = walker.nextNode()
+    if (descendant) return descendant as Text
   }
-  return 1
+
+  walker.currentNode = range.startContainer
+  return walker.nextNode() as Text | null
+}
+
+/**
+ * 只从 Range 起点前进到上限；不创建完整 `Selection.toString()` 字符串，也不扫描历史根。
+ */
+function getBoundedRangeText(
+  range: Range,
+  root: HTMLElement,
+  maxChars: number,
+): { rawText: string; truncated: boolean; containsExcludedContent: boolean } {
+  const first = getFirstTextNodeInRange(range, root)
+  if (!first) return { rawText: '', truncated: false, containsExcludedContent: false }
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  walker.currentNode = first
+  const chunks: string[] = []
+  let consumed = 0
+  let node: Node | null = first
+
+  while (node) {
+    if (!range.intersectsNode(node)) {
+      if (consumed > 0) break
+      node = walker.nextNode()
+      continue
+    }
+
+    if (isInsideExcludedSubtree(node, root)) {
+      // 即使 Range 两端可见，也不能跨过中间折叠/隐藏内容并把它带进引用。
+      return { rawText: '', truncated: false, containsExcludedContent: true }
+    }
+
+    const textNode = node as Text
+    const value = textNode.data
+    const start = textNode === range.startContainer ? range.startOffset : 0
+    const end = textNode === range.endContainer ? range.endOffset : value.length
+    if (end > start) {
+      const remaining = maxChars + 1 - consumed
+      if (remaining <= 0) return { rawText: chunks.join(''), truncated: true, containsExcludedContent: false }
+      const part = value.slice(start, Math.min(end, start + remaining))
+      chunks.push(part)
+      consumed += part.length
+      if (consumed > maxChars) {
+        return { rawText: chunks.join('').slice(0, maxChars), truncated: true, containsExcludedContent: false }
+      }
+    }
+
+    if (textNode === range.endContainer) break
+    node = walker.nextNode()
+  }
+
+  return { rawText: chunks.join(''), truncated: false, containsExcludedContent: false }
 }
 
 export function AgentHistorySelectionLayer({
   sessionId,
   rootRef,
   onAddToAgent,
-}: AgentHistorySelectionLayerProps): React.ReactElement {
+}: AgentHistorySelectionLayerProps): React.ReactElement | null {
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
   const selectedChatModel = useAtomValue(selectedModelAtom)
   const setConversations = useSetAtom(conversationsAtom)
@@ -93,11 +214,13 @@ export function AgentHistorySelectionLayer({
   const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const focusAgentSessionInput = useFocusAgentSessionInput()
   const [selection, setSelection] = React.useState<AgentHistorySelection | null>(null)
+  const selectionRef = React.useRef<AgentHistorySelection | null>(null)
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
   const openChatPendingRef = React.useRef(false)
 
   const clearSelection = React.useCallback((): void => {
+    selectionRef.current = null
     setSelection((current) => current === null ? current : null)
   }, [])
 
@@ -107,73 +230,83 @@ export function AgentHistorySelectionLayer({
     const activeEl = document.activeElement
     if (activeEl?.closest?.(`.ProseMirror, [data-input-mode], ${SELECTION_ACTION_POPOVER_SELECTOR}`)) return
 
-    const sel = window.getSelection()
-    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+    const selection = window.getSelection()
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
       clearSelection()
       return
     }
 
-    const range = sel.getRangeAt(0)
+    const range = selection.getRangeAt(0)
     const startEl = getElementFromNode(range.startContainer)
     const endEl = getElementFromNode(range.endContainer)
-    if (!startEl || !endEl || !root.contains(startEl) || !root.contains(endEl)) {
+    if (
+      !startEl
+      || !endEl
+      || !root.contains(startEl)
+      || !root.contains(endEl)
+      || isInsideExcludedSubtree(range.startContainer, root)
+      || isInsideExcludedSubtree(range.endContainer, root)
+    ) {
       clearSelection()
       return
     }
 
-    const startMessageEl = startEl.closest('[data-message-id]')
-    const endMessageEl = endEl.closest('[data-message-id]')
+    const startMessageEl = startEl.closest<HTMLElement>('[data-message-id][data-message-role]')
+    const endMessageEl = endEl.closest<HTMLElement>('[data-message-id][data-message-role]')
+    const role = startMessageEl?.dataset.messageRole ?? null
     if (
       !startMessageEl
       || !endMessageEl
-      || startMessageEl.getAttribute('data-agent-live') === 'true'
-      || endMessageEl.getAttribute('data-agent-live') === 'true'
+      || !isAgentHistoryMessageRole(role)
+      || startMessageEl.dataset.agentLive === 'true'
+      || endMessageEl.dataset.agentLive === 'true'
     ) {
       // 流式尾部只渲染有界预览，文本偏移与完成后的完整消息不同，不能生成不可恢复引用。
       clearSelection()
       return
     }
 
-    const rawText = normalizeSelectedText(sel.toString())
-    if (!rawText) {
+    const anchorRect = isVisibleRange(range, root)
+    if (!anchorRect) {
       clearSelection()
       return
     }
 
-    const truncated = rawText.length > MAX_AGENT_HISTORY_QUOTED_CHARS
-    const text = truncated ? rawText.slice(0, MAX_AGENT_HISTORY_QUOTED_CHARS) : rawText
-    const rect = range.getBoundingClientRect()
-    const firstRect = range.getClientRects()[0]
-    const anchorRect = rect.width > 0 || rect.height > 0 ? rect : firstRect
-    if (!anchorRect) return
+    const { rawText, truncated, containsExcludedContent } = getBoundedRangeText(range, root, MAX_AGENT_HISTORY_QUOTED_CHARS)
+    if (containsExcludedContent) {
+      clearSelection()
+      return
+    }
+    const text = normalizeSelectedText(rawText)
+    if (!text) {
+      clearSelection()
+      return
+    }
 
     const sameMessage = startMessageEl === endMessageEl
-    const role = sameMessage
-      ? (startMessageEl.getAttribute('data-message-role') as AgentHistorySelection['messageRole'] | null)
-      : null
-    const messageId = sameMessage ? startMessageEl.getAttribute('data-message-id') ?? undefined : undefined
     const selectionStart = sameMessage
       ? getTextOffsetWithin(startMessageEl, range.startContainer, range.startOffset)
       : undefined
     const unboundedSelectionEnd = sameMessage
       ? getTextOffsetWithin(endMessageEl, range.endContainer, range.endOffset)
       : undefined
-    const selectionEnd = truncated && selectionStart !== undefined && unboundedSelectionEnd !== undefined
-      ? Math.min(unboundedSelectionEnd, selectionStart + text.length)
+    const selectionEnd = truncated && selectionStart !== undefined
+      ? selectionStart + rawText.length
       : unboundedSelectionEnd
-    const turn = sameMessage ? getMessageTurn(root, startMessageEl) : undefined
-
-    setSelection({
+    const turn = sameMessage ? Number(startMessageEl.dataset.messageTurn) || undefined : undefined
+    const nextSelection: AgentHistorySelection = {
       text,
       x: anchorRect.left + anchorRect.width / 2,
       y: Math.max(12, anchorRect.top - 12),
-      sourceLabel: sameMessage ? getRoleLabel(role ?? undefined) : 'Agent 历史 · 多条消息',
-      messageId,
-      messageRole: role ?? undefined,
+      sourceLabel: sameMessage ? getRoleLabel(role) : 'Agent 历史 · 多条消息',
+      messageId: sameMessage ? startMessageEl.dataset.messageId : undefined,
+      messageRole: sameMessage ? role : undefined,
       selectionStart,
       selectionEnd,
       turn,
-    })
+    }
+    selectionRef.current = nextSelection
+    setSelection(nextSelection)
 
     if (truncated) {
       toast.warning(`已选中超过 ${MAX_AGENT_HISTORY_QUOTED_CHARS} 字符，仅引用前 ${MAX_AGENT_HISTORY_QUOTED_CHARS} 字符`, {
@@ -184,33 +317,21 @@ export function AgentHistorySelectionLayer({
   }, [clearSelection, rootRef, sessionId])
 
   const scheduleCaptureSelection = React.useCallback((): void => {
-    if (captureTimerRef.current != null) {
-      window.clearTimeout(captureTimerRef.current)
-    }
+    if (captureTimerRef.current != null) window.clearTimeout(captureTimerRef.current)
     captureTimerRef.current = window.setTimeout(() => {
       captureTimerRef.current = null
       captureSelection()
-    }, 80)
+    }, SELECTION_CAPTURE_DEBOUNCE_MS)
   }, [captureSelection])
 
   React.useEffect(() => {
-    const onSelectionChange = (): void => {
-      if (pointerSelectingRef.current) return
-      // contenteditable 的光标移动会在每次输入时触发 selectionchange。
-      // 历史选区已在 pointerdown 时清理，此处不要读取或改写编辑器选区热路径。
-      const activeElement = document.activeElement
-      if (activeElement?.closest?.('.ProseMirror, [data-input-mode]')) return
-      const sel = window.getSelection()
-      if (!sel || sel.isCollapsed) clearSelection()
-    }
+    const root = rootRef.current
+    if (!root) return
+
     const onPointerDown = (event: PointerEvent): void => {
       const target = event.target
       if (target instanceof Element && target.closest(SELECTION_ACTION_POPOVER_SELECTOR)) return
-      if (target instanceof Element && rootRef.current?.contains(target)) {
-        pointerSelectingRef.current = true
-        clearSelection()
-        return
-      }
+      pointerSelectingRef.current = true
       clearSelection()
     }
     const onPointerUp = (): void => {
@@ -222,59 +343,68 @@ export function AgentHistorySelectionLayer({
       pointerSelectingRef.current = false
     }
     const onKeyUp = (event: KeyboardEvent): void => {
-      if (!event.shiftKey && !['Shift', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'].includes(event.key)) return
+      if (!event.shiftKey && !SELECTION_NAVIGATION_KEYS.has(event.key)) return
       scheduleCaptureSelection()
     }
 
-    document.addEventListener('selectionchange', onSelectionChange)
-    document.addEventListener('pointerdown', onPointerDown, true)
-    document.addEventListener('pointerup', onPointerUp, true)
-    document.addEventListener('pointercancel', onPointerCancel, true)
-    document.addEventListener('keyup', onKeyUp, true)
+    const onDocumentPointerDown = (event: PointerEvent): void => {
+      const target = event.target
+      if (target instanceof Element && target.closest(SELECTION_ACTION_POPOVER_SELECTOR)) return
+      if (target instanceof Node && root.contains(target)) return
+      // 根外点击只清理陈旧候选，不读取 Selection、不计算 Range，也不触发 atom 写入。
+      clearSelection()
+    }
+
+    // 选区计算监听只绑定到历史根：composer 连续输入和页面其余交互不会进入捕获热路径。
+    root.addEventListener('pointerdown', onPointerDown)
+    root.addEventListener('pointerup', onPointerUp)
+    root.addEventListener('pointercancel', onPointerCancel)
+    root.addEventListener('keyup', onKeyUp, true)
+    document.addEventListener('pointerdown', onDocumentPointerDown, true)
     return () => {
       if (captureTimerRef.current != null) {
         window.clearTimeout(captureTimerRef.current)
         captureTimerRef.current = null
       }
-      document.removeEventListener('selectionchange', onSelectionChange)
-      document.removeEventListener('pointerdown', onPointerDown, true)
-      document.removeEventListener('pointerup', onPointerUp, true)
-      document.removeEventListener('pointercancel', onPointerCancel, true)
-      document.removeEventListener('keyup', onKeyUp, true)
+      root.removeEventListener('pointerdown', onPointerDown)
+      root.removeEventListener('pointerup', onPointerUp)
+      root.removeEventListener('pointercancel', onPointerCancel)
+      root.removeEventListener('keyup', onKeyUp, true)
+      document.removeEventListener('pointerdown', onDocumentPointerDown, true)
     }
   }, [clearSelection, rootRef, scheduleCaptureSelection])
 
+  const createQuotedSelection = React.useCallback((candidate: AgentHistorySelection): QuotedSelection => ({
+    text: candidate.text,
+    filePath: candidate.sourceLabel,
+    sourceType: 'agent-history',
+    sourceLabel: candidate.sourceLabel,
+    messageId: candidate.messageId,
+    messageRole: candidate.messageRole,
+    selectionStart: candidate.selectionStart,
+    selectionEnd: candidate.selectionEnd,
+    turn: candidate.turn,
+    capturedAt: Date.now(),
+  }), [])
+
   const handleAddToAgent = React.useCallback((): void => {
-    if (!selection) return
-    const quotedSelection: QuotedSelection = {
-      text: selection.text,
-      filePath: selection.sourceLabel,
-      sourceType: 'agent-history',
-      sourceLabel: selection.sourceLabel,
-      messageId: selection.messageId,
-      messageRole: selection.messageRole,
-      selectionStart: selection.selectionStart,
-      selectionEnd: selection.selectionEnd,
-      turn: selection.turn,
-      capturedAt: Date.now(),
-    }
+    const candidate = selectionRef.current
+    if (!candidate) return
+    const quotedSelection = createQuotedSelection(candidate)
     const insertedInline = onAddToAgent?.(quotedSelection) ?? false
     if (!insertedInline) {
-      setQuotedSelectionMap((prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, quotedSelection)
-        return next
-      })
+      // 只有用户明确点击“添加到 Agent”后，才允许 fallback 写入全局 atom。
+      setQuotedSelectionMap((prev) => new Map(prev).set(sessionId, quotedSelection))
     }
     window.getSelection()?.removeAllRanges()
     clearSelection()
     focusAgentSessionInput(sessionId)
     toast.success('已添加到 Agent 引用')
-  }, [clearSelection, focusAgentSessionInput, onAddToAgent, selection, sessionId, setQuotedSelectionMap])
+  }, [clearSelection, createQuotedSelection, focusAgentSessionInput, onAddToAgent, sessionId, setQuotedSelectionMap])
 
   const handleOpenChatTab = React.useCallback(async (): Promise<void> => {
-    if (!selection) return
-    if (openChatPendingRef.current) return
+    const candidate = selectionRef.current
+    if (!candidate || openChatPendingRef.current) return
     openChatPendingRef.current = true
     try {
       const conversation = await window.electronAPI.createConversation(
@@ -282,42 +412,14 @@ export function AgentHistorySelectionLayer({
         selectedChatModel?.modelId,
         selectedChatModel?.channelId,
       )
-      setConversations((prev) => {
-        if (prev.some((item) => item.id === conversation.id)) return prev
-        return [conversation, ...prev]
-      })
-      setConversationDrafts((prev) => {
-        const next = new Map(prev)
-        next.set(conversation.id, '我的问题：')
-        return next
-      })
-      setQuotedSelectionMap((prev) => {
-        const next = new Map(prev)
-        next.set(conversation.id, {
-          text: selection.text,
-          filePath: selection.sourceLabel,
-          sourceType: 'agent-history',
-          sourceLabel: selection.sourceLabel,
-          messageId: selection.messageId,
-          messageRole: selection.messageRole,
-          selectionStart: selection.selectionStart,
-          selectionEnd: selection.selectionEnd,
-          turn: selection.turn,
-          capturedAt: Date.now(),
-        })
-        return next
-      })
-      setSideChatMap((prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, conversation.id)
-        return next
-      })
+      const quotedSelection = createQuotedSelection(candidate)
+      setConversations((prev) => prev.some((item) => item.id === conversation.id) ? prev : [conversation, ...prev])
+      setConversationDrafts((prev) => new Map(prev).set(conversation.id, '我的问题：'))
+      // 打开问答 Tab 同样是用户确认动作，允许写入目标会话的待引用 atom。
+      setQuotedSelectionMap((prev) => new Map(prev).set(conversation.id, quotedSelection))
+      setSideChatMap((prev) => new Map(prev).set(sessionId, conversation.id))
       setSidePanelOpen(true)
-      setSidePanelTabMap((prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, 'chat')
-        return next
-      })
+      setSidePanelTabMap((prev) => new Map(prev).set(sessionId, 'chat'))
       window.getSelection()?.removeAllRanges()
       clearSelection()
     } catch (error) {
@@ -326,29 +428,14 @@ export function AgentHistorySelectionLayer({
     } finally {
       openChatPendingRef.current = false
     }
-  }, [
-    clearSelection,
-    selectedChatModel,
-    selection,
-    sessionId,
-    setConversationDrafts,
-    setConversations,
-    setQuotedSelectionMap,
-    setSideChatMap,
-    setSidePanelOpen,
-    setSidePanelTabMap,
-  ])
+  }, [clearSelection, createQuotedSelection, selectedChatModel, sessionId, setConversationDrafts, setConversations, setQuotedSelectionMap, setSideChatMap, setSidePanelOpen, setSidePanelTabMap])
 
-  return (
-    <>
-      {selection && (
-        <SelectionActionPopover
-          x={selection.x}
-          y={selection.y}
-          onAddToAgent={handleAddToAgent}
-          onOpenChat={handleOpenChatTab}
-        />
-      )}
-    </>
+  return selection && (
+    <SelectionActionPopover
+      x={selection.x}
+      y={selection.y}
+      onAddToAgent={handleAddToAgent}
+      onOpenChat={handleOpenChatTab}
+    />
   )
 }

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -635,9 +635,13 @@ export const AgentMessages = React.memo(function AgentMessages({
   }, [sessionId])
 
   React.useEffect(() => {
+    const root = historySelectionRootRef.current
+    if (!root) return
     const clearOnPointerDown = (): void => {
+      // 仅清理已存在的高亮；不读取 Selection 或触发历史渲染。
       clearHistoryQuoteHighlight()
     }
+    // 保留根外点击的高亮清理；该监听不参与选区捕获热路径。
     document.addEventListener('pointerdown', clearOnPointerDown, true)
     return () => {
       document.removeEventListener('pointerdown', clearOnPointerDown, true)
@@ -903,6 +907,17 @@ export const AgentMessages = React.memo(function AgentMessages({
     [sessionPath, attachedDirs],
   )
 
+  // turn 在消息渲染时一次性标注到 DOM；历史划选只需读取锚点属性，绝不回扫全部消息。
+  const groupHistoryTurns = React.useMemo(() => {
+    let turn = 0
+    const turns = new Map<MessageGroup, number>()
+    for (const group of visibleGroups) {
+      if (group.type === 'user') turn += 1
+      turns.set(group, Math.max(turn, 1))
+    }
+    return turns
+  }, [visibleGroups])
+
   return (
     <BasePathsProvider basePaths={messageBasePaths}>
       <AgentBrowserLinkProvider sessionId={sessionId}>
@@ -945,6 +960,7 @@ export const AgentMessages = React.memo(function AgentMessages({
                     onRelinkProjectRoot={shouldDisableActions ? undefined : onRelinkProjectRoot}
                     onRestoreProjectRoot={shouldDisableActions ? undefined : onRestoreProjectRoot}
                     onCompact={shouldDisableActions ? undefined : onCompact}
+                    historyTurn={groupHistoryTurns.get(group)}
                     isStreaming={isLive || undefined}
                     stoppedByUser={isLastAssistantTurn || undefined}
                     sessionModelId={sessionModelId}

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -599,6 +599,7 @@ function ThinkingBlock({ block, dimmed = false }: ThinkingBlockProps): React.Rea
       >
         <div
           ref={contentRef}
+          data-agent-history-selection-excluded={shouldCollapse && !isExpanded ? 'true' : undefined}
           className={cn(
             'prose prose-sm dark:prose-invert max-w-none prose-p:my-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 text-[14px] leading-relaxed overflow-hidden transition-[max-height] duration-200',
             dimmed ? 'text-muted-foreground' : 'text-foreground/90',

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
@@ -328,6 +328,7 @@ export function ProcessBlockGroup({ blocks, isStreaming, isMessageTail = false, 
       {shouldRenderContent && (
         <div
           ref={contentRef}
+          data-agent-history-selection-excluded={expanded ? undefined : 'true'}
           className="overflow-hidden"
           style={{
             height: measuredHeight !== undefined ? `${measuredHeight}px` : 'auto',

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -1398,6 +1398,8 @@ export interface MessageGroupRendererProps {
   onCompact?: () => void
   onRelinkProjectRoot?: () => void
   onRestoreProjectRoot?: () => void
+  /** 当前历史轮次；直接写入消息 DOM，避免划选时回扫整段历史。 */
+  historyTurn?: number
   /** 是否正在流式输出中（隐藏操作栏） */
   isStreaming?: boolean
   /** 是否被用户中断 */
@@ -1452,12 +1454,12 @@ export function getGroupId(group: MessageGroup): string {
 
 // getGroupPreview 已迁移至 @proma/session-core（本文件从该包 import 并 re-export）
 
-export const MessageGroupRenderer = React.memo(function MessageGroupRenderer({ group, allMessages, basePath, onFork, onRewind, onAgentHistoryQuoteClick, onCreateTodo, onRetry, onRetryInNewSession, onCompact, onRelinkProjectRoot, onRestoreProjectRoot, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
+export const MessageGroupRenderer = React.memo(function MessageGroupRenderer({ group, allMessages, basePath, onFork, onRewind, onAgentHistoryQuoteClick, onCreateTodo, onRetry, onRetryInNewSession, onCompact, onRelinkProjectRoot, onRestoreProjectRoot, historyTurn, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
   const groupId = getGroupId(group)
 
   if (group.type === 'user') {
     return (
-      <div data-message-id={groupId} data-message-role="user">
+      <div data-message-id={groupId} data-message-role="user" data-message-turn={historyTurn}>
         <UserInputMessage message={group.message} onAgentHistoryQuoteClick={onAgentHistoryQuoteClick} />
       </div>
     )
@@ -1465,8 +1467,14 @@ export const MessageGroupRenderer = React.memo(function MessageGroupRenderer({ g
 
   if (group.type === 'system') {
     const subtype = group.message.subtype
-    if (getSDKCompactStatus(group.message)) return <div data-message-id={groupId}><CompactStatusNotice message={group.message} /></div>
-    if (subtype === 'permission_denied') return <div data-message-id={groupId}><PermissionDeniedNotice message={group.message} /></div>
+    // system 消息同样需要稳定 DOM 锚点，保留既有历史引用与精确回跳能力。
+    const historySelectionAttributes = {
+      'data-message-id': groupId,
+      'data-message-role': 'system',
+      'data-message-turn': historyTurn,
+    }
+    if (getSDKCompactStatus(group.message)) return <div {...historySelectionAttributes}><CompactStatusNotice message={group.message} /></div>
+    if (subtype === 'permission_denied') return <div {...historySelectionAttributes}><PermissionDeniedNotice message={group.message} /></div>
     return null
   }
 
@@ -1475,6 +1483,7 @@ export const MessageGroupRenderer = React.memo(function MessageGroupRenderer({ g
     <div
       data-message-id={groupId}
       data-message-role="assistant"
+      data-message-turn={historyTurn}
       data-agent-live={isStreaming ? 'true' : undefined}
     >
       <AssistantTurnRenderer
@@ -1507,6 +1516,7 @@ export const MessageGroupRenderer = React.memo(function MessageGroupRenderer({ g
   && previous.onCompact === next.onCompact
   && previous.onRelinkProjectRoot === next.onRelinkProjectRoot
   && previous.onRestoreProjectRoot === next.onRestoreProjectRoot
+  && previous.historyTurn === next.historyTurn
   && previous.isStreaming === next.isStreaming
   && previous.stoppedByUser === next.stoppedByUser
   && previous.sessionModelId === next.sessionModelId


### PR DESCRIPTION
## 概述

重构 Agent 历史选区引用的捕获热路径，保留既有引用协议、inline chip、发送和精确回跳能力。

## 改动

- 将 pointer/keyboard 选区事件限制在历史容器，避免 composer 连续中文输入和页面其他交互触发捕获。
- 以 `data-message-turn` 作为消息 DOM 锚点，移除划选时对全历史消息的扫描。
- 用有 2000 字上限的 `Range`/`TreeWalker` 按需提取选区，避免完整 `Selection.toString()` 分配。
- 忽略流式、折叠和隐藏内容，避免生成无法稳定回跳的引用。
- 候选态保持组件本地；仅在用户确认添加引用或打开问答 Tab 后写入全局 atom。

## 验证

- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`
- `bun test apps/electron/src/renderer/lib/quoted-selection.test.ts apps/electron/src/renderer/lib/agent-message-queue.test.ts`
- `git diff --check`

全量 `bun test` 的 4 个失败均为既有 Electron/环境依赖测试，和本改动无关。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)