### PR TITLE
perf(agent): optimize multi-session streaming and rendering

### DIFF
--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -39,6 +39,7 @@ import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-man
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
 import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
+import { AgentStreamForwarder } from './agent-stream-forwarder'
 
 // ===== 实例创建 =====
 
@@ -61,6 +62,9 @@ import('./agent-collaboration-tools').then(({ registerCollaborationEventBus }) =
  * runAgent 开始时注册，结束时清理。
  */
 const sessionWebContents = new Map<string, WebContents>()
+/** 每个 renderer 当前可见的 Agent 会话；仅该会话维持 20fps partial。 */
+const visibleAgentSessionByWebContents = new WeakMap<WebContents, string | null>()
+const streamForwarder = new AgentStreamForwarder()
 
 /**
  * 已挂载 destroyed 回收钩子的 webContents 集合。
@@ -77,15 +81,22 @@ const wcWithCleanupHook = new WeakSet<WebContents>()
  * webContents 提前销毁的场景——destroyed 事件兜底。
  */
 function registerWebContents(sessionId: string, wc: WebContents): void {
-  // 旧 wc 的 destroyed 钩子仍由 WeakSet 持有，触发时会扫描 sessionWebContents 清理所有指向它的条目。
+  // 同一 session 切换 renderer 时，丢弃捕获旧 wc 的等待 partial。
+  const previousWebContents = sessionWebContents.get(sessionId)
+  if (previousWebContents && previousWebContents !== wc) streamForwarder.clear(sessionId)
+  // 旧 wc 的 destroyed 钩子仍由 WeakSet 持有，会扫描 sessionWebContents 清理所有指向它的条目。
   sessionWebContents.set(sessionId, wc)
   if (wcWithCleanupHook.has(wc)) return
   wcWithCleanupHook.add(wc)
   wc.once('destroyed', () => {
     // 单个 wc 可能映射到多个 sessionId（同窗口多 tab），需要清理所有指向它的条目
     for (const [sid, mappedWc] of sessionWebContents) {
-      if (mappedWc === wc) sessionWebContents.delete(sid)
+      if (mappedWc === wc) {
+        sessionWebContents.delete(sid)
+        streamForwarder.clear(sid)
+      }
     }
+    visibleAgentSessionByWebContents.delete(wc)
   })
 }
 
@@ -142,7 +153,13 @@ eventBus.use((sessionId, payload, next, runEvent) => {
   const wc = sessionWebContents.get(sessionId)
   if (wc && !wc.isDestroyed()) {
     try {
-      wc.send(AGENT_IPC_CHANNELS.STREAM_EVENT, runEvent satisfies AgentStreamEvent)
+      streamForwarder.forward(
+        runEvent satisfies AgentStreamEvent,
+        (event) => {
+          if (!wc.isDestroyed()) wc.send(AGENT_IPC_CHANNELS.STREAM_EVENT, event)
+        },
+        visibleAgentSessionByWebContents.get(wc) === sessionId,
+      )
     } catch (err) {
       console.error(`[EventBus] wc.send 失败: sessionId=${sessionId}, payload.kind=${(payload as Record<string, unknown>)?.kind}`, err)
     }
@@ -150,8 +167,18 @@ eventBus.use((sessionId, payload, next, runEvent) => {
   next()
 })
 
-/** Pi-native delta 已在 adapter 单点合帧；保留 IPC API 兼容，不再做第二层前后台丢帧。 */
-export function setVisibleAgentSession(_webContents: WebContents, _sessionId: string | null): void {}
+/** renderer 切换标签时更新流式优先级。 */
+export function setVisibleAgentSession(webContents: WebContents, sessionId: string | null): void {
+  const previousSessionId = visibleAgentSessionByWebContents.get(webContents)
+  if (previousSessionId && previousSessionId !== sessionId) {
+    streamForwarder.reprioritize(previousSessionId, false)
+  }
+  visibleAgentSessionByWebContents.set(webContents, sessionId)
+  if (sessionId) {
+    streamForwarder.reprioritize(sessionId, true)
+    streamForwarder.promote(sessionId)
+  }
+}
 
 // ===== IPC 薄包装函数 =====
 
@@ -198,6 +225,7 @@ export async function runAgent(
   try {
     await orchestrator.sendMessage(runInput, {
       onError: (error) => {
+        streamForwarder.flush(runInput.sessionId)
         if (!webContents.isDestroyed()) {
           webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
             sessionId: runInput.sessionId,
@@ -208,6 +236,7 @@ export async function runAgent(
         }
       },
       onComplete: (opts) => {
+        streamForwarder.flush(runInput.sessionId)
         try {
           publishRunStopped(runInput.sessionId, runInput.runId!, opts?.stoppedByUser, opts?.startedAt)
           if (!webContents.isDestroyed()) {
@@ -247,6 +276,7 @@ export async function runAgent(
   } catch (err) {
     console.error('[Agent 服务] runAgent 未处理异常:', err)
     const errorMessage = err instanceof Error ? err.message : '未知错误'
+    streamForwarder.flush(runInput.sessionId)
     try {
       if (!webContents.isDestroyed()) {
         webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
@@ -269,6 +299,7 @@ export async function runAgent(
     // 避免被拒绝的请求误删仍在运行的会话映射
     if (!orchestrator.isActive(runInput.sessionId)) {
       sessionWebContents.delete(runInput.sessionId)
+      streamForwarder.clear(runInput.sessionId)
     }
   }
 }
@@ -309,6 +340,7 @@ export async function runAgentHeadless(
   try {
     await orchestrator.sendMessage(runInput, {
       onError: (error) => {
+        streamForwarder.flush(runInput.sessionId)
         callbacks.onError(error)
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
@@ -321,6 +353,7 @@ export async function runAgentHeadless(
         }
       },
       onComplete: (opts) => {
+        streamForwarder.flush(runInput.sessionId)
         try {
           callbacks.onComplete()
           publishRunStopped(runInput.sessionId, runInput.runId!, opts?.stoppedByUser, opts?.startedAt)
@@ -378,6 +411,7 @@ export async function runAgentHeadless(
   } catch (err) {
     console.error('[Agent 服务] runAgentHeadless 未处理异常:', err)
     const errorMessage = err instanceof Error ? err.message : '未知错误'
+    streamForwarder.flush(runInput.sessionId)
     try {
       callbacks.onError(errorMessage)
       callbacks.onComplete()
@@ -400,6 +434,7 @@ export async function runAgentHeadless(
   } finally {
     if (!orchestrator.isActive(runInput.sessionId)) {
       sessionWebContents.delete(runInput.sessionId)
+      streamForwarder.clear(runInput.sessionId)
     }
   }
 }

--- a/apps/electron/src/main/lib/agent-stream-forwarder.ts
+++ b/apps/electron/src/main/lib/agent-stream-forwarder.ts
@@ -1,0 +1,185 @@
+import type {
+  AgentAssistantDeltaOperation,
+  AgentAssistantMessageDelta,
+  AgentRunEvent,
+  AgentStreamPayload,
+} from '@proma/shared'
+
+export const FOREGROUND_PARTIAL_INTERVAL_MS = 50
+export const BACKGROUND_PARTIAL_INTERVAL_MS = 250
+
+type TimerHandle = ReturnType<typeof setTimeout>
+type AppendOperation = Extract<AgentAssistantDeltaOperation, {
+  type: 'append_text' | 'append_thinking'
+}>
+type ThrottlablePartial = AgentAssistantMessageDelta & { operations: AppendOperation[] }
+
+interface PendingPartial {
+  event: AgentRunEvent
+  send: (event: AgentRunEvent) => void
+  foreground: boolean
+  timer?: TimerHandle
+}
+
+export interface AgentStreamForwarderOptions {
+  now?: () => number
+  schedule?: (callback: () => void, delayMs: number) => TimerHandle
+  cancel?: (timer: TimerHandle) => void
+}
+
+function isAppendOperation(operation: AgentAssistantDeltaOperation): operation is AppendOperation {
+  return operation.type === 'append_text' || operation.type === 'append_thinking'
+}
+
+function isThrottlablePartial(payload: AgentStreamPayload): payload is ThrottlablePartial {
+  return payload.kind === 'assistant_message_delta'
+    && !payload.reset
+    && payload.operations.length > 0
+    && payload.operations.every(isAppendOperation)
+}
+
+function mergeAppendOperations(
+  previous: AppendOperation[],
+  next: AppendOperation[],
+): AppendOperation[] {
+  const merged: AppendOperation[] = []
+  for (const operation of [...previous, ...next]) {
+    const last = merged[merged.length - 1]
+    if (
+      last
+      && last.type === operation.type
+      && last.blockIndex === operation.blockIndex
+    ) {
+      if (operation.type === 'append_text' && last.type === 'append_text') {
+        merged[merged.length - 1] = { ...last, text: last.text + operation.text }
+      } else if (operation.type === 'append_thinking' && last.type === 'append_thinking') {
+        merged[merged.length - 1] = { ...last, thinking: last.thinking + operation.thinking }
+      }
+    } else {
+      merged.push(operation)
+    }
+  }
+  return merged
+}
+
+function mergePartialEvents(
+  previous: PendingPartial,
+  incoming: AgentRunEvent,
+): AgentRunEvent | null {
+  const previousPayload = previous.event.payload
+  const incomingPayload = incoming.payload
+  if (!isThrottlablePartial(previousPayload) || !isThrottlablePartial(incomingPayload)) return null
+  if (
+    previousPayload.runId !== incomingPayload.runId
+    || previousPayload.messageId !== incomingPayload.messageId
+  ) return null
+
+  const payload: AgentAssistantMessageDelta = {
+    ...incomingPayload,
+    operations: mergeAppendOperations(previousPayload.operations, incomingPayload.operations),
+    // Renderer 只需要知道这是完整合并后的操作集，不应再要求 sequence 连续。
+    coalesced: true,
+  }
+  return { ...incoming, payload }
+}
+
+/**
+ * main -> renderer 的按会话流式调度器。
+ *
+ * Pi-native 已经在 adapter 内把原始字符串合并到 50ms，但后台会话仍不应
+ * 以相同频率占用 renderer。这里只合并可安全拼接的文本操作；结构变化、reset
+ * 和所有控制/终态事件先 flush，再立即发送。
+ */
+export class AgentStreamForwarder {
+  private readonly pending = new Map<string, PendingPartial>()
+  private readonly lastSentAt = new Map<string, number>()
+  private readonly now: () => number
+  private readonly schedule: (callback: () => void, delayMs: number) => TimerHandle
+  private readonly cancel: (timer: TimerHandle) => void
+
+  constructor(options: AgentStreamForwarderOptions = {}) {
+    this.now = options.now ?? Date.now
+    this.schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs))
+    this.cancel = options.cancel ?? clearTimeout
+  }
+
+  forward(event: AgentRunEvent, send: (event: AgentRunEvent) => void, foreground: boolean): void {
+    const { sessionId, payload } = event
+    if (!isThrottlablePartial(payload)) {
+      this.emit(sessionId)
+      this.lastSentAt.delete(sessionId)
+      send(event)
+      return
+    }
+
+    const existing = this.pending.get(sessionId)
+    if (existing) {
+      const mergedEvent = mergePartialEvents(existing, event)
+      if (mergedEvent) {
+        existing.event = mergedEvent
+        return
+      }
+      this.emit(sessionId)
+    }
+
+    const pending: PendingPartial = {
+      event,
+      send,
+      foreground,
+    }
+    this.pending.set(sessionId, pending)
+    this.schedulePending(sessionId, pending)
+  }
+
+  /** 会话切换前后台时重新安排尚未发送的 partial。 */
+  reprioritize(sessionId: string, foreground: boolean): void {
+    const pending = this.pending.get(sessionId)
+    if (!pending) return
+    pending.foreground = foreground
+    if (pending.timer) this.cancel(pending.timer)
+    this.schedulePending(sessionId, pending)
+  }
+
+  /** 切入会话时立即交付已合并快照。 */
+  promote(sessionId: string): void {
+    this.emit(sessionId)
+  }
+
+  /** 终态通知前交付当前 session 尚未发送的最新 partial。 */
+  flush(sessionId: string): void {
+    this.emit(sessionId)
+    this.lastSentAt.delete(sessionId)
+  }
+
+  clear(sessionId: string): void {
+    const pending = this.pending.get(sessionId)
+    if (pending?.timer) this.cancel(pending.timer)
+    this.pending.delete(sessionId)
+    this.lastSentAt.delete(sessionId)
+  }
+
+  dispose(): void {
+    for (const sessionId of this.pending.keys()) this.clear(sessionId)
+  }
+
+  private schedulePending(sessionId: string, pending: PendingPartial): void {
+    const intervalMs = pending.foreground
+      ? FOREGROUND_PARTIAL_INTERVAL_MS
+      : BACKGROUND_PARTIAL_INTERVAL_MS
+    const lastSentAt = this.lastSentAt.get(sessionId)
+    const elapsed = lastSentAt == null ? 0 : this.now() - lastSentAt
+    pending.timer = this.schedule(
+      () => this.emit(sessionId),
+      Math.max(0, intervalMs - elapsed),
+    )
+  }
+
+  private emit(sessionId: string): void {
+    const pending = this.pending.get(sessionId)
+    if (!pending) return
+    this.pending.delete(sessionId)
+    if (pending.timer) this.cancel(pending.timer)
+    this.lastSentAt.set(sessionId, this.now())
+    pending.send(pending.event)
+  }
+}

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -6,7 +6,8 @@
  */
 
 import { atom } from 'jotai'
-import { atomFamily, atomWithStorage, selectAtom } from 'jotai/utils'
+import { atomFamily } from 'jotai-family'
+import { atomWithStorage, selectAtom } from 'jotai/utils'
 import type { AgentSessionMeta, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, SDKMessage, UnstagedChangesResult } from '@proma/shared'
 import type { AgentLiveUpdate } from '@/lib/agent-canonical-stream'
 import { PROMA_DEFAULT_PERMISSION_MODE } from '@proma/shared'

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -6,7 +6,8 @@
  */
 
 import { atom } from 'jotai'
-import { atomFamily, atomWithStorage } from 'jotai/utils'
+import { atomFamily } from 'jotai-family'
+import { atomWithStorage } from 'jotai/utils'
 import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
 
 /** 全局渠道列表缓存（启动时加载一次，设置变更时刷新） */

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -6,6 +6,8 @@
  */
 
 import * as React from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { useStickToBottomContext } from 'use-stick-to-bottom'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { Bot, RotateCw, AlertTriangle, CheckCircle2, Ban, ChevronDown, ChevronRight } from 'lucide-react'
 import { WelcomeEmptyState } from '@/components/welcome/WelcomeEmptyState'
@@ -38,6 +40,7 @@ import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
 import { applyOptimisticAssistantTurnMetadata, createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
 import { useAgentLiveTranscriptMessages } from '@/lib/agent-live-transcript-store'
+import { getScrollTopAfterPrepend } from '@/lib/agent-scroll-anchor'
 import type { AgentEventUsage, RetryAttempt, SDKMessage, SDKSystemMessage } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
 import { agentLiveMessagesAtomFamily, agentSessionMessagesStreamStateAtomFamily, type AgentStreamState } from '@/atoms/agent-atoms'
@@ -760,6 +763,143 @@ const AgentTranscriptTail = React.memo(function AgentTranscriptTail({
   )
 })
 
+interface AgentTranscriptHistoryProps {
+  groups: MessageGroup[]
+  liveGroupSet: ReadonlySet<MessageGroup>
+  allMessages: SDKMessage[]
+  taskNotificationSignature: string
+  sessionPath?: string
+  sessionModelId?: string
+  groupHistoryTurns: Map<MessageGroup, number>
+  onFork?: (upToMessageUuid: string) => void
+  onRewind?: (assistantMessageUuid: string) => void
+  onAgentHistoryQuoteClick?: (quote: QuotedSelection) => void
+  onCreateTodo?: (text: string) => void
+  onRetry?: () => void
+  onRetryInNewSession?: () => void
+  onCompact?: () => void
+  onRelinkProjectRoot?: () => void
+  onRestoreProjectRoot?: () => void
+}
+
+/**
+ * 历史消息只挂载视口附近的 group；当前正在增长的 assistant turn 由 tail 独立承载。
+ * prepend 时按实际 scrollHeight 差值补偿，保持用户正在阅读的消息不跳动。
+ */
+const AgentTranscriptHistory = React.memo(function AgentTranscriptHistory({
+  groups,
+  liveGroupSet,
+  allMessages,
+  taskNotificationSignature,
+  sessionPath,
+  sessionModelId,
+  groupHistoryTurns,
+  onFork,
+  onRewind,
+  onAgentHistoryQuoteClick,
+  onCreateTodo,
+  onRetry,
+  onRetryInNewSession,
+  onCompact,
+  onRelinkProjectRoot,
+  onRestoreProjectRoot,
+}: AgentTranscriptHistoryProps): React.ReactElement {
+  const { scrollRef, isAtBottom } = useStickToBottomContext()
+  const virtualizer = useVirtualizer({
+    count: groups.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 160,
+    getItemKey: (index) => {
+      const group = groups[index]
+      return group ? getGroupId(group) : index
+    },
+    overscan: 6,
+    // measureElement 可能在 React commit 期间回调；避免 TanStack 默认 flushSync 触发 React 警告。
+    useFlushSync: false,
+  })
+  const virtualItems = virtualizer.getVirtualItems()
+  const previousLayoutRef = React.useRef<{
+    count: number
+    firstGroupId: string | undefined
+    scrollHeight: number
+    isAtBottom: boolean
+  } | null>(null)
+
+  React.useLayoutEffect(() => {
+    const element = scrollRef.current
+    if (!element) return
+
+    const previous = previousLayoutRef.current
+    const firstGroupId = groups[0] ? getGroupId(groups[0]) : undefined
+    if (
+      previous
+      && groups.length > previous.count
+      && firstGroupId !== previous.firstGroupId
+      && !previous.isAtBottom
+    ) {
+      const heightDelta = element.scrollHeight - previous.scrollHeight
+      if (heightDelta > 0) {
+        element.scrollTop = getScrollTopAfterPrepend(
+          element.scrollTop,
+          previous.scrollHeight,
+          element.scrollHeight,
+        )
+      }
+    }
+
+    previousLayoutRef.current = {
+      count: groups.length,
+      firstGroupId,
+      scrollHeight: element.scrollHeight,
+      isAtBottom,
+    }
+  }, [groups, isAtBottom, scrollRef])
+
+  return (
+    <div
+      className="relative w-full shrink-0"
+      style={{ height: virtualizer.getTotalSize() }}
+    >
+      {virtualItems.map((item) => {
+        const group = groups[item.index]
+        if (!group) return null
+        const isLive = liveGroupSet.has(group)
+        const isErrorGroup = group.type === 'assistant-turn'
+          && group.assistantMessages.some((message) => !!message.error)
+        const shouldDisableActions = isLive && !isErrorGroup
+        return (
+          <div
+            key={item.key}
+            ref={virtualizer.measureElement}
+            data-index={item.index}
+            className="absolute left-0 top-0 w-full pb-1"
+            style={{ transform: `translateY(${item.start}px)` }}
+          >
+            <MessageGroupRenderer
+              group={group}
+              allMessages={group.type === 'assistant-turn' ? allMessages : EMPTY_SDK_MESSAGES}
+              externalMetadataSignature={group.type === 'assistant-turn' ? taskNotificationSignature : ''}
+              basePath={sessionPath}
+              onFork={shouldDisableActions ? undefined : onFork}
+              onRewind={shouldDisableActions ? undefined : onRewind}
+              onAgentHistoryQuoteClick={onAgentHistoryQuoteClick}
+              onCreateTodo={shouldDisableActions ? undefined : onCreateTodo}
+              onRetry={shouldDisableActions ? undefined : onRetry}
+              onRetryInNewSession={shouldDisableActions ? undefined : onRetryInNewSession}
+              onRelinkProjectRoot={shouldDisableActions ? undefined : onRelinkProjectRoot}
+              onRestoreProjectRoot={shouldDisableActions ? undefined : onRestoreProjectRoot}
+              onCompact={shouldDisableActions ? undefined : onCompact}
+              historyTurn={groupHistoryTurns.get(group)}
+              isStreaming={isLive || undefined}
+              sessionModelId={sessionModelId}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+})
+
 export const AgentMessages = React.memo(function AgentMessages({
   sessionId,
   sessionModelId,
@@ -1073,34 +1213,24 @@ export const AgentMessages = React.memo(function AgentMessages({
             <EmptyState />
           ) : (
             <>
-              {/* 统一消息渲染（持久化 + 实时合并为一个列表，确保 system 消息位置正确） */}
-              {transcriptGroups.map((group) => {
-                const isLive = liveGroupSet.has(group)
-                const isErrorGroup = group.type === 'assistant-turn'
-                  && group.assistantMessages.some((m) => !!m.error)
-                const shouldDisableActions = isLive && !isErrorGroup
-                const renderer = (
-                  <MessageGroupRenderer
-                    group={group}
-                    allMessages={group.type === 'assistant-turn' ? allSDKMessages : EMPTY_SDK_MESSAGES}
-                    externalMetadataSignature={group.type === 'assistant-turn' ? taskNotificationSignature : ''}
-                    basePath={sessionPath || undefined}
-                    onFork={shouldDisableActions ? undefined : onFork}
-                    onRewind={shouldDisableActions ? undefined : onRewind}
-                    onAgentHistoryQuoteClick={onAgentHistoryQuoteClick}
-                    onCreateTodo={shouldDisableActions ? undefined : onCreateTodo}
-                    onRetry={shouldDisableActions ? undefined : onRetry}
-                    onRetryInNewSession={shouldDisableActions ? undefined : onRetryInNewSession}
-                    onRelinkProjectRoot={shouldDisableActions ? undefined : onRelinkProjectRoot}
-                    onRestoreProjectRoot={shouldDisableActions ? undefined : onRestoreProjectRoot}
-                    onCompact={shouldDisableActions ? undefined : onCompact}
-                    historyTurn={groupHistoryTurns.get(group)}
-                    isStreaming={isLive || undefined}
-                    sessionModelId={sessionModelId}
-                  />
-                )
-                return <React.Fragment key={getGroupId(group)}>{renderer}</React.Fragment>
-              })}
+              <AgentTranscriptHistory
+                groups={transcriptGroups}
+                liveGroupSet={liveGroupSet}
+                allMessages={allSDKMessages}
+                taskNotificationSignature={taskNotificationSignature}
+                sessionPath={sessionPath || undefined}
+                sessionModelId={sessionModelId}
+                groupHistoryTurns={groupHistoryTurns}
+                onFork={onFork}
+                onRewind={onRewind}
+                onAgentHistoryQuoteClick={onAgentHistoryQuoteClick}
+                onCreateTodo={onCreateTodo}
+                onRetry={onRetry}
+                onRetryInNewSession={onRetryInNewSession}
+                onRelinkProjectRoot={onRelinkProjectRoot}
+                onRestoreProjectRoot={onRestoreProjectRoot}
+                onCompact={onCompact}
+              />
 
               <AgentTranscriptTail
                 sessionId={sessionId}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1163,10 +1163,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const cached = store.get(agentSDKMessagesCacheAtom).get(sessionId)
       if (cached) {
         setPersistedSDKMessages(cached)
-        setMessagesLoaded(false)
-        // 缓存只作为最新 IPC 快照到达前的预热数据。若立即揭示，完成中的会话
-        // 可能先显示旧尾部，随后 IPC 返回的新 Agent 消息再单独跳出来。
-        // 保持 messagesLoaded=false 会让 AgentMessages 在同一批更新完成后整体显示。
+        // 缓存页可直接作为首屏数据，IPC 只负责后台校准；刷新期间仍由 messagesRefreshing
+        // 阻止非流式发送，避免用户操作与旧快照覆盖竞态。
+        setMessagesLoaded(true)
+        setMessagesLoadedSessionId(sessionId)
       } else {
         setPersistedSDKMessages([])
         setMessagesLoaded(false)

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -21,7 +21,7 @@ import * as React from 'react'
 import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
-import rehypeKatex from 'rehype-katex'
+import { REHYPE_KATEX_PLUGINS } from '@/lib/rehype-katex-options'
 import { CalendarDays, ChevronDown, ChevronUp, Paperclip, FileText, ListTodo, Sparkles, Server, Download, MessageSquareText, Quote } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { shouldInspectMermaidCodeBlock, shouldRenderMermaidCodeBlock } from '@/lib/mermaid-detection'
@@ -514,7 +514,7 @@ interface MessageResponseProps {
 
 /** 稳定引用的插件数组，避免 react-markdown 每帧重建插件管线 */
 const REMARK_PLUGINS = [remarkGfm, remarkMath]
-const REHYPE_PLUGINS = [rehypeKatex]
+const REHYPE_PLUGINS = REHYPE_KATEX_PLUGINS
 
 /** 允许 mention:// 和本地绝对路径通过 URL 清洗 */
 function mentionUrlTransform(url: string): string {

--- a/apps/electron/src/renderer/components/ai-elements/reasoning.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/reasoning.tsx
@@ -15,7 +15,7 @@ import * as React from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
-import rehypeKatex from 'rehype-katex'
+import { REHYPE_KATEX_PLUGINS } from '@/lib/rehype-katex-options'
 import { Brain, ChevronDown } from 'lucide-react'
 import {
   Collapsible,
@@ -218,7 +218,7 @@ export const ReasoningContent = React.memo(
         <div className="prose prose-sm dark:prose-invert max-w-none prose-p:my-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
           <Markdown
             remarkPlugins={[remarkGfm, remarkMath]}
-            rehypePlugins={[rehypeKatex]}
+            rehypePlugins={REHYPE_KATEX_PLUGINS}
             components={{
               a: ({ href, children: linkChildren, ...linkProps }) => (
                 <a

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -329,7 +329,7 @@ export function MainArea(): React.ReactElement {
                 ) : tabs.length === 0 ? (
                   <WelcomeView />
                 ) : activeTabId ? (
-                  <div key={activeTabId} className="flex-1 min-h-0 titlebar-no-drag animate-session-content-in">
+                  <div className="flex-1 min-h-0 titlebar-no-drag">
                     {/* 会话内容必须与侧栏/右侧面板使用同一个活动 Tab，不能延迟到旧会话。 */}
                     <TabContent tabId={activeTabId} />
                   </div>

--- a/apps/electron/src/renderer/hooks/useScrollPositionMemory.ts
+++ b/apps/electron/src/renderer/hooks/useScrollPositionMemory.ts
@@ -27,6 +27,12 @@ export function ScrollPositionManager({ id, ready }: { id: string; ready: boolea
   const restoredRef = useRef(false)
   const prevIdRef = useRef(id)
 
+  // 在 layout effect 之前同步重置，避免 sessionId 变化但 ready 仍为 true 时错过恢复。
+  if (id !== prevIdRef.current) {
+    prevIdRef.current = id
+    restoredRef.current = false
+  }
+
   // 持续保存滚动位置（距底部距离）
   // 关键：仅在恢复完成后才注册监听，防止初始化/恢复前的自动滚动污染缓存
   useEffect(() => {
@@ -41,14 +47,6 @@ export function ScrollPositionManager({ id, ready }: { id: string; ready: boolea
     el.addEventListener('scroll', savePosition, { passive: true })
     return () => el.removeEventListener('scroll', savePosition)
   }, [scrollRef, id, ready])  // ready 作为依赖：确保 ready->true 后重新运行
-
-  // id 变化时重置恢复标记
-  useEffect(() => {
-    if (id !== prevIdRef.current) {
-      prevIdRef.current = id
-      restoredRef.current = false
-    }
-  }, [id])
 
   // ready 后恢复位置 — useLayoutEffect 在浏览器绘制前执行，配合 opacity=0 无闪烁
   useLayoutEffect(() => {

--- a/apps/electron/src/renderer/index.html
+++ b/apps/electron/src/renderer/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https: proma-file:; font-src 'self' data: http: https:; media-src 'self' data: blob: http: https:; connect-src 'self' http://127.0.0.1:5173 ws://127.0.0.1:5173 wss://127.0.0.1:5173 https:; object-src 'none'; base-uri 'self'; frame-src 'self' https:;"
+    />
     <title>Proma</title>
     <script>
       // 主题初始化脚本（在 React 加载前执行，避免闪烁）

--- a/apps/electron/src/renderer/lib/agent-live-transcript-store.ts
+++ b/apps/electron/src/renderer/lib/agent-live-transcript-store.ts
@@ -131,6 +131,7 @@ export class AgentLiveTranscriptStore {
       && delta.runId === previous.runId
       && delta.sequence !== previous.sequence + 1
       && !delta.reset
+      && !delta.coalesced
     ) return null
     if (!previous && !delta.reset) return null
 

--- a/apps/electron/src/renderer/lib/agent-scroll-anchor.ts
+++ b/apps/electron/src/renderer/lib/agent-scroll-anchor.ts
@@ -1,0 +1,10 @@
+/**
+ * 计算顶部 prepend 历史消息后的滚动位置，保持原先可见内容的屏幕位置。
+ */
+export function getScrollTopAfterPrepend(
+  currentScrollTop: number,
+  previousScrollHeight: number,
+  nextScrollHeight: number,
+): number {
+  return currentScrollTop + Math.max(0, nextScrollHeight - previousScrollHeight)
+}

--- a/apps/electron/src/renderer/lib/rehype-katex-options.ts
+++ b/apps/electron/src/renderer/lib/rehype-katex-options.ts
@@ -1,0 +1,10 @@
+import rehypeKatex from 'rehype-katex'
+import type { Options as RehypeKatexOptions } from 'rehype-katex'
+import type { Pluggable } from 'unified'
+
+/** 中文文本落入数学表达式时保留可见内容，但不把 KaTeX 的兼容性提示刷满 Console。 */
+export const REHYPE_KATEX_OPTIONS: RehypeKatexOptions = {
+  strict: (errorCode) => errorCode === 'unicodeTextInMathMode' ? 'ignore' : 'warn',
+}
+
+export const REHYPE_KATEX_PLUGINS: Pluggable[] = [[rehypeKatex, REHYPE_KATEX_OPTIONS]]

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "proma",
       "dependencies": {
         "jotai": "^2.17.1",
+        "jotai-family": "^1.1.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -1701,6 +1702,8 @@
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
     "jotai": ["jotai@2.20.2", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-aHB4CNb9qRcyf0mwSB6EO5bCGAjx8cTwFgOFCE2leOnTzqACbnSWG8XoWB3LxCT1Qoj03I1OWAHszDmN4uHb/w=="],
+
+    "jotai-family": ["jotai-family@1.1.0", "", { "peerDependencies": { "jotai": ">=2.9.0" } }, "sha512-T1ACRsLnN5Mu0B8/DIWUW1hW7x1RmpBprm/+CWmUTf4ZZUmIFEQpBJ9PNQtXPjdUD2uu8RvwBxr7nJPdCw5BXg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "jotai": "^2.17.1"
+    "jotai": "^2.17.1",
+    "jotai-family": "^1.1.0"
   },
   "overrides": {
     "@earendil-works/pi-agent-core": "0.84.2",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -680,6 +680,8 @@ export interface AgentAssistantMessageDelta {
   sequence: number
   reset?: SDKAssistantMessage
   operations: AgentAssistantDeltaOperation[]
+  /** main -> renderer 调度器已合并多个连续 delta，sequence 允许出现跳跃。 */
+  coalesced?: boolean
   metadata?: AgentAssistantDeltaMetadata
 }
 


### PR DESCRIPTION
## Summary

- 恢复 main -> renderer 的 per-session Agent stream scheduler：前台 50ms、后台 250ms，结构/控制/终态事件即时发送并在终态前 flush。
- 使用 TanStack Virtual 虚拟化长 Agent 历史消息，live assistant tail 独立渲染，降低长列表布局和测量开销。
- 优化 session cache-first 切换、顶部历史 prepend 的 scrollHeight 锚点补偿，并移除外层 session 重建动画。
- 迁移 Jotai atomFamily、处理 KaTeX Unicode 警告，并为 Shiki Oniguruma WASM 增加 wasm-unsafe-eval CSP 权限。

## Verification

- `bun run --cwd apps/electron typecheck`
- `bun run --cwd apps/electron build:renderer`
- `git diff --check`
- 本轮新增测试文件已按要求移除；实现代码此前已通过 29 项定向测试。

## Follow-up

- 仍需在真实 Electron/Chromium 中录制 8 个后台 Agent、连续输入、长会话切换和顶部加载历史的 Performance/React Profiler 数据。
- 后续重点验证输入到 paint p95、long task、React commit、partial FPS、切换首屏时间、layout/ResizeObserver 开销，以及完成后 60 秒稳态资源释放。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)