### PR TITLE
Perf: remove blur from live Agent surfaces

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -3056,7 +3056,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px]" data-input-mode="agent">
           <div
             className={cn(
-              'rounded-[17px] border-[0.5px] border-border bg-background/70 backdrop-blur-sm transition-all duration-200',
+              'rounded-[17px] border-[0.5px] border-border bg-background/95 transition-[border-color,background-color] duration-200',
               (isPlanMode || isPermissionPlanMode) && !isDragOver && 'plan-mode-border',
               isDragOver && 'border-[2px] border-dashed border-[#2ecc71] bg-[#2ecc71]/[0.03]'
             )}

--- a/apps/electron/src/renderer/components/agent/TaskProgressOverlay.tsx
+++ b/apps/electron/src/renderer/components/agent/TaskProgressOverlay.tsx
@@ -196,7 +196,7 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
   if (!showTaskProgress) {
     return (
       <Button
-        className="absolute bottom-[26px] left-1/2 size-10 -translate-x-1/2 rounded-md border border-border/60 bg-background/85 shadow-sm backdrop-blur-sm transition-[background-color,transform] duration-200 hover:bg-accent/80 active:scale-[0.96]"
+        className="absolute bottom-[26px] left-1/2 size-10 -translate-x-1/2 rounded-md border border-border/60 bg-background/95 shadow-sm transition-[background-color,transform] duration-200 hover:bg-accent/80 active:scale-[0.96]"
         onClick={() => scrollToBottom()}
         type="button"
         variant="ghost"
@@ -216,7 +216,7 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
           <button
             type="button"
             className={cn(
-              'pointer-events-auto flex min-h-10 max-w-[min(460px,calc(100vw-9rem))] items-center gap-2 rounded-md border border-border/60 bg-background/85 py-2 pr-3 pl-2.5 text-left shadow-sm backdrop-blur-sm',
+              'pointer-events-auto flex min-h-10 max-w-[min(460px,calc(100vw-9rem))] items-center gap-2 rounded-md border border-border/60 bg-background/95 py-2 pr-3 pl-2.5 text-left shadow-sm',
               'transition-[background-color,transform] duration-200 hover:bg-accent/80 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
             )}
           >
@@ -243,7 +243,7 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
             )}
           </button>
         </PopoverTrigger>
-        <PopoverContent className="w-[min(420px,calc(100vw-2rem))] rounded-md border-border/60 bg-background/95 p-2 backdrop-blur-sm" side="top" align="center">
+        <PopoverContent className="w-[min(420px,calc(100vw-2rem))] rounded-md border-border/60 bg-background p-2" side="top" align="center">
           {displayCompaction
             ? <CompactionProgressDetails progress={displayCompaction} />
             : <TaskProgressCard activities={displayActivities} alwaysExpanded />}
@@ -253,7 +253,7 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
       {!isAtBottom && (
         <Button
           aria-label="回到最下方"
-          className="pointer-events-auto size-10 rounded-md border border-border/60 bg-background/85 shadow-sm backdrop-blur-sm transition-[background-color,transform] duration-200 hover:bg-accent/80 active:scale-[0.96]"
+          className="pointer-events-auto size-10 rounded-md border border-border/60 bg-background/95 shadow-sm transition-[background-color,transform] duration-200 hover:bg-accent/80 active:scale-[0.96]"
           onClick={() => scrollToBottom()}
           type="button"
           variant="ghost"

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -438,7 +438,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
         {/* 卡片式输入容器 — 对标 Cherry Studio: border-radius 17px, 0.5px border */}
         <div
           className={cn(
-            'rounded-[17px] border-[0.5px] border-border bg-background/70 backdrop-blur-sm transition-all duration-200',
+            'rounded-[17px] border-[0.5px] border-border bg-background/95 transition-[border-color,background-color] duration-200',
             'focus-within:border-foreground/20',
             isDragOver && 'border-[2px] border-dashed border-[#2ecc71] bg-[#2ecc71]/[0.03]'
           )}


### PR DESCRIPTION
## Summary

- Replace persistent translucent Blur surfaces in Agent and Chat composers with near-opaque backgrounds.
- Remove `backdrop-filter` from the live TaskProgressOverlay controls that overlap scrolling and streaming Agent output.
- Narrow composer transitions to border and background changes rather than `transition-all`.

This targets the renderer GPU composition path during Agent streaming, typing, and history scrolling. It intentionally does not change Settings or low-frequency image/FAQ overlays, which do not use this live rendering path.

## Validation

- `bun run typecheck` (`apps/electron`)
- `bun run build:renderer` (`apps/electron`)
- `bun test apps/electron/src/renderer/components/agent/compaction-progress.test.ts` (9 passed)
- `git diff --check`
- Verified no `backdrop-blur` / `backdrop-filter` remains in the three affected components.

## Manual performance check

Compare before/after with a long Agent history, active stream, rapid bidirectional scrolling, and Chinese IME typing. Capture Chrome/Electron Performance tracks and GPU usage; verify composer and task-progress visual hierarchy remains clear without Blur.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
