### PR TITLE
fix(agent): prevent long-running session performance degradation

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.26",
+  "version": "0.17.27",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -268,7 +268,9 @@ import {
   listAgentSessions,
   createAgentSession,
   getAgentSessionMeta,
+  getAgentSessionCounts,
   getAgentSessionSDKMessages,
+  getAgentSessionSDKMessagesPage,
   updateAgentSessionMeta,
   deleteAgentSession,
   migrateChatToAgentSession,
@@ -2050,10 +2052,20 @@ export function registerIpcHandlers(): void {
 
   // ===== Agent 会话管理相关 =====
 
-  // 获取 Agent 会话列表
+  // renderer 热路径显式取 active；保留 all 默认值以兼容低频既有调用。
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_SESSIONS,
-    async (): Promise<AgentSessionMeta[]> => listAgentSessions()
+    async (_, scope: 'active' | 'archived' | 'all' = 'all'): Promise<AgentSessionMeta[]> => listAgentSessions(scope)
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_SESSION_META,
+    async (_, id: string): Promise<AgentSessionMeta | undefined> => getAgentSessionMeta(id),
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_SESSION_COUNTS,
+    async (): Promise<{ active: number; archived: number }> => getAgentSessionCounts(),
   )
 
   // 创建 Agent 会话
@@ -2157,6 +2169,14 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.GET_SDK_MESSAGES,
     async (_, id: string): Promise<SDKMessage[]> => {
       return getAgentSessionSDKMessages(id)
+    }
+  )
+
+  // 渲染器消息区默认从尾部按页读取，避免长 transcript 全量读取、解析和 IPC。
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_SDK_MESSAGES_PAGE,
+    async (_, id: string, input?: { before?: number; limit?: number }) => {
+      return getAgentSessionSDKMessagesPage(id, input)
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
@@ -21,6 +21,8 @@ import { sanitizeToolResultImageContent } from '../image-content-validation'
 
 const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_MCP_STARTUP_TIMEOUT_MS = 30_000
+/** 保留相邻回合的热连接，同时回收长期闲置的 stdio/HTTP MCP 进程。 */
+const MCP_CONNECTION_IDLE_TTL_MS = 5 * 60_000
 const OPTIONAL_MCP_BOOTSTRAP_TIMEOUT_MS = 500
 const HTTP_SESSION_REJECTION_PATTERN = /missing session id|no valid session id provided|mcp-session-id header is required/i
 
@@ -55,6 +57,7 @@ interface McpConnectionEntry {
   activeLeases: number
   stale: boolean
   closed: boolean
+  idleTimer?: ReturnType<typeof setTimeout>
 }
 
 interface McpConnectionLease {
@@ -256,6 +259,7 @@ class PiMcpClientManager {
     this.lifecycleGeneration += 1
     const entries = [...this.connections.values()]
     this.connections.clear()
+    for (const entry of entries) this.clearIdleTimer(entry)
     await Promise.allSettled(
       entries.map(async (entry) => {
         try {
@@ -266,6 +270,24 @@ class PiMcpClientManager {
         }
       }),
     )
+  }
+
+  private clearIdleTimer(entry: McpConnectionEntry): void {
+    if (!entry.idleTimer) return
+    clearTimeout(entry.idleTimer)
+    entry.idleTimer = undefined
+  }
+
+  private scheduleIdleClose(key: string, entry: McpConnectionEntry): void {
+    this.clearIdleTimer(entry)
+    entry.idleTimer = setTimeout(() => {
+      entry.idleTimer = undefined
+      if (entry.activeLeases !== 0 || entry.stale || entry.closed || this.connections.get(key) !== entry) return
+      entry.stale = true
+      entry.closed = true
+      this.connections.delete(key)
+      void entry.promise.then((connection) => connection.close()).catch(() => {})
+    }, MCP_CONNECTION_IDLE_TTL_MS)
   }
 
   async listTools(serverName: string, config: PiMcpServerConfig): Promise<McpToolInfo[]> {
@@ -355,12 +377,14 @@ class PiMcpClientManager {
     if (!entry) {
       let createdEntry!: McpConnectionEntry
       const promise = this.createConnection(serverName, config, () => {
+        this.clearIdleTimer(createdEntry)
         createdEntry.stale = true
         createdEntry.closed = true
         if (this.connections.get(key) === createdEntry) {
           this.connections.delete(key)
         }
       }).catch((error) => {
+        this.clearIdleTimer(createdEntry)
         createdEntry.stale = true
         if (this.connections.get(key) === createdEntry) {
           this.connections.delete(key)
@@ -377,6 +401,7 @@ class PiMcpClientManager {
       this.connections.set(key, entry)
     }
 
+    this.clearIdleTimer(entry)
     entry.activeLeases += 1
     try {
       return {
@@ -391,6 +416,7 @@ class PiMcpClientManager {
   }
 
   private markConnectionStale(lease: McpConnectionLease): void {
+    this.clearIdleTimer(lease.entry)
     lease.entry.stale = true
     if (this.connections.get(lease.key) === lease.entry) {
       this.connections.delete(lease.key)
@@ -399,7 +425,12 @@ class PiMcpClientManager {
 
   private async releaseConnection(lease: McpConnectionLease): Promise<void> {
     lease.entry.activeLeases -= 1
-    if (!lease.entry.stale || lease.entry.closed || lease.entry.activeLeases > 0) return
+    if (lease.entry.activeLeases > 0 || lease.entry.closed) return
+    if (!lease.entry.stale) {
+      this.scheduleIdleClose(lease.key, lease.entry)
+      return
+    }
+    lease.entry.closed = true
     try {
       await lease.connection.close()
     } catch {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -49,7 +49,7 @@ import { getAdapter, fetchTitle } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
-import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, removeSDKErrorMessage, updateSDKUserMessageSkillActivations, rewindPiAgentSession, resolveAgentCwd, getActiveWorktreePath, getAgentCwdMode, getSessionWorkbenchLayout } from './agent-session-manager'
+import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, removeSDKErrorMessage, updateSDKUserMessageSkillActivations, rewindPiAgentSession, resolveAgentCwd, getActiveWorktreePath, getAgentCwdMode, getSessionWorkbenchLayout } from './agent-session-manager'
 import { getAgentWorkspace, getLocalProjectRootStatus, getProjectFilesPath, getWorkspaceMcpConfig, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles, getWorkspaceAgentsMdPath, readWorkspaceAgentsMd, getWorkspaceMemoryGuidance, isWorkspaceProjectKnowledgeMaintenanceApproved } from './agent-workspace-manager'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceSkillsDir } from './config-paths'
 import { getRuntimeStatus } from './runtime-init'
@@ -89,7 +89,7 @@ export interface SessionCallbacks {
   /** 发送流式错误 */
   onError: (error: string) => void
   /** 发送流式完成（携带已持久化的消息列表） */
-  onComplete: (messages?: AgentMessage[], opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; resultErrors?: string[]; backgroundTasksPending?: boolean }) => void
+  onComplete: (opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; resultErrors?: string[]; backgroundTasksPending?: boolean }) => void
   /** 发送标题更新 */
   onTitleUpdated: (title: string) => void
   /** 用户消息已持久化，外部入口可据此通知前端切到实时会话 */
@@ -659,7 +659,7 @@ export class AgentOrchestrator {
       // 后续消息会随每次点击重复落盘。
       console.warn(`[Agent 编排] 会话 ${sessionId} 正在处理中，拒绝新请求且不保存用户消息`)
       callbacks.onError(getActiveRunRejectionMessage())
-      callbacks.onComplete([], { startedAt: streamStartedAt })
+      callbacks.onComplete({ startedAt: streamStartedAt })
       return
     }
 
@@ -680,7 +680,7 @@ export class AgentOrchestrator {
         const message = error instanceof Error ? error.message : String(error)
         console.error('[Agent 编排] 持久化用户消息失败:', error)
         callbacks.onError(`消息保存失败：${message}`)
-        callbacks.onComplete([], { startedAt: streamStartedAt })
+        callbacks.onComplete({ startedAt: streamStartedAt })
         return
       }
     }
@@ -712,7 +712,7 @@ export class AgentOrchestrator {
         console.error('[Agent 编排] 持久化 preflight error 失败:', e)
       }
       callbacks.onError(errorContent)
-      callbacks.onComplete([], { startedAt: streamStartedAt })
+      callbacks.onComplete({ startedAt: streamStartedAt })
     }
 
     // 会话元数据是运行项目的权威来源。渲染端的当前项目只是导航状态，不能
@@ -851,20 +851,18 @@ export class AgentOrchestrator {
       }
     }
     const completeRun = (
-      messages?: AgentMessage[],
       opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; resultErrors?: string[] },
     ): void => {
       releaseActiveRun()
-      callbacks.onComplete(messages, opts)
+      callbacks.onComplete(opts)
     }
     const failRun = (
       error: string,
-      messages?: AgentMessage[],
       opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; resultErrors?: string[] },
     ): void => {
       releaseActiveRun()
       callbacks.onError(error)
-      callbacks.onComplete(messages, opts)
+      callbacks.onComplete(opts)
     }
 
     // 3. 构建 Pi runtime 环境（代理与 Windows shell 配置）。
@@ -1727,7 +1725,7 @@ export class AgentOrchestrator {
                 // 透传归一化后的错误消息到前端，避免 SDK 原始 API Error 直接暴露给用户。
                 this.eventBus.emit(sessionId, { kind: 'sdk_message', message: errorSDKMsg })
                 try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
-                completeRun(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+                completeRun({ startedAt: streamStartedAt })
                 return
               }
             }
@@ -1857,7 +1855,7 @@ export class AgentOrchestrator {
 
           if (!wasStoppedByUser && visibleRunMessageCount === 0) {
             const errorContent = this.persistEmptyResponseError(sessionId, capturedResultSubtype, capturedResultErrors)
-            failRun(errorContent, getAgentSessionMessages(sessionId), {
+            failRun(errorContent, {
               startedAt: streamStartedAt,
               resultSubtype: EMPTY_RESPONSE_RESULT_SUBTYPE,
               resultErrors: [errorContent],
@@ -1875,7 +1873,7 @@ export class AgentOrchestrator {
           }
 
           // 发送完成信号
-          completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt, resultSubtype: capturedResultSubtype, resultErrors: capturedResultErrors })
+          completeRun({ stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt, resultSubtype: capturedResultSubtype, resultErrors: capturedResultErrors })
 
           return
 
@@ -1884,7 +1882,7 @@ export class AgentOrchestrator {
             const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
-            completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
+            completeRun({ stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
             return
           }
 
@@ -2005,7 +2003,7 @@ export class AgentOrchestrator {
             console.error('[Agent 编排] 保存错误消息失败:', saveError)
           }
 
-          failRun(userFacingError, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+          failRun(userFacingError, { startedAt: streamStartedAt })
 
           // 保留 Pi session ID，确保网络或上游临时失败后的下一轮可继续 resume。
           if (existingSdkSessionId) {
@@ -2028,7 +2026,7 @@ export class AgentOrchestrator {
         _errorTitle: '会话恢复失败',
       } as unknown as SDKMessage
       appendSDKMessages(sessionId, [recoveryError])
-      failRun(recoveryFailure, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+      failRun(recoveryFailure, { startedAt: streamStartedAt })
 
     } finally {
       // 只在 generation 匹配时才清理，防止旧流的 finally 误删新流的注册

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -216,11 +216,10 @@ export async function runAgent(
           })
         }
       },
-      onComplete: (messages, opts) => {
+      onComplete: (opts) => {
         publishRunStopped(input.sessionId, opts?.stoppedByUser, opts?.startedAt)
         if (!webContents.isDestroyed()) {
           sendAgentStreamComplete(webContents, input, {
-            messages,
             stoppedByUser: opts?.stoppedByUser ?? false,
             startedAt: opts?.startedAt,
             resultSubtype: opts?.resultSubtype,
@@ -259,7 +258,6 @@ export async function runAgent(
         error: errorMessage,
       })
       sendAgentStreamComplete(webContents, input, {
-        messages: [],
         stoppedByUser: false,
       })
     }
@@ -283,7 +281,7 @@ export async function runAgentHeadless(
   input: AgentSendInput,
   callbacks: {
     onError: (error: string) => void
-    onComplete: (messages?: AgentMessage[]) => void
+    onComplete: () => void
     onTitleUpdated: (title: string) => void
     source?: AgentExternalRunSource
     originSessionId?: string
@@ -314,13 +312,12 @@ export async function runAgentHeadless(
           })
         }
       },
-      onComplete: (messages, opts) => {
-        callbacks.onComplete(messages)
+      onComplete: (opts) => {
+        callbacks.onComplete()
         publishRunStopped(runInput.sessionId, opts?.stoppedByUser, opts?.startedAt)
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
           sendAgentStreamComplete(wc, runInput, {
-            messages,
             stoppedByUser: opts?.stoppedByUser ?? false,
             startedAt: opts?.startedAt,
             resultSubtype: opts?.resultSubtype,
@@ -370,7 +367,6 @@ export async function runAgentHeadless(
     if (wc && !wc.isDestroyed()) {
       wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, { sessionId: runInput.sessionId, error: errorMessage })
       sendAgentStreamComplete(wc, runInput, {
-        messages: [],
         stoppedByUser: false,
         startedAt,
       })

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -8,7 +8,7 @@
  * 照搬 conversation-manager.ts 的模式。
  */
 
-import { readFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, createReadStream, createWriteStream, statSync, type WriteStream } from 'node:fs'
+import { readFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, createReadStream, createWriteStream, statSync, openSync, closeSync, readSync, type WriteStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 import { writeJsonFileAtomic, writeTextFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
@@ -251,12 +251,29 @@ function writeIndex(index: AgentSessionsIndex): void {
   }
 }
 
+export type AgentSessionListScope = 'active' | 'archived' | 'all'
+
 /**
- * 获取所有会话（按 updatedAt 降序）
+ * 获取会话（按 updatedAt 降序）。主进程内部默认 all；renderer 应显式请求 active，
+ * 归档列表仅在用户打开归档视图时按需读取。
  */
-export function listAgentSessions(): AgentSessionMeta[] {
+export function listAgentSessions(scope: AgentSessionListScope = 'all'): AgentSessionMeta[] {
   const index = readIndex()
-  return index.sessions.sort((a, b) => b.updatedAt - a.updatedAt)
+  return index.sessions
+    .filter((session) => scope === 'all' || (scope === 'archived' ? !!session.archived : !session.archived))
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+/** 仅返回列表标识数量，避免为归档入口 IPC 传输完整历史元数据。 */
+export function getAgentSessionCounts(): { active: number; archived: number } {
+  return readIndex().sessions.reduce(
+    (counts, session) => {
+      if (session.archived) counts.archived++
+      else counts.active++
+      return counts
+    },
+    { active: 0, archived: 0 },
+  )
 }
 
 /**
@@ -516,6 +533,106 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
   } catch (error) {
     console.error(`[Agent 会话] 读取 SDKMessage 失败 (${id}):`, error)
     return []
+  }
+}
+
+/** 渲染器首次展示的历史消息上限；更早历史由用户按需向前加载。 */
+const AGENT_SESSION_MESSAGE_PAGE_SIZE = 400
+const AGENT_SESSION_MESSAGE_PAGE_MAX_SIZE = 500
+const AGENT_SESSION_MESSAGE_READ_CHUNK_SIZE = 64 * 1024
+
+export interface AgentSessionSDKMessagesPage {
+  messages: SDKMessage[]
+  /** 下一页的文件字节上界；缺失表示已经到达文件开头。 */
+  nextBefore?: number
+}
+
+interface JsonlTailLine {
+  line: string
+  start: number
+}
+
+/**
+ * 从 JSONL 尾部按行读取，避免打开长会话时把整份 transcript 读入主进程和 IPC。
+ *
+ * 返回的行按文件原始顺序排列；`nextBefore` 可直接作为下一次请求的 before。
+ */
+function readJsonlTailLines(filePath: string, before: number | undefined, limit: number): {
+  lines: JsonlTailLine[]
+  hasMore: boolean
+} {
+  const fileSize = statSync(filePath).size
+  let position = Math.min(Math.max(before ?? fileSize, 0), fileSize)
+  let trailing = Buffer.alloc(0)
+  const newestFirst: JsonlTailLine[] = []
+  const fileDescriptor = openSync(filePath, 'r')
+
+  try {
+    while (position > 0 && newestFirst.length <= limit) {
+      const chunkSize = Math.min(AGENT_SESSION_MESSAGE_READ_CHUNK_SIZE, position)
+      position -= chunkSize
+      const chunk = Buffer.allocUnsafe(chunkSize)
+      readSync(fileDescriptor, chunk, 0, chunkSize, position)
+
+      const combined = Buffer.concat([chunk, trailing])
+      let lineEnd = combined.length
+      for (let index = combined.length - 1; index >= 0 && newestFirst.length <= limit; index--) {
+        if (combined[index] !== 0x0a) continue
+        const lineBuffer = combined.subarray(index + 1, lineEnd)
+        if (lineBuffer.toString('utf-8').trim()) {
+          newestFirst.push({
+            line: lineBuffer.toString('utf-8'),
+            start: position + index + 1,
+          })
+        }
+        lineEnd = index
+      }
+      trailing = combined.subarray(0, lineEnd)
+    }
+
+    if (newestFirst.length <= limit && position === 0 && trailing.toString('utf-8').trim()) {
+      newestFirst.push({ line: trailing.toString('utf-8'), start: 0 })
+    }
+  } finally {
+    closeSync(fileDescriptor)
+  }
+
+  const pageNewestFirst = newestFirst.slice(0, limit)
+  return {
+    lines: pageNewestFirst.reverse(),
+    hasMore: newestFirst.length > limit,
+  }
+}
+
+/**
+ * 分页读取会话历史。默认只读取最后 400 条 JSONL 记录，避免长会话阻塞主进程与 renderer。
+ */
+export function getAgentSessionSDKMessagesPage(
+  id: string,
+  input: { before?: number; limit?: number } = {},
+): AgentSessionSDKMessagesPage {
+  const filePath = getAgentSessionMessagesPath(id)
+  if (!existsSync(filePath)) return { messages: [] }
+
+  const limit = Math.min(
+    Math.max(Math.floor(input.limit ?? AGENT_SESSION_MESSAGE_PAGE_SIZE), 1),
+    AGENT_SESSION_MESSAGE_PAGE_MAX_SIZE,
+  )
+
+  try {
+    const { lines, hasMore } = readJsonlTailLines(filePath, input.before, limit)
+    const messages = parseJsonlLenient<unknown>(
+      lines.map((item) => item.line),
+      `分页读取 SDKMessage (${id})`,
+    ).map(normalizePersistedSDKMessage)
+    const earliestLine = lines[0]
+    return {
+      messages,
+      nextBefore: hasMore && earliestLine ? earliestLine.start : undefined,
+    }
+  } catch (error) {
+    console.error(`[Agent 会话] 分页读取 SDKMessage 失败 (${id}):`, error)
+    return { messages: [] }
   }
 }
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -501,14 +501,26 @@ export interface ElectronAPI {
 
   // ===== Agent 会话管理相关 =====
 
-  /** 获取 Agent 会话列表 */
-  listAgentSessions: () => Promise<AgentSessionMeta[]>
+  /** 获取 Agent 会话列表；renderer 热路径必须显式请求 active，兼容调用默认 all。 */
+  listAgentSessions: (scope?: 'active' | 'archived' | 'all') => Promise<AgentSessionMeta[]>
+
+  /** 按 ID 获取会话元数据，用于恢复少量已打开的归档 Tab。 */
+  getAgentSessionMeta: (id: string) => Promise<AgentSessionMeta | undefined>
+
+  /** 获取活跃/归档会话计数，避免归档入口传输完整 metadata。 */
+  getAgentSessionCounts: () => Promise<{ active: number; archived: number }>
 
   /** 创建 Agent 会话 */
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => Promise<AgentSessionMeta>
 
-  /** 获取 Agent 会话 SDKMessage（Phase 4 新格式） */
+  /** 获取 Agent 会话 SDKMessage（兼容需要完整历史的功能） */
   getAgentSessionSDKMessages: (id: string) => Promise<SDKMessage[]>
+
+  /** 从会话尾部按页读取 SDKMessage，避免长历史一次性进入 renderer。 */
+  getAgentSessionSDKMessagesPage: (
+    id: string,
+    input?: { before?: number; limit?: number },
+  ) => Promise<{ messages: SDKMessage[]; nextBefore?: number }>
 
   /** 更新 Agent 会话标题 */
   updateAgentSessionTitle: (id: string, title: string) => Promise<AgentSessionMeta>
@@ -1691,8 +1703,16 @@ const electronAPI: ElectronAPI = {
   },
 
   // Agent 会话管理
-  listAgentSessions: () => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_SESSIONS)
+  listAgentSessions: (scope: 'active' | 'archived' | 'all' = 'all') => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_SESSIONS, scope)
+  },
+
+  getAgentSessionMeta: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SESSION_META, id)
+  },
+
+  getAgentSessionCounts: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SESSION_COUNTS)
   },
 
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => {
@@ -1701,6 +1721,10 @@ const electronAPI: ElectronAPI = {
 
   getAgentSessionSDKMessages: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SDK_MESSAGES, id)
+  },
+
+  getAgentSessionSDKMessagesPage: (id: string, input?: { before?: number; limit?: number }) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SDK_MESSAGES_PAGE, id, input)
   },
 
   updateAgentSessionTitle: (id: string, title: string) => {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -196,6 +196,12 @@ interface AgentMessagesProps {
   messagesLoaded?: boolean
   /** Phase 4: 持久化的 SDKMessage（新格式） */
   persistedSDKMessages?: SDKMessage[]
+  /** 是否还有未加载的更早历史记录。 */
+  hasEarlierMessages?: boolean
+  /** 正在向前读取更早历史记录。 */
+  loadingEarlierMessages?: boolean
+  /** 用户主动请求加载更早历史记录。 */
+  onLoadEarlierMessages?: () => void
   /** 当前会话工作目录，用于解析相对文件路径 */
   sessionPath?: string | null
   /** 附加目录列表（与 sessionPath 一并用作相对路径解析候选） */
@@ -589,6 +595,9 @@ export const AgentMessages = React.memo(function AgentMessages({
   sessionModelId,
   messagesLoaded,
   persistedSDKMessages,
+  hasEarlierMessages,
+  loadingEarlierMessages,
+  onLoadEarlierMessages,
   sessionPath,
   attachedDirs,
   stoppedByUser,
@@ -931,6 +940,19 @@ export const AgentMessages = React.memo(function AgentMessages({
           <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
         <ScrollPositionManager id={sessionId} ready={ready} />
         <ConversationContent>
+          {hasEarlierMessages && (
+            <div className="flex justify-center py-2">
+              <button
+                type="button"
+                onClick={onLoadEarlierMessages}
+                disabled={loadingEarlierMessages || !onLoadEarlierMessages}
+                className="titlebar-no-drag inline-flex items-center gap-1.5 rounded-full border border-foreground/10 bg-background/70 px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+              >
+                {loadingEarlierMessages && <Spinner size="sm" />}
+                {loadingEarlierMessages ? '正在加载更早消息…' : '加载更早消息'}
+              </button>
+            </div>
+          )}
           {!hasContent && !streaming ? (
             <EmptyState />
           ) : (

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -425,6 +425,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [persistedSDKMessages, setPersistedSDKMessages] = React.useState<SDKMessage[]>([])
   const persistedSDKMessagesRef = React.useRef<SDKMessage[]>([])
   persistedSDKMessagesRef.current = persistedSDKMessages
+  // 长会话默认仅加载末页；用户需要时再向前展开，避免把完整 transcript 放进 renderer。
+  const [earlierMessagesCursor, setEarlierMessagesCursor] = React.useState<number | undefined>()
+  const [loadingEarlierMessages, setLoadingEarlierMessages] = React.useState(false)
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   // 只订阅输入区/工具栏需要的低频流状态。逐 token content/toolActivities 由
   // AgentMessages 独立消费，不能让 3000 行 AgentView 和输入框跟随每个 token 重渲染。
@@ -1165,18 +1168,22 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         setPersistedSDKMessages([])
         setMessagesLoaded(false)
       }
+      setEarlierMessagesCursor(undefined)
     }
     messagesRefreshingRef.current = true
     setMessagesRefreshing(true)
     let cancelled = false
-    window.electronAPI.getAgentSessionSDKMessages(sessionId)
-      .then((sdkMsgs) => {
+    window.electronAPI.getAgentSessionSDKMessagesPage(sessionId)
+      .then((page) => {
         if (cancelled) return
+        const sdkMsgs = page.messages
         // 写入缓存（含 LRU 淘汰，防止会话数增长导致内存无限膨胀）
         setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, sdkMsgs))
         unstable_batchedUpdates(() => {
           persistedSDKMessagesRef.current = sdkMsgs
           setPersistedSDKMessages(sdkMsgs)
+          setEarlierMessagesCursor(page.nextBefore)
+          setLoadingEarlierMessages(false)
           setMessagesLoaded(true)
           messagesRefreshingRef.current = false
           setMessagesRefreshing(false)
@@ -1242,6 +1249,25 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
     return () => { cancelled = true }
   }, [sessionId, refreshVersion, setStreamingStates, setLiveMessagesMap, setMessagesCache, store])
+
+  const handleLoadEarlierMessages = React.useCallback(async (): Promise<void> => {
+    const before = earlierMessagesCursor
+    if (before === undefined || loadingEarlierMessages) return
+
+    setLoadingEarlierMessages(true)
+    try {
+      const page = await window.electronAPI.getAgentSessionSDKMessagesPage(sessionId, { before })
+      const next = [...page.messages, ...persistedSDKMessagesRef.current]
+      persistedSDKMessagesRef.current = next
+      setPersistedSDKMessages(next)
+      setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, next))
+      setEarlierMessagesCursor(page.nextBefore)
+    } catch (error) {
+      console.error('[Agent 会话] 加载更早消息失败:', error)
+    } finally {
+      setLoadingEarlierMessages(false)
+    }
+  }, [earlierMessagesCursor, loadingEarlierMessages, sessionId, setMessagesCache])
 
   // 从会话元数据初始化附加目录（仅冷启动水合，后续由 handleAttachContent/handleDetachDirectory 实时写入）
   React.useEffect(() => {
@@ -2989,6 +3015,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           sessionModelId={agentModelId || undefined}
           messagesLoaded={messagesLoaded}
           persistedSDKMessages={persistedSDKMessages}
+          hasEarlierMessages={earlierMessagesCursor !== undefined}
+          loadingEarlierMessages={loadingEarlierMessages}
+          onLoadEarlierMessages={handleLoadEarlierMessages}
           sessionPath={sessionPath}
           attachedDirs={allAttachedDirs}
           stoppedByUser={stoppedByUser}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -105,6 +105,7 @@ import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-regi
 import {
   collectAgentSessionTreeIds,
   isAgentSessionVisibleInTrees,
+  mergeActiveAgentSessions,
   replaceAgentSessionInFreshnessOrder,
   sortAgentSessionsByUpdatedAtDesc,
 } from '@/lib/agent-session-list'
@@ -813,6 +814,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
   // 归档 & 搜索状态
   const [viewMode, setViewMode] = useAtom(sidebarViewModeAtom)
+  // 归档会话通常数量远大于活跃会话：仅在用户打开归档视图时保留在 renderer 内存中。
+  const [archivedAgentSessions, setArchivedAgentSessions] = React.useState<AgentSessionMeta[]>([])
+  const [archivedAgentSessionCount, setArchivedAgentSessionCount] = React.useState(0)
   const searchDialogOpen = useAtomValue(searchDialogOpenAtom)
   const setSearchDialogOpen = useSetAtom(searchDialogOpenAtom)
   const newChatShortcutLabel = getAcceleratorDisplay(getActiveAccelerator('new-session'))
@@ -825,6 +829,19 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setSettingsTab('about')
     setSettingsOpen(true)
   }, [setSettingsOpen, setSettingsTab])
+
+  // active 列表刷新不能覆盖仍在 Tab 中打开的归档会话，否则 AgentView 会丢失
+  // workspace/model 等会话级 metadata。只保留少量被 Tab 引用的归档项。
+  const replaceActiveSessionsPreservingOpenArchived = React.useCallback((active: AgentSessionMeta[]) => {
+    setAgentSessions((previous) => {
+      const openSessionIds = new Set(
+        tabs
+          .filter((tab) => tab.type === 'agent' || tab.type === 'preview')
+          .map((tab) => tab.sessionId),
+      )
+      return mergeActiveAgentSessions(previous, active, openSessionIds)
+    })
+  }, [setAgentSessions, tabs])
 
   React.useEffect(() => {
     const id = window.setInterval(() => setRelativeTimeNow(Date.now()), 60_000)
@@ -1019,12 +1036,6 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     [conversations]
   )
 
-  /** 已归档 Agent 会话数量（跨项目） */
-  const archivedAgentSessionCount = React.useMemo(
-    () => agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id)).length,
-    [agentSessions, draftSessionIds]
-  )
-
   // 初始加载对话列表 + 用户档案 + Agent 会话
   React.useEffect(() => {
     window.electronAPI
@@ -1038,21 +1049,41 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       .then(setUserProfile)
       .catch(console.error)
     window.electronAPI
-      .listAgentSessions()
-      .then(setAgentSessions)
+      .listAgentSessions('active')
+      .then(replaceActiveSessionsPreservingOpenArchived)
+      .catch(console.error)
+    window.electronAPI
+      .getAgentSessionCounts()
+      .then((counts) => setArchivedAgentSessionCount(counts.archived))
       .catch(console.error)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setConversations, setUserProfile, setAgentSessions])
+  }, [setConversations, setUserProfile, replaceActiveSessionsPreservingOpenArchived])
 
   // 窗口聚焦时重新同步列表，修复长时间后前后端不一致
   React.useEffect(() => {
     const handleFocus = (): void => {
       window.electronAPI.listConversations().then(setConversations).catch(console.error)
-      window.electronAPI.listAgentSessions().then(setAgentSessions).catch(console.error)
+      window.electronAPI.listAgentSessions('active').then(replaceActiveSessionsPreservingOpenArchived).catch(console.error)
+      window.electronAPI.getAgentSessionCounts().then((counts) => setArchivedAgentSessionCount(counts.archived)).catch(console.error)
     }
     window.addEventListener('focus', handleFocus)
     return () => window.removeEventListener('focus', handleFocus)
-  }, [setConversations, setAgentSessions])
+  }, [setConversations, replaceActiveSessionsPreservingOpenArchived])
+
+  // 归档历史按需加载，离开归档视图立即释放，避免一次访问后长期常驻数千条 metadata。
+  React.useEffect(() => {
+    if (mode !== 'agent' || viewMode !== 'archived') {
+      setArchivedAgentSessions([])
+      return
+    }
+    let cancelled = false
+    window.electronAPI.listAgentSessions('archived')
+      .then((sessions) => {
+        if (!cancelled) setArchivedAgentSessions(sessions)
+      })
+      .catch(console.error)
+    return () => { cancelled = true }
+  }, [mode, viewMode])
 
   /** 打开/关闭自动任务列表 */
   const handleOpenAutomations = React.useCallback((): void => {
@@ -1236,12 +1267,17 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         }
         await window.electronAPI.deleteAgentSession(pendingDeleteId)
         // 全量刷新确保与后端同步
-        const sessions = await window.electronAPI.listAgentSessions()
+        const sessions = await window.electronAPI.listAgentSessions('active')
         setAgentSessions(sessions)
+        setArchivedAgentSessions((prev) => prev.filter((session) => session.id !== pendingDeleteId && !childIds.includes(session.id)))
+        window.electronAPI.getAgentSessionCounts()
+          .then((counts) => setArchivedAgentSessionCount(counts.archived))
+          .catch(console.error)
       } catch (error) {
         console.error('[侧边栏] 删除 Agent 会话失败:', error)
         // 即使后端报错，也从本地列表移除（可能是会话已不存在）
         setAgentSessions((prev) => prev.filter((s) => s.id !== pendingDeleteId))
+        setArchivedAgentSessions((prev) => prev.filter((session) => session.id !== pendingDeleteId && !childIds.includes(session.id)))
       } finally {
         // 清理该会话的消息缓存，避免已删除会话的消息数组滞留内存
         setAgentMessagesCache((prev) => {
@@ -1421,11 +1457,15 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
       const [remainingWorkspaces, sessions] = await Promise.all([
         window.electronAPI.listAgentWorkspaces(),
-        window.electronAPI.listAgentSessions(),
+        window.electronAPI.listAgentSessions('active'),
       ])
 
       setWorkspaces(remainingWorkspaces)
       setAgentSessions(sessions)
+      setArchivedAgentSessions((prev) => prev.filter((session) => session.workspaceId !== workspaceId))
+      window.electronAPI.getAgentSessionCounts()
+        .then((counts) => setArchivedAgentSessionCount(counts.archived))
+        .catch(console.error)
 
       setExpandedExtraCountMap((prev) => {
         if (!prev.has(workspaceId)) return prev
@@ -1705,6 +1745,11 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
   /** 选择 Agent 会话（打开或聚焦标签页） */
   const handleSelectAgentSession = React.useCallback((id: string, title: string): void => {
+    // 已归档会话是按需加载的；打开后将它并入运行中所需的 atom，避免 AgentView 缺少元数据。
+    const archived = archivedAgentSessions.find((session) => session.id === id)
+    if (archived) {
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, archived))
+    }
     openSession('agent', id, title)
     setActiveView('conversations')
     // 清除该会话的"已完成未查看"标记
@@ -1714,7 +1759,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       next.delete(id)
       return next
     })
-  }, [openSession, setActiveView, setUnviewedCompleted])
+  }, [archivedAgentSessions, openSession, setActiveView, setAgentSessions, setUnviewedCompleted])
 
   const clearQuickSwitchHints = React.useCallback((): void => {
     for (const row of quickSwitchHintRowsRef.current) {
@@ -2010,12 +2055,25 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         }
       }
       const refreshedSessions = delegatedChildren.length > 0
-        ? await window.electronAPI.listAgentSessions()
+        ? await window.electronAPI.listAgentSessions('active')
         : null
       if (refreshedSessions) {
         setAgentSessions(refreshedSessions)
+        const archived = await window.electronAPI.listAgentSessions('archived')
+        setArchivedAgentSessions(archived)
       } else {
         setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+        if (original?.archived && !updated.archived) {
+          setArchivedAgentSessions((prev) => prev.filter((session) => session.id !== updated.id))
+          window.electronAPI.getAgentSessionCounts()
+            .then((counts) => setArchivedAgentSessionCount(counts.archived))
+            .catch(console.error)
+        }
+      }
+      if (delegatedChildren.length > 0) {
+        window.electronAPI.getAgentSessionCounts()
+          .then((counts) => setArchivedAgentSessionCount(counts.archived))
+          .catch(console.error)
       }
       if (updated.pinned) {
         if (original?.archived && !updated.archived) {
@@ -2039,7 +2097,14 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       // 重新拉取磁盘真实状态，避免侧边栏与磁盘不一致直到下次重载。
       if (delegatedChildren.length > 0) {
         try {
-          setAgentSessions(await window.electronAPI.listAgentSessions())
+          const [active, archived] = await Promise.all([
+            window.electronAPI.listAgentSessions('active'),
+            window.electronAPI.listAgentSessions('archived'),
+          ])
+          setAgentSessions(active)
+          setArchivedAgentSessions(archived)
+          const counts = await window.electronAPI.getAgentSessionCounts()
+          setArchivedAgentSessionCount(counts.archived)
         } catch (refreshError) {
           console.error('[侧边栏] 置顶失败后刷新会话列表失败:', refreshError)
         }
@@ -2059,7 +2124,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
   /** 切换 Agent 会话归档状态 */
   const handleToggleArchiveAgent = React.useCallback(async (id: string): Promise<void> => {
-    const sessions = store.get(agentSessionsAtom)
+    // 归档视图是惰性数据源，级联判断须同时考虑活跃与已加载归档会话。
+    const activeSessions = store.get(agentSessionsAtom)
+    const sessions = [...activeSessions, ...archivedAgentSessions.filter((archived) => !activeSessions.some((active) => active.id === archived.id))]
     // 在 try 外追踪级联状态，便于失败时重新同步与关闭已归档子会话的标签页。
     let cascaded = false
     const changedChildIds: string[] = []
@@ -2085,13 +2152,22 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         }
       }
       const refreshedSessions = delegatedChildren.length > 0
-        ? await window.electronAPI.listAgentSessions()
+        ? await window.electronAPI.listAgentSessions('active')
         : null
       if (refreshedSessions) {
         setAgentSessions(refreshedSessions)
+        const archived = await window.electronAPI.listAgentSessions('archived')
+        setArchivedAgentSessions(archived)
+      } else if (updated.archived) {
+        setAgentSessions((prev) => prev.filter((session) => session.id !== updated.id))
+        setArchivedAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
       } else {
         setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+        setArchivedAgentSessions((prev) => prev.filter((session) => session.id !== updated.id))
       }
+      window.electronAPI.getAgentSessionCounts()
+        .then((counts) => setArchivedAgentSessionCount(counts.archived))
+        .catch(console.error)
       // 归档时自动关闭该会话的标签页，并同步新激活标签的副作用，
       // 否则 RightSidePanel（依赖 currentAgentSessionIdAtom）会因为
       // 指针被错误置 null 而消失。
@@ -2116,13 +2192,20 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           closeArchivedAgentTabs(changedChildIds)
         }
         try {
-          setAgentSessions(await window.electronAPI.listAgentSessions())
+          const [active, archived] = await Promise.all([
+            window.electronAPI.listAgentSessions('active'),
+            window.electronAPI.listAgentSessions('archived'),
+          ])
+          setAgentSessions(active)
+          setArchivedAgentSessions(archived)
+          const counts = await window.electronAPI.getAgentSessionCounts()
+          setArchivedAgentSessionCount(counts.archived)
         } catch (refreshError) {
           console.error('[侧边栏] 归档失败后刷新会话列表失败:', refreshError)
         }
       }
     }
-  }, [closeArchivedAgentTabs, draftSessionIds, store, setAgentSessions])
+  }, [archivedAgentSessions, closeArchivedAgentTabs, draftSessionIds, store, setAgentSessions])
 
   /** 请求迁移会话到其他项目（弹出迁移对话框） */
   const handleRequestMove = React.useCallback((id: string): void => {
@@ -2223,13 +2306,13 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   /** Agent 归档会话按日期分组（跨项目），含委派树 */
   const archivedAgentSessionTrees = React.useMemo(() => {
     const archived = sortAgentSessionsByUpdatedAtDesc(
-      agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id))
+      archivedAgentSessions.filter((s) => !draftSessionIds.has(s.id))
     )
     const trees = buildAgentSessionTrees(archived)
     // groupByDate 要求 T extends { updatedAt: number }，AgentSessionTreeItem 不直接满足
     const wrapped = trees.map((tree) => ({ updatedAt: tree.session.updatedAt, tree }))
     return groupByDate(wrapped).map((g) => ({ label: g.label, items: g.items.map((w) => w.tree) }))
-  }, [agentSessions, draftSessionIds])
+  }, [archivedAgentSessions, draftSessionIds])
 
   const handleRailModeSwitch = React.useCallback((targetMode: AppMode) => {
     setViewMode('active')

--- a/apps/electron/src/renderer/hooks/useCloseTab.tsx
+++ b/apps/electron/src/renderer/hooks/useCloseTab.tsx
@@ -23,7 +23,19 @@ import {
 import {
   agentSessionsAtom,
   agentSessionIndicatorMapAtom,
+  agentStreamingStatesAtom,
+  liveMessagesMapAtom,
   unviewedCompletedSessionIdsAtom,
+  agentSessionStreamingStateAtomFamily,
+  agentSessionViewStreamStateAtomFamily,
+  agentLiveMessagesAtomFamily,
+  agentSessionDraftAtomFamily,
+  agentSessionDraftHtmlAtomFamily,
+  agentPendingFilesAtomFamily,
+  agentMessageQueueAtomFamily,
+  backgroundTasksAtomFamily,
+  sessionPersistedPermissionModeAtom,
+  sessionExistsAtom,
 } from '@/atoms/agent-atoms'
 import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
@@ -103,6 +115,36 @@ export function useCloseTab(): UseCloseTabReturn {
           next.delete(closingTab.sessionId)
           return next
         })
+        // atomFamily 按 string key 强引用缓存。关闭 Tab 不清除运行态 base map，
+        // 以免后台 Agent 失去状态；但释放派生 atom 实例，避免频繁打开历史会话长期累积。
+        agentSessionStreamingStateAtomFamily.remove(closingTab.sessionId)
+        agentSessionViewStreamStateAtomFamily.remove(closingTab.sessionId)
+        agentLiveMessagesAtomFamily.remove(closingTab.sessionId)
+        agentSessionDraftAtomFamily.remove(closingTab.sessionId)
+        agentSessionDraftHtmlAtomFamily.remove(closingTab.sessionId)
+        agentPendingFilesAtomFamily.remove(closingTab.sessionId)
+        agentMessageQueueAtomFamily.remove(closingTab.sessionId)
+        backgroundTasksAtomFamily.remove(closingTab.sessionId)
+        sessionPersistedPermissionModeAtom.remove(closingTab.sessionId)
+        sessionExistsAtom.remove(closingTab.sessionId)
+
+        // 已停止会话关闭后不再需要保留全局 Map 中的终态流数据。
+        // 运行/阻塞会话必须保留，左侧状态和后台恢复仍依赖它们。
+        const status = store.get(agentSessionIndicatorMapAtom).get(closingTab.sessionId)
+        if (status !== 'running' && status !== 'blocked') {
+          store.set(agentStreamingStatesAtom, (prev) => {
+            if (!prev.has(closingTab.sessionId)) return prev
+            const next = new Map(prev)
+            next.delete(closingTab.sessionId)
+            return next
+          })
+          store.set(liveMessagesMapAtom, (prev) => {
+            if (!prev.has(closingTab.sessionId)) return prev
+            const next = new Map(prev)
+            next.delete(closingTab.sessionId)
+            return next
+          })
+        }
       } else if (closingTab.type === 'chat') {
         setSideChatMap((prev) => {
           let changed = false

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -71,7 +71,7 @@ import { toast } from 'sonner'
 import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta, ProviderType } from '@proma/shared'
 import { inferContextWindow } from '@proma/shared'
 import { buildExternalAgentRunActivation, shouldActivateExternalAgentRun } from '@/lib/external-agent-run'
-import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
+import { mergeActiveAgentSessions, upsertAgentSession } from '@/lib/agent-session-list'
 import {
   getAgentCompletionMarkers,
   notifyAgentCompletion,
@@ -458,6 +458,16 @@ export function useGlobalAgentListeners(): void {
   const store = useStore()
 
   useEffect(() => {
+    // 所有 active scope 刷新统一保留仍被 Tab 引用的归档 metadata。
+    const mergeActiveSnapshot = (active: import('@proma/shared').AgentSessionMeta[]): void => {
+      const openSessionIds = new Set(
+        store.get(tabsAtom)
+          .filter((tab) => tab.type === 'agent' || tab.type === 'preview')
+          .map((tab) => tab.sessionId),
+      )
+      store.set(agentSessionsAtom, (previous) => mergeActiveAgentSessions(previous, active, openSessionIds))
+    }
+
     /** 正在执行的写工具；写入前的文件存在性用于区分新建和编辑。 */
     const pendingWriteTools = new Map<string, {
       path: string
@@ -771,7 +781,7 @@ export function useGlobalAgentListeners(): void {
         return
       }
 
-      window.electronAPI.listAgentSessions()
+      window.electronAPI.listAgentSessions('active')
         .then((sessions) => {
           unstable_batchedUpdates(() => applyActivation(sessions))
         })
@@ -968,7 +978,7 @@ export function useGlobalAgentListeners(): void {
     })
 
     // ===== 0. 初始化：从持久化 meta 恢复 stoppedByUser 状态 =====
-    window.electronAPI.listAgentSessions().then((sessions) => {
+    window.electronAPI.listAgentSessions('active').then((sessions) => {
       const stoppedIds = new Set<string>(
         sessions.filter((s) => s.stoppedByUser).map((s) => s.id)
       )
@@ -1001,8 +1011,8 @@ export function useGlobalAgentListeners(): void {
         // 自动任务会话被用户接管（毕业）：向用户提示，后续定时运行将新建独立会话
         if (payload.kind === 'proma_event' && payload.event.type === 'automation_graduated') {
           toast('已接管自动任务会话，后续定时运行将创建新会话。', { duration: 3000 })
-          window.electronAPI.listAgentSessions()
-            .then((sessions) => store.set(agentSessionsAtom, (prev) => mergeFetchedAgentSessions(prev, sessions)))
+          window.electronAPI.listAgentSessions('active')
+            .then(mergeActiveSnapshot)
             .catch(console.error)
         }
 
@@ -1010,8 +1020,8 @@ export function useGlobalAgentListeners(): void {
         // 如果收到未知会话的事件（跨工作区场景），立即刷新会话列表
         const knownSessions = store.get(agentSessionsAtom)
         if (!knownSessions.some((s) => s.id === sessionId)) {
-          window.electronAPI.listAgentSessions()
-            .then((sessions) => store.set(agentSessionsAtom, (prev) => mergeFetchedAgentSessions(prev, sessions)))
+          window.electronAPI.listAgentSessions('active')
+            .then(mergeActiveSnapshot)
             .catch(console.error)
         }
 
@@ -1630,6 +1640,25 @@ export function useGlobalAgentListeners(): void {
         // 通知 AgentView 重新加载消息（无论是否为当前会话）
         if (!isNewStreamRunning()) {
           bumpRefresh()
+
+          // 非当前会话不会等待 AgentView 的异步分页刷新；若保留其终态流
+          // state，历史访问越多，后续任一 Agent 的 token 更新就越要复制更大的 Map。
+          // JSONL 已在主进程落盘，重新打开时会按页加载，因此可立即释放。
+          if (!backgroundTasksPending && currentSessionId !== data.sessionId) {
+            store.set(agentStreamingStatesAtom, (prev) => {
+              const state = prev.get(data.sessionId)
+              if (!state || state.running || state.backgroundWaiting) return prev
+              const next = new Map(prev)
+              next.delete(data.sessionId)
+              return next
+            })
+            store.set(liveMessagesMapAtom, (prev) => {
+              if (!prev.has(data.sessionId)) return prev
+              const next = new Map(prev)
+              next.delete(data.sessionId)
+              return next
+            })
+          }
         }
         finalize()
         }) // unstable_batchedUpdates
@@ -1698,10 +1727,10 @@ export function useGlobalAgentListeners(): void {
         }))
         return
       }
-      // 外部桥接可能先发标题、后发 run-start；仅在本地未知该会话时走恢复性全量同步。
+      // 外部桥接可能先发标题、后发 run-start；仅在本地未知该会话时刷新 active metadata。
       window.electronAPI
-        .listAgentSessions()
-        .then((sessions) => store.set(agentSessionsAtom, (prev) => mergeFetchedAgentSessions(prev, sessions)))
+        .listAgentSessions('active')
+        .then(mergeActiveSnapshot)
         .catch(console.error)
     })
 

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -22,6 +22,19 @@ export function replaceAgentSessionInFreshnessOrder(
 }
 
 /**
+ * 合并 active scope 刷新，同时保留仍有 Tab 引用的归档会话。
+ * active 列表本身不含归档条目，直接覆盖会让已打开归档会话丢失 workspace/model metadata。
+ */
+export function mergeActiveAgentSessions(
+  previous: readonly AgentSessionMeta[],
+  active: readonly AgentSessionMeta[],
+  openSessionIds: ReadonlySet<string>,
+): AgentSessionMeta[] {
+  const openArchived = previous.filter((session) => session.archived && openSessionIds.has(session.id))
+  return sortAgentSessionsByUpdatedAtDesc([...active, ...openArchived])
+}
+
+/**
  * 仅插入或更新单个会话条目，保留其余条目原样。
  *
  * 用于 external_run_started 等「我只知道这一个会话的新状态」的场景：

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -63,6 +63,7 @@ import {
   initializeMarkdownFontSize,
 } from './atoms/markdown-font-size'
 import { useGlobalAgentListeners } from './hooks/useGlobalAgentListeners'
+import { mergeActiveAgentSessions } from './lib/agent-session-list'
 import { useGlobalChatListeners } from './hooks/useGlobalChatListeners'
 import { tabsAtom, activeTabIdAtom, ensureScratchPadTab, getPersistableTabState, scratchPadContentAtom, scratchPadLoadedAtom, SCRATCH_PAD_ID } from './atoms/tab-atoms'
 import type { TabItem } from './atoms/tab-atoms'
@@ -71,7 +72,7 @@ import { feishuBotStatesAtom } from './atoms/feishu-atoms'
 import { dingtalkBotStatesAtom } from './atoms/dingtalk-atoms'
 import { currentConversationIdAtom, channelsAtom, channelsLoadedAtom, selectedModelAtom } from './atoms/chat-atoms'
 import { appModeAtom } from './atoms/app-mode'
-import type { FeishuBotBridgeState, FeishuBridgeState, DingTalkBotBridgeState, DingTalkBridgeState } from '@proma/shared'
+import type { AgentSessionMeta, FeishuBotBridgeState, FeishuBridgeState, DingTalkBotBridgeState, DingTalkBridgeState } from '@proma/shared'
 import { Toaster } from './components/ui/sonner'
 import { toast } from 'sonner'
 import { ArrowUpRight } from 'lucide-react'
@@ -523,17 +524,24 @@ function PlanningInitializer(): null {
 
 function AutomationInitializer(): null {
   const setAutomations = useSetAtom(automationsAtom)
-  const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const store = useStore()
 
   useEffect(() => {
     const load = (): void => {
       window.electronAPI.listAutomations().then(setAutomations).catch(console.error)
-      window.electronAPI.listAgentSessions().then(setAgentSessions).catch(console.error)
+      window.electronAPI.listAgentSessions('active').then((active) => {
+        const openSessionIds = new Set(
+          store.get(tabsAtom)
+            .filter((tab) => tab.type === 'agent' || tab.type === 'preview')
+            .map((tab) => tab.sessionId),
+        )
+        store.set(agentSessionsAtom, (previous) => mergeActiveAgentSessions(previous, active, openSessionIds))
+      }).catch(console.error)
     }
     load()
     const unsub = window.electronAPI.onAutomationChanged(load)
     return unsub
-  }, [setAutomations, setAgentSessions])
+  }, [setAutomations, store])
 
   return null
 }
@@ -838,9 +846,19 @@ function TabStatePersistenceInitializer(): null {
     Promise.all([
       window.electronAPI.getSettings(),
       window.electronAPI.listConversations(),
-      window.electronAPI.listAgentSessions(),
-    ]).then(([settings, conversations, agentSessions]) => {
+      window.electronAPI.listAgentSessions('active'),
+    ]).then(async ([settings, conversations, activeAgentSessions]) => {
       const tabState = settings.tabState
+      const persistedAgentSessionIds = [...new Set(
+        (tabState?.tabs ?? [])
+          .filter((tab): tab is TabItem => typeof tab === 'object' && tab !== null && 'type' in tab && 'sessionId' in tab && tab.type === 'agent' && typeof tab.sessionId === 'string')
+          .map((tab) => tab.sessionId),
+      )]
+      // 启动恢复只读取持久化 Tab 对应的少量归档 metadata，避免重引入全量归档 IPC。
+      const restoredAgentSessions = (await Promise.all(
+        persistedAgentSessionIds.map((id) => window.electronAPI.getAgentSessionMeta(id)),
+      )).filter((session): session is AgentSessionMeta => session !== undefined)
+      const agentSessions = [...activeAgentSessions, ...restoredAgentSessions.filter((session) => session.archived)]
       if (!tabState?.tabs?.length) {
         restoredRef.current = true
         return
@@ -888,6 +906,20 @@ function TabStatePersistenceInitializer(): null {
       const activeTab = validTabs.find((t) => t.id === restoredActiveTabId) ?? validTabs[0] ?? null
       store.set(tabsAtom, ensureScratchPadTab(activeTab ? [activeTab] : []))
       store.set(activeTabIdAtom, restoredActiveTabId)
+
+      // 常规侧栏只持有 active metadata；恢复中的归档 Tab 仍需要会话级
+      // workspace/model/settings，故只合并这些少量已打开会话，不能丢回整份归档列表。
+      const restoredAgentSessionIds = new Set(
+        validTabs.filter((tab) => tab.type === 'agent').map((tab) => tab.sessionId),
+      )
+      if (restoredAgentSessionIds.size > 0) {
+        const restoredAgentSessions = agentSessions.filter((session) => restoredAgentSessionIds.has(session.id))
+        store.set(agentSessionsAtom, (prev) => {
+          const byId = new Map(prev.map((session) => [session.id, session]))
+          for (const session of restoredAgentSessions) byId.set(session.id, session)
+          return [...byId.values()].sort((a, b) => b.updatedAt - a.updatedAt)
+        })
+      }
 
       // 同步 appMode 和 currentSessionId
       if (activeTab) {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1278,15 +1278,13 @@ export interface AgentStreamEvent {
 }
 
 /**
- * Agent 流式完成事件载荷（主进程 → 渲染进程）
- * 包含已持久化的消息列表，避免异步重新加载的竞态窗口。
+ * Agent 流式完成事件载荷（主进程 → 渲染进程）。
+ * 消息已在主进程落盘；renderer 收到完成事件后自行按页刷新，避免传输整段历史。
  */
 export interface AgentStreamCompletePayload {
   sessionId: string
   /** 触发来源：用于区分顶层会话与父 Agent 委派的子会话完成 */
   triggeredBy?: AgentSendInput['triggeredBy']
-  /** 已持久化的完整消息列表 */
-  messages?: AgentMessage[]
   /** 是否由用户手动中止 */
   stoppedByUser?: boolean
   /** 本轮流式开始时间戳（用于区分新旧流，防止旧流的 complete 事件重置新流状态） */
@@ -1596,10 +1594,16 @@ export const AGENT_IPC_CHANNELS = {
   // 会话管理
   /** 获取会话列表 */
   LIST_SESSIONS: 'agent:list-sessions',
+  /** 按 ID 获取单条会话元数据（启动恢复归档 Tab 时使用） */
+  GET_SESSION_META: 'agent:get-session-meta',
+  /** 获取活跃/归档会话的数量，不传输完整元数据 */
+  GET_SESSION_COUNTS: 'agent:get-session-counts',
   /** 创建会话 */
   CREATE_SESSION: 'agent:create-session',
   /** 获取会话 SDKMessage（Phase 4 新格式） */
   GET_SDK_MESSAGES: 'agent:get-sdk-messages',
+  /** 分页获取会话尾部 SDKMessage，避免长历史一次性进入 renderer */
+  GET_SDK_MESSAGES_PAGE: 'agent:get-sdk-messages-page',
   /** 更新会话标题 */
   UPDATE_TITLE: 'agent:update-title',
   /** 更新会话模型选择 */


### PR DESCRIPTION
## Summary
- Load active and archived session metadata on demand, and page long SDK message histories from the JSONL tail.
- Remove full-history reads and IPC payloads from Agent completion paths.
- Bound renderer streaming-state retention and reclaim idle MCP connections after five minutes.

## Validation
- `bun run typecheck`
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)