### PR TITLE
Fix THINKING rendering before first chunk

### DIFF
--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -760,7 +760,8 @@ export function ContentBlock({ block, allMessages, basePath, basePaths, animate 
   // thinking 块
   if (block.type === 'thinking') {
     const thinkingBlock = block as SDKThinkingBlock
-    if (!thinkingBlock.thinking && !isStreaming) return null
+    // Pi 会先发送空的 thinking block，再逐步追加内容；首个 chunk 前不显示外框。
+    if (!thinkingBlock.thinking) return null
     return <ThinkingBlock block={thinkingBlock} dimmed={dimmed} isStreaming={isStreaming} />
   }
 


### PR DESCRIPTION
## Summary

- Defer rendering an empty streaming THINKING block until its first content chunk arrives.

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`
- [x] Start the Electron development environment and verify it launches.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
