### PR TITLE
perf(agent): reduce background stream churn

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.25",
+  "version": "0.17.26",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -279,7 +279,7 @@ import {
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -2825,6 +2825,17 @@ export function registerIpcHandlers(): void {
       }
       await runAgent(input, event.sender)
     }
+  )
+
+  // renderer 的当前 Agent Tab 决定 partial 消息是前台 20fps 还是后台 4fps。
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SET_VISIBLE_STREAM_SESSION,
+    async (event, sessionId: string | null): Promise<void> => {
+      if (sessionId !== null && (typeof sessionId !== 'string' || sessionId.length === 0)) {
+        throw new Error('可见 Agent 会话 ID 非法')
+      }
+      setVisibleAgentSession(event.sender, sessionId)
+    },
   )
 
   // 中止 Agent 执行

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -38,6 +38,7 @@ import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-man
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
 import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
+import { AgentStreamForwarder } from './agent-stream-forwarder'
 
 // ===== 实例创建 =====
 
@@ -60,6 +61,9 @@ import('./agent-collaboration-tools').then(({ registerCollaborationEventBus }) =
  * runAgent 开始时注册，结束时清理。
  */
 const sessionWebContents = new Map<string, WebContents>()
+/** 每个 renderer 当前可见的 Agent 会话；仅该会话维持 20fps partial。 */
+const visibleAgentSessionByWebContents = new WeakMap<WebContents, string | null>()
+const streamForwarder = new AgentStreamForwarder()
 
 /**
  * 已挂载 destroyed 回收钩子的 webContents 集合。
@@ -76,16 +80,22 @@ const wcWithCleanupHook = new WeakSet<WebContents>()
  * webContents 提前销毁的场景——destroyed 事件兜底。
  */
 function registerWebContents(sessionId: string, wc: WebContents): void {
-  // 同一 sessionId 切换 webContents 时直接覆盖；旧 wc 的 destroyed 钩子仍由 WeakSet 持有，
-  // 触发时会扫描 sessionWebContents 清理所有指向旧 wc 的条目（见下方实现）。
+  // 同一 sessionId 切换 renderer 时，先丢弃捕获旧 wc.send 的等待 partial，避免投递到旧窗口。
+  const previousWebContents = sessionWebContents.get(sessionId)
+  if (previousWebContents && previousWebContents !== wc) streamForwarder.clear(sessionId)
+  // 旧 wc 的 destroyed 钩子仍由 WeakSet 持有，触发时会扫描 sessionWebContents 清理所有指向它的条目。
   sessionWebContents.set(sessionId, wc)
   if (wcWithCleanupHook.has(wc)) return
   wcWithCleanupHook.add(wc)
   wc.once('destroyed', () => {
     // 单个 wc 可能映射到多个 sessionId（同窗口多 tab），需要清理所有指向它的条目
     for (const [sid, mappedWc] of sessionWebContents) {
-      if (mappedWc === wc) sessionWebContents.delete(sid)
+      if (mappedWc === wc) {
+        sessionWebContents.delete(sid)
+        streamForwarder.clear(sid)
+      }
     }
+    visibleAgentSessionByWebContents.delete(wc)
   })
 }
 
@@ -136,13 +146,28 @@ eventBus.use((sessionId, payload, next) => {
   const wc = sessionWebContents.get(sessionId)
   if (wc && !wc.isDestroyed()) {
     try {
-      wc.send(AGENT_IPC_CHANNELS.STREAM_EVENT, { sessionId, payload } as AgentStreamEvent)
+      streamForwarder.forward(
+        { sessionId, payload } as AgentStreamEvent,
+        (event) => wc.send(AGENT_IPC_CHANNELS.STREAM_EVENT, event),
+        visibleAgentSessionByWebContents.get(wc) === sessionId,
+      )
     } catch (err) {
       console.error(`[EventBus] wc.send 失败: sessionId=${sessionId}, payload.kind=${(payload as Record<string, unknown>)?.kind}`, err)
     }
   }
   next()
 })
+
+/** renderer 切换标签时更新流式优先级；切入会话立即 flush 等待中的后台快照。 */
+export function setVisibleAgentSession(webContents: WebContents, sessionId: string | null): void {
+  const previousSessionId = visibleAgentSessionByWebContents.get(webContents)
+  if (previousSessionId && previousSessionId !== sessionId) {
+    // 切出后将已排队的前台帧按后台频率重排，避免继续以 20fps 发送。
+    streamForwarder.reprioritize(previousSessionId, false)
+  }
+  visibleAgentSessionByWebContents.set(webContents, sessionId)
+  if (sessionId) streamForwarder.promote(sessionId)
+}
 
 // ===== IPC 薄包装函数 =====
 
@@ -243,6 +268,7 @@ export async function runAgent(
     // 避免被拒绝的请求误删仍在运行的会话映射
     if (!orchestrator.isActive(input.sessionId)) {
       sessionWebContents.delete(input.sessionId)
+      streamForwarder.clear(input.sessionId)
     }
   }
 }
@@ -352,6 +378,7 @@ export async function runAgentHeadless(
   } finally {
     if (!orchestrator.isActive(runInput.sessionId)) {
       sessionWebContents.delete(runInput.sessionId)
+      streamForwarder.clear(runInput.sessionId)
     }
   }
 }

--- a/apps/electron/src/main/lib/agent-stream-forwarder.ts
+++ b/apps/electron/src/main/lib/agent-stream-forwarder.ts
@@ -1,0 +1,102 @@
+import type { AgentStreamEvent, AgentStreamPayload, SDKMessage } from '@proma/shared'
+
+export const FOREGROUND_PARTIAL_INTERVAL_MS = 50
+export const BACKGROUND_PARTIAL_INTERVAL_MS = 250
+
+type TimerHandle = ReturnType<typeof setTimeout>
+
+interface PendingPartial {
+  event: AgentStreamEvent
+  send: (event: AgentStreamEvent) => void
+  timer?: TimerHandle
+}
+
+export interface AgentStreamForwarderOptions {
+  now?: () => number
+  schedule?: (callback: () => void, delayMs: number) => TimerHandle
+  cancel?: (timer: TimerHandle) => void
+}
+
+function isPartialAssistantPayload(payload: AgentStreamPayload): boolean {
+  return payload.kind === 'sdk_message'
+    && (payload.message as SDKMessage & { _partial?: unknown })._partial === true
+}
+
+/**
+ * 在 main → renderer 边界合并 Pi 的累计 partial 消息。
+ *
+ * 前台会话保持 20fps，后台会话降为 4fps；终态消息直接发送并丢弃旧 partial，
+ * 从而不会在 final 后倒灌一个过期快照。
+ */
+export class AgentStreamForwarder {
+  private readonly pending = new Map<string, PendingPartial>()
+  private readonly lastSentAt = new Map<string, number>()
+  private readonly now: () => number
+  private readonly schedule: (callback: () => void, delayMs: number) => TimerHandle
+  private readonly cancel: (timer: TimerHandle) => void
+
+  constructor(options: AgentStreamForwarderOptions = {}) {
+    this.now = options.now ?? Date.now
+    this.schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs))
+    this.cancel = options.cancel ?? clearTimeout
+  }
+
+  forward(
+    event: AgentStreamEvent,
+    send: (event: AgentStreamEvent) => void,
+    foreground: boolean,
+  ): void {
+    const { sessionId, payload } = event
+    if (!isPartialAssistantPayload(payload)) {
+      this.clear(sessionId)
+      send(event)
+      return
+    }
+
+    const existing = this.pending.get(sessionId)
+    if (existing) {
+      existing.event = event
+      existing.send = send
+      return
+    }
+
+    const pending: PendingPartial = { event, send }
+    this.pending.set(sessionId, pending)
+    this.schedulePending(sessionId, pending, foreground)
+  }
+
+  /** 会话切换前后台时按新频率重排尚未发送的快照。 */
+  reprioritize(sessionId: string, foreground: boolean): void {
+    const pending = this.pending.get(sessionId)
+    if (!pending) return
+    if (pending.timer) this.cancel(pending.timer)
+    this.schedulePending(sessionId, pending, foreground)
+  }
+
+  /** 当前会话切到前台时立即交付已合并快照，避免等待后台的 250ms 窗口。 */
+  promote(sessionId: string): void {
+    if (this.pending.has(sessionId)) this.emit(sessionId)
+  }
+
+  clear(sessionId: string): void {
+    const pending = this.pending.get(sessionId)
+    if (pending?.timer) this.cancel(pending.timer)
+    this.pending.delete(sessionId)
+    this.lastSentAt.delete(sessionId)
+  }
+
+  private schedulePending(sessionId: string, pending: PendingPartial, foreground: boolean): void {
+    const intervalMs = foreground ? FOREGROUND_PARTIAL_INTERVAL_MS : BACKGROUND_PARTIAL_INTERVAL_MS
+    const elapsed = this.now() - (this.lastSentAt.get(sessionId) ?? 0)
+    pending.timer = this.schedule(() => this.emit(sessionId), Math.max(0, intervalMs - elapsed))
+  }
+
+  private emit(sessionId: string): void {
+    const pending = this.pending.get(sessionId)
+    if (!pending) return
+    this.pending.delete(sessionId)
+    if (pending.timer) this.cancel(pending.timer)
+    this.lastSentAt.set(sessionId, this.now())
+    pending.send(pending.event)
+  }
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -719,6 +719,9 @@ export interface ElectronAPI {
   approveWorkspaceProjectKnowledgeMaintenance: (workspaceSlug: string) => Promise<void>
 
 
+  /** renderer 报告当前可见的 Agent 会话，用于提升其流式更新频率。 */
+  setVisibleAgentStreamSession: (sessionId: string | null) => Promise<void>
+
   /** 订阅 Agent 流式事件（返回清理函数） */
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => () => void
 
@@ -2003,6 +2006,10 @@ const electronAPI: ElectronAPI = {
 
   approveWorkspaceProjectKnowledgeMaintenance: (workspaceSlug: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.APPROVE_WORKSPACE_PROJECT_KNOWLEDGE_MAINTENANCE, workspaceSlug)
+  },
+
+  setVisibleAgentStreamSession: (sessionId: string | null) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SET_VISIBLE_STREAM_SESSION, sessionId)
   },
 
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -61,7 +61,7 @@ import {
   playNotificationSoundForType,
 } from '@/atoms/notifications'
 import { appModeAtom } from '@/atoms/app-mode'
-import { tabsAtom, activeTabIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
+import { tabsAtom, activeTabIdAtom, activeSessionIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
@@ -82,6 +82,7 @@ import { detectIsWindows } from '@/lib/platform'
 import { getSessionFileChangeKind, arePathsEqual, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
 import { buildQueuedMessageSendPayload, removeQueuedMessage, restoreQueuedMessageToFront, shouldAutoDispatchQueuedMessage } from '@/lib/agent-message-queue'
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
+import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -980,8 +981,7 @@ export function useGlobalAgentListeners(): void {
     // [FLASH-DEBUG] 事件频率计数器
     let eventCount = 0
     let lastLogTime = Date.now()
-    const cleanupEvent = window.electronAPI.onAgentStreamEvent(
-      (streamEvent: AgentStreamEvent) => {
+    const handleStreamEvent = (streamEvent: AgentStreamEvent): void => {
         // [FLASH-DEBUG] 每 2 秒输出一次事件频率
         eventCount++
         const now = Date.now()
@@ -1433,12 +1433,18 @@ export function useGlobalAgentListeners(): void {
           }
         }
         }) // unstable_batchedUpdates
-      }
-    )
+    }
+    // partial 仅保留每个会话在一帧内最新的累计全文，非 partial（尤其 final）立即处理。
+    const streamEventBatcher = createAgentStreamEventBatcher({ dispatch: handleStreamEvent })
+    const cleanupEvent = window.electronAPI.onAgentStreamEvent((streamEvent) => {
+      streamEventBatcher.push(streamEvent)
+    })
 
     // ===== 2. 流式完成 =====
     const cleanupComplete = window.electronAPI.onAgentStreamComplete(
       (data: AgentStreamCompletePayload) => {
+        // 无终态 assistant 的异常路径也不能让等待中的 partial 在完成后倒灌。
+        streamEventBatcher.clear(data.sessionId)
         console.log(`[FLASH-DEBUG] STREAM_COMPLETE for session=${data.sessionId.slice(0, 8)}, stoppedByUser=${data.stoppedByUser}, resultSubtype=${data.resultSubtype}`)
         unstable_batchedUpdates(() => {
         // 后台任务等待态：turn 主体结束但仍有后台任务在飞行，UI 进入"空闲可输入"。
@@ -1793,8 +1799,25 @@ export function useGlobalAgentListeners(): void {
     }
     window.addEventListener('focus', onWindowFocus)
 
+    const syncVisibleAgentStreamSession = (): void => {
+      const sessionId = store.get(activeSessionIdAtom)
+      const activeTab = store.get(tabsAtom).find((tab) => tab.id === store.get(activeTabIdAtom))
+      const visibleAgentSessionId = activeTab?.type === 'agent' || activeTab?.type === 'preview'
+        ? sessionId
+        : null
+      // 开发时 renderer HMR 可能先于 preload/main 重启；缺少新 IPC 不应让整个应用白屏。
+      const setVisibleAgentStreamSession = window.electronAPI.setVisibleAgentStreamSession
+      if (setVisibleAgentStreamSession) {
+        void setVisibleAgentStreamSession(visibleAgentSessionId).catch(console.error)
+      }
+    }
+    syncVisibleAgentStreamSession()
+    const unsubscribeVisibleSession = store.sub(activeSessionIdAtom, syncVisibleAgentStreamSession)
+
     return () => {
       cleanupEvent()
+      streamEventBatcher.dispose()
+      unsubscribeVisibleSession()
       cleanupComplete()
       cleanupError()
       cleanupTodoAgentSessionReady()

--- a/apps/electron/src/renderer/lib/agent-stream-event-batcher.ts
+++ b/apps/electron/src/renderer/lib/agent-stream-event-batcher.ts
@@ -1,0 +1,50 @@
+import type { AgentStreamEvent } from '@proma/shared'
+
+export interface AgentStreamEventBatcherOptions {
+  dispatch: (event: AgentStreamEvent) => void
+  requestFrame?: (callback: FrameRequestCallback) => number
+  cancelFrame?: (handle: number) => void
+}
+
+function isPartialAssistantEvent(event: AgentStreamEvent): boolean {
+  return event.payload.kind === 'sdk_message'
+    && (event.payload.message as Record<string, unknown>)._partial === true
+}
+
+/**
+ * renderer 每帧最多处理每个会话的一条 partial；非 partial 直接通过并替换等待中的快照。
+ * 这样后台流即使抵达同一帧，也不会在主线程重复执行 live/legacy 两套状态归约。
+ */
+export function createAgentStreamEventBatcher(options: AgentStreamEventBatcherOptions) {
+  const pending = new Map<string, AgentStreamEvent>()
+  const requestFrame = options.requestFrame ?? window.requestAnimationFrame
+  const cancelFrame = options.cancelFrame ?? window.cancelAnimationFrame
+  let frame: number | null = null
+
+  const flush = (): void => {
+    frame = null
+    const events = [...pending.values()]
+    pending.clear()
+    for (const event of events) options.dispatch(event)
+  }
+
+  return {
+    push(event: AgentStreamEvent): void {
+      if (!isPartialAssistantEvent(event)) {
+        pending.delete(event.sessionId)
+        options.dispatch(event)
+        return
+      }
+      pending.set(event.sessionId, event)
+      if (frame === null) frame = requestFrame(flush)
+    },
+    clear(sessionId: string): void {
+      pending.delete(sessionId)
+    },
+    dispose(): void {
+      if (frame !== null) cancelFrame(frame)
+      frame = null
+      pending.clear()
+    },
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1759,6 +1759,8 @@ export const AGENT_IPC_CHANNELS = {
   STREAM_COMPLETE: 'agent:stream:complete',
   /** Agent 流式错误 */
   STREAM_ERROR: 'agent:stream:error',
+  /** renderer 报告当前可见的 Agent 会话，用于流式优先级。 */
+  SET_VISIBLE_STREAM_SESSION: 'agent:set-visible-stream-session',
 
   // 附件
   /** 保存文件到 Agent session 工作目录 */


### PR DESCRIPTION
## Summary
- Throttle cumulative assistant partials for every background Agent session to 4fps while keeping the visible Agent/preview session at 20fps.
- Coalesce same-frame partial updates per session in the renderer, while tool, permission, error, final, and completion events remain immediate.
- Promote queued partials immediately on returning to a session; discard stale partials when a terminal event arrives.

## Validation
- `bun run typecheck`
- `bun run electron:build`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
