### PR TITLE
Fix stale browser view on session switch

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2122,6 +2122,14 @@ export function registerIpcHandlers(): void {
     },
   )
   ipcMain.handle(
+    AGENT_IPC_CHANNELS.HIDE_BROWSER_PRESENTATION,
+    async (event, revision: number): Promise<void> => {
+      await assertMainRenderer(event.sender.id)
+      if (!Number.isSafeInteger(revision)) throw new Error('无效的浏览器展示 revision。')
+      browserController.hidePresentation(revision)
+    },
+  )
+  ipcMain.handle(
     AGENT_IPC_CHANNELS.NAVIGATE_BROWSER,
     async (event, input: BrowserNavigateInput): Promise<BrowserViewState> => {
       await assertBrowserSessionAccess(event.sender.id, input.sessionId)

--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -740,6 +740,24 @@ export class BrowserController {
     for (const browserSession of changedSessions) this.emit(browserSession)
   }
 
+  /** 清空跨 Session 共享的原生浏览器展示槽，避免切换期间旧 view 短暂覆盖新 Session。 */
+  hidePresentation(revision: number): void {
+    if (!Number.isSafeInteger(revision)) return
+    const changedSessions = new Set<BrowserSessionRecord>()
+    for (const browserSession of this.sessions.values()) {
+      for (const tab of browserSession.tabs.values()) {
+        tab.view.setVisible(false)
+        if (tab.state.visible) {
+          tab.state.visible = false
+          changedSessions.add(browserSession)
+        }
+      }
+    }
+    this.presentation = null
+    this.latestPresentationRevision = Math.max(this.latestPresentationRevision, revision)
+    this.emitChangedSessions(changedSessions)
+  }
+
   setLayout(layout: BrowserViewLayout): void {
     const browserSession = this.sessions.get(layout.sessionId)
     if (!browserSession) return

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -231,6 +231,7 @@ export interface ElectronAPI {
   closeAgentBrowserTab: (input: import('@proma/shared').BrowserTabInput) => Promise<import('@proma/shared').BrowserViewState | null>
   getAgentBrowserState: (sessionId: string) => Promise<import('@proma/shared').BrowserViewState | null>
   setAgentBrowserLayout: (layout: import('@proma/shared').BrowserViewLayout) => Promise<void>
+  hideAgentBrowserPresentation: (revision: number) => Promise<void>
   navigateAgentBrowser: (input: import('@proma/shared').BrowserNavigateInput) => Promise<import('@proma/shared').BrowserViewState>
   goBackAgentBrowser: (sessionId: string) => Promise<import('@proma/shared').BrowserViewState>
   goForwardAgentBrowser: (sessionId: string) => Promise<import('@proma/shared').BrowserViewState>
@@ -1338,6 +1339,9 @@ const electronAPI: ElectronAPI = {
   },
   setAgentBrowserLayout: (layout: import('@proma/shared').BrowserViewLayout) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SET_BROWSER_LAYOUT, layout)
+  },
+  hideAgentBrowserPresentation: (revision: number) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.HIDE_BROWSER_PRESENTATION, revision)
   },
   navigateAgentBrowser: (input: import('@proma/shared').BrowserNavigateInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.NAVIGATE_BROWSER, input)

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -34,6 +34,7 @@ import { interfaceVariantAtom } from '@/atoms/theme'
 import { cn } from '@/lib/utils'
 import { browserPanelOpenMapAtom, browserPendingNavigationMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
 import { BrowserPanel } from '@/components/browser/BrowserPanel'
+import { nextBrowserLayoutRevision } from '@/components/browser/browser-layout-revision'
 
 interface BrowserClosingState {
   sessionId: string
@@ -63,6 +64,14 @@ export function MainArea(): React.ReactElement {
   const previewDragging = React.useRef(false)
   const rightWorkspaceDragging = React.useRef(false)
   const browserSessionId = activeTab?.type === 'agent' ? activeTab.sessionId : null
+
+  // 原生 WebContentsView 不受 React DOM 卸载同步控制。Session 或主视图切换时先在
+  // layout effect 中清空共享展示槽，避免旧 Session 的页面参与新一帧绘制。
+  React.useLayoutEffect(() => {
+    const hidePresentation = (window.electronAPI as Partial<typeof window.electronAPI>).hideAgentBrowserPresentation
+    if (typeof hidePresentation !== 'function') return
+    void hidePresentation(nextBrowserLayoutRevision()).catch(() => undefined)
+  }, [activeView, browserSessionId])
 
   const publishBrowserState = React.useCallback((state: BrowserViewState) => {
     setBrowserStateMap((previous) => { const next = new Map(previous); next.set(state.sessionId, state); return next })

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1733,6 +1733,7 @@ export const AGENT_IPC_CHANNELS = {
   CLOSE_BROWSER_TAB: 'agent:close-browser-tab',
   GET_BROWSER_STATE: 'agent:get-browser-state',
   SET_BROWSER_LAYOUT: 'agent:set-browser-layout',
+  HIDE_BROWSER_PRESENTATION: 'agent:hide-browser-presentation',
   NAVIGATE_BROWSER: 'agent:navigate-browser',
   GO_BACK_BROWSER: 'agent:go-back-browser',
   GO_FORWARD_BROWSER: 'agent:go-forward-browser',


### PR DESCRIPTION
## Summary

- 65d5d7fb fix(browser): hide stale view when switching sessions

## Test plan

- [x] Electron typecheck
- [x] main/preload/renderer build
- [x] shared type test

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)