### PR TITLE
Fix session message reveal after refresh

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1153,6 +1153,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   // 消息是否已完成首次加载（用于 auto-send 等待）
   const [messagesLoaded, setMessagesLoaded] = React.useState(false)
+  const [messagesLoadedSessionId, setMessagesLoadedSessionId] = React.useState<string | null>(null)
+  const messagesLoadedForCurrentSession = messagesLoaded && messagesLoadedSessionId === sessionId
   const [messagesRefreshing, setMessagesRefreshing] = React.useState(false)
   const messagesRefreshingRef = React.useRef(false)
   const loadingSessionIdRef = React.useRef<string | null>(null)
@@ -1171,7 +1173,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const cached = store.get(agentSDKMessagesCacheAtom).get(sessionId)
       if (cached) {
         setPersistedSDKMessages(cached)
-        setMessagesLoaded(true)
+        setMessagesLoaded(false)
+        // 缓存只作为最新 IPC 快照到达前的预热数据。若立即揭示，完成中的会话
+        // 可能先显示旧尾部，随后 IPC 返回的新 Agent 消息再单独跳出来。
+        // 保持 messagesLoaded=false 会让 AgentMessages 在同一批更新完成后整体显示。
       } else {
         setPersistedSDKMessages([])
         setMessagesLoaded(false)
@@ -1193,6 +1198,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           setEarlierMessagesCursor(page.nextBefore)
           setLoadingEarlierMessages(false)
           setMessagesLoaded(true)
+          setMessagesLoadedSessionId(sessionId)
           messagesRefreshingRef.current = false
           setMessagesRefreshing(false)
 
@@ -1251,6 +1257,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         if (cancelled) return
         console.error(error)
         setMessagesLoaded(true)
+        setMessagesLoadedSessionId(sessionId)
         messagesRefreshingRef.current = false
         setMessagesRefreshing(false)
       })
@@ -1310,7 +1317,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   // 等待 messagesLoaded 确保消息加载完成后再插入乐观消息，避免被加载结果覆盖。
   // 使用 queueMicrotask 延迟发送：避免 setState → 重渲染 → cleanup 取消 timer 的竞态。
   React.useEffect(() => {
-    if (!messagesLoaded) return
+    if (!messagesLoadedForCurrentSession) return
     if (!pendingPrompt) return
     if (pendingPrompt.sessionId !== sessionId) return
     if (!agentChannelId || streaming) return
@@ -1386,7 +1393,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         })
       })
     })
-  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, permissionMode, attachedDirs, attachedFileDirectories])
+  }, [messagesLoadedForCurrentSession, pendingPrompt, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, permissionMode, attachedDirs, attachedFileDirectories])
   // ===== 附件处理 =====
 
   /** 为文件生成唯一文件名（避免粘贴多张图片时文件名重复导致覆盖） */
@@ -2134,7 +2141,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
     const pendingFilesSnapshot = pendingFilesRef.current
-    if (!messagesLoaded || (!effectiveText && pendingFilesSnapshot.length === 0) || !agentChannelId || !hasAvailableModel) return
+    if (!messagesLoadedForCurrentSession || (!effectiveText && pendingFilesSnapshot.length === 0) || !agentChannelId || !hasAvailableModel) return
     if (isStopping) {
       toast.info('正在停止上一轮 Agent', { description: '请等待停止完成后再发送消息。' })
       return
@@ -2351,7 +2358,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage, isLegacyTranscript, isStopping])
+  }, [createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoadedForCurrentSession, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage, isLegacyTranscript, isStopping])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -2724,7 +2731,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     (allAskUserRequests.get(sessionId)?.length ?? 0) > 0 ||
     (allExitPlanRequests.get(sessionId)?.length ?? 0) > 0
   const hasBlockingRequests = hasBannerOverlay || (allPermissionRequests.get(sessionId)?.length ?? 0) > 0
-  const canSendQueuedNow = messagesLoaded && (streaming || !messagesRefreshing) && !!agentChannelId && hasAvailableModel && !hasBlockingRequests && !isStopping
+  const canSendQueuedNow = messagesLoadedForCurrentSession && (streaming || !messagesRefreshing) && !!agentChannelId && hasAvailableModel && !hasBlockingRequests && !isStopping
   const queuedSendInFlightRef = React.useRef(false)
   const sendingQueuedMessageIdsRef = React.useRef<Set<string>>(new Set())
 
@@ -2824,7 +2831,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setInputHasContent(hasContent)
   }, [])
   const hasTextInput = inputHasContent
-  const canSend = !isStopping && messagesLoaded && (streaming || !messagesRefreshing) && (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && hasAvailableModel && (!streaming || hasTextInput)
+  const canSend = !isStopping && messagesLoadedForCurrentSession && (streaming || !messagesRefreshing) && (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && hasAvailableModel && (!streaming || hasTextInput)
 
   const inputToolbarItems = React.useMemo<ToolbarItem[]>(() => [
     ...(isCodexFastModeAvailable ? [{
@@ -3020,7 +3027,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         <AgentMessages
           sessionId={sessionId}
           sessionModelId={agentModelId || undefined}
-          messagesLoaded={messagesLoaded}
+          messagesLoaded={messagesLoadedForCurrentSession}
           persistedSDKMessages={persistedSDKMessages}
           hasEarlierMessages={earlierMessagesCursor !== undefined}
           loadingEarlierMessages={loadingEarlierMessages}


### PR DESCRIPTION
## Summary
- Keep cached session messages hidden until the latest IPC snapshot is loaded.
- Track the loaded session id so switching views cannot reuse the previous session readiness state.
- Prevent sending and auto-send flows from running before the current session is ready.

## Verification
- `bun run --filter=@proma/electron typecheck`
- `bun run --filter=@proma/electron build:renderer`
- `bun test ./apps/electron/src/renderer/lib/agent-session-list.test.ts`
- `bun test ./apps/electron/src/renderer/components/agent/compaction-progress.test.ts`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)