### PR TITLE
feat(channel): add GLM-5.3 model presets

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -52,7 +52,7 @@ interface PiModelDefaults {
 const ZERO_MODEL_COST: PiModelCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 const DEFAULT_MAX_TOKENS = 64_000
-const VOLCENGINE_GLM_52_MAX_TOKENS = 128_000
+const VOLCENGINE_GLM_MAX_TOKENS = 128_000
 /**
  * GLM-5.3 尚未进入 Pi 模型目录，走 catalog 缺失分支会回落到 64K 默认输出上限。
  * 智谱官方文档标注 GLM-5.3 最大输出 128K，与目录中 GLM-5.2 的 131072 同一口径。
@@ -537,9 +537,10 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const codexAlignedCapabilities = getCodexAlignedGPT5Capabilities(input.model)
   const api = normalizePiApi(input.provider)
   const providerSpecificCapabilities = compilePiReasoningCapabilities(api, input.model)
-  const isVolcengineGlm52 = (input.provider === 'doubao' || input.provider === 'ark-coding-plan')
-    && input.model?.toLowerCase() === 'glm-5.2'
-  const isCatalogMissingGlm53 = !catalogModel && input.model?.toLowerCase() === 'glm-5.3'
+  const glmModelId = input.model?.toLowerCase()
+  const isVolcengineGlm5x = (input.provider === 'doubao' || input.provider === 'ark-coding-plan')
+    && (glmModelId === 'glm-5.2' || glmModelId === 'glm-5.3')
+  const isCatalogMissingGlm53 = !catalogModel && glmModelId === 'glm-5.3'
   const catalogContextWindow = catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
   const inferredContextWindow = inferContextWindow(input.model) ?? DEFAULT_CONTEXT_WINDOW
   return {
@@ -551,9 +552,9 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
     cost: catalogModel ? { ...catalogModel.cost } : { ...ZERO_MODEL_COST },
     // Codex 对齐策略优先；其他模型仍保留 catalog 与 shared inference 中更大的已验证能力。
     contextWindow: codexAlignedCapabilities?.contextWindow ?? Math.max(catalogContextWindow, inferredContextWindow),
-    // Pi 的智谱目录将 GLM-5.2 标为 131072，但火山方舟兼容端点上限为 128000。
-    maxTokens: isVolcengineGlm52
-      ? VOLCENGINE_GLM_52_MAX_TOKENS
+    // Pi 的智谱目录将 GLM-5.2 标为 131072，但火山方舟兼容端点上限为 128000；GLM-5.3 同理。
+    maxTokens: isVolcengineGlm5x
+      ? VOLCENGINE_GLM_MAX_TOKENS
       : (catalogModel?.maxTokens ?? (isCatalogMissingGlm53 ? GLM_53_MAX_TOKENS : DEFAULT_MAX_TOKENS)),
   }
 }

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -53,6 +53,11 @@ const ZERO_MODEL_COST: PiModelCost = { input: 0, output: 0, cacheRead: 0, cacheW
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 const DEFAULT_MAX_TOKENS = 64_000
 const VOLCENGINE_GLM_52_MAX_TOKENS = 128_000
+/**
+ * GLM-5.3 尚未进入 Pi 模型目录，走 catalog 缺失分支会回落到 64K 默认输出上限。
+ * 智谱官方文档标注 GLM-5.3 最大输出 128K，与目录中 GLM-5.2 的 131072 同一口径。
+ */
+const GLM_53_MAX_TOKENS = 131_072
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api'
 const CODEX_MAX_TOKENS = 128_000
 /**
@@ -534,6 +539,7 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const providerSpecificCapabilities = compilePiReasoningCapabilities(api, input.model)
   const isVolcengineGlm52 = (input.provider === 'doubao' || input.provider === 'ark-coding-plan')
     && input.model?.toLowerCase() === 'glm-5.2'
+  const isCatalogMissingGlm53 = !catalogModel && input.model?.toLowerCase() === 'glm-5.3'
   const catalogContextWindow = catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
   const inferredContextWindow = inferContextWindow(input.model) ?? DEFAULT_CONTEXT_WINDOW
   return {
@@ -548,7 +554,7 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
     // Pi 的智谱目录将 GLM-5.2 标为 131072，但火山方舟兼容端点上限为 128000。
     maxTokens: isVolcengineGlm52
       ? VOLCENGINE_GLM_52_MAX_TOKENS
-      : (catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS),
+      : (catalogModel?.maxTokens ?? (isCatalogMissingGlm53 ? GLM_53_MAX_TOKENS : DEFAULT_MAX_TOKENS)),
   }
 }
 

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -89,6 +89,7 @@ const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
   { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
   { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
   { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
+  { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
   { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
   { id: 'k3', name: 'Kimi K3', enabled: true },
   { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -419,6 +419,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
       } else if (p === 'opencode-go-openai') {
         setModels([
           { id: 'grok-4.5', name: 'Grok 4.5', enabled: true },
+          { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
           { id: 'glm-5.1', name: 'GLM-5.1', enabled: true },
           { id: 'kimi-k3', name: 'Kimi K3', enabled: true },
@@ -437,9 +438,12 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         ])
       } else if (p === 'ark-coding-plan') {
         setModels([
+          { id: 'doubao-seed-2.1-pro', name: 'Doubao Seed 2.1 Pro', enabled: true },
+          { id: 'doubao-seed-2.1-turbo', name: 'Doubao Seed 2.1 Turbo', enabled: true },
           { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
           { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
           { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
+          { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
           { id: 'k3', name: 'Kimi K3', enabled: true },
           { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -431,6 +431,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         ])
       } else if (p === 'zhipu' || p === 'zhipu-coding' || p === 'zhipu-coding-team') {
         setModels([
+          { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
           { id: 'glm-5.1', name: 'GLM-5.1', enabled: false },
         ])

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -87,6 +87,11 @@ export interface ResolveReasoningProfileInput {
 const DEEPSEEK_V4_LEVELS = ['off', 'low', 'high', 'xhigh', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const K3_LEVELS = ['off', 'low', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const GLM_52_LEVELS = ['off', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
+/**
+ * 智谱自 GLM-5.2 起才支持 reasoning_effort（high / max），且新旗舰沿用同一套语义，
+ * 因此 5.2 与 5.3 共用一个 profile；GLM-5.1 及更早仍只有思考开关，不在此列。
+ */
+const GLM_52_PROFILE_MODEL_IDS = new Set(['glm-5.2', 'glm-5.3'])
 const OPENAI_STANDARD_LEVELS = ['off', 'low', 'medium', 'high', 'xhigh'] as const satisfies readonly AgentThinkingLevel[]
 const OPENAI_MAX_LEVELS = [...OPENAI_STANDARD_LEVELS, 'max'] as const satisfies readonly AgentThinkingLevel[]
 
@@ -290,7 +295,7 @@ export function resolveReasoningProfile(input: ResolveReasoningProfileInput): Re
       ? DEEPSEEK_V4_PRO_PROFILE
       : /^(?:k3(?:-256k)?|kimi-k3)$/.test(modelId)
         ? K3_PROFILE
-        : modelId === 'glm-5.2'
+        : GLM_52_PROFILE_MODEL_IDS.has(modelId)
           ? GLM_52_PROFILE
           : isOpenAITransport && isOpenAIReasoningModel
             ? /^gpt-5\.6(?:-|$)/.test(modelId) ? OPENAI_MAX_PROFILE : OPENAI_STANDARD_PROFILE

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -53,7 +53,7 @@ const ONE_MILLION_CONTEXT_RULES = {
   // DeepSeek
   deepseek: ['deepseek-v4'],
   // 智谱 GLM
-  glm: ['glm-5.2'],
+  glm: ['glm-5.3', 'glm-5.2'],
   // 小米 MiMo
   mimo: ['mimo-v2.5'],
   // MiniMax


### PR DESCRIPTION
## Summary

- f5c02d57 feat(channel): OpenCode Go 与火山方舟 Coding Plan 预设补齐 GLM-5.3
- 8c6c014e feat(channel): 智谱 API 与 Coding Plan 预设新增 GLM-5.3

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归