### PR TITLE
Fix session history content mismatch

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.29",
+  "version": "0.17.30",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -49,11 +49,6 @@ export function MainArea(): React.ReactElement {
   const isClassic = interfaceVariant === 'classic'
   const store = useStore()
 
-  // Tab 内容渲染降级为非紧急：TabBar 立即高亮新 tab，主区域昂贵渲染（含 PreviewPanel 中
-  // DiffTabContent → ProseMirror editor mount + Shiki tokenize）让出主线程，避免点击 tab
-  // 后必须等主区域渲染完才能看到 tab 切换效果
-  const deferredActiveTabId = React.useDeferredValue(activeTabId)
-
   const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
   const [browserOpenMap, setBrowserOpenMap] = useAtom(browserPanelOpenMapAtom)
   const [browserStateMap, setBrowserStateMap] = useAtom(browserStateMapAtom)
@@ -275,9 +270,10 @@ export function MainArea(): React.ReactElement {
                   <AutomationFormView />
                 ) : tabs.length === 0 ? (
                   <WelcomeView />
-                ) : deferredActiveTabId ? (
+                ) : activeTabId ? (
                   <div className="flex-1 min-h-0 titlebar-no-drag">
-                    <TabContent tabId={deferredActiveTabId} />
+                    {/* 会话内容必须与侧栏/右侧面板使用同一个活动 Tab，不能延迟到旧会话。 */}
+                    <TabContent tabId={activeTabId} />
                   </div>
                 ) : null}
               </>


### PR DESCRIPTION
## 概要
- 让主内容区直接按当前 `activeTabId` 渲染，避免历史会话切换时保留旧 Agent Session。
- Electron 版本递增至 0.17.30。

## 验证
- `bun test apps/electron/src/renderer/atoms/tab-atoms.test.ts`
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)