### PR TITLE
feat(agent): animate history and session transitions

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -4236,6 +4236,67 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
 
 // ===== 项目分组历史 =====
 
+const PROJECT_HISTORY_ANIMATION_MS = 160
+
+/**
+ * 仅在收起动画结束后卸载会话树：避免常驻隐藏历史占用渲染与监听开销。
+ * 使用 CSS grid 的固定轨道过渡，不读取内容高度，也不在动画帧中执行 JS。
+ */
+function ProjectSessionList({
+  id,
+  collapsed,
+  children,
+}: {
+  id: string
+  collapsed: boolean
+  children: React.ReactNode
+}): React.ReactElement | null {
+  const [shouldRender, setShouldRender] = React.useState(!collapsed)
+  const [isOpen, setIsOpen] = React.useState(!collapsed)
+
+  React.useEffect(() => {
+    let frameId: number | undefined
+    let cleanupTimer: number | undefined
+
+    if (collapsed) {
+      setIsOpen(false)
+      cleanupTimer = window.setTimeout(() => setShouldRender(false), PROJECT_HISTORY_ANIMATION_MS)
+    } else {
+      setShouldRender(true)
+      // 先以 0fr 挂载，再在下一帧展开，确保首次展开能触发 CSS 过渡。
+      frameId = window.requestAnimationFrame(() => setIsOpen(true))
+    }
+
+    return () => {
+      if (frameId !== undefined) window.cancelAnimationFrame(frameId)
+      if (cleanupTimer !== undefined) window.clearTimeout(cleanupTimer)
+    }
+  }, [collapsed])
+
+  return (
+    <div
+      id={id}
+      className={cn(
+        'ml-4 mt-px grid transition-[grid-template-rows] duration-[160ms] ease-out motion-reduce:transition-none',
+        isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">
+        {shouldRender && (
+          <div
+            className={cn(
+              'transition-[opacity,transform] duration-[160ms] ease-out motion-reduce:transition-none',
+              isOpen ? 'translate-y-0 opacity-100' : '-translate-y-0.5 opacity-0',
+            )}
+          >
+            {children}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 interface AgentProjectGroupItemProps {
   group: AgentProjectGroup
   currentWorkspaceId: string | null
@@ -4608,8 +4669,8 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         )}
       </div>
 
-      <div id={`project-sessions-${group.workspace.id}`} className="ml-4 mt-px">
-        {!collapsed ? (
+      <ProjectSessionList id={`project-sessions-${group.workspace.id}`} collapsed={collapsed}>
+        {(
           treeItems.length > 0 ? (
             <div className="flex flex-col gap-0.5">
               {sessions.map((item) => {
@@ -4714,8 +4775,8 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               暂无会话
             </div>
           )
-        ) : null}
-      </div>
+        )}
+      </ProjectSessionList>
       {dropPosition === 'after' && (
         <div className="absolute -bottom-0.5 left-3 right-3 h-0.5 rounded-full bg-primary z-10" />
       )}

--- a/apps/electron/src/renderer/components/tabs/TabContent.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabContent.tsx
@@ -15,7 +15,39 @@ import { PreviewTabContent } from '@/components/diff/PreviewTabContent'
 import { MarkdownRichEditor } from '@/components/diff/MarkdownRichEditor'
 import { MarkdownToc } from '@/components/diff/MarkdownToc'
 import { ScratchPadView } from '@/components/scratch-pad/ScratchPadView'
+import { cn } from '@/lib/utils'
 import { TabErrorBoundary } from './TabErrorBoundary'
+
+const AGENT_SESSION_TRANSITION_MS = 140
+
+/**
+ * 切换时立即挂载新会话（不保留旧会话），只给新内容一段短暂进入过渡。
+ * 仅合成 opacity，避免为整段对话测量高度或触发布局动画。
+ */
+function AgentSessionTransition({ children, animate }: { children: React.ReactNode; animate: boolean }): React.ReactElement {
+  const [entered, setEntered] = React.useState(!animate)
+
+  React.useEffect(() => {
+    if (!animate) {
+      setEntered(true)
+      return
+    }
+    const frameId = window.requestAnimationFrame(() => setEntered(true))
+    return () => window.cancelAnimationFrame(frameId)
+  }, [animate])
+
+  return (
+    <div
+      className={cn(
+        'h-full min-h-0 transition-opacity ease-out motion-reduce:transition-none',
+        entered ? 'opacity-100' : 'opacity-0',
+      )}
+      style={{ transitionDuration: `${AGENT_SESSION_TRANSITION_MS}ms` }}
+    >
+      {children}
+    </div>
+  )
+}
 
 export interface TabContentProps {
   tabId: string
@@ -24,6 +56,12 @@ export interface TabContentProps {
 function TabContentView({ tabId }: TabContentProps): React.ReactElement {
   const tabs = useAtomValue(tabsAtom)
   const tab = tabs.find((t) => t.id === tabId)
+  const hasShownAgentSessionRef = React.useRef(false)
+  const shouldAnimateAgentSession = tab?.type === 'agent' && hasShownAgentSessionRef.current
+
+  React.useEffect(() => {
+    if (tab?.type === 'agent') hasShownAgentSessionRef.current = true
+  }, [tab?.sessionId, tab?.type])
 
   // [FLASH-DEBUG] 监控 tab 查找失败（说明 tabId 指向了不存在的标签）
   React.useEffect(() => {
@@ -65,9 +103,11 @@ function TabContentView({ tabId }: TabContentProps): React.ReactElement {
   }
 
   return (
-    <TabErrorBoundary key={tab.sessionId} sessionId={tab.sessionId}>
-      <AgentView sessionId={tab.sessionId} />
-    </TabErrorBoundary>
+    <AgentSessionTransition key={tab.sessionId} animate={shouldAnimateAgentSession}>
+      <TabErrorBoundary sessionId={tab.sessionId}>
+        <AgentView sessionId={tab.sessionId} />
+      </TabErrorBoundary>
+    </AgentSessionTransition>
   )
 }
 


### PR DESCRIPTION
## Summary
- Add a lightweight expand/collapse transition for Agent project history.
- Add a fade-only transition when switching between Agent sessions.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)