### PR TITLE
Improve agent tool call display

### DIFF
--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -491,10 +491,9 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
           ) : null}
 
           <ToolIcon className="size-3.5 shrink-0 text-muted-foreground" />
-          <span className="shrink-0 text-[14px] font-medium text-muted-foreground/65">{toolKindLabel}</span>
+          <span className="min-w-0 max-w-[28%] truncate text-[14px] font-medium text-muted-foreground/65">{toolKindLabel}</span>
           <span className="shrink-0 text-muted-foreground/30">·</span>
-
-          {/* 子工具计数（折叠时显示） */}
+          <span className="min-w-0 flex-1 truncate text-[14px] text-muted-foreground">{displayLabel}</span>
           {childToolCount > 0 && !childrenExpanded && (
             <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/55">
               {childToolCount} 项工具
@@ -568,7 +567,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
           ) : null}
 
           <ToolIcon className="size-3.5 shrink-0 text-muted-foreground" />
-          <span className="shrink-0 text-[14px] font-medium text-muted-foreground/65">{toolKindLabel}</span>
+          <span className="min-w-0 max-w-[28%] truncate text-[14px] font-medium text-muted-foreground/65">{toolKindLabel}</span>
           <span className="shrink-0 text-muted-foreground/30">·</span>
           <span className={cn(
             'min-w-0 flex-1 truncate text-[14px]',
@@ -597,13 +596,13 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
           )}
 
           {taskGetSummary && (
-            <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+            <span className="flex min-w-0 max-w-[40%] overflow-hidden items-center gap-1.5">
               <TaskGetCollapsedSummary task={taskGetSummary} />
             </span>
           )}
 
           {taskListSummary && (
-            <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+            <span className="flex min-w-0 max-w-[40%] overflow-hidden items-center gap-1.5">
               <TaskListCollapsedSummary tasks={taskListSummary} />
             </span>
           )}

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -21,7 +21,7 @@ import { cn } from '@/lib/utils'
 import { MessageResponse } from '@/components/ai-elements/message'
 import { useSmoothStream } from '@proma/ui'
 import { getToolIcon, extractFilePath } from './tool-utils'
-import { getToolPhrase } from './tool-phrase'
+import { getToolPhrase, getToolResultSummary } from './tool-phrase'
 import { ToolResultRenderer } from './tool-result-renderers'
 import { PreviewOpenButton } from './tool-result-renderers/preview-open-button'
 import { getTaskGetStatusLabel, parseTaskGetResult, type ParsedTaskGetResult } from './tool-result-renderers/task-get-result'
@@ -438,8 +438,10 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
 
   const phrase = getToolPhrase(block.name, block.input)
   const ToolIcon = getToolIcon(block.name)
+  const toolKindLabel = block.name.startsWith('mcp__') ? block.name.split('__').slice(1).join(' / ') : block.name
 
   const isCompleted = toolResult !== null
+  const resultSummary = getToolResultSummary(block.name, resultText, isError)
 
   // 运行中显示进行时短语，完成或非流式（已终止）显示完成态短语
   const displayLabel = (isCompleted || !isStreaming) ? phrase.label : phrase.loadingLabel
@@ -469,37 +471,33 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         )}
         style={animate ? { animationDelay: delay } : undefined}
       >
-        {/* 头部行：折叠箭头 + 状态 + 语义短语 */}
         <button
           type="button"
