### PR TITLE
perf(agent): reduce input rendering churn during streams

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.34",
+  "version": "0.17.35",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -237,6 +237,27 @@ export function areAgentViewStreamStatesEqual(
     && previous.isCompacting === next.isCompacting
 }
 
+export type AgentInputStreamState = Pick<AgentStreamState, 'running' | 'backgroundWaiting'>
+
+const EMPTY_AGENT_INPUT_STREAM_STATE: AgentInputStreamState = { running: false }
+
+function areAgentInputStreamStatesEqual(
+  previous: AgentInputStreamState,
+  next: AgentInputStreamState,
+): boolean {
+  return previous.running === next.running
+    && previous.backgroundWaiting === next.backgroundWaiting
+}
+
+/** 输入区只订阅发送/排队需要的生命周期状态，避免 usage_update 触发整页重渲染。 */
+export const agentSessionInputStreamStateAtomFamily = atomFamily((sessionId: string) =>
+  selectAtom(
+    agentSessionStreamingStateAtomFamily(sessionId),
+    (state): AgentInputStreamState => state ?? EMPTY_AGENT_INPUT_STREAM_STATE,
+    areAgentInputStreamStatesEqual,
+  ),
+)
+
 /**
  * AgentView 不订阅逐 token content；完整状态只由 AgentMessages 消费。
  * selectAtom 的 equalityFn 保证纯文本流式更新不会重渲染输入框和工具栏。

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -65,7 +65,7 @@ import { previewPanelOpenMapAtom, quotedSelectionMapAtom, currentQuotedSelection
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
-  agentSessionViewStreamStateAtomFamily,
+  agentSessionInputStreamStateAtomFamily,
   agentChannelIdAtom,
   agentModelIdAtom,
   agentSessionChannelMapAtom,
@@ -106,7 +106,6 @@ import {
   allPendingExitPlanRequestsAtom,
   finalizeStreamingActivities,
 } from '@/atoms/agent-atoms'
-import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
 import { channelsAtom } from '@/atoms/chat-atoms'
@@ -433,7 +432,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   // 只订阅输入区/工具栏需要的低频流状态。逐 token content/toolActivities 由
   // AgentMessages 独立消费，不能让 3000 行 AgentView 和输入框跟随每个 token 重渲染。
-  const streamViewState = useAtomValue(agentSessionViewStreamStateAtomFamily(sessionId))
+  const streamViewState = useAtomValue(agentSessionInputStreamStateAtomFamily(sessionId))
   const streaming = streamViewState.running
   // 软空闲态：本轮主体已结束、UI 可输入，但 SDK 通道仍开着等后台任务唤醒。
   // 此时服务端 activeSessions 仍保留，新消息须走注入通道而非新建 run。
@@ -524,15 +523,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [sessionId, sessionMetaChannelId, sessionMetaModelId, hasSessionMeta, defaultChannelId, defaultModelId, setSessionChannelMap, setSessionModelMap])
 
-  const contextStatus: AgentContextStatus = {
-    isCompacting: streamViewState.isCompacting ?? false,
-    inputTokens: streamViewState.inputTokens,
-    outputTokens: streamViewState.outputTokens,
-    cacheReadTokens: streamViewState.cacheReadTokens,
-    cacheCreationTokens: streamViewState.cacheCreationTokens,
-    contextWindow: streamViewState.contextWindow,
-    contextUsageIsEstimated: streamViewState.contextUsageIsEstimated,
-  }
   const setAgentStreamErrors = useSetAtom(agentStreamErrorsAtom)
   const streamErrors = useAtomValue(agentStreamErrorsAtom)
   const agentError = streamErrors.get(sessionId) ?? null
@@ -2895,13 +2885,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       key: 'context-usage',
       node: (
         <ContextUsageBadge
-          inputTokens={contextStatus.inputTokens}
-          outputTokens={contextStatus.outputTokens}
-          cacheReadTokens={contextStatus.cacheReadTokens}
-          cacheCreationTokens={contextStatus.cacheCreationTokens}
-          contextWindow={contextStatus.contextWindow}
-          isEstimated={contextStatus.contextUsageIsEstimated === true}
-          isCompacting={contextStatus.isCompacting}
           isProcessing={streaming}
           sessionId={sessionId}
           channelId={planQuotaChannelId}
@@ -2924,12 +2907,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     sessionId,
     agentThinking,
     setAgentThinking,
-    contextStatus.inputTokens,
-    contextStatus.outputTokens,
-    contextStatus.cacheReadTokens,
-    contextStatus.cacheCreationTokens,
-    contextStatus.contextWindow,
-    contextStatus.isCompacting,
     streaming,
     handleAttachContent,
     handleCompact,

--- a/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
+++ b/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
@@ -10,10 +10,12 @@
  */
 
 import * as React from 'react'
