### PR TITLE
refactor(agent): use single live transcript path

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1718,6 +1718,10 @@ export class AgentOrchestrator {
                   const partialOutput = stripPiAssistantError(assistantMsg)
                   if (modelId) partialOutput._channelModelId = modelId
                   partialOutput._channelProvider = channel.provider
+                  const partialRecord = partialOutput as SDKAssistantMessage & { _createdAt?: number }
+                  if (typeof partialRecord._createdAt !== 'number') {
+                    partialRecord._createdAt = streamStartedAt
+                  }
                   accumulatedMessages.push(partialOutput)
                   // Reuse the Pi UUID to replace the latest partial frame with normal markdown output.
                   this.eventBus.emit(sessionId, { kind: 'sdk_message', message: partialOutput })
@@ -1783,10 +1787,14 @@ export class AgentOrchestrator {
                   }
                   // 为 assistant 消息注入渠道信息，确保持久化后能正确匹配模型显示名与上下文窗口
                   if (msg.type === 'assistant') {
-                    if (modelId) {
-                      (msg as Record<string, unknown>)._channelModelId = modelId
+                    const assistantRecord = msg as Record<string, unknown>
+                    if (typeof assistantRecord._createdAt !== 'number') {
+                      assistantRecord._createdAt = streamStartedAt
                     }
-                    ;(msg as Record<string, unknown>)._channelProvider = channel.provider
+                    if (modelId) {
+                      assistantRecord._channelModelId = modelId
+                    }
+                    assistantRecord._channelProvider = channel.provider
                   }
                   accumulatedMessages.push(msg)
                 }

--- a/apps/electron/src/renderer/atoms/agent-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.test.ts
@@ -12,7 +12,6 @@ import {
 function createStreamState(overrides: Partial<AgentStreamState> = {}): AgentStreamState {
   return {
     running: true,
-    content: '',
     toolActivities: [],
     inputTokens: 180_000,
     outputTokens: 2_000,
@@ -223,7 +222,7 @@ describe('Agent retry 状态机', () => {
     expect(exhausted.retrying?.history[0]).toMatchObject({ attempt: 8, timestamp: 2_000, reason: '最终请求仍然失败' })
   })
 
-  test('given retry 成功 when 后续输出到达 then 成功状态被自然收起', () => {
+  test('given retry 成功 when 后续工具调用到达 then 成功状态被自然收起', () => {
     const running = applyAgentEvent(createStreamState({ startedAt: runStartedAt }), {
       type: 'retry_attempt',
       attemptData: retryAttempt,
@@ -238,7 +237,18 @@ describe('Agent retry 状态机', () => {
     })
 
     expect(succeeded.retrying?.phase).toBe('succeeded')
-    expect(applyAgentEvent(succeeded, { type: 'text_delta', text: '已恢复' }).retrying).toBeUndefined()
+    expect(applyAgentEvent(succeeded, {
+      type: 'tool_start',
+      toolName: 'Read',
+      toolUseId: 'resume-read',
+      input: {},
+    }).retrying).toBeUndefined()
+  })
+
+  test('given legacy text delta when the runtime reducer receives it then it does not duplicate the live transcript', () => {
+    const state = createStreamState()
+
+    expect(applyAgentEvent(state, { type: 'text_delta', text: '只由 live SDKMessage 渲染' })).toBe(state)
   })
 
   test('given 旧 run 的 retry 终态 when 新流已经开始 then 忽略迟到事件', () => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -99,7 +99,6 @@ export interface AgentStreamState {
    * 此状态下 running 为 false，但服务端 activeSessions 仍保留，新消息必须走注入通道而非新建 run。
    */
   backgroundWaiting?: boolean
-  content: string
   toolActivities: ToolActivity[]
   model?: string
   /** 当前输入 token 数（上下文使用量） */
@@ -146,6 +145,11 @@ function clearFinishedCompactionForResumedWork(prev: AgentStreamState): AgentStr
     compactInFlight: false,
     contextCompaction: undefined,
   }
+}
+
+export function resumeAgentStreamState(prev: AgentStreamState): AgentStreamState {
+  const resumed = clearFinishedCompactionForResumedWork(prev)
+  return resumed.retrying === undefined ? resumed : { ...resumed, retrying: undefined }
 }
 
 /** 从 ToolActivity 派生状态 */
@@ -668,12 +672,6 @@ export const agentStreamingAtom = atom<boolean>((get) => {
   return get(agentStreamingStatesAtom).get(currentId)?.running ?? false
 })
 
-export const agentStreamingContentAtom = atom<string>((get) => {
-  const currentId = get(currentAgentSessionIdAtom)
-  if (!currentId) return ''
-  return get(agentStreamingStatesAtom).get(currentId)?.content ?? ''
-})
-
 export const agentToolActivitiesAtom = atom<ToolActivity[]>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return []
@@ -773,18 +771,6 @@ export function applyAgentEvent(
   event: AgentEvent,
 ): AgentStreamState {
   switch (event.type) {
-    case 'text_delta': {
-      // 开始接收文本 - 清除重试状态（重试成功）
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      return { ...resumed, content: resumed.content + event.text, retrying: undefined }
-    }
-
-    case 'text_complete': {
-      // 用完整文本替换增量累积的文本（用于回放场景：只需 text_complete 即可重建文本状态）
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      return { ...resumed, content: event.text }
-    }
-
     case 'tool_start': {
       const resumed = clearFinishedCompactionForResumedWork(prev)
       const existing = resumed.toolActivities.find((t) => t.toolUseId === event.toolUseId)

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -7,13 +7,13 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Bot, RotateCw, AlertTriangle, CheckCircle2, Ban, ChevronDown, ChevronRight } from 'lucide-react'
+import { RotateCw, AlertTriangle, CheckCircle2, Ban, ChevronDown, ChevronRight } from 'lucide-react'
 import { WelcomeEmptyState } from '@/components/welcome/WelcomeEmptyState'
 import {
-  Message,
-  MessageHeader,
-  MessageContent,
   BasePathsProvider,
+  Message,
+  MessageContent,
+  MessageHeader,
 } from '@/components/ai-elements/message'
 import {
   Conversation,
@@ -22,11 +22,10 @@ import {
 import { ScrollMinimap } from '@/components/ai-elements/scroll-minimap'
 import type { MinimapItem } from '@/components/ai-elements/scroll-minimap'
 import { StickyUserMessage } from '@/components/ai-elements/sticky-user-message'
-import { useSmoothStream } from '@proma/ui'
 import { useStickToBottomContext } from 'use-stick-to-bottom'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
-import { getModelLogo, resolveModelDisplayName, resolveModelProvider } from '@/lib/model-logo'
+import { resolveModelDisplayName } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
@@ -34,11 +33,9 @@ import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
 import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, buildTaskProgressDataForTurn, type MessageGroup } from './SDKMessageRenderer'
+import { groupIntoTurns, AssistantLogo, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, buildTaskProgressDataForTurn, type MessageGroup } from './SDKMessageRenderer'
 import { buildLiveGroupSet } from './live-group-set'
-import { ContentBlock } from './ContentBlock'
 import { AgentBrowserLinkProvider } from '@/components/browser/AgentBrowserLinkProvider'
-import { parseThinkTagsFromText } from './thinking-tag-parser'
 import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
 import { createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
@@ -298,24 +295,6 @@ function applyAgentHistoryQuoteHighlight(range: Range): boolean {
 /** 空状态引导 — 使用 WelcomeEmptyState */
 function EmptyState(): React.ReactElement {
   return <WelcomeEmptyState />
-}
-
-function AssistantLogo({ model }: { model?: string }): React.ReactElement {
-  const channels = useAtomValue(channelsAtom)
-  if (model) {
-    return (
-      <img
-        src={getModelLogo(model, resolveModelProvider(model, channels))}
-        alt={model}
-        className="size-[35px] rounded-[25%] object-cover"
-      />
-    )
-  }
-  return (
-    <div className="size-[35px] rounded-[25%] bg-primary/10 flex items-center justify-center">
-      <Bot size={18} className="text-primary" />
-    </div>
-  )
 }
 
 /** 重试提示组件 - 折叠式 */
@@ -856,8 +835,8 @@ export const AgentMessages = React.memo(function AgentMessages({
   const liveMessages = useAtomValue(agentLiveMessagesAtomFamily(sessionId))
   const streaming = streamState?.running ?? false
   const userProfile = useAtomValue(userProfileAtom)
-  const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
+  const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const historySelectionRootRef = React.useRef<HTMLDivElement>(null)
   const historyVirtualizerRef = React.useRef<AgentTranscriptHistoryHandle>(null)
   const visibleGroupsRef = React.useRef<MessageGroup[]>([])
@@ -962,28 +941,15 @@ export const AgentMessages = React.memo(function AgentMessages({
     return () => { cancelled = true }
   }, [streaming, liveMessages, persistedSDKMessages, messagesLoaded])
 
-  // 从 streamState 属性中计算派生值
-  const streamingContent = streamState?.content ?? ''
-  const streamingModelId = streamState?.model || sessionModelId
-  const agentStreamingModel = streamingModelId ? resolveModelDisplayName(streamingModelId, channels) : undefined
+  // 实时文本仅从 liveMessages 读取。AgentStreamState 只保留运行/控制状态，
+  // 避免每个 sdk_delta 同时更新 transcript 和 legacy content 两条路径。
   const retrying = streamState?.retrying
   const startedAt = streamState?.startedAt
-
-  const { displayedContent: rawSmoothContent } = useSmoothStream({
-    content: streamingContent,
-    isStreaming: streaming,
-  })
-
-  // 防闪屏守卫：useSmoothStream 通过 useEffect 重置 displayedContent，比 render 晚一帧。
-  // 当 streamingContent 已清空但 smoothContent 仍持有旧值时，
-  // 会导致 fallback 气泡与持久化消息同时渲染一帧（重复内容闪烁）。
-  // 用原始 streamingContent 作为守卫：内容已清空且不在流式中，立即归零。
-  const smoothContent = (streaming || streamingContent) ? rawSmoothContent : ''
-  const smoothContentBlocks = React.useMemo(() => {
-    if (!smoothContent) return []
-    return parseThinkTagsFromText(smoothContent)
-  }, [smoothContent])
-  const hasSmoothTextContent = smoothContentBlocks.some((block) => block.type === 'text')
+  const optimisticModelId = streamState?.model || sessionModelId
+  const optimisticModel = optimisticModelId
+    ? resolveModelDisplayName(optimisticModelId, channels)
+    : undefined
+  const optimisticTime = startedAt ? formatMessageTime(startedAt) : undefined
 
   /**
    * 流式完成过渡：streaming 结束到持久化消息加载完成之间，
@@ -998,7 +964,7 @@ export const AgentMessages = React.memo(function AgentMessages({
 
   // render-phase 判断：是否处于需要 instant resize 的过渡期
   // liveMessages 非空说明持久化消息还没加载完（加载完后会清空 liveMessages）
-  const needsInstant = !streaming && (!!streamingContent || !!smoothContent || (liveMessages != null && liveMessages.length > 0))
+  const needsInstant = !streaming && liveMessages != null && liveMessages.length > 0
 
   React.useEffect(() => {
     // 刚从 streaming → not-streaming：启动 cooldown
@@ -1231,38 +1197,17 @@ export const AgentMessages = React.memo(function AgentMessages({
                 </div>
               )}
 
-              {/* 无实时助手内容时：显示完整气泡（含头像/名称/时间） */}
-              {/* 注意：工具活动已通过 SDK 渲染路径（liveGroups）展示 */}
-              {!hasLiveAssistantContent && !suppressAgentRunning && (streaming || smoothContent || retrying) && (
+              {/* 首个 live assistant block 到达前，先乐观渲染 assistant 外壳和 Logo；文本仍完全由 SDKMessage 渲染。 */}
+              {!hasLiveAssistantContent && !suppressAgentRunning && (streaming || retrying) && (
                 <Message from="assistant">
                   <MessageHeader
-                    model={agentStreamingModel}
-                    time={formatMessageTime(Date.now())}
-                    logo={<AssistantLogo model={streamingModelId} />}
+                    model={optimisticModel}
+                    time={optimisticTime}
+                    logo={<AssistantLogo model={optimisticModelId} />}
                   />
                   <MessageContent>
                     {retrying && <RetryingNotice retrying={retrying} />}
-                    {smoothContent ? (
-                      <>
-                        <div className={cn('space-y-2')}>
-                          {smoothContentBlocks.map((block, index) => (
-                            <ContentBlock
-                              key={index}
-                              block={block}
-                              allMessages={allSDKMessages}
-                              basePath={sessionPath || undefined}
-                              basePaths={attachedDirs}
-                              index={index}
-                              dimmed={hasSmoothTextContent && block.type !== 'text'}
-                              isStreaming={streaming}
-                            />
-                          ))}
-                        </div>
-                        {streaming && <AgentRunningIndicator startedAt={startedAt} />}
-                      </>
-                    ) : (
-                      streaming && <AgentRunningIndicator startedAt={startedAt} />
-                    )}
+                    {streaming && <AgentRunningIndicator startedAt={startedAt} />}
                   </MessageContent>
                 </Message>
               )}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1026,7 +1026,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
-        content: '',
         toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
@@ -1180,14 +1179,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             // 仍在运行中：不清除
             if (!state || state.running) return prev
             const map = new Map(prev)
-            // 软空闲态（后台任务等待）：必须保留 backgroundWaiting 标志（否则 handleSend 误走新建 run），
-            // 但展示字段 content/toolActivities 仍要清空——否则上一轮流式文本残留会被兜底气泡渲染成重复消息。
+            // 软空闲态（后台任务等待）：必须保留 backgroundWaiting 标志（否则 handleSend 误走新建 run）。
+            // 实时文本只在 liveMessages 中，完成消息刷新时随其统一清理。
             if (state.inputTokens !== undefined) {
-              // 保留 usage 数据，仅清除流式展示字段
+              // 保留 usage 数据，仅清除本轮工具活动展示状态。
               map.set(sessionId, {
                 running: false,
                 backgroundWaiting: state.backgroundWaiting,
-                content: '',
                 toolActivities: [],
                 inputTokens: state.inputTokens,
                 outputTokens: state.outputTokens,
@@ -1203,7 +1201,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               map.set(sessionId, {
                 running: false,
                 backgroundWaiting: state.backgroundWaiting,
-                content: '',
                 toolActivities: [],
                 contextCompaction: state.contextCompaction,
               })
@@ -1294,7 +1291,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         const existing = prev.get(sessionId)
         map.set(sessionId, {
           running: true,
-          content: '',
           toolActivities: [],
           model: snapshot.modelId,
           startedAt: streamStartedAt,
@@ -2253,7 +2249,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
-        content: '',
         toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
@@ -2362,7 +2357,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const map = new Map(prev)
       const current = prev.get(sessionId) ?? {
         running: true,
-        content: '',
         toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
@@ -2487,7 +2481,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
-        content: '',
         toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
@@ -2533,7 +2526,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         const map = new Map(prev)
         map.set(meta.id, {
           running: true,
-          content: '',
           toolActivities: [],
           model: agentModelId || undefined,
           startedAt: streamStartedAt,

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -266,7 +266,7 @@ function extractToolResultForTask(message: SDKUserMessage, resultBlock: SDKToolR
 
 // ===== 助手头像 =====
 
-function AssistantLogo({ model }: { model?: string }): React.ReactElement {
+export function AssistantLogo({ model }: { model?: string }): React.ReactElement {
   const channels = useAtomValue(channelsAtom)
   if (model) {
     return (

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -217,7 +217,7 @@ function createAssistantDeltaPreview(payload: AgentAssistantDeltaPayload, metada
     session_id: payload.session_id,
     uuid: payload.uuid,
     _partial: true,
-    _createdAt: Date.now(),
+    _createdAt: payload.runStartedAt ?? Date.now(),
     ...metadata,
   } as SDKAssistantMessage
 }
@@ -1176,15 +1176,18 @@ export function useGlobalAgentListeners(): void {
           } else if (msgRecord.type === 'system' && msgRecord.subtype === 'thinking_tokens') {
             // thinking_tokens 是高频进度估算，只更新流式状态，不进入消息转录。
           } else if (!msgRecord.isReplay) {
+            // 当前 run 的 assistant 消息沿用 run 起始时间，与首个 Delta 预览和乐观 header 保持一致。
+            const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
             // 为实时消息补充 _createdAt 时间戳（与持久化时的逻辑一致），
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
             if (typeof msgRecord._createdAt !== 'number') {
-              msgRecord._createdAt = Date.now()
+              msgRecord._createdAt = msgRecord.type === 'assistant'
+                ? (activeRunStartedAt ?? Date.now())
+                : Date.now()
             }
 
             // 队列自动派发会在上一轮实时消息尚未落盘刷新时开始下一轮。
             // 标记每条实时消息所属 run，渲染层即可把上一轮立即视为完成并自动收起过程块。
-            const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
             if (activeRunStartedAt != null) {
               msgRecord._promaLiveRunStartedAt = activeRunStartedAt
             }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -26,6 +26,7 @@ import {
   RECENTLY_MODIFIED_TTL_MS,
   applyAgentEvent,
   clearAgentStreamError,
+  resumeAgentStreamState,
   isRetryEventForCurrentStream,
   liveMessagesMapAtom,
   agentSessionModelMapAtom,
@@ -134,25 +135,17 @@ function isRunScopedRetryEvent(event: AgentEvent): event is Extract<AgentEvent, 
     || event.type === 'retry_cancelled'
 }
 
-function deltaToLegacyEvents(delta: AgentAssistantDelta): AgentEvent[] {
-  switch (delta.type) {
-    case 'text_delta':
-      return delta.delta ? [{ type: 'text_delta', text: delta.delta }] : []
-    case 'toolcall_start':
-    case 'toolcall_end': {
-      const toolCall = delta.toolCall
-      if (!toolCall) return []
-      return [{
-        type: 'tool_start',
-        toolName: toolCall.name,
-        toolUseId: toolCall.id,
-        input: toolCall.arguments ?? {},
-        parentToolUseId: undefined,
-      }]
-    }
-    default:
-      return []
-  }
+function deltaToLegacyControlEvents(delta: AgentAssistantDelta): AgentEvent[] {
+  if (delta.type !== 'toolcall_start' && delta.type !== 'toolcall_end') return []
+  const toolCall = delta.toolCall
+  if (!toolCall) return []
+  return [{
+    type: 'tool_start',
+    toolName: toolCall.name,
+    toolUseId: toolCall.id,
+    input: toolCall.arguments ?? {},
+    parentToolUseId: undefined,
+  }]
 }
 
 function applyAssistantDeltaToPreview(
@@ -229,13 +222,10 @@ function createAssistantDeltaPreview(payload: AgentAssistantDeltaPayload, metada
   } as SDKAssistantMessage
 }
 
-function deltaPayloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
-  if (payload.kind !== 'sdk_delta') return []
-  return payload.delta.deltas.flatMap(deltaToLegacyEvents)
-}
-
 function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
-  if (payload.kind === 'sdk_delta') return deltaPayloadToLegacyEvents(payload)
+  // sdk_delta 的文本和 thinking 已直接写入 liveMessages；只保留工具启动控制状态，
+  // 避免每个 token 都触发第二份 AgentStreamState 更新和渲染路径。
+  if (payload.kind === 'sdk_delta') return payload.delta.deltas.flatMap(deltaToLegacyControlEvents)
   if (payload.kind === 'proma_event') {
     const evt = payload.event
     switch (evt.type) {
@@ -335,9 +325,7 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
       }
       const events: AgentEvent[] = []
       for (const block of aMsg.message.content) {
-        if (block.type === 'text' && 'text' in block) {
-          events.push({ type: 'text_complete', text: (block as { text: string }).text, isIntermediate: false, parentToolUseId: aMsg.parent_tool_use_id ?? undefined })
-        } else if (block.type === 'tool_use') {
+        if (block.type === 'tool_use') {
           const tb = block as SDKContentBlock & { id: string; name: string; input: Record<string, unknown> }
           const intent = (tb.input._intent as string | undefined)
             ?? (tb.name === 'Bash' ? (tb.input.description as string | undefined) : undefined)
@@ -663,7 +651,6 @@ export function useGlobalAgentListeners(): void {
         const map = new Map(prev)
         map.set(sessionId, {
           running: true,
-          content: '',
           toolActivities: [],
           model: modelId || undefined,
           startedAt: streamStartedAt,
@@ -1162,6 +1149,22 @@ export function useGlobalAgentListeners(): void {
             }
             return map
           })
+
+          // 文本/思考恢复后只收束一次 retry 或已完成的压缩状态；正常 token
+          // 不会触碰 AgentStreamState，从而避免重新引入逐 token 的第二次 Map 更新。
+          const hasAssistantActivity = deltaPayload.deltas.some((delta) => delta.type !== 'start')
+          if (hasAssistantActivity) {
+            store.set(agentStreamingStatesAtom, (prev) => {
+              const current = prev.get(sessionId)
+              const shouldResume = current?.retrying !== undefined
+                || current?.contextCompaction?.status === 'success'
+                || current?.contextCompaction?.status === 'noop'
+              if (!current || !shouldResume) return prev
+              const map = new Map(prev)
+              map.set(sessionId, resumeAgentStreamState(current))
+              return map
+            })
+          }
         }
 
         if (payload.kind === 'sdk_message') {
@@ -1272,7 +1275,6 @@ export function useGlobalAgentListeners(): void {
               }
               const current: AgentStreamState = existing ?? {
                 running: true,
-                content: '',
                 toolActivities: [],
                 model: undefined,
                 // 无 run 标识的历史事件才允许 fallback；带标识的 retry 必须已在上方匹配。

--- a/apps/electron/src/renderer/lib/external-agent-run.test.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.test.ts
@@ -40,7 +40,6 @@ describe('外部 Agent 运行激活', () => {
     ]
     const currentStreamState = {
       running: true,
-      content: '已有输出',
       toolActivities: [{
         toolUseId: 'tool-1',
         toolName: 'Bash',
@@ -61,7 +60,6 @@ describe('外部 Agent 运行激活', () => {
     expect(result.tabs).toBe(tabs)
     expect(result.activeTabId).toBe(session.id)
     expect(result.streamState.toolActivities).toBe(currentStreamState.toolActivities)
-    expect(result.streamState.content).toBe('已有输出')
     expect(result.streamState.startedAt).toBe(200)
   })
 
@@ -102,7 +100,6 @@ describe('外部 Agent 运行激活', () => {
   test('Given the same run has already completed When a delayed start event arrives Then keep it terminal', () => {
     expect(shouldActivateExternalAgentRun({
       running: false,
-      content: 'completed',
       toolActivities: [],
       startedAt: 500,
     }, 500)).toBeFalse()
@@ -111,7 +108,6 @@ describe('外部 Agent 运行激活', () => {
   test('Given a newer run is active When an older start event arrives Then ignore the old event', () => {
     expect(shouldActivateExternalAgentRun({
       running: true,
-      content: 'newer run',
       toolActivities: [],
       startedAt: 700,
     }, 600)).toBeFalse()
@@ -126,7 +122,6 @@ describe('外部 Agent 运行激活', () => {
     })
 
     expect(result.streamState.running).toBe(true)
-    expect(result.streamState.content).toBe('')
     expect(result.streamState.toolActivities).toEqual([])
     expect(result.streamState.model).toBeUndefined()
     expect(result.streamState.startedAt).toBe(400)

--- a/apps/electron/src/renderer/lib/external-agent-run.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.ts
@@ -62,7 +62,6 @@ export function buildExternalAgentRunActivation(
     streamState: {
       ...input.currentStreamState,
       running: true,
-      content: input.currentStreamState?.content ?? '',
       toolActivities: input.currentStreamState?.toolActivities ?? [],
       model: input.modelId ?? input.currentStreamState?.model,
       startedAt: input.startedAt,


### PR DESCRIPTION
## Summary
- remove per-delta legacy text/content updates in the renderer
- render assistant text only from live SDK messages while preserving tool/control state handling
- restore an optimistic assistant shell with Logo, model, time, running indicator, and retry state before the first live assistant block
- keep completion, retry, compaction, tool activity, and persistence transitions intact

## Validation
- `cd apps/electron && bun run typecheck`
- `cd apps/electron && bun test ./src/renderer`
- `cd apps/electron && bun run build:renderer`
- focused Agent tests: 29 passed
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)