### PR TITLE
perf(agent): throttle background delegation streaming

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.25",
+  "version": "0.17.26",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -279,7 +279,7 @@ import {
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession, setActiveAgentStreamSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -2803,6 +2803,17 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.STOP_WORKSPACE_MEMORY_WATCH,
     async (event, workspaceSlug: string): Promise<void> => {
       stopWorkspaceMemoryWatch(event.sender.id, workspaceSlug)
+    },
+  )
+
+  // Renderer 只汇报当前实际可见会话，用于将未查看 delegation partial 降频；不落盘。
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SET_ACTIVE_STREAM_SESSION,
+    async (event, sessionId: string | null): Promise<void> => {
+      if (sessionId !== null && (typeof sessionId !== 'string' || sessionId.length === 0)) {
+        throw new Error('活动流式会话参数无效')
+      }
+      setActiveAgentStreamSession(event.sender, sessionId)
     },
   )
 

--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -131,6 +131,8 @@ export interface PiAgentQueryOptions extends AgentQueryInput {
   onRetry?: (update: import('./pi-retry-control').PiRetryUpdate) => void
   /** 渲染进程创建的本轮流式开始时间，用于隔离迟到的 native retry 事件。 */
   retryRunStartedAt?: number
+  /** partial 助手消息的动态合并间隔；后台协作会话打开后可立即恢复前台频率。 */
+  getPartialUpdateIntervalMs?: () => number
   thinkingLevel?: AgentThinkingLevel
   maxBudgetUsd?: number
   outputFormat?: JsonSchemaOutputFormat
@@ -1544,7 +1546,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
           uuid,
         })
         if (converted?.type === 'assistant') queue.push(converted)