+import { useAtomValue } from 'jotai'
 import { Loader2, Minimize2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
+import { agentSessionViewStreamStateAtomFamily } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
 import {
   calculatePiAutoCompactionThresholdTokens,
@@ -30,7 +32,7 @@ const HOVER_CLOSE_DELAY = 150
 const CONFIRM_RESET_DELAY = 3000
 const UNSUPPORTED_PLAN_QUOTA_MESSAGE = '当前渠道不支持订阅 Plan 额度查询'
 
-interface ContextUsageBadgeProps {
+export interface ContextUsageBadgeProps {
   inputTokens?: number
   outputTokens?: number
   cacheReadTokens?: number
@@ -38,8 +40,8 @@ interface ContextUsageBadgeProps {
   costUsd?: number
   contextWindow?: number
   /** 当前上下文 token 是否为 Pi 手动压缩后的预估值 */
-  isEstimated: boolean
-  isCompacting: boolean
+  isEstimated?: boolean
+  isCompacting?: boolean
   isProcessing: boolean
   onCompact: () => void
   /**
@@ -178,6 +180,20 @@ export function ContextUsageBadge({
   channelId,
   channelUpdatedAt,
 }: ContextUsageBadgeProps): React.ReactElement | null {
+  // usage 高频更新只唤醒这个小组件，不再让 AgentView 和输入框参与 reconciliation。
+  const sessionStreamState = useAtomValue(agentSessionViewStreamStateAtomFamily(sessionId ?? ''))
+  const displayInputTokens = sessionId ? sessionStreamState.inputTokens : inputTokens
+  const displayOutputTokens = sessionId ? sessionStreamState.outputTokens : outputTokens
+  const displayCacheReadTokens = sessionId ? sessionStreamState.cacheReadTokens : cacheReadTokens
+  const displayCacheCreationTokens = sessionId ? sessionStreamState.cacheCreationTokens : cacheCreationTokens
+  const displayContextWindow = sessionId ? sessionStreamState.contextWindow : contextWindow
+  const displayIsEstimated = sessionId
+    ? sessionStreamState.contextUsageIsEstimated === true
+    : isEstimated === true
+  const displayIsCompacting = sessionId
+    ? sessionStreamState.isCompacting === true
+    : isCompacting === true
+
   // 保留最近一次有效的 token 值，避免切换会话时闪烁消失
   const stableRef = React.useRef<{
     inputTokens: number
@@ -194,8 +210,14 @@ export function ContextUsageBadge({
       lastSessionRef.current = sessionId
     }
   }, [sessionId])
-  if (inputTokens && inputTokens > 0) {
-    stableRef.current = { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, contextWindow }
+  if (displayInputTokens && displayInputTokens > 0) {
+    stableRef.current = {
+      inputTokens: displayInputTokens,
+      outputTokens: displayOutputTokens,
+      cacheReadTokens: displayCacheReadTokens,
+      cacheCreationTokens: displayCacheCreationTokens,
+      contextWindow: displayContextWindow,
+    }
   }
 
   const [open, setOpen] = React.useState(false)
@@ -249,7 +271,7 @@ export function ContextUsageBadge({
   }, [open, channelId, channelUpdatedAt])
 
   // 压缩中 → 按钮位置显示 spinner
-  if (isCompacting) {
+  if (displayIsCompacting) {
     return (
       <Button
         type="button"
@@ -265,12 +287,12 @@ export function ContextUsageBadge({
 
   // 使用稳定值：优先当前数据，回退到上次有效数据
   const stable = stableRef.current
-  const hasCurrent = inputTokens != null && inputTokens > 0
-  const displayTokens = hasCurrent ? inputTokens : stable?.inputTokens
-  const displayWindow = hasCurrent ? contextWindow : stable?.contextWindow
-  const displayOutput = hasCurrent ? outputTokens : stable?.outputTokens
-  const displayCacheRead = hasCurrent ? cacheReadTokens : stable?.cacheReadTokens
-  const displayCacheCreation = hasCurrent ? cacheCreationTokens : stable?.cacheCreationTokens
+  const hasCurrent = displayInputTokens != null && displayInputTokens > 0
+  const displayTokens = hasCurrent ? displayInputTokens : stable?.inputTokens
+  const displayWindow = hasCurrent ? displayContextWindow : stable?.contextWindow
+  const displayOutput = hasCurrent ? displayOutputTokens : stable?.outputTokens
+  const displayCacheRead = hasCurrent ? displayCacheReadTokens : stable?.cacheReadTokens
+  const displayCacheCreation = hasCurrent ? displayCacheCreationTokens : stable?.cacheCreationTokens
 
   // 从未有过 usage 数据 → 不显示
   if (!displayTokens || displayTokens <= 0) return null
@@ -325,7 +347,7 @@ export function ContextUsageBadge({
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <div className="flex flex-col gap-1.5">
-          {isEstimated ? (
+          {displayIsEstimated ? (
             <DetailRow
               label="压缩后"
               value={`预估 ${formatTokens(displayTokens)} tokens${percent != null ? `（${percent}%）` : ''}`}


### PR DESCRIPTION
## Summary

- isolate AgentView from high-frequency token usage updates
- let ContextUsageBadge subscribe to usage state independently
- bump Electron patch version to 0.17.35

## Validation

- `bun run typecheck`
- 16 Agent renderer tests passed
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)