### PR TITLE
chore(agent): 命名 utility 进程为 Proma Runtime

### DIFF
--- a/apps/electron/src/main/lib/agent-runtime-client.ts
+++ b/apps/electron/src/main/lib/agent-runtime-client.ts
@@ -184,6 +184,7 @@ export class AgentRuntimeClient {
     const generation = ++this.generation
     this.state = { ...this.state, status: 'starting', lastError: undefined }
     const runtimeProcess = utilityProcess.fork(this.entryPath, [], {
+      serviceName: 'Proma Runtime',
       env: { ...process.env, ...this.env, PROMA_AGENT_SESSION_ID: this.sessionId },
     })
     this.runtimeProcess = runtimeProcess


### PR DESCRIPTION
## 变更

将 Pi Agent utility process 的 Electron `serviceName` 固定为 `Proma Runtime`，方便在进程指标、诊断日志和生命周期事件中识别。

Session ID 仍然只通过 `PROMA_AGENT_SESSION_ID` 保留内部关联，不拼接进公开进程名称。

## 验证

- `bun run typecheck`
- `bun run --cwd apps/electron build:main`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