-      }, PI_PARTIAL_UPDATE_INTERVAL_MS)
+      }, input.getPartialUpdateIntervalMs ?? PI_PARTIAL_UPDATE_INTERVAL_MS)
 
       unsubscribe = session.subscribe((event: AgentSessionEvent) => {
         try {

--- a/apps/electron/src/main/lib/adapters/pi-streaming-control.ts
+++ b/apps/electron/src/main/lib/adapters/pi-streaming-control.ts
@@ -9,7 +9,7 @@ export interface PartialMessageCoalescer<T> {
  */
 export function createPartialMessageCoalescer<T>(
   emit: (value: T) => void,
-  intervalMs: number,
+  intervalMs: number | (() => number),
 ): PartialMessageCoalescer<T> {
   let pending: T | undefined
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -31,7 +31,9 @@ export function createPartialMessageCoalescer<T>(
       pending = value
       if (timer) return
       const elapsed = Date.now() - lastEmittedAt
-      timer = setTimeout(emitPending, Math.max(0, intervalMs - elapsed))
+      // 协作子会话可在用户打开时恢复前台频率；每次排程读取最新优先级。
+      const resolvedInterval = typeof intervalMs === 'function' ? intervalMs() : intervalMs
+      timer = setTimeout(emitPending, Math.max(0, resolvedInterval - elapsed))
     },
     flush() {
       if (timer) clearTimeout(timer)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -634,7 +634,10 @@ export class AgentOrchestrator {
   async sendMessage(
     input: AgentSendInput,
     callbacks: SessionCallbacks,
-    extensions: { piCustomTools?: ToolDefinition[] } = {},
+    extensions: {
+      piCustomTools?: ToolDefinition[]
+      getPartialUpdateIntervalMs?: () => number
+    } = {},
   ): Promise<void> {
     const { sessionId, userMessage, rawUserMessage, channelId, modelId, workspaceId: requestedWorkspaceId, additionalDirectories, permissionModeOverride, mentionedSkills, mentionedMcpServers, mentionedSessionIds, mentionedTodoIds, mentionedCalendarEventIds, automationContext, retryOfErrorUuid } = input
     const streamStartedAt = input.startedAt ?? Date.now()
@@ -1511,6 +1514,7 @@ export class AgentOrchestrator {
         onModelResolved: handleModelResolved,
         onContextWindow: handleContextWindow,
         retryRunStartedAt: streamStartedAt,
+        ...(extensions.getPartialUpdateIntervalMs && { getPartialUpdateIntervalMs: extensions.getPartialUpdateIntervalMs }),
         onRetry: (retry) => {
           this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'retry', ...retry } })
         },

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -38,6 +38,7 @@ import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-man
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
 import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
+import { resolvePartialUpdateIntervalMs } from './agent-stream-priority'
 
 // ===== 实例创建 =====
 
@@ -60,6 +61,9 @@ import('./agent-collaboration-tools').then(({ registerCollaborationEventBus }) =
  * runAgent 开始时注册，结束时清理。
  */
 const sessionWebContents = new Map<string, WebContents>()
+
+/** 每个主 Renderer 当前真正打开的 Agent 会话；仅用于流式传输优先级，不做持久化。 */
+const activeAgentSessionByWebContents = new WeakMap<WebContents, string | null>()
 
 /**
  * 已挂载 destroyed 回收钩子的 webContents 集合。
@@ -86,6 +90,21 @@ function registerWebContents(sessionId: string, wc: WebContents): void {
     for (const [sid, mappedWc] of sessionWebContents) {
       if (mappedWc === wc) sessionWebContents.delete(sid)
     }
+  })
+}
+
+/**
+ * Renderer 汇报当前可见 Agent 会话后，后台 delegation 可降至 4fps；
+ * 打开某个子会话时，此映射会让它在下一次 partial 排程恢复 20fps。
+ */
+export function setActiveAgentStreamSession(webContents: WebContents, sessionId: string | null): void {
+  activeAgentSessionByWebContents.set(webContents, sessionId)
+}
+
+function getPartialUpdateInterval(sessionId: string, webContents: WebContents): number {
+  return resolvePartialUpdateIntervalMs({
+    isDelegation: Boolean(getAgentSessionMeta(sessionId)?.sourceDelegationId),
+    isActiveSession: activeAgentSessionByWebContents.get(webContents) === sessionId,
   })
 }
 
@@ -149,6 +168,7 @@ eventBus.use((sessionId, payload, next) => {
 /** 仅主进程内部使用的单次运行扩展，绝不经 IPC 序列化。 */
 export interface AgentRunExtensions {
   piCustomTools?: ToolDefinition[]
+  getPartialUpdateIntervalMs?: () => number
 }
 
 /**
@@ -224,6 +244,8 @@ export async function runAgent(
           })
         }
       },
+    }, {
+      getPartialUpdateIntervalMs: () => getPartialUpdateInterval(input.sessionId, webContents),
     })
   } catch (err) {
     console.error('[Agent 服务] runAgent 未处理异常:', err)
@@ -335,7 +357,12 @@ export async function runAgentHeadless(
           },
         })
       },
-    }, extensions)
+    }, {
+      ...extensions,
+      getPartialUpdateIntervalMs: () => wc
+        ? getPartialUpdateInterval(runInput.sessionId, wc)
+        : resolvePartialUpdateIntervalMs({ isDelegation: Boolean(getAgentSessionMeta(runInput.sessionId)?.sourceDelegationId), isActiveSession: false }),
+    })
   } catch (err) {
     console.error('[Agent 服务] runAgentHeadless 未处理异常:', err)
     const errorMessage = err instanceof Error ? err.message : '未知错误'

--- a/apps/electron/src/main/lib/agent-stream-priority.ts
+++ b/apps/electron/src/main/lib/agent-stream-priority.ts
@@ -1,0 +1,19 @@
+export const FOREGROUND_PARTIAL_UPDATE_INTERVAL_MS = 50
+export const BACKGROUND_DELEGATION_PARTIAL_UPDATE_INTERVAL_MS = 250
+
+export interface PartialUpdatePriorityInput {
+  isDelegation: boolean
+  isActiveSession: boolean
+}
+
+/**
+ * 协作子会话默认属于后台工作：限制其累计全文 partial 的发送频率，
+ * 避免多个并行 Agent 争用主 Renderer 的 IPC/反序列化预算。
+ * 用户实际打开子会话时立即恢复前台更新速率。
+ */
+export function resolvePartialUpdateIntervalMs(input: PartialUpdatePriorityInput): number {
+  if (!input.isDelegation || input.isActiveSession) {
+    return FOREGROUND_PARTIAL_UPDATE_INTERVAL_MS
+  }
+  return BACKGROUND_DELEGATION_PARTIAL_UPDATE_INTERVAL_MS
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -719,6 +719,9 @@ export interface ElectronAPI {
   approveWorkspaceProjectKnowledgeMaintenance: (workspaceSlug: string) => Promise<void>
 
 
+  /** 汇报主界面当前实际可见的 Agent 会话，供后台子会话流式限流。 */
+  setActiveAgentStreamSession: (sessionId: string | null) => Promise<void>
+
   /** 订阅 Agent 流式事件（返回清理函数） */
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => () => void
 
@@ -2003,6 +2006,10 @@ const electronAPI: ElectronAPI = {
 
   approveWorkspaceProjectKnowledgeMaintenance: (workspaceSlug: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.APPROVE_WORKSPACE_PROJECT_KNOWLEDGE_MAINTENANCE, workspaceSlug)
+  },
+
+  setActiveAgentStreamSession: (sessionId: string | null) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SET_ACTIVE_STREAM_SESSION, sessionId)
   },
 
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -61,7 +61,7 @@ import {
   playNotificationSoundForType,
 } from '@/atoms/notifications'
 import { appModeAtom } from '@/atoms/app-mode'
-import { tabsAtom, activeTabIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
+import { tabsAtom, activeTabIdAtom, activeSessionIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
@@ -91,6 +91,12 @@ const GIT_MUTATING_SUBCOMMANDS = /\bgit\s+(commit|checkout|reset|restore|stash|c
 
 function isAbsolutePath(path: string): boolean {
   return path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)
+}
+
+function isPartialAssistantStreamEvent(event: AgentStreamEvent): boolean {
+  if (event.payload.kind !== 'sdk_message') return false
+  const message = event.payload.message as Record<string, unknown>
+  return message.type === 'assistant' && message._partial === true
 }
 
 function getParentDir(path: string): string {
@@ -980,8 +986,13 @@ export function useGlobalAgentListeners(): void {
     // [FLASH-DEBUG] 事件频率计数器
     let eventCount = 0
     let lastLogTime = Date.now()
-    const cleanupEvent = window.electronAPI.onAgentStreamEvent(
-      (streamEvent: AgentStreamEvent) => {
+
+    // 主进程已把未查看 delegation 的 partial 限制为最多 4fps；Renderer 再按帧合并，
+    // 防止多个子会话恰好同一帧到达时反复同步 Jotai/React，而非流式状态一律即时处理。
+    const pendingBackgroundPartialEvents = new Map<string, AgentStreamEvent>()
+    let backgroundPartialFrame: number | null = null
+
+    const processStreamEvent = (streamEvent: AgentStreamEvent): void => {
         // [FLASH-DEBUG] 每 2 秒输出一次事件频率
         eventCount++
         const now = Date.now()
@@ -1433,12 +1444,53 @@ export function useGlobalAgentListeners(): void {
           }
         }
         }) // unstable_batchedUpdates
+    }
+
+    const flushBackgroundPartialEvents = (): void => {
+      backgroundPartialFrame = null
+      const events = [...pendingBackgroundPartialEvents.values()]
+      pendingBackgroundPartialEvents.clear()
+      for (const event of events) processStreamEvent(event)
+    }
+
+    const flushBackgroundPartialForSession = (sessionId: string): void => {
+      const pending = pendingBackgroundPartialEvents.get(sessionId)
+      if (!pending) return
+      pendingBackgroundPartialEvents.delete(sessionId)
+      processStreamEvent(pending)
+    }
+
+    const isBackgroundDelegation = (sessionId: string): boolean => {
+      const session = store.get(agentSessionsAtom).find((item) => item.id === sessionId)
+      return Boolean(session?.sourceDelegationId) && store.get(activeSessionIdAtom) !== sessionId
+    }
+
+    const publishActiveStreamSession = (): void => {
+      void window.electronAPI.setActiveAgentStreamSession(store.get(activeSessionIdAtom))
+        .catch((error) => console.warn('[GlobalAgentListeners] 汇报活动流式会话失败:', error))
+    }
+    publishActiveStreamSession()
+    const unsubscribeActiveStreamSession = store.sub(activeSessionIdAtom, publishActiveStreamSession)
+
+    const cleanupEvent = window.electronAPI.onAgentStreamEvent((streamEvent: AgentStreamEvent) => {
+      if (isPartialAssistantStreamEvent(streamEvent) && isBackgroundDelegation(streamEvent.sessionId)) {
+        pendingBackgroundPartialEvents.set(streamEvent.sessionId, streamEvent)
+        if (backgroundPartialFrame === null) {
+          backgroundPartialFrame = requestAnimationFrame(flushBackgroundPartialEvents)
+        }
+        return
       }
-    )
+
+      // partial 的最终帧必须在 result/工具等后续事件前应用，避免终态覆盖被延迟帧反向替换。
+      flushBackgroundPartialForSession(streamEvent.sessionId)
+      processStreamEvent(streamEvent)
+    })
 
     // ===== 2. 流式完成 =====
     const cleanupComplete = window.electronAPI.onAgentStreamComplete(
       (data: AgentStreamCompletePayload) => {
+        // STREAM_COMPLETE 可以紧跟最终 partial 到达；先同步该帧，再清理 liveMessages。
+        flushBackgroundPartialForSession(data.sessionId)
         console.log(`[FLASH-DEBUG] STREAM_COMPLETE for session=${data.sessionId.slice(0, 8)}, stoppedByUser=${data.stoppedByUser}, resultSubtype=${data.resultSubtype}`)
         unstable_batchedUpdates(() => {
         // 后台任务等待态：turn 主体结束但仍有后台任务在飞行，UI 进入"空闲可输入"。
@@ -1794,6 +1846,9 @@ export function useGlobalAgentListeners(): void {
     window.addEventListener('focus', onWindowFocus)
 
     return () => {
+      if (backgroundPartialFrame !== null) cancelAnimationFrame(backgroundPartialFrame)
+      pendingBackgroundPartialEvents.clear()
+      unsubscribeActiveStreamSession()
       cleanupEvent()
       cleanupComplete()
       cleanupError()

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1752,8 +1752,10 @@ export const AGENT_IPC_CHANNELS = {
   WORKSPACE_MEMORY_FILE_CHANGED: 'agent:workspace-memory-file-changed',
   APPROVE_WORKSPACE_PROJECT_KNOWLEDGE_MAINTENANCE: 'agent:approve-workspace-project-knowledge-maintenance',
 
-  // 流式事件（主进程 → 渲染进程推送）
-  /** Agent 流式事件 */
+  // 流式事件
+  /** Renderer 汇报当前实际可见的 Agent 会话，仅用于主进程动态设置流式优先级。 */
+  SET_ACTIVE_STREAM_SESSION: 'agent:set-active-stream-session',
+  /** Agent 流式事件（主进程 → 渲染进程推送） */
   STREAM_EVENT: 'agent:stream:event',
   /** Agent 流式完成 */
   STREAM_COMPLETE: 'agent:stream:complete',


### PR DESCRIPTION
## Summary
- 将未查看的协作子会话 assistant partial 流降至 4fps，避免并行委派挤占主 Renderer。
- 用户打开子会话后自动恢复 20fps；工具、权限与完成事件保持即时。
- Renderer 端按帧合并后台 partial，并在终态前 flush 最后一帧。

## Validation
- `bun run typecheck`
- `bun run electron:build`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)