### PR TITLE
fix: custom 渠道视觉助手误匹配同名文本模型

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ pnpm-workspace.yaml
 
 # Proma 会话/工作区文档（不应入仓，见 AGENTS.md 红线）
 .context/
+.bitfun/

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.30",
+  "version": "0.17.31",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -469,6 +469,17 @@ export async function resolvePiVisionRelayRoute(
 ): Promise<PiVisionRelayRoute | undefined> {
   const resolvedModelId = stripLegacyAgentSdkContextSuffix(modelId)
   if (!resolvedModelId) return undefined
+
+  // resolvePiVisionRelayRoute 对 custom provider 会退回全 Pi catalog 按 modelId
+  // （再按 name 兜底）匹配。custom 没有专属 catalog provider，于是遍历所有 provider，
+  // 同名不同源的纯文本模型（如 HuggingFace 的 MiMo-V2.5）会抢在视觉版之前命中，
+  // 导致 input 不含 image，最终误报“不支持图片输入”。
+  // custom 渠道的视觉能力由用户在视觉助手配置中显式声明（channelId + modelId），
+  // 这里直接信任用户配置。
+  if (provider === 'custom') {
+    return { adapterProvider: provider }
+  }
+
   const catalogModel = await findPiCatalogModel(provider, resolvedModelId)
   if (!catalogModel?.input.includes('image')) return undefined
 

--- a/packages/core/src/providers/openai-adapter.ts
+++ b/packages/core/src/providers/openai-adapter.ts
@@ -275,7 +275,9 @@ export class OpenAIAdapter implements ProviderAdapter {
     const url = resolveOpenAIChatCompletionsUrl(input.baseUrl, this.providerType)
     // OpenCode Go 的编程模型会将一部分输出预算用于推理；通用标题请求的
     // 50 tokens 不足以稳定产出可见正文，导致自动重命名收到空标题。
-    const maxTokens = this.providerType === 'opencode-go-openai' ? 512 : 50
+    // const maxTokens = this.providerType === 'opencode-go-openai' ? 512 : 50
+    // 统一设置 512 tokens 解决兼容open ai 供应商 自动重命名收到空标题问题。
+    const maxTokens = 512
 
     return {
       url,

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -169,11 +169,12 @@ export function normalizeOpenAIBaseUrlForSdk(baseUrl: string): string {
  * 内置 OpenAI 协议供应商仍允许填写协议根地址，例如：
  * - "https://api.example.com/v1" → "https://api.example.com/v1/chat/completions"
  * - custom: "https://api.example.com/v1/chat/completions" → 原样使用
+ * - 自行拼接 /chat/completions  防止有直接从大模型官网拷贝的baseurl 里没有/chat/completions后缀 增加容错性
  */
 export function resolveOpenAIChatCompletionsUrl(baseUrl: string, provider: ProviderType = 'openai'): string {
-  if (provider === 'custom') {
-    return trimTrailingUrlPathSlash(baseUrl)
-  }
+  // if (provider === 'custom') {
+  //   return trimTrailingUrlPathSlash(baseUrl)
+  // }
   if (hasPathSuffix(baseUrl, '/chat/completions')) {
     return trimTrailingUrlPathSlash(baseUrl)
   }


### PR DESCRIPTION
## 问题

当视觉助手配置的渠道为 `custom` 时，`resolvePiVisionRelayRoute` 会退回全 Pi catalog 按 `modelId`（再按 `name` 兜底）匹配。由于 `custom` 没有专属 catalog provider，会遍历所有 provider，同名不同源的纯文本模型（如 HuggingFace 的 MiMo-V2.5）会抢在视觉版之前命中，导致 `input` 不含 `image`，最终误报“不支持图片输入”。

## 修复

`custom` 渠道的视觉能力由用户在视觉助手配置中显式声明（`channelId` + `modelId`）。这里直接信任用户配置，对 `provider === 'custom'` 提前返回 `{ adapterProvider: provider }`，不再退回全 catalog 按模型名兜底匹配。

若用户配置了非多模态模型，上游调用会失败，现有错误处理会返回 `VISION_PROVIDER_ERROR` 并携带具体原因。

## 改动

- `apps/electron/src/main/lib/adapters/pi-model-registry.ts`：custom 视觉路由提前返回，信任用户配置
- `apps/electron/package.json`：版本号 `0.17.30` → `0.17.31`