### PR TITLE
Optimize Agent stream rendering

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.32",
+  "version": "0.17.33",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -743,12 +743,17 @@ export function useGlobalAgentListeners(): void {
           }
         }
 
+        let liveUpdates = payload.kind === 'assistant_message_delta'
+          ? []
+          : projectAgentLiveUpdates(payload)
         if (payload.kind === 'assistant_message_delta') {
           if (payload.reset) {
             enrichLiveAssistantMessage(sessionId, payload.reset as unknown as Record<string, unknown>)
           }
-          // delta 被 store 拒绝时，不得再进入 tool/usage projector 触发副作用。
-          if (!agentLiveTranscriptStore.apply(sessionId, payload)) return
+          // assistant delta 在归约正文时同步产出语义更新，避免再次扫描同一份 operations。
+          const applied = agentLiveTranscriptStore.applyWithUpdates(sessionId, payload)
+          if (!applied) return
+          liveUpdates = applied.updates
         }
 
         if (payload.kind === 'proma_event' && payload.event.type === 'external_run_started') {
@@ -840,8 +845,7 @@ export function useGlobalAgentListeners(): void {
           }
         }
 
-        // 唯一 IPC payload 直接投影为 UI 状态更新；正文不会进入 Jotai 或旧文本 reducer。
-        const liveUpdates = projectAgentLiveUpdates(payload)
+        // canonical payload 直接投影为 UI 状态更新；assistant partial 已在正文归约时同步生成投影。
 
         for (const event of liveUpdates) {
           // 带 run 标识的 retry 更新必须在所有外围副作用前严格匹配当前流；

--- a/apps/electron/src/renderer/lib/agent-canonical-stream.ts
+++ b/apps/electron/src/renderer/lib/agent-canonical-stream.ts
@@ -127,7 +127,7 @@ function isToolUseBlock(block: SDKContentBlock): block is SDKContentBlock & {
     && block.input !== null
 }
 
-function toolStartFromBlock(
+export function toolStartFromBlock(
   block: SDKContentBlock,
   parentToolUseId: string | undefined,
   isFinal: boolean,
@@ -147,7 +147,7 @@ function toolStartFromBlock(
   }
 }
 
-function usageUpdateFromAssistant(message: SDKAssistantMessage): Extract<AgentLiveUpdate, { type: 'usage_update' }> | null {
+export function usageUpdateFromAssistant(message: SDKAssistantMessage): Extract<AgentLiveUpdate, { type: 'usage_update' }> | null {
   if (message.parent_tool_use_id || !message.message.usage) return null
   const usage = message.message.usage
   const modelName = message._channelModelId ?? message.message.model

--- a/apps/electron/src/renderer/lib/agent-live-transcript-store.ts
+++ b/apps/electron/src/renderer/lib/agent-live-transcript-store.ts
@@ -6,6 +6,11 @@ import type {
   SDKContentBlock,
 } from '@proma/shared'
 
+import type { AgentLiveUpdate } from './agent-canonical-stream'
+import { toolStartFromBlock, usageUpdateFromAssistant } from './agent-canonical-stream'
+
+const EMPTY_MESSAGES: SDKAssistantMessage[] = []
+
 interface LiveAssistantRecord {
   message: SDKAssistantMessage
   sequence: number
@@ -19,7 +24,10 @@ interface SessionLiveTranscript {
   listeners: Set<() => void>
 }
 
-const EMPTY_MESSAGES: SDKAssistantMessage[] = []
+export interface AppliedAgentAssistantDelta {
+  message: SDKAssistantMessage
+  updates: AgentLiveUpdate[]
+}
 
 function cloneAssistantMessage(message: SDKAssistantMessage): SDKAssistantMessage {
   return {
@@ -30,6 +38,15 @@ function cloneAssistantMessage(message: SDKAssistantMessage): SDKAssistantMessag
       ...(message.message.usage && { usage: { ...message.message.usage } }),
     },
   }
+}
+
+function collectToolStart(
+  toolStarts: Map<string, Extract<AgentLiveUpdate, { type: 'tool_start' }>>,
+  block: SDKContentBlock,
+  parentToolUseId: string | undefined,
+): void {
+  const toolStart = toolStartFromBlock(block, parentToolUseId, false)
+  if (toolStart) toolStarts.set(toolStart.toolUseId, toolStart)
 }
 
 function applyOperation(
@@ -97,13 +114,17 @@ export class AgentLiveTranscriptStore {
   private readonly sessions = new Map<string, SessionLiveTranscript>()
 
   apply(sessionId: string, delta: AgentAssistantMessageDelta): SDKAssistantMessage | null {
+    return this.applyWithUpdates(sessionId, delta)?.message ?? null
+  }
+
+  applyWithUpdates(sessionId: string, delta: AgentAssistantMessageDelta): AppliedAgentAssistantDelta | null {
     const session = this.getOrCreateSession(sessionId)
     const previous = session.records.get(delta.messageId)
 
     // run scope 必须先于 sequence 判断：新 run 的 reset 不能被旧 run 的高 sequence 拒绝。
     if (previous && delta.runId !== previous.runId && !delta.reset) return null
     if (previous && delta.runId === previous.runId && delta.sequence <= previous.sequence) {
-      return previous.message
+      return { message: previous.message, updates: [] }
     }
     if (
       previous
@@ -113,9 +134,24 @@ export class AgentLiveTranscriptStore {
     ) return null
     if (!previous && !delta.reset) return null
 
+    const toolStarts = new Map<string, Extract<AgentLiveUpdate, { type: 'tool_start' }>>()
+    const updates: AgentLiveUpdate[] = []
+    const parentToolUseId = delta.metadata?.parentToolUseId ?? delta.reset?.parent_tool_use_id ?? undefined
+
+    if (delta.reset) {
+      if (delta.reset.message.content.length > 0) updates.push({ type: 'assistant_progress' })
+      for (const block of delta.reset.message.content) {
+        collectToolStart(toolStarts, block, parentToolUseId)
+      }
+      const usage = usageUpdateFromAssistant(delta.reset)
+      if (usage) updates.push(usage)
+    }
+
+    if (delta.operations.length > 0) updates.push({ type: 'assistant_progress' })
+
     let nextMessage = delta.reset
       ? cloneAssistantMessage(delta.reset)
-      : cloneAssistantMessage(previous!.message)
+      : previous!.message
 
     for (const operation of delta.operations) {
       const nextBlocks = applyOperation(nextMessage.message.content, operation)
@@ -124,8 +160,17 @@ export class AgentLiveTranscriptStore {
         ...nextMessage,
         message: { ...nextMessage.message, content: nextBlocks },
       }
+      if (operation.type === 'append_block' || operation.type === 'replace_block') {
+        collectToolStart(toolStarts, operation.block, parentToolUseId)
+      }
     }
     nextMessage = applyMetadata(nextMessage, delta)
+
+    if (!delta.reset && delta.metadata?.usage) {
+      const usage = usageUpdateFromAssistant(nextMessage)
+      if (usage) updates.push(usage)
+    }
+    updates.push(...toolStarts.values())
 
     session.records.set(delta.messageId, {
       message: nextMessage,
@@ -134,7 +179,7 @@ export class AgentLiveTranscriptStore {
     })
     if (!session.order.includes(delta.messageId)) session.order.push(delta.messageId)
     this.publish(session)
-    return nextMessage
+    return { message: nextMessage, updates }
   }
 
   finalize(sessionId: string, messageId: string): void {


### PR DESCRIPTION
## Summary

- 减少 Agent partial assistant 流式消息的重复复制，复用未变化的 content block。
- 在 transcript 归约过程中同步产出工具、进度和 usage 更新，避免 renderer 对同一 delta 重复扫描。
- 保留 Agent 原有的 useSmoothStream 逐字流式体验。
- Electron 版本递增到 0.17.33。

## Validation

- `bun run typecheck` 通过。
- `bun run --filter=@proma/electron build:renderer` 通过。
- `git diff --check` 通过。
- `bun test`: 483 pass / 4 fail；失败为现有 Electron Bun/环境相关用例：Electron named export、OAuth proxy scope、planning 原生执行路径，未涉及本次改动文件。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)