### PR TITLE
Restore natural sidebar tooltip dismissal

### DIFF
--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -108,7 +108,7 @@ export default function App(): React.ReactElement {
   // 显示 onboarding 界面
   if (showOnboarding) {
     return (
-      <TooltipProvider delayDuration={200}>
+      <TooltipProvider delayDuration={200} disableHoverableContent>
         <div className="relative h-screen w-screen overflow-hidden">
           {/* Onboarding 绕过 AppShell 时仍需提供隐藏标题栏窗口的拖拽区，并避开 Windows 控制按钮。 */}
           <div
@@ -133,7 +133,7 @@ export default function App(): React.ReactElement {
 
   // 显示主界面
   return (
-    <TooltipProvider delayDuration={200}>
+    <TooltipProvider delayDuration={200} disableHoverableContent>
       <AppShell contextValue={contextValue} />
       <PlanningReminderRail />
       <ShortcutGuideDialog />

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -90,7 +90,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
   const Icon = MODE_ICONS[displayMode]
 
   return (
-    <TooltipProvider delayDuration={300}>
+    <TooltipProvider delayDuration={300} disableHoverableContent>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -191,7 +191,7 @@ export function MessageAction({
 
   if (tooltip) {
     return (
-      <TooltipProvider>
+      <TooltipProvider disableHoverableContent>
         <Tooltip>
           <TooltipTrigger asChild>{button}</TooltipTrigger>
           <TooltipContent>

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -309,7 +309,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
     }
 
     return (
-      <TooltipProvider>
+      <TooltipProvider disableHoverableContent>
         <MentionErrorBoundary>
       <div
         ref={containerRef}


### PR DESCRIPTION
## Summary

#1683 的回退基线覆盖了 #1680 中的 Tooltip 行为。本 PR 基于当前 main 仅恢复 4 处 `disableHoverableContent` 配置，使左侧列表及相关嵌套 Tooltip 在离开触发器后自然消失。

## Changes

- 恢复 `App` 的主界面与 onboarding TooltipProvider 配置
- 恢复权限模式选择器、消息操作按钮、文件提及列表的 TooltipProvider 配置

## Validation

- `git diff --check` 通过
- 类型检查未执行成功：worktree 未安装依赖，环境报 `tsc: command not found`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)