-          className="w-full flex items-center gap-2 py-0.5 text-left hover:opacity-70 transition-opacity group"
+          className="group flex w-full min-w-0 items-center gap-2 rounded-md py-1 text-left transition-[background-color,opacity] hover:bg-muted/40 hover:opacity-90"
           onClick={() => setChildrenExpanded(!childrenExpanded)}
         >
           <ChevronRight
             className={cn(
-              'size-3 text-muted-foreground/50 transition-transform duration-150 shrink-0',
+              'size-3 shrink-0 text-muted-foreground/45 transition-transform duration-150',
               childrenExpanded && 'rotate-90',
             )}
           />
 
           {/* 状态指示：仅流式中的未完成工具才显示 spinner */}
           {!isCompleted && isStreaming ? (
-            <Loader2 className="size-3.5 animate-spin text-primary/50 shrink-0" />
+            <Loader2 className="size-3.5 shrink-0 animate-spin text-primary/60" />
           ) : isError ? (
-            <XCircle className="size-3.5 text-destructive/70 shrink-0" />
+            <XCircle className="size-3.5 shrink-0 text-destructive/70" />
           ) : null}
 
-          <ToolIcon className={cn('size-3.5 shrink-0', dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground')} />
-
-          <span className={cn(
-            'truncate text-[14px]',
-            dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
-          )}>{displayLabel}</span>
+          <ToolIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="shrink-0 text-[14px] font-medium text-muted-foreground/65">{toolKindLabel}</span>
+          <span className="shrink-0 text-muted-foreground/30">·</span>
 
           {/* 子工具计数（折叠时显示） */}
           {childToolCount > 0 && !childrenExpanded && (
-            <span className="shrink-0 text-[11px] text-muted-foreground/50 tabular-nums">
-              {childToolCount} 项工具调用
+            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/55">
+              {childToolCount} 项工具
             </span>
           )}
         </button>
@@ -558,63 +556,69 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
       )}
       style={animate ? { animationDelay: delay } : undefined}
     >
-      <button
-        type="button"
-        className={cn(
-          'inline-flex max-w-full items-center gap-2 py-0.5 text-left transition-opacity group',
-          'hover:opacity-70',
-        )}
-        onClick={() => setExpanded(!expanded)}
-      >
-        {!isCompleted && isStreaming ? (
-          <Loader2 className="size-3.5 animate-spin text-primary/50 shrink-0" />
-        ) : isError ? (
-          <XCircle className="size-3.5 text-destructive/70 shrink-0" />
-        ) : null}
+        <button
+          type="button"
+          className="group flex w-full min-w-0 items-center gap-2 rounded-md py-1 text-left transition-[background-color,opacity] hover:bg-muted/40 hover:opacity-90"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {!isCompleted && isStreaming ? (
+            <Loader2 className="size-3.5 shrink-0 animate-spin text-primary/60" />
+          ) : isError ? (
+            <XCircle className="size-3.5 shrink-0 text-destructive/70" />
+          ) : null}
 
-        <ToolIcon className={cn('size-3.5 shrink-0', dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground')} />
+          <ToolIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="shrink-0 text-[14px] font-medium text-muted-foreground/65">{toolKindLabel}</span>
+          <span className="shrink-0 text-muted-foreground/30">·</span>
+          <span className={cn(
+            'min-w-0 flex-1 truncate text-[14px]',
+            dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
+          )}>{displayLabel}</span>
 
-        <span className={cn(
-          'min-w-0 truncate text-[14px]',
-          taskGetSummary || taskListSummary ? 'shrink-0' : '',
-          dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
-        )}>{displayLabel}</span>
-
-        {phrase.diffStats && (isCompleted || !isStreaming) && (
-          <span className="shrink-0 text-[14px] tabular-nums">
-            {phrase.diffStats.additions > 0 && (
-              <span className="text-green-500">+{phrase.diffStats.additions}</span>
-            )}
-            {phrase.diffStats.additions > 0 && phrase.diffStats.deletions > 0 && ' '}
-            {phrase.diffStats.deletions > 0 && (
-              <span className="text-red-500">-{phrase.diffStats.deletions}</span>
-            )}
-          </span>
-        )}
-
-        {taskGetSummary && (
-          <span className="flex min-w-0 items-center gap-1.5">
-            <TaskGetCollapsedSummary task={taskGetSummary} />
-          </span>
-        )}
-
-        {taskListSummary && (
-          <span className="flex min-w-0 items-center gap-1.5">
-            <TaskListCollapsedSummary tasks={taskListSummary} />
-          </span>
-        )}
-
-        <ChevronRight
-          className={cn(
-            'shrink-0 size-3 text-muted-foreground/45 transition-transform duration-150',
-            expanded && 'rotate-90',
+          {resultSummary && (
+            <span className={cn(
+              'shrink-0 text-[11px] tabular-nums',
+              isError ? 'text-destructive/70' : 'text-muted-foreground/55',
+            )}>
+              {resultSummary}
+            </span>
           )}
-        />
 
-        {isPreviewable && (
-          <PreviewOpenButton filePath={filePath} />
-        )}
-      </button>
+          {phrase.diffStats && (isCompleted || !isStreaming) && (
+            <span className="shrink-0 font-mono text-[12px] tabular-nums">
+              {phrase.diffStats.additions > 0 && (
+                <span className="text-emerald-600 dark:text-emerald-400">+{phrase.diffStats.additions}</span>
+              )}
+              {phrase.diffStats.additions > 0 && phrase.diffStats.deletions > 0 && ' '}
+              {phrase.diffStats.deletions > 0 && (
+                <span className="text-red-600 dark:text-red-400">-{phrase.diffStats.deletions}</span>
+              )}
+            </span>
+          )}
+
+          {taskGetSummary && (
+            <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+              <TaskGetCollapsedSummary task={taskGetSummary} />
+            </span>
+          )}
+
+          {taskListSummary && (
+            <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+              <TaskListCollapsedSummary tasks={taskListSummary} />
+            </span>
+          )}
+
+          <ChevronRight
+            className={cn(
+              'size-3 shrink-0 text-muted-foreground/40 transition-transform duration-150',
+              expanded && 'rotate-90',
+            )}
+          />
+
+          {isPreviewable && (
+            <PreviewOpenButton filePath={filePath} />
+          )}
+        </button>
 
       {shouldShowResult && resultText && expanded && (
         <div className={cn(

--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -445,8 +445,11 @@ export function getToolResultSummary(toolName: string, result: string | undefine
   if (!result?.trim()) return null
 
   if (toolName === 'Read') {
-    const lineCount = result.match(/total\s+(\d+)\s+lines?/i)?.[1]
-    if (lineCount) return `${lineCount} 行`
+    const totalLineMatch = result.match(/total\s+(\d+)\s+lines?/i) ?? result.match(/\bof\s+(\d+)\b/i)
+    if (totalLineMatch?.[1]) return `${totalLineMatch[1]} 行`
+
+    const remainingLineCount = result.match(/\[(\d+)\s+more\s+lines?\s+in\s+file/i)?.[1]
+    if (remainingLineCount) return `还有 ${remainingLineCount} 行`
   }
   if (toolName === 'Grep' && /(?:no matches|没有匹配|未找到)/i.test(result)) return '无匹配'
   if (toolName === 'Bash') return '已完成'

--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -17,6 +17,24 @@ export interface ToolPhrase {
   diffStats?: { additions: number; deletions: number }
 }
 
+/**
+ * 优先使用 Agent 为工具调用提供的短意图。
+ * `_intent` 是内部展示元数据；Bash 的 `description` 兼容旧的语义化调用格式。
+ */
+function getExplicitToolIntent(toolName: string, input: Record<string, unknown>): string | null {
+  const intent = input._intent
+  if (typeof intent === 'string' && intent.trim()) return truncate(intent.trim(), 96)
+
+  if (toolName === 'Bash') {
+    const description = input.description
+    if (typeof description === 'string' && description.trim()) {
+      return truncate(description.trim(), 96)
+    }
+  }
+
+  return null
+}
+
 /** 从路径中提取文件名（同时兼容 POSIX `/` 与 Windows `\` 分隔符） */
 function filename(path: string): string {
   return path.split(/[/\\]/).pop() || path
@@ -45,6 +63,11 @@ function truncate(text: string, max: number): string {
  * 返回的 label 应读起来像一个完整动宾短语，无冗余信息。
  */
 export function getToolPhrase(toolName: string, input: Record<string, unknown>): ToolPhrase {
+  const explicitIntent = getExplicitToolIntent(toolName, input)
+  if (explicitIntent && toolName !== 'Edit' && toolName !== 'Write') {
+    return phrase(explicitIntent)
+  }
+
   switch (toolName) {
     case 'Read': {
       const fp = input.file_path ?? input.filePath
@@ -70,25 +93,35 @@ export function getToolPhrase(toolName: string, input: Record<string, unknown>):
       const fp = input.file_path ?? input.filePath
       const name = typeof fp === 'string' ? filename(fp) : '文件'
       const diff = computeDiffStats('Edit', input)
+      const explicitIntent = getExplicitToolIntent(toolName, input)
+      const basePhrase = explicitIntent
+        ? phrase(explicitIntent)
+        : phrase(`编辑 ${name}`)
       if (diff && (diff.additions > 0 || diff.deletions > 0)) {
-        return { ...phrase(`编辑 ${name}`), diffStats: diff }
+        return { ...basePhrase, diffStats: diff }
       }
-      return phrase(`编辑 ${name}`)
+      return basePhrase
     }
 
     case 'Write': {
       const fp = input.file_path ?? input.filePath
       const name = typeof fp === 'string' ? filename(fp) : '文件'
       const content = input.content
+      const explicitIntent = getExplicitToolIntent(toolName, input)
+      const basePhrase = explicitIntent
+        ? phrase(explicitIntent)
+        : phrase(`写入 ${name}`)
       if (typeof content === 'string' && content.length > 0) {
         const lines = content.split('\n').length
-        return { ...phrase(`写入 ${name}`), diffStats: { additions: lines, deletions: 0 } }
+        return { ...basePhrase, diffStats: { additions: lines, deletions: 0 } }
       }
-      return phrase(`写入 ${name}`)
+      return basePhrase
     }
 
     case 'Bash': {
       const cmd = input.command
+      const intent = getExplicitToolIntent(toolName, input)
+      if (intent) return phrase(intent)
       if (typeof cmd === 'string') {
         return phrase(`执行 ${truncate(cmd, 80)}`)
       }
@@ -401,6 +434,26 @@ function phrase(label: string): ToolPhrase {
     label,
     loadingLabel: `正在${label}...`,
   }
+}
+
+/**
+ * 从工具结果提取一条不会挤占主描述的短摘要。
+ * 完整结果仍由 ToolResultRenderer 展示，主行只保留用户需要快速扫读的事实。
+ */
+export function getToolResultSummary(toolName: string, result: string | undefined, isError = false): string | null {
+  if (isError) return '失败'
+  if (!result?.trim()) return null
+
+  if (toolName === 'Read') {
+    const lineCount = result.match(/total\s+(\d+)\s+lines?/i)?.[1]
+    if (lineCount) return `${lineCount} 行`
+  }
+  if (toolName === 'Grep' && /(?:no matches|没有匹配|未找到)/i.test(result)) return '无匹配'
+  if (toolName === 'Bash') return '已完成'
+  if (toolName === 'Edit' || toolName === 'Write') return '已更新'
+  if (toolName === 'Glob') return '已完成'
+
+  return null
 }
 
 /** 从 input 中提取第一个有意义的字符串值作为摘要 */


### PR DESCRIPTION
## Summary
- Improve Chat tool call rows with readable tool labels, intent descriptions, and compact result summaries.
- Preserve the original process-group statistics and existing expanded result/sub-agent behavior.
- Remove completed-state checkmarks and the temporary tool phrase test file.

## Verification
- bun run --filter=@proma/electron typecheck
- bun run --filter=@proma/electron build
- git diff --check

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)