### PR TITLE
fix(agent): preserve message channel identity

### DIFF
--- a/apps/electron/src/main/lib/agent-message-channel-identity.test.ts
+++ b/apps/electron/src/main/lib/agent-message-channel-identity.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+import type { SDKMessage } from '@proma/shared'
+import { withAgentMessageChannelIdentity } from './agent-message-channel-identity'
+
+describe('Agent 消息渠道身份', () => {
+  test('Given assistant/result 输出 When 持久化前归档 Then 记录实际渠道且不修改原消息', () => {
+    const assistant = {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: '完成' }] },
+      parent_tool_use_id: null,
+    } as SDKMessage
+    const result = { type: 'result', subtype: 'success', usage: { input_tokens: 1, output_tokens: 1 } } as SDKMessage
+
+    const persistedAssistant = withAgentMessageChannelIdentity(assistant, 'channel-official')
+    const persistedResult = withAgentMessageChannelIdentity(result, 'channel-official')
+
+    expect(persistedAssistant).toMatchObject({ _channelId: 'channel-official' })
+    expect(persistedResult).toMatchObject({ _channelId: 'channel-official' })
+    expect(assistant).not.toHaveProperty('_channelId')
+  })
+
+  test('Given 已有渠道身份或非输出消息 When 归档 Then 保留原值', () => {
+    const existing = {
+      type: 'assistant',
+      message: { content: [] },
+      parent_tool_use_id: null,
+      _channelId: 'channel-original',
+    } as SDKMessage
+    const user = { type: 'user', parent_tool_use_id: null } as SDKMessage
+
+    expect(withAgentMessageChannelIdentity(existing, 'channel-new')).toBe(existing)
+    expect(withAgentMessageChannelIdentity(user, 'channel-new')).toBe(user)
+  })
+})

--- a/apps/electron/src/main/lib/agent-message-channel-identity.test.ts
+++ b/apps/electron/src/main/lib/agent-message-channel-identity.test.ts
@@ -8,13 +8,14 @@ describe('Agent 消息渠道身份', () => {
       type: 'assistant',
       message: { content: [{ type: 'text', text: '完成' }] },
       parent_tool_use_id: null,
+      _partial: true,
     } as SDKMessage
     const result = { type: 'result', subtype: 'success', usage: { input_tokens: 1, output_tokens: 1 } } as SDKMessage
 
     const persistedAssistant = withAgentMessageChannelIdentity(assistant, 'channel-official')
     const persistedResult = withAgentMessageChannelIdentity(result, 'channel-official')
 
-    expect(persistedAssistant).toMatchObject({ _channelId: 'channel-official' })
+    expect(persistedAssistant).toMatchObject({ _channelId: 'channel-official', _partial: true })
     expect(persistedResult).toMatchObject({ _channelId: 'channel-official' })
     expect(assistant).not.toHaveProperty('_channelId')
   })

--- a/apps/electron/src/main/lib/agent-message-channel-identity.ts
+++ b/apps/electron/src/main/lib/agent-message-channel-identity.ts
@@ -1,0 +1,14 @@
+import type { SDKMessage } from '@proma/shared'
+
+/**
+ * 为可持久化的 Agent 输出保留本次运行实际使用的渠道身份。
+ *
+ * 模型 ID 只在单个渠道内唯一；会话恢复时需要 channelId 才能在同名模型间
+ * 还原正确的别名、provider 与 logo。保留 SDK 或上游已经提供的有效值。
+ */
+export function withAgentMessageChannelIdentity<T extends SDKMessage>(message: T, channelId: string): T {
+  if (!channelId || (message.type !== 'assistant' && message.type !== 'result')) return message
+  if (typeof message._channelId === 'string') return message
+
+  return { ...message, _channelId: channelId } as T
+}

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -42,6 +42,7 @@ import { getMainRepoRoot } from './git-diff-service'
 import { getPiAssistantErrorDetails, hasPiAssistantTextContent, stripPiAssistantError } from './adapters/pi-message-adapter'
 import { friendlyErrorMessage, isPromptTooLongError, isThinkingSignatureError, mapAgentErrorToTypedError } from './agent-error-utils'
 import { getActiveRunRejectionMessage, shouldPersistInitialUserMessage } from './agent-send-message-policy'
+import { withAgentMessageChannelIdentity } from './agent-message-channel-identity'
 import { isSessionNotFoundError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels, persistCodexOAuthCredentials, persistXaiOAuthCredentials, resolveChannelRuntimeApiKey, resolveCodexOAuthCredentials, resolveXaiOAuthCredentials } from './channel-manager'
@@ -708,7 +709,7 @@ export class AgentOrchestrator {
         _errorCanRetry: typedError.canRetry,
         _errorActions: typedError.actions,
       } as unknown as SDKMessage
-      try { appendSDKMessages(sessionId, [errorSDKMsg]) } catch (e) {
+      try { appendSDKMessages(sessionId, [withAgentMessageChannelIdentity(errorSDKMsg, channelId)]) } catch (e) {
         console.error('[Agent 编排] 持久化 preflight error 失败:', e)
       }
       callbacks.onError(errorContent)
@@ -1595,6 +1596,10 @@ export class AgentOrchestrator {
               }
               pendingSkillActivations = []
             }
+            // 只在最终可持久化消息上注入渠道身份；partial 帧仅用于实时渲染。
+            if (!isPartialMessage) {
+              msg = withAgentMessageChannelIdentity(msg, channelId)
+            }
             // isVisibleRunMessage 已抽到独立模块，不含 partial 判断；
             // pi runtime 的流式 partial 消息不应计入可见消息数，故在此显式排除。
             if (!isPartialMessage && isVisibleRunMessage(msg)) {
@@ -1686,7 +1691,7 @@ export class AgentOrchestrator {
                 // 不可重试 → 终止
                 const hasPiPartialOutput = hasPiAssistantTextContent(assistantMsg)
                 if (hasPiPartialOutput) {
-                  const partialOutput = stripPiAssistantError(assistantMsg)
+                  const partialOutput = withAgentMessageChannelIdentity(stripPiAssistantError(assistantMsg), channelId)
                   if (modelId) partialOutput._channelModelId = modelId
                   partialOutput._channelProvider = channel.provider
                   accumulatedMessages.push(partialOutput)
@@ -1719,7 +1724,7 @@ export class AgentOrchestrator {
                   _errorCanRetry: typedError.canRetry,
                   _errorActions: typedError.actions,
                 } as unknown as SDKMessage
-                appendSDKMessages(sessionId, [errorSDKMsg])
+                appendSDKMessages(sessionId, [withAgentMessageChannelIdentity(errorSDKMsg, channelId)])
                 console.log(`[Agent 编排] 已保存 TypedError 消息: ${typedError.code} - ${typedError.title}`)
 
                 // 透传归一化后的错误消息到前端，避免 SDK 原始 API Error 直接暴露给用户。
@@ -1997,7 +2002,7 @@ export class AgentOrchestrator {
               _errorTitle: errorTitle,
               _errorActions: errorActions,
             } as unknown as SDKMessage
-            appendSDKMessages(sessionId, [errMsg])
+            appendSDKMessages(sessionId, [withAgentMessageChannelIdentity(errMsg, channelId)])
             console.log(`[Agent 编排] 已保存错误消息到 JSONL`)
           } catch (saveError) {
             console.error('[Agent 编排] 保存错误消息失败:', saveError)
@@ -2025,7 +2030,7 @@ export class AgentOrchestrator {
         _errorCode: 'unknown_error',
         _errorTitle: '会话恢复失败',
       } as unknown as SDKMessage
-      appendSDKMessages(sessionId, [recoveryError])
+      appendSDKMessages(sessionId, [withAgentMessageChannelIdentity(recoveryError, channelId)])
       failRun(recoveryFailure, { startedAt: streamStartedAt })
 
     } finally {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -594,6 +594,7 @@ export class AgentOrchestrator {
 
   private persistEmptyResponseError(
     sessionId: string,
+    channelId: string,
     resultSubtype: string | undefined,
     resultErrors: string[] | undefined,
   ): string {
@@ -621,7 +622,7 @@ export class AgentOrchestrator {
         { key: 'm', label: '重新选择模型', action: 'select_model' },
       ],
     } as unknown as SDKMessage
-    appendSDKMessages(sessionId, [errorSDKMsg])
+    appendSDKMessages(sessionId, [withAgentMessageChannelIdentity(errorSDKMsg, channelId)])
     console.warn(`[Agent 编排] 本轮没有收到可展示内容: sessionId=${sessionId}, resultSubtype=${subtype}`)
     return errorContent
   }
@@ -1722,11 +1723,12 @@ export class AgentOrchestrator {
                   _errorCanRetry: typedError.canRetry,
                   _errorActions: typedError.actions,
                 } as unknown as SDKMessage
-                appendSDKMessages(sessionId, [withAgentMessageChannelIdentity(errorSDKMsg, channelId)])
+                const persistedErrorSDKMsg = withAgentMessageChannelIdentity(errorSDKMsg, channelId)
+                appendSDKMessages(sessionId, [persistedErrorSDKMsg])
                 console.log(`[Agent 编排] 已保存 TypedError 消息: ${typedError.code} - ${typedError.title}`)
 
-                // 透传归一化后的错误消息到前端，避免 SDK 原始 API Error 直接暴露给用户。
-                this.eventBus.emit(sessionId, { kind: 'sdk_message', message: errorSDKMsg })
+                // 实时帧与持久化帧必须共用同一渠道身份，避免运行中切换下一轮模型时显示错渠道。
+                this.eventBus.emit(sessionId, { kind: 'sdk_message', message: persistedErrorSDKMsg })
                 try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
                 completeRun({ startedAt: streamStartedAt })
                 return
@@ -1857,7 +1859,7 @@ export class AgentOrchestrator {
           try { updateAgentSessionMeta(sessionId, wasStoppedByUser ? { stoppedByUser: true } : {}) } catch { /* 忽略 */ }
 
           if (!wasStoppedByUser && visibleRunMessageCount === 0) {
-            const errorContent = this.persistEmptyResponseError(sessionId, capturedResultSubtype, capturedResultErrors)
+            const errorContent = this.persistEmptyResponseError(sessionId, channelId, capturedResultSubtype, capturedResultErrors)
             failRun(errorContent, {
               startedAt: streamStartedAt,
               resultSubtype: EMPTY_RESPONSE_RESULT_SUBTYPE,

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1596,10 +1596,8 @@ export class AgentOrchestrator {
               }
               pendingSkillActivations = []
             }
-            // 只在最终可持久化消息上注入渠道身份；partial 帧仅用于实时渲染。
-            if (!isPartialMessage) {
-              msg = withAgentMessageChannelIdentity(msg, channelId)
-            }
+            // assistant partial 帧也需要渠道身份：它们会立即进入实时 UI，但不会被持久化。
+            msg = withAgentMessageChannelIdentity(msg, channelId)
             // isVisibleRunMessage 已抽到独立模块，不含 partial 判断；
             // pi runtime 的流式 partial 消息不应计入可见消息数，故在此显式排除。
             if (!isPartialMessage && isVisibleRunMessage(msg)) {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -353,6 +353,7 @@ export async function runAgentHeadless(
             title: session?.title,
             workspaceId: runInput.workspaceId ?? session?.workspaceId,
             modelId: runInput.modelId,
+            channelId: runInput.channelId,
             startedAt: persistedStartedAt,
             ...(session ? { session } : {}),
           },

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -102,6 +102,8 @@ export interface AgentStreamState {
   content: string
   toolActivities: ToolActivity[]
   model?: string
+  /** 本次运行启动时的渠道 ID；运行中切换模型只影响下一轮，不能覆盖它。 */
+  channelId?: string
   /** 当前输入 token 数（上下文使用量） */
   inputTokens?: number
   /** 输出 token 数 */

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -110,6 +110,8 @@ export interface TabMinimapItem {
   preview: string
   avatar?: string
   model?: string
+  /** Agent 历史消息的来源渠道，用于同名模型解析。 */
+  channelId?: string
 }
 export const tabMinimapCacheAtom = atom<Map<string, TabMinimapItem[]>>(new Map())
 

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -304,12 +304,12 @@ function EmptyState(): React.ReactElement {
   return <WelcomeEmptyState />
 }
 
-function AssistantLogo({ model }: { model?: string }): React.ReactElement {
+function AssistantLogo({ model, channelId }: { model?: string; channelId?: string }): React.ReactElement {
   const channels = useAtomValue(channelsAtom)
   if (model) {
     return (
       <img
-        src={getModelLogo(model, resolveModelProvider(model, channels))}
+        src={getModelLogo(model, resolveModelProvider(model, channels, channelId))}
         alt={model}
         className="size-[35px] rounded-[25%] object-cover"
       />
@@ -873,6 +873,7 @@ export const AgentMessages = React.memo(function AgentMessages({
       preview: getGroupPreview(group),
       avatar: group.type === 'user' ? userProfile.avatar : undefined,
       model: group.type === 'assistant-turn' ? group.model : undefined,
+      channelId: group.type === 'assistant-turn' ? group.channelId : undefined,
     })),
     [visibleGroups, userProfile.avatar]
   )

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -714,7 +714,10 @@ export const AgentMessages = React.memo(function AgentMessages({
   // 从 streamState 属性中计算派生值
   const streamingContent = streamState?.content ?? ''
   const streamingModelId = streamState?.model || sessionModelId
-  const agentStreamingModel = streamingModelId ? resolveModelDisplayName(streamingModelId, channels) : undefined
+  const streamingChannelId = streamState?.channelId
+  const agentStreamingModel = streamingModelId
+    ? resolveModelDisplayName(streamingModelId, channels, streamingChannelId)
+    : undefined
   const retrying = streamState?.retrying
   const startedAt = streamState?.startedAt
 
@@ -1009,7 +1012,7 @@ export const AgentMessages = React.memo(function AgentMessages({
                   <MessageHeader
                     model={agentStreamingModel}
                     time={formatMessageTime(Date.now())}
-                    logo={<AssistantLogo model={streamingModelId} />}
+                    logo={<AssistantLogo model={streamingModelId} channelId={streamingChannelId} />}
                   />
                   <MessageContent>
                     {retrying && <RetryingNotice retrying={retrying} />}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1042,6 +1042,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         content: '',
         toolActivities: [],
         model: agentModelId || undefined,
+        channelId,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
         contextWindow: existing?.contextWindow,
@@ -1213,6 +1214,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                 contextWindow: state.contextWindow,
                 contextUsageIsEstimated: state.contextUsageIsEstimated,
                 model: state.model,
+                channelId: state.channelId,
                 contextCompaction: state.contextCompaction,
               })
             } else if (state.backgroundWaiting || state.contextCompaction) {
@@ -1333,6 +1335,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           content: '',
           toolActivities: [],
           model: snapshot.modelId,
+          channelId: snapshot.channelId,
           startedAt: streamStartedAt,
           inputTokens: existing?.inputTokens,
           contextWindow: resolveRunContextWindow(snapshot.modelId, existing?.contextWindow),
@@ -2292,6 +2295,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         content: '',
         toolActivities: [],
         model: agentModelId || undefined,
+        channelId: agentChannelId,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
         contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow),
@@ -2401,6 +2405,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         content: '',
         toolActivities: [],
         model: agentModelId || undefined,
+        channelId: agentChannelId,
         startedAt: streamStartedAt,
       }
       map.set(sessionId, {
@@ -2526,6 +2531,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         content: '',
         toolActivities: [],
         model: agentModelId || undefined,
+        channelId: agentChannelId,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
         contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow),
@@ -2572,6 +2578,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           content: '',
           toolActivities: [],
           model: agentModelId || undefined,
+          channelId: agentChannelId,
           startedAt: streamStartedAt,
         })
         return map

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -266,12 +266,12 @@ function extractToolResultForTask(message: SDKUserMessage, resultBlock: SDKToolR
 
 // ===== 助手头像 =====
 
-function AssistantLogo({ model }: { model?: string }): React.ReactElement {
+function AssistantLogo({ model, channelId }: { model?: string; channelId?: string }): React.ReactElement {
   const channels = useAtomValue(channelsAtom)
   if (model) {
     return (
       <img
-        src={getModelLogo(model, resolveModelProvider(model, channels))}
+        src={getModelLogo(model, resolveModelProvider(model, channels, channelId))}
         alt={model}
         className="size-[35px] rounded-[25%] object-cover"
       />
@@ -531,9 +531,9 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
   return (
     <Message from="assistant">
       <MessageHeader
-        model={turn.model ? resolveModelDisplayName(turn.model, channels) : undefined}
+        model={turn.model ? resolveModelDisplayName(turn.model, channels, turn.channelId) : undefined}
         time={turn.createdAt ? formatMessageTime(turn.createdAt) : undefined}
-        logo={<AssistantLogo model={turn.model} />}
+        logo={<AssistantLogo model={turn.model} channelId={turn.channelId} />}
       />
       <MessageContent>
         <TurnFileMapProvider map={turnFileMap}>
@@ -683,9 +683,9 @@ export function SDKMessageRenderer({
       <Message from="assistant">
         {showHeader && (
           <MessageHeader
-            model={model ? resolveModelDisplayName(model, channels) : undefined}
+            model={model ? resolveModelDisplayName(model, channels, aMsg._channelId) : undefined}
             time={meta.createdAt ? formatMessageTime(meta.createdAt) : undefined}
-            logo={<AssistantLogo model={model} />}
+            logo={<AssistantLogo model={model} channelId={aMsg._channelId} />}
           />
         )}
         <MessageContent>

--- a/apps/electron/src/renderer/components/agent/message-group-rendering.test.ts
+++ b/apps/electron/src/renderer/components/agent/message-group-rendering.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import type { AssistantTurn } from '@proma/session-core'
+import { stabilizeMessageGroups } from './message-group-rendering'
+
+function assistantTurn(channelId: string): AssistantTurn {
+  return {
+    type: 'assistant-turn',
+    assistantMessages: [],
+    turnMessages: [],
+    model: 'shared-model',
+    channelId,
+  }
+}
+
+describe('消息分组渲染缓存', () => {
+  test('Given 同一模型的渠道身份改变 When 稳定化分组 Then 不复用旧 header', () => {
+    const previous = assistantTurn('channel-a')
+    const next = assistantTurn('channel-b')
+
+    expect(stabilizeMessageGroups([previous], [next])).toEqual([next])
+    expect(stabilizeMessageGroups([previous], [next])[0]).toBe(next)
+  })
+})

--- a/apps/electron/src/renderer/components/agent/message-group-rendering.ts
+++ b/apps/electron/src/renderer/components/agent/message-group-rendering.ts
@@ -36,6 +36,7 @@ function canReuseMessageGroup(previous: MessageGroup, next: MessageGroup): boole
 
   return previous.inputMessage === next.inputMessage
     && previous.model === next.model
+    && previous.channelId === next.channelId
     && previous.createdAt === next.createdAt
     && previous.startsAfterWake === next.startsAfterWake
     && arraysShareItems(previous.assistantMessages, next.assistantMessages)

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -26,6 +26,7 @@ export interface MinimapItem {
   preview: string
   avatar?: string
   model?: string
+  channelId?: string
 }
 
 interface ScrollMinimapProps {
@@ -573,7 +574,7 @@ function ItemIcon({ item }: { item: MinimapItem }): React.ReactElement {
   if ((item.role === 'assistant') && item.model) {
     return (
       <img
-        src={getModelLogo(item.model, resolveModelProvider(item.model, channels))}
+        src={getModelLogo(item.model, resolveModelProvider(item.model, channels, item.channelId))}
         alt=""
         className="size-4 shrink-0 mt-0.5 rounded-[20%] object-cover"
       />

--- a/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
+++ b/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
@@ -206,6 +206,7 @@ function buildAgentMinimapItems(messages: SDKMessage[], userAvatar?: string): Ta
         role: 'assistant',
         preview,
         model: assistant._channelModelId ?? assistant.message?.model,
+        channelId: assistant._channelId,
       })
       continue
     }
@@ -339,7 +340,7 @@ function ItemIcon({ item, type }: { item: TabMinimapItem; type: SessionMiniMapTy
   if (item.role === 'assistant' && item.model) {
     return (
       <img
-        src={getModelLogo(item.model, resolveModelProvider(item.model, channels))}
+        src={getModelLogo(item.model, resolveModelProvider(item.model, channels, item.channelId))}
         alt=""
         className="size-4 shrink-0 mt-0.5 rounded-[20%] object-cover"
       />

--- a/apps/electron/src/renderer/components/tabs/TabPreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabPreviewPanel.tsx
@@ -47,7 +47,7 @@ function ItemIcon({ item }: { item: TabMinimapItem }): React.ReactElement {
   if (item.role === 'assistant' && item.model) {
     return (
       <img
-        src={getModelLogo(item.model, resolveModelProvider(item.model, channels))}
+        src={getModelLogo(item.model, resolveModelProvider(item.model, channels, item.channelId))}
         alt=""
         className="size-4 shrink-0 mt-0.5 rounded-[20%] object-cover"
       />

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -722,6 +722,7 @@ export function useGlobalAgentListeners(): void {
           title: event.title,
           workspaceId: event.workspaceId,
           modelId: event.modelId,
+          channelId: event.channelId ?? eventSession?.channelId,
           startedAt: event.startedAt,
           currentStreamState,
         })
@@ -765,12 +766,7 @@ export function useGlobalAgentListeners(): void {
         })
         store.set(agentStreamingStatesAtom, (prev) => {
           const map = new Map(prev)
-          // 外部 run 没有 AgentView 的本地启动快照；在 activation 时冻结会话渠道，
-          // 防止用户随后切换下一轮模型而污染正在运行的 fallback 气泡。
-          map.set(event.sessionId, {
-            ...activation.streamState,
-            ...(sessionMeta?.channelId ? { channelId: sessionMeta.channelId } : {}),
-          })
+          map.set(event.sessionId, activation.streamState)
           return map
         })
       }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -765,7 +765,12 @@ export function useGlobalAgentListeners(): void {
         })
         store.set(agentStreamingStatesAtom, (prev) => {
           const map = new Map(prev)
-          map.set(event.sessionId, activation.streamState)
+          // 外部 run 没有 AgentView 的本地启动快照；在 activation 时冻结会话渠道，
+          // 防止用户随后切换下一轮模型而污染正在运行的 fallback 气泡。
+          map.set(event.sessionId, {
+            ...activation.streamState,
+            ...(sessionMeta?.channelId ? { channelId: sessionMeta.channelId } : {}),
+          })
           return map
         })
       }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -1054,6 +1054,14 @@ export function useGlobalAgentListeners(): void {
               const defaultModelId = store.get(agentModelIdAtom)
               msgRecord._channelModelId = sessionModelMap.get(sessionId) ?? defaultModelId ?? undefined
             }
+            if (msgRecord.type === 'assistant' && !msgRecord._channelId) {
+              const sessionChannelMap = store.get(agentSessionChannelMapAtom)
+              const defaultChannelId = store.get(agentChannelIdAtom)
+              const channelId = sessionChannelMap.get(sessionId) ?? defaultChannelId ?? undefined
+              if (channelId) {
+                msgRecord._channelId = channelId
+              }
+            }
             if (msgRecord.type === 'assistant' && !msgRecord._channelProvider) {
               const sessionChannelMap = store.get(agentSessionChannelMapAtom)
               const defaultChannelId = store.get(agentChannelIdAtom)

--- a/apps/electron/src/renderer/lib/external-agent-run.test.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.test.ts
@@ -20,6 +20,7 @@ describe('外部 Agent 运行激活', () => {
       sessionId: session.id,
       startedAt: 100,
       modelId: 'claude-sonnet-4-6',
+      channelId: 'channel-runtime',
     })
 
     expect(result.tabs).toEqual([
@@ -30,6 +31,7 @@ describe('外部 Agent 运行激活', () => {
     expect(result.streamState).toMatchObject({
       running: true,
       model: 'claude-sonnet-4-6',
+      channelId: 'channel-runtime',
       startedAt: 100,
     })
   })

--- a/apps/electron/src/renderer/lib/external-agent-run.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.ts
@@ -15,6 +15,8 @@ export interface ExternalAgentRunActivationInput {
   title?: string
   workspaceId?: string
   modelId?: string
+  /** 实际启动本轮的渠道；可能与 session metadata 不同。 */
+  channelId?: string
   startedAt: number
   currentStreamState?: AgentStreamState
 }
@@ -65,6 +67,7 @@ export function buildExternalAgentRunActivation(
       content: input.currentStreamState?.content ?? '',
       toolActivities: input.currentStreamState?.toolActivities ?? [],
       model: input.modelId ?? input.currentStreamState?.model,
+      channelId: input.channelId ?? input.currentStreamState?.channelId,
       startedAt: input.startedAt,
     },
   }

--- a/apps/electron/src/renderer/lib/model-logo.test.ts
+++ b/apps/electron/src/renderer/lib/model-logo.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import type { Channel } from '@proma/shared'
+import { resolveModelDisplayName, resolveModelProvider } from './model-logo'
+
+const channels = [
+  { id: 'channel-a', provider: 'anthropic', models: [{ id: 'shared-model', name: '渠道 A 别名' }] },
+  { id: 'channel-b', provider: 'openai', models: [{ id: 'shared-model', name: '渠道 B 别名' }] },
+] as unknown as Channel[]
+
+describe('模型渠道解析', () => {
+  test('Given 同名模型位于多个渠道 When 提供来源渠道 Then 使用该渠道的别名和 provider', () => {
+    expect(resolveModelDisplayName('shared-model', channels, 'channel-b')).toBe('渠道 B 别名')
+    expect(resolveModelProvider('shared-model', channels, 'channel-b')).toBe('openai')
+  })
+
+  test('Given 旧消息没有渠道身份 When 解析 Then 保持既有全渠道 fallback', () => {
+    expect(resolveModelDisplayName('shared-model', channels)).toBe('渠道 A 别名')
+    expect(resolveModelProvider('shared-model', channels)).toBe('anthropic')
+  })
+
+  test('Given 已删除的消息来源渠道 When 解析 Then 不错误匹配另一渠道', () => {
+    expect(resolveModelDisplayName('shared-model', channels, 'channel-removed')).toBe('shared-model')
+    expect(resolveModelProvider('shared-model', channels, 'channel-removed')).toBeUndefined()
+  })
+})

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -369,11 +369,12 @@ export function getChannelLogo(channel: { provider: ProviderType; baseUrl: strin
 /**
  * 根据模型 ID 在渠道列表中查找显示名称
  *
- * 优先返回别名（name !== id），未找到则返回原始 modelId。
- * 用于将 SDK 返回的 model ID 转为用户友好的显示名称。
+ * 提供 channelId 时仅在该渠道内查找，避免同名模型落到另一渠道；
+ * 未提供时保持旧会话的全渠道 fallback。
  */
-export function resolveModelDisplayName(modelId: string, channels: import('@proma/shared').Channel[]): string {
+export function resolveModelDisplayName(modelId: string, channels: import('@proma/shared').Channel[], channelId?: string): string {
   for (const channel of channels) {
+    if (channelId && channel.id !== channelId) continue
     for (const model of channel.models) {
       if (model.id === modelId && model.name && model.name !== model.id) {
         return model.name
@@ -384,10 +385,11 @@ export function resolveModelDisplayName(modelId: string, channels: import('@prom
 }
 
 /**
- * 根据模型 ID 在渠道列表中查找供应商类型
+ * 根据模型 ID 在渠道列表中查找供应商类型；提供 channelId 时只查该渠道。
  */
-export function resolveModelProvider(modelId: string, channels: import('@proma/shared').Channel[]): ProviderType | undefined {
+export function resolveModelProvider(modelId: string, channels: import('@proma/shared').Channel[], channelId?: string): ProviderType | undefined {
   for (const channel of channels) {
+    if (channelId && channel.id !== channelId) continue
     for (const model of channel.models) {
       if (model.id === modelId) {
         return channel.provider

--- a/packages/session-core/src/group.ts
+++ b/packages/session-core/src/group.ts
@@ -70,6 +70,8 @@ export interface AssistantTurn {
   inputMessage?: SDKUserMessage
   /** 模型名称（取首条 assistant 消息的 model） */
   model?: string
+  /** 产生此 turn 的渠道 ID；与 model 共同构成历史展示身份。 */
+  channelId?: string
   /** 创建时间（取首条 assistant 消息的时间） */
   createdAt?: number
   /**
@@ -145,6 +147,7 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
           turnMessages: [msg],
           inputMessage: pendingInputMessage,
           model: aMsg._channelModelId || aMsg.message?.model || sessionModelId,
+          channelId: aMsg._channelId,
           createdAt: meta.createdAt,
           // 紧跟在后台任务唤醒之后的新 turn：阻断与上一轮的合并
           startsAfterWake: pendingWakeBoundary || undefined,
@@ -240,7 +243,7 @@ function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
       if (prev.type === 'user') break // 真正的用户输入阻断合并
       if (prev.type === 'system' && isPersistableSDKSystemMessage(prev.message as SDKSystemMessage)) break
       if (prev.type === 'assistant-turn') {
-        if (prev.model === group.model) {
+        if (prev.model === group.model && prev.channelId === group.channelId) {
           mergeTargetIdx = i
         }
         break // 遇到第一个 assistant-turn 就停止（不跨越不同模型的 turn）

--- a/packages/session-core/src/session-core.test.ts
+++ b/packages/session-core/src/session-core.test.ts
@@ -191,3 +191,23 @@ describe('容错与渐进式读取原语', () => {
     expect(md).toContain('答案含关键词 needle')
   })
 })
+
+describe('消息级渠道身份', () => {
+  test('Given 同名模型的历史 assistant 消息 When 分组 Then 保留来源渠道', () => {
+    const groups = groupIntoTurns([
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        _channelModelId: 'gpt-5',
+        _channelId: 'channel-official',
+        message: { content: [{ type: 'text', text: '完成' }] },
+      },
+    ])
+
+    expect(groups).toMatchObject([{
+      type: 'assistant-turn',
+      model: 'gpt-5',
+      channelId: 'channel-official',
+    }])
+  })
+})

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -227,6 +227,8 @@ export interface SDKAssistantMessage {
   isReplay?: boolean
   /** 渠道配置的模型 ID，持久化/流式期间注入，用于正确匹配模型显示名 */
   _channelModelId?: string
+  /** 产生此消息的渠道 ID；用于在同名模型跨渠道时恢复精确展示信息。 */
+  _channelId?: string
   /** 渠道 provider，用于按 Agent SDK 实际运行窗口计算压缩阈值 */
   _channelProvider?: ProviderType
 }
@@ -290,6 +292,8 @@ export interface SDKResultMessage {
   skill_activations?: SkillActivation[]
   /** 渠道配置的模型 ID，用于缺失 modelUsage.contextWindow 时按 Agent SDK 运行窗口兜底 */
   _channelModelId?: string
+  /** 产生此消息的渠道 ID；用于在同名模型跨渠道时恢复精确展示信息。 */
+  _channelId?: string
   /** 渠道 provider，用于按 Agent SDK 实际运行窗口计算压缩阈值 */
   _channelProvider?: ProviderType
 }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -631,7 +631,7 @@ export type PromaEvent =
   | { type: 'context_window'; contextWindow: number }
   | { type: 'permission_mode_changed'; mode: PromaPermissionMode }
   | { type: 'title_updated'; title: string }
-  | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number; session?: AgentSessionMeta }
+  | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; channelId?: string; startedAt: number; session?: AgentSessionMeta }
   /** 普通桌面会话已开始执行；startedAt 用于区分同一会话的连续运行。 */
   | { type: 'run_started'; startedAt: number }
   | { type: 'run_resumed'; sessionId: string }


### PR DESCRIPTION
## Summary
- persist the runtime channel ID with assistant and result messages without mutating SDK events
- preserve channel identity on real-time assistant partial frames as well as persisted history
- use the message channel when resolving historical model aliases, providers, and minimap icons
- invalidate cached message groups when channel identity changes, while retaining legacy fallback behavior

## Validation
- `bun test packages/session-core/src/session-core.test.ts apps/electron/src/main/lib/agent-message-channel-identity.test.ts apps/electron/src/renderer/lib/model-logo.test.ts apps/electron/src/renderer/components/agent/message-group-rendering.test.ts`
- `bun run --filter @proma/electron typecheck`
- `bun run --filter @proma/electron build:main`
- `bun run --filter @proma/electron build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)