### PR TITLE
fix(agent): deduplicate delegated live user messages

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.39",
+  "version": "0.17.40",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -41,6 +41,7 @@ import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgr
 import { applyOptimisticAssistantTurnMetadata, createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
 import { useAgentLiveTranscriptMessages } from '@/lib/agent-live-transcript-store'
 import { getScrollTopAfterPrepend } from '@/lib/agent-scroll-anchor'
+import { mergePersistedAndLiveAgentMessages } from '@/lib/agent-message-merge'
 import type { AgentEventUsage, RetryAttempt, SDKMessage, SDKSystemMessage } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
 import { agentLiveMessagesAtomFamily, agentSessionMessagesStreamStateAtomFamily, type AgentStreamState } from '@/atoms/agent-atoms'
@@ -1039,8 +1040,12 @@ export const AgentMessages = React.memo(function AgentMessages({
 
     const persistedWithKeys = persisted.map(stampStableKey)
     const liveWithKeys = live.map(stampStableKey)
-    if (streaming || liveWithKeys.length === 0 || persistedWithKeys.length === 0) {
+    if (liveWithKeys.length === 0 || persistedWithKeys.length === 0) {
       return [...persistedWithKeys, ...liveWithKeys]
+    }
+
+    if (streaming) {
+      return mergePersistedAndLiveAgentMessages(persistedWithKeys, liveWithKeys)
     }
 
     // 流式结束后的刷新中，持久化消息尾部可能已经包含 live 序列。

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -104,12 +104,15 @@ import { detectIsMac } from '@/lib/platform'
 import { ShortcutKeycaps } from '@/components/shortcuts/ShortcutKeycaps'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
+  buildAgentSessionTrees,
   collectAgentSessionTreeIds,
+  isDelegatedChildSession,
   isAgentSessionVisibleInTrees,
   mergeActiveAgentSessions,
   replaceAgentSessionInFreshnessOrder,
   sortAgentSessionsByUpdatedAtDesc,
 } from '@/lib/agent-session-list'
+import type { AgentSessionTreeItem } from '@/lib/agent-session-list'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -322,11 +325,6 @@ interface AgentProjectGroup {
   sessions: AgentSessionMeta[]
 }
 
-interface AgentSessionTreeItem {
-  session: AgentSessionMeta
-  childSessions: AgentSessionMeta[]
-}
-
 /** 合成「自动任务」虚拟项目组的工作区 ID（不对应真实 workspace，仅用于聚合自动任务会话） */
 const AUTOMATION_GROUP_ID = '__automations__'
 /** 供合成组复用 AgentProjectGroupItem 时填充无意义的 workspace 专属回调 */
@@ -483,36 +481,6 @@ function getRailInitial(title: string): string {
  */
 function isHiddenAutomationSession(session: AgentSessionMeta): boolean {
   return !!session.sourceAutomationId && !session.pinned
-}
-
-function isDelegatedChildSession(session: AgentSessionMeta): boolean {
-  return !!session.parentSessionId && !!session.sourceDelegationId
-}
-
-function buildAgentSessionTrees(sessions: AgentSessionMeta[]): AgentSessionTreeItem[] {
-  const sessionIds = new Set(sessions.map((session) => session.id))
-  const childrenByParentId = new Map<string, AgentSessionMeta[]>()
-  const roots: AgentSessionMeta[] = []
-
-  for (const session of sessions) {
-    if (
-      isDelegatedChildSession(session)
-      && session.parentSessionId
-      && sessionIds.has(session.parentSessionId)
-    ) {
-      const children = childrenByParentId.get(session.parentSessionId) ?? []
-      children.push(session)
-      childrenByParentId.set(session.parentSessionId, children)
-      continue
-    }
-
-    roots.push(session)
-  }
-
-  return roots.map((session) => ({
-    session,
-    childSessions: childrenByParentId.get(session.id) ?? [],
-  }))
 }
 
 function getDelegatedChildStatus(
@@ -1002,6 +970,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       const filtered = agentSessions.filter((s) =>
         s.pinned
         && !draftSessionIds.has(s.id)
+        && !isDelegatedChildSession(s)
         && !hasPinnedVisibleParent(s, agentSessions)
       )
       return sortAgentSessionsByUpdatedAtDesc(filtered)

--- a/apps/electron/src/renderer/lib/agent-message-merge.ts
+++ b/apps/electron/src/renderer/lib/agent-message-merge.ts
@@ -1,0 +1,51 @@
+import type { SDKMessage } from '@proma/shared'
+
+interface SDKMessageRecord {
+  uuid?: unknown
+}
+
+function getMessageUuid(message: SDKMessage): string | undefined {
+  const uuid = (message as unknown as SDKMessageRecord).uuid
+  return typeof uuid === 'string' && uuid.length > 0 ? uuid : undefined
+}
+
+/**
+ * 合并持久化历史与当前 live 消息。
+ *
+ * headless/委派 run 启动时，user 消息可能已经写入 JSONL，同时又通过
+ * external_run_started 或实时 SDK 事件进入 live 列表。按 UUID 原位更新，
+ * 保留消息顺序并避免同一消息在 AgentTranscriptTail 中生成两个 React key。
+ * 没有 UUID 的控制消息不做内容推断，继续按原顺序保留。
+ */
+export function mergePersistedAndLiveAgentMessages(
+  persisted: readonly SDKMessage[],
+  live: readonly SDKMessage[],
+): SDKMessage[] {
+  const merged: SDKMessage[] = []
+  const indexByUuid = new Map<string, number>()
+
+  const appendOrReplace = (message: SDKMessage): void => {
+    const uuid = getMessageUuid(message)
+    if (!uuid) {
+      merged.push(message)
+      return
+    }
+
+    const existingIndex = indexByUuid.get(uuid)
+    if (existingIndex === undefined) {
+      indexByUuid.set(uuid, merged.length)
+      merged.push(message)
+      return
+    }
+
+    const existing = merged[existingIndex]
+    merged[existingIndex] = {
+      ...(existing as unknown as Record<string, unknown>),
+      ...(message as unknown as Record<string, unknown>),
+    } as unknown as SDKMessage
+  }
+
+  for (const message of persisted) appendOrReplace(message)
+  for (const message of live) appendOrReplace(message)
+  return merged
+}

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -5,6 +5,49 @@ interface AgentSessionTreeLike {
   childSessions: readonly Pick<AgentSessionMeta, 'id'>[]
 }
 
+export interface AgentSessionTreeItem {
+  session: AgentSessionMeta
+  childSessions: AgentSessionMeta[]
+}
+
+/** 委派子会话必须跟随父会话展示，不能在父会话尚未加载时降级为根会话。 */
+export function isDelegatedChildSession(session: AgentSessionMeta): boolean {
+  return !!session.parentSessionId && !!session.sourceDelegationId
+}
+
+/**
+ * 将 Agent 会话构建为父子树。
+ *
+ * 冷启动时子会话的 external_run_started 可能先于父会话元数据进入 renderer；
+ * 这类 orphan child 只暂存于列表状态，不能作为顶层用户会话渲染，否则父会话
+ * 到达后会同时出现一个根节点和一个嵌套节点。
+ */
+export function buildAgentSessionTrees(
+  sessions: readonly AgentSessionMeta[],
+): AgentSessionTreeItem[] {
+  const sessionIds = new Set(sessions.map((session) => session.id))
+  const childrenByParentId = new Map<string, AgentSessionMeta[]>()
+  const roots: AgentSessionMeta[] = []
+
+  for (const session of sessions) {
+    if (isDelegatedChildSession(session)) {
+      if (session.parentSessionId && sessionIds.has(session.parentSessionId)) {
+        const children = childrenByParentId.get(session.parentSessionId) ?? []
+        children.push(session)
+        childrenByParentId.set(session.parentSessionId, children)
+      }
+      continue
+    }
+
+    roots.push(session)
+  }
+
+  return roots.map((session) => ({
+    session,
+    childSessions: childrenByParentId.get(session.id) ?? [],
+  }))
+}
+
 /** 按最近更新时间排序 Agent 会话，保持与主进程 listAgentSessions 一致。 */
 export function sortAgentSessionsByUpdatedAtDesc(
   sessions: readonly AgentSessionMeta[],


### PR DESCRIPTION
## Summary
- 修复派生子会话启动时 persisted/live user message 重复渲染的问题
- 按 UUID 原位合并历史与实时消息，避免 AgentTranscriptTail 产生重复 React key
- 委派子会话在父会话元数据尚未到达时不再降级为侧栏根会话
- 清理本次新增的测试文件与测试改动，保留生产修复代码

## Verification
- bun run typecheck
- bun test apps/electron/src/renderer/lib/agent-session-list.test.ts

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)