### PR TITLE
Fix sidebar tooltips dismiss naturally

### DIFF
--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -108,7 +108,7 @@ export default function App(): React.ReactElement {
   // 显示 onboarding 界面
   if (showOnboarding) {
     return (
-      <TooltipProvider delayDuration={200}>
+      <TooltipProvider delayDuration={200} disableHoverableContent>
         <div className="relative h-screen w-screen overflow-hidden">
           {/* Onboarding 绕过 AppShell 时仍需提供隐藏标题栏窗口的拖拽区，并避开 Windows 控制按钮。 */}
           <div
@@ -133,7 +133,7 @@ export default function App(): React.ReactElement {
 
   // 显示主界面
   return (
-    <TooltipProvider delayDuration={200}>
+    <TooltipProvider delayDuration={200} disableHoverableContent>
       <AppShell contextValue={contextValue} />
       <PlanningReminderRail />
       <ShortcutGuideDialog />

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -90,7 +90,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
   const Icon = MODE_ICONS[displayMode]
 
   return (
-    <TooltipProvider delayDuration={300}>
+    <TooltipProvider delayDuration={300} disableHoverableContent>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -192,7 +192,7 @@ export function MessageAction({
 
   if (tooltip) {
     return (
-      <TooltipProvider>
+      <TooltipProvider disableHoverableContent>
         <Tooltip>
           <TooltipTrigger asChild>{button}</TooltipTrigger>
           <TooltipContent>

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -309,7 +309,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
     }
 
     return (
-      <TooltipProvider>
+      <TooltipProvider disableHoverableContent>
         <MentionErrorBoundary>
       <div
         ref={containerRef}


### PR DESCRIPTION
## Summary

- Enable Radix TooltipProvider `disableHoverableContent` for the main app and onboarding surfaces.
- Prevent sidebar tooltips from lingering when the pointer quickly sweeps across action buttons.

## Validation

- [x] `bun run --cwd apps/electron typecheck`
- [x] `bun run --cwd apps/electron build:renderer`
- [x] `git diff --check`
- [ ] Manual Electron interaction test

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)