### PR TITLE
fix: 解决 OpenAI 兼容供应商会话标题自动重命名失败问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ pnpm-workspace.yaml
 
 # Proma 会话/工作区文档（不应入仓，见 AGENTS.md 红线）
 .context/
+.bitfun/

--- a/packages/core/src/providers/openai-adapter.ts
+++ b/packages/core/src/providers/openai-adapter.ts
@@ -275,7 +275,9 @@ export class OpenAIAdapter implements ProviderAdapter {
     const url = resolveOpenAIChatCompletionsUrl(input.baseUrl, this.providerType)
     // OpenCode Go 的编程模型会将一部分输出预算用于推理；通用标题请求的
     // 50 tokens 不足以稳定产出可见正文，导致自动重命名收到空标题。
-    const maxTokens = this.providerType === 'opencode-go-openai' ? 512 : 50
+    // const maxTokens = this.providerType === 'opencode-go-openai' ? 512 : 50
+    // 统一设置 512 tokens 解决兼容open ai 供应商 自动重命名收到空标题问题。
+    const maxTokens = 512
 
     return {
       url,

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -169,11 +169,12 @@ export function normalizeOpenAIBaseUrlForSdk(baseUrl: string): string {
  * 内置 OpenAI 协议供应商仍允许填写协议根地址，例如：
  * - "https://api.example.com/v1" → "https://api.example.com/v1/chat/completions"
  * - custom: "https://api.example.com/v1/chat/completions" → 原样使用
+ * - 自行拼接 /chat/completions  防止有直接从大模型官网拷贝的baseurl 里没有/chat/completions后缀 增加容错性
  */
 export function resolveOpenAIChatCompletionsUrl(baseUrl: string, provider: ProviderType = 'openai'): string {
-  if (provider === 'custom') {
-    return trimTrailingUrlPathSlash(baseUrl)
-  }
+  // if (provider === 'custom') {
+  //   return trimTrailingUrlPathSlash(baseUrl)
+  // }
   if (hasPathSuffix(baseUrl, '/chat/completions')) {
     return trimTrailingUrlPathSlash(baseUrl)
   }


### PR DESCRIPTION
## 问题描述

在使用部分 OpenAI 协议兼容供应商时，Proma 的**会话标题自动重命名功能**出现失败，表现为：
- 新创建的会话标题无法自动生成，保持默认名称
- 标题请求返回空内容
- 部分供应商因 URL 路径问题直接 404

## 根因分析

1. **Token 预算不足**：标题生成请求仅分配 50 tokens，部分供应商（尤其是推理型模型）需要更多 tokens 才能输出可见正文
2. **URL 拼接缺失**：用户从供应商官网直接拷贝的 `baseUrl` 常缺少 `/chat/completions` 后缀，`custom` 类型供应商原逻辑不做自动拼接，导致请求失败

## 修改内容

### 1. 统一标题生成 Token 预算
**文件**：`packages/core/src/providers/openai-adapter.ts`

取消按供应商类型区分 token 数量的逻辑，统一设置为 512 tokens，确保所有 OpenAI 兼容供应商都能稳定返回非空标题。

```typescript
// 修改前：仅 opencode-go-openai 使用 512，其余默认 50
const maxTokens = this.providerType === 'opencode-go-openai' ? 512 : 50

// 修改后：统一 512 tokens
const maxTokens = 512

2. 增强 baseUrl 容错拼接
文件：packages/core/src/providers/url-utils.ts

取消 custom 供应商类型的特殊处理，对所有供应商统一检查并自动拼接 /chat/completions 后缀。


// 修改前：custom 类型直接返回原始 baseUrl，不做任何拼接
if (provider === 'custom') {
  return trimTrailingUrlPathSlash(baseUrl)
}

// 修改后：
// 已带 /chat/completions 则直接返回，否则自动拼接

/**
 * 解析 OpenAI Chat Completions 请求地址。
 *
 * OpenAI 兼容格式（custom）要求用户直接填写完整请求端点。
 * 内置 OpenAI 协议供应商仍允许填写协议根地址，例如：
 * - "https://api.example.com/v1" → "https://api.example.com/v1/chat/completions"
 * - custom: "https://api.example.com/v1/chat/completions" → 原样使用
 * - 自行拼接 /chat/completions  防止有直接从大模型官网拷贝的baseurl 里没有/chat/completions后缀 增加容错性
 */
export function resolveOpenAIChatCompletionsUrl(baseUrl: string, provider: ProviderType = 'openai'): string {
  // if (provider === 'custom') {
  //   return trimTrailingUrlPathSlash(baseUrl)
  // }
  if (hasPathSuffix(baseUrl, '/chat/completions')) {
    return trimTrailingUrlPathSlash(baseUrl)
  }
  return `${normalizeBaseUrl(baseUrl)}/chat/completions`
}