### PR TITLE
feat: 火山方舟 Coding Plan 新增 Doubao Seed 2.1 Pro / Turbo 模型

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -84,6 +84,8 @@ const QWEN_TOKEN_PLAN_PRESET_MODELS: ChannelModel[] = [
   { id: 'qwen3.6-flash', name: 'Qwen3.6 Flash', enabled: true },
 ]
 const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
+  { id: 'doubao-seed-2.1-pro', name: 'Doubao Seed 2.1 Pro', enabled: true },
+  { id: 'doubao-seed-2.1-turbo', name: 'Doubao Seed 2.1 Turbo', enabled: true },
   { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
   { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
   { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },


### PR DESCRIPTION
### 变更内容

- 在火山方舟 Coding Plan 预设模型列表中新增 **Doubao Seed 2.1 Pro**（）
- 在火山方舟 Coding Plan 预设模型列表中新增 **Doubao Seed 2.1 Turbo**（）

### 上下文长度验证

经火山方舟官方文档确认，两款模型上下文窗口均为 **256K**，非 1M 上下文：
-  → 256K 上下文窗口
-  → 256K 上下文窗口

目前  中未针对 Doubao Seed 系列配置精确值，走 200K 默认推断，用于 UI 进度环估算偏保守，影响不大。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)