### PR TITLE
fix: virtualize Agent transcript and active sidebar

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -656,6 +656,18 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
     scrollHeight: number
     isAtBottom: boolean
   } | null>(null)
+  const pendingNavigationFrameRef = React.useRef<number | null>(null)
+  const navigationGenerationRef = React.useRef(0)
+
+  React.useEffect(() => {
+    return () => {
+      navigationGenerationRef.current += 1
+      if (pendingNavigationFrameRef.current !== null) {
+        window.cancelAnimationFrame(pendingNavigationFrameRef.current)
+        pendingNavigationFrameRef.current = null
+      }
+    }
+  }, [groups])
 
   React.useLayoutEffect(() => {
     const element = scrollRef.current
@@ -697,8 +709,14 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
       if (!onMounted) return
 
       // 目标行可能在远距离跳转后才挂载；持续等待挂载而不是依赖固定帧数。
+      const generation = ++navigationGenerationRef.current
+      if (pendingNavigationFrameRef.current !== null) {
+        window.cancelAnimationFrame(pendingNavigationFrameRef.current)
+      }
       let frame = 0
       const waitForMounted = (): void => {
+        pendingNavigationFrameRef.current = null
+        if (navigationGenerationRef.current !== generation) return
         frame += 1
         const target = Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-message-id]') ?? [])
           .find((element) => element.dataset.messageId === messageId)
@@ -706,9 +724,11 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
           onMounted(target)
           return
         }
-        if (frame < 120) window.requestAnimationFrame(waitForMounted)
+        if (frame < 120) {
+          pendingNavigationFrameRef.current = window.requestAnimationFrame(waitForMounted)
+        }
       }
-      window.requestAnimationFrame(waitForMounted)
+      pendingNavigationFrameRef.current = window.requestAnimationFrame(waitForMounted)
     },
     getStickyUserMessageId: (scrollTop) => {
       const measurements = virtualizer.measurementsCache
@@ -716,6 +736,8 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
         const measurement = measurements[index]
         const group = measurement ? groups[measurement.index] : undefined
         if (group?.type === 'user' && measurement && measurement.end < scrollTop) {
+          // 未测量行只含 estimateSize，不能据此决定 Sticky 的真实用户消息。
+          if (!virtualizer.itemSizeCache.has(measurement.key)) return null
           return getGroupId(group)
         }
       }

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -767,9 +767,16 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
       if (candidate < 0) return null
 
       const groupIndex = userGroupIndices[candidate]!
-      const measurement = measurements[groupIndex]
-      const group = groups[groupIndex]
-      if (!measurement || !group || !virtualizer.itemSizeCache.has(measurement.key)) return null
+      let measurement = measurements[groupIndex]
+      let group = groups[groupIndex]
+      while (candidate >= 0 && (!measurement || !virtualizer.itemSizeCache.has(measurement.key))) {
+        candidate -= 1
+        if (candidate < 0) return null
+        const fallbackGroupIndex = userGroupIndices[candidate]!
+        measurement = measurements[fallbackGroupIndex]
+        group = groups[fallbackGroupIndex]
+      }
+      if (!measurement || !group) return null
       return getGroupId(group)
     },
   }), [groups, scrollRef, stopScroll, userGroupIndices, virtualizer])

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -587,7 +587,8 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
 }
 
 interface AgentTranscriptHistoryHandle {
-  scrollToMessage: (messageId: string, onMounted: (target: HTMLElement) => void) => void
+  scrollToMessage: (messageId: string, onMounted?: (target: HTMLElement) => void) => void
+  getStickyUserMessageId: (scrollTop: number) => string | null
 }
 
 interface AgentTranscriptHistoryProps {
@@ -635,7 +636,7 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
   onRestoreProjectRoot,
   onCompact,
 }, ref): React.ReactElement {
-  const { scrollRef, isAtBottom } = useStickToBottomContext()
+  const { scrollRef, isAtBottom, stopScroll } = useStickToBottomContext()
   const virtualizer = useVirtualizer({
     count: groups.length,
     getScrollElement: () => scrollRef.current,
@@ -690,23 +691,37 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
     scrollToMessage: (messageId, onMounted) => {
       const index = groups.findIndex((group) => getGroupId(group) === messageId)
       if (index < 0) return
-      virtualizer.scrollToIndex(index, { align: 'center', behavior: 'smooth' })
+      stopScroll()
+      virtualizer.scrollToIndex(index, { align: 'center', behavior: 'auto' })
 
-      // TanStack virtualizer 提交挂载行后再计算 Range；两帧也覆盖了平滑滚动的首帧布局。
+      if (!onMounted) return
+
+      // 目标行可能在远距离跳转后才挂载；持续等待挂载而不是依赖固定帧数。
       let frame = 0
       const waitForMounted = (): void => {
         frame += 1
         const target = Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-message-id]') ?? [])
           .find((element) => element.dataset.messageId === messageId)
-        if (target || frame >= 3) {
-          if (target) onMounted(target)
+        if (target) {
+          onMounted(target)
           return
         }
-        window.requestAnimationFrame(waitForMounted)
+        if (frame < 120) window.requestAnimationFrame(waitForMounted)
       }
       window.requestAnimationFrame(waitForMounted)
     },
-  }), [groups, scrollRef, virtualizer])
+    getStickyUserMessageId: (scrollTop) => {
+      const measurements = virtualizer.measurementsCache
+      for (let index = measurements.length - 1; index >= 0; index -= 1) {
+        const measurement = measurements[index]
+        const group = measurement ? groups[measurement.index] : undefined
+        if (group?.type === 'user' && measurement && measurement.end < scrollTop) {
+          return getGroupId(group)
+        }
+      }
+      return null
+    },
+  }), [groups, scrollRef, stopScroll, virtualizer])
 
   return (
     <div
@@ -1106,6 +1121,13 @@ export const AgentMessages = React.memo(function AgentMessages({
     return turns
   }, [visibleGroups])
 
+  const scrollToTranscriptMessage = React.useCallback((messageId: string): void => {
+    historyVirtualizerRef.current?.scrollToMessage(messageId)
+  }, [])
+  const getStickyTranscriptMessageId = React.useCallback((scrollTop: number): string | null => (
+    historyVirtualizerRef.current?.getStickyUserMessageId(scrollTop) ?? null
+  ), [])
+
   return (
     <BasePathsProvider basePaths={messageBasePaths}>
       <AgentBrowserLinkProvider sessionId={sessionId}>
@@ -1195,7 +1217,7 @@ export const AgentMessages = React.memo(function AgentMessages({
             </>
           )}
         </ConversationContent>
-        <ScrollMinimap items={minimapItems} />
+        <ScrollMinimap items={minimapItems} onScrollToMessage={scrollToTranscriptMessage} />
         <TaskProgressOverlay
           key={sessionId}
           activities={liveTaskActivities}
@@ -1203,7 +1225,11 @@ export const AgentMessages = React.memo(function AgentMessages({
           contextCompaction={contextCompaction}
         />
         {allUserMessagesData.length > 0 && (
-          <StickyUserMessage userMessages={allUserMessagesData} />
+          <StickyUserMessage
+            userMessages={allUserMessagesData}
+            getStickyMessageId={getStickyTranscriptMessageId}
+            onScrollToMessage={scrollToTranscriptMessage}
+          />
         )}
           </Conversation>
           <AgentHistorySelectionLayer

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -592,6 +592,7 @@ interface AgentTranscriptHistoryHandle {
 }
 
 interface AgentTranscriptHistoryProps {
+  sessionId: string
   groups: MessageGroup[]
   liveGroupSet: ReadonlySet<MessageGroup>
   allMessages: SDKMessage[]
@@ -617,6 +618,7 @@ interface AgentTranscriptHistoryProps {
  * 因此 ScrollMinimap、StickyUserMessage 和 ScrollPositionManager 仍然使用同一个 root。
  */
 const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, AgentTranscriptHistoryProps>(function AgentTranscriptHistory({
+  sessionId,
   groups,
   liveGroupSet,
   allMessages,
@@ -667,7 +669,7 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
         pendingNavigationFrameRef.current = null
       }
     }
-  }, [groups])
+  }, [sessionId])
 
   React.useLayoutEffect(() => {
     const element = scrollRef.current
@@ -699,20 +701,28 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
     [groups],
   )
 
+  const userGroupIndices = React.useMemo(() => (
+    groups.reduce<number[]>((indices, group, index) => {
+      if (group.type === 'user') indices.push(index)
+      return indices
+    }, [])
+  ), [groups])
+
   React.useImperativeHandle(ref, () => ({
     scrollToMessage: (messageId, onMounted) => {
       const index = groups.findIndex((group) => getGroupId(group) === messageId)
       if (index < 0) return
+      const generation = ++navigationGenerationRef.current
+      if (pendingNavigationFrameRef.current !== null) {
+        window.cancelAnimationFrame(pendingNavigationFrameRef.current)
+        pendingNavigationFrameRef.current = null
+      }
       stopScroll()
       virtualizer.scrollToIndex(index, { align: 'center', behavior: 'auto' })
 
       if (!onMounted) return
 
       // 目标行可能在远距离跳转后才挂载；持续等待挂载而不是依赖固定帧数。
-      const generation = ++navigationGenerationRef.current
-      if (pendingNavigationFrameRef.current !== null) {
-        window.cancelAnimationFrame(pendingNavigationFrameRef.current)
-      }
       let frame = 0
       const waitForMounted = (): void => {
         pendingNavigationFrameRef.current = null
@@ -732,18 +742,37 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
     },
     getStickyUserMessageId: (scrollTop) => {
       const measurements = virtualizer.measurementsCache
-      for (let index = measurements.length - 1; index >= 0; index -= 1) {
-        const measurement = measurements[index]
-        const group = measurement ? groups[measurement.index] : undefined
-        if (group?.type === 'user' && measurement && measurement.end < scrollTop) {
-          // 未测量行只含 estimateSize，不能据此决定 Sticky 的真实用户消息。
-          if (!virtualizer.itemSizeCache.has(measurement.key)) return null
-          return getGroupId(group)
+      const scrollElement = scrollRef.current
+      const firstRow = scrollElement?.querySelector<HTMLElement>('[data-index]')
+      const virtualContent = firstRow?.parentElement
+      const contentOffset = scrollElement && virtualContent
+        ? virtualContent.getBoundingClientRect().top
+          - scrollElement.getBoundingClientRect().top
+          + scrollElement.scrollTop
+        : 0
+      let low = 0
+      let high = userGroupIndices.length - 1
+      let candidate = -1
+      while (low <= high) {
+        const middle = Math.floor((low + high) / 2)
+        const groupIndex = userGroupIndices[middle]!
+        const measurement = measurements[groupIndex]
+        if (measurement && measurement.end + contentOffset < scrollTop) {
+          candidate = middle
+          low = middle + 1
+        } else {
+          high = middle - 1
         }
       }
-      return null
+      if (candidate < 0) return null
+
+      const groupIndex = userGroupIndices[candidate]!
+      const measurement = measurements[groupIndex]
+      const group = groups[groupIndex]
+      if (!measurement || !group || !virtualizer.itemSizeCache.has(measurement.key)) return null
+      return getGroupId(group)
     },
-  }), [groups, scrollRef, stopScroll, virtualizer])
+  }), [groups, scrollRef, stopScroll, userGroupIndices, virtualizer])
 
   return (
     <div
@@ -1170,6 +1199,7 @@ export const AgentMessages = React.memo(function AgentMessages({
               {/* 统一消息渲染（持久化 + 实时合并为一个列表，确保 system 消息位置正确） */}
               <AgentTranscriptHistory
                 ref={historyVirtualizerRef}
+                sessionId={sessionId}
                 groups={visibleGroups}
                 liveGroupSet={liveGroupSet}
                 allMessages={allSDKMessages}

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -189,7 +189,37 @@ export function ScrollMinimap({ items, onScrollToMessage }: ScrollMinimapProps):
     }, { root: el, threshold: 0 })
 
     updateCenterVisibleRef.current = updateCenterVisible
+    const observeMessageNode = (node: Node): void => {
+      if (node.nodeType !== Node.ELEMENT_NODE) return
+      const element = node as HTMLElement
+      if (element.matches('[data-message-id]')) observer.observe(element)
+      for (const message of element.querySelectorAll<HTMLElement>('[data-message-id]')) {
+        observer.observe(message)
+      }
+    }
     for (const message of el.querySelectorAll<HTMLElement>('[data-message-id]')) observer.observe(message)
+
+    const mutationObserver = new MutationObserver((mutations) => {
+      let changed = false
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) observeMessageNode(node)
+        for (const node of mutation.removedNodes) {
+          if (node.nodeType !== Node.ELEMENT_NODE) continue
+          const element = node as HTMLElement
+          const removedMessages = element.matches('[data-message-id]')
+            ? [element]
+            : [...element.querySelectorAll<HTMLElement>('[data-message-id]')]
+          for (const message of removedMessages) {
+            observer.unobserve(message)
+            const id = message.getAttribute('data-message-id')
+            if (id) visibleElementsRef.current.delete(id)
+            if (id && visible.delete(id)) changed = true
+          }
+        }
+      }
+      if (changed) updateVisibleIds(new Set(visible))
+    })
+    mutationObserver.observe(el, { childList: true, subtree: true })
     updateThumb()
 
     const onScroll = (): void => {
@@ -205,6 +235,7 @@ export function ScrollMinimap({ items, onScrollToMessage }: ScrollMinimapProps):
     return () => {
       el.removeEventListener('scroll', onScroll)
       observer.disconnect()
+      mutationObserver.disconnect()
       resizeObserver.disconnect()
       updateCenterVisibleRef.current = null
       visibleIdsRef.current = new Set()

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -352,14 +352,16 @@ export function ScrollMinimap({ items, onScrollToMessage }: ScrollMinimapProps):
   const scrollToMessage = React.useCallback((id: string) => {
     const el = scrollRef.current
     if (!el) return
-    const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
-      (node) => node.getAttribute('data-message-id') === id
-    )
-    if (!target) {
-      onScrollToMessage?.(id)
+    if (onScrollToMessage) {
+      onScrollToMessage(id)
       setHovered(false)
       return
     }
+
+    const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
+      (node) => node.getAttribute('data-message-id') === id
+    )
+    if (!target) return
 
     stopScroll()
     stickyState.animation = undefined

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -30,6 +30,7 @@ export interface MinimapItem {
 
 interface ScrollMinimapProps {
   items: MinimapItem[]
+  onScrollToMessage?: (id: string) => void
 }
 
 /** 最少消息数才显示迷你地图 */
@@ -74,7 +75,7 @@ function escapeRegExp(str: string): string {
 
 // ── 主组件 ──
 
-export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement | null {
+export function ScrollMinimap({ items, onScrollToMessage }: ScrollMinimapProps): React.ReactElement | null {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const [hovered, setHovered] = React.useState(false)
   const [isLeaving, setIsLeaving] = React.useState(false)
@@ -323,7 +324,11 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
       (node) => node.getAttribute('data-message-id') === id
     )
-    if (!target) return
+    if (!target) {
+      onScrollToMessage?.(id)
+      setHovered(false)
+      return
+    }
 
     stopScroll()
     stickyState.animation = undefined
@@ -339,7 +344,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     el.scrollTo({ top: Math.max(0, scrollTarget), behavior: 'smooth' })
 
     setHovered(false)
-  }, [scrollRef, stopScroll, stickyState])
+  }, [onScrollToMessage, scrollRef, stopScroll, stickyState])
 
   // ── 搜索过滤 ──
 

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -165,6 +165,10 @@ export function StickyUserMessage({
       }
       if (entries.some((entry) => entry.target !== el)) scheduleMeasure()
     })
+    const virtualContent = el.querySelector<HTMLElement>('[data-index]')?.parentElement
+      ?? el.firstElementChild
+    if (virtualContent && virtualContent !== el) resizeObserver.observe(virtualContent)
+
     const mutationObserver = getStickyMessageId ? null : new MutationObserver(scheduleMeasure)
     // 只有最后一条用户消息及其之前的内容会改变用户消息的绝对位置。
     // 当前流式 assistant 位于它之后，不纳入观察，避免每个流式高度更新重测整段历史。

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -42,6 +42,8 @@ interface UserMessageData {
 
 interface StickyUserMessageProps {
   userMessages: UserMessageData[]
+  getStickyMessageId?: (scrollTop: number) => string | null
+  onScrollToMessage?: (id: string) => void
 }
 
 interface UserMessagePosition {
@@ -49,7 +51,11 @@ interface UserMessagePosition {
   bottom: number
 }
 
-export function StickyUserMessage({ userMessages }: StickyUserMessageProps): React.ReactElement {
+export function StickyUserMessage({
+  userMessages,
+  getStickyMessageId,
+  onScrollToMessage,
+}: StickyUserMessageProps): React.ReactElement {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const userProfile = useAtomValue(userProfileAtom)
   const stickyEnabled = useAtomValue(stickyUserMessageEnabledAtom)
@@ -87,6 +93,13 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
 
     const updateStickyMessage = (): void => {
       const scrollTop = el.scrollTop
+      if (getStickyMessageId) {
+        const id = getStickyMessageId(scrollTop)
+        const found = id ? messageMap.get(id) ?? null : null
+        setStickyMessage((previous) => previous?.id === found?.id ? previous : found)
+        return
+      }
+
       const positions = positionsRef.current
       let low = 0
       let high = positions.length - 1
@@ -115,6 +128,15 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
         positions.push({ id, bottom: rect.bottom - containerRect.top + el.scrollTop })
       }
       positionsRef.current = positions
+      if (!getStickyMessageId) {
+        const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+        const lastUserMessageIndex = messageElements.findLastIndex(
+          (message) => message.dataset.messageRole === 'user',
+        )
+        for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
+          resizeObserver.observe(message)
+        }
+      }
       updateStickyMessage()
     }
 
@@ -143,24 +165,30 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
       }
       if (entries.some((entry) => entry.target !== el)) scheduleMeasure()
     })
+    const mutationObserver = getStickyMessageId ? null : new MutationObserver(scheduleMeasure)
     // 只有最后一条用户消息及其之前的内容会改变用户消息的绝对位置。
     // 当前流式 assistant 位于它之后，不纳入观察，避免每个流式高度更新重测整段历史。
-    const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
-    const lastUserMessageIndex = messageElements.findLastIndex(
-      (message) => message.dataset.messageRole === 'user',
-    )
-    for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
-      resizeObserver.observe(message)
+    if (!getStickyMessageId) {
+      const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+      const lastUserMessageIndex = messageElements.findLastIndex(
+        (message) => message.dataset.messageRole === 'user',
+      )
+      for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
+        resizeObserver.observe(message)
+      }
+      mutationObserver?.observe(el, { childList: true, subtree: true })
     }
+
     scheduleMeasure()
 
     return () => {
       if (scrollFrame !== null) cancelAnimationFrame(scrollFrame)
       if (measureFrame !== null) cancelAnimationFrame(measureFrame)
       el.removeEventListener('scroll', scheduleScrollUpdate)
+      mutationObserver?.disconnect()
       resizeObserver.disconnect()
     }
-  }, [scrollRef, userMessageSignature, messageMap, stickyEnabled])
+  }, [getStickyMessageId, scrollRef, userMessageSignature, messageMap, stickyEnabled])
 
   // 点击回滚到原始消息
   const scrollToOriginal = React.useCallback(() => {
@@ -170,7 +198,10 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
     const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
       (node) => node.getAttribute('data-message-id') === stickyMessage.id
     )
-    if (!target) return
+    if (!target) {
+      onScrollToMessage?.(stickyMessage.id)
+      return
+    }
 
     stopScroll()
     stickyState.animation = undefined
@@ -181,7 +212,7 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
     const targetRect = target.getBoundingClientRect()
     const targetScrollTop = el.scrollTop + (targetRect.top - containerRect.top)
     el.scrollTo({ top: Math.max(0, targetScrollTop - 24), behavior: 'smooth' })
-  }, [scrollRef, stopScroll, stickyState, stickyMessage])
+  }, [onScrollToMessage, scrollRef, stopScroll, stickyState, stickyMessage])
 
   const isSticky = stickyMessage !== null
   const hasContent = stickyMessage && (stickyMessage.text || stickyMessage.attachments.length > 0)

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -3011,6 +3011,20 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     currentWorkspaceId,
   ])
 
+  const activeAgentRowId = React.useMemo(() => {
+    if (!activeSessionId) return null
+    const directRow = agentActiveVirtualRows.find((row) => (
+      row.id === `agent-${activeSessionId}` || row.id === `agent-child-${activeSessionId}`
+    ))
+    if (directRow) return directRow.id
+
+    const parentItem = [
+      ...pinnedAgentSessionTrees,
+      ...displayProjectGroups.flatMap((group) => buildAgentSessionTrees(group.sessions)),
+    ].find((item) => treeContainsSessionId(item, activeSessionId))
+    return parentItem ? `agent-${parentItem.session.id}` : null
+  }, [activeSessionId, agentActiveVirtualRows, displayProjectGroups, pinnedAgentSessionTrees])
+
   // ===== 折叠状态：精简图标视图 =====
   if (sidebarCollapsed) {
     return (
@@ -3367,7 +3381,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           key="agent-active-list"
           className="flex-1 px-2 pb-3"
           rows={agentActiveVirtualRows}
-          activeRowId={activeSessionId ? `agent-${activeSessionId}` : null}
+          activeRowId={activeAgentRowId}
         />
       ) : (
         <>
@@ -4548,7 +4562,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
           <button
             type="button"
             aria-expanded={!collapsed}
-            aria-controls={`project-sessions-${group.workspace.id}`}
+            aria-controls={hideSessions ? undefined : `project-sessions-${group.workspace.id}`}
             onClick={(e) => {
               e.stopPropagation()
               onSelectProject(group.workspace.id)


### PR DESCRIPTION
## Summary
- Restore variable-height virtualization for long Agent transcript history.
- Flatten the active Agent sidebar into virtual rows for projects, sessions, delegated children, and controls.
- Preserve history quote navigation, prepend scroll anchoring, delegation expansion, project actions, and drag/drop behavior.

## Verification
- `bun run typecheck`
- `cd apps/electron && bun run build:renderer`
- `bun test apps/electron/src/renderer/lib/agent-session-list.test.ts apps/electron/src/renderer/atoms/agent-atoms.test.ts`
- 25 tests passed

Runtime Electron profiling remains follow-up validation for frame-level improvements.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)