### PR TITLE
refactor(agent): remove transcript virtualization

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.28",
+  "version": "0.17.29",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -23,7 +23,6 @@ import { ScrollMinimap } from '@/components/ai-elements/scroll-minimap'
 import type { MinimapItem } from '@/components/ai-elements/scroll-minimap'
 import { StickyUserMessage } from '@/components/ai-elements/sticky-user-message'
 import { useStickToBottomContext } from 'use-stick-to-bottom'
-import { useVirtualizer } from '@tanstack/react-virtual'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
 import { resolveModelDisplayName } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
@@ -567,11 +566,9 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
 
 interface AgentTranscriptHistoryHandle {
   scrollToMessage: (messageId: string, onMounted?: (target: HTMLElement) => void) => void
-  getStickyUserMessageId: (scrollTop: number) => string | null
 }
 
 interface AgentTranscriptHistoryProps {
-  sessionId: string
   groups: MessageGroup[]
   liveGroupSet: ReadonlySet<MessageGroup>
   allMessages: SDKMessage[]
@@ -593,11 +590,10 @@ interface AgentTranscriptHistoryProps {
 }
 
 /**
- * 历史消息只挂载视口附近的 group；虚拟列表外保留当前 Conversation 的滚动容器，
- * 因此 ScrollMinimap、StickyUserMessage 和 ScrollPositionManager 仍然使用同一个 root。
+ * Agent 历史消息使用普通 DOM 列表，避免滚动期间反复挂载和测量重型消息组件。
+ * 历史 group 仍通过 message-group-rendering 缓存和 MessageGroupRenderer.memo 隔离更新。
  */
 const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, AgentTranscriptHistoryProps>(function AgentTranscriptHistory({
-  sessionId,
   groups,
   liveGroupSet,
   allMessages,
@@ -618,37 +614,12 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
   onCompact,
 }, ref): React.ReactElement {
   const { scrollRef, isAtBottom, stopScroll } = useStickToBottomContext()
-  const virtualizer = useVirtualizer({
-    count: groups.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => 160,
-    getItemKey: (index) => {
-      const group = groups[index]
-      return group ? getGroupId(group) : index
-    },
-    overscan: 6,
-    // measureElement 可能在 React commit 期间回调；避免默认 flushSync 触发 React 警告。
-    useFlushSync: false,
-  })
-  const virtualItems = virtualizer.getVirtualItems()
   const previousLayoutRef = React.useRef<{
     count: number
     firstGroupId: string | undefined
     scrollHeight: number
     isAtBottom: boolean
   } | null>(null)
-  const pendingNavigationFrameRef = React.useRef<number | null>(null)
-  const navigationGenerationRef = React.useRef(0)
-
-  React.useEffect(() => {
-    return () => {
-      navigationGenerationRef.current += 1
-      if (pendingNavigationFrameRef.current !== null) {
-        window.cancelAnimationFrame(pendingNavigationFrameRef.current)
-        pendingNavigationFrameRef.current = null
-      }
-    }
-  }, [sessionId])
 
   React.useLayoutEffect(() => {
     const element = scrollRef.current
@@ -680,110 +651,34 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
     [groups],
   )
 
-  const userGroupIndices = React.useMemo(() => (
-    groups.reduce<number[]>((indices, group, index) => {
-      if (group.type === 'user') indices.push(index)
-      return indices
-    }, [])
-  ), [groups])
-
   React.useImperativeHandle(ref, () => ({
     scrollToMessage: (messageId, onMounted) => {
-      const index = groups.findIndex((group) => getGroupId(group) === messageId)
-      if (index < 0) return
-      const generation = ++navigationGenerationRef.current
-      if (pendingNavigationFrameRef.current !== null) {
-        window.cancelAnimationFrame(pendingNavigationFrameRef.current)
-        pendingNavigationFrameRef.current = null
-      }
+      const target = Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-message-id]') ?? [])
+        .find((element) => element.dataset.messageId === messageId)
+      if (!target) return
+
       stopScroll()
-      virtualizer.scrollToIndex(index, { align: 'center', behavior: 'auto' })
-
-      if (!onMounted) return
-
-      // 目标行可能在远距离跳转后才挂载；持续等待挂载而不是依赖固定帧数。
-      let frame = 0
-      const waitForMounted = (): void => {
-        pendingNavigationFrameRef.current = null
-        if (navigationGenerationRef.current !== generation) return
-        frame += 1
-        const target = Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-message-id]') ?? [])
-          .find((element) => element.dataset.messageId === messageId)
-        if (target) {
-          onMounted(target)
-          return
-        }
-        if (frame < 120) {
-          pendingNavigationFrameRef.current = window.requestAnimationFrame(waitForMounted)
-        }
+      if (onMounted) {
+        onMounted(target)
+        return
       }
-      pendingNavigationFrameRef.current = window.requestAnimationFrame(waitForMounted)
+      target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
     },
-    getStickyUserMessageId: (scrollTop) => {
-      const measurements = virtualizer.measurementsCache
-      const scrollElement = scrollRef.current
-      const firstRow = scrollElement?.querySelector<HTMLElement>('[data-index]')
-      const virtualContent = firstRow?.parentElement
-      const contentOffset = scrollElement && virtualContent
-        ? virtualContent.getBoundingClientRect().top
-          - scrollElement.getBoundingClientRect().top
-          + scrollElement.scrollTop
-        : 0
-      let low = 0
-      let high = userGroupIndices.length - 1
-      let candidate = -1
-      while (low <= high) {
-        const middle = Math.floor((low + high) / 2)
-        const groupIndex = userGroupIndices[middle]!
-        const measurement = measurements[groupIndex]
-        if (measurement && measurement.end + contentOffset < scrollTop) {
-          candidate = middle
-          low = middle + 1
-        } else {
-          high = middle - 1
-        }
-      }
-      if (candidate < 0) return null
-
-      const groupIndex = userGroupIndices[candidate]!
-      let measurement = measurements[groupIndex]
-      let group = groups[groupIndex]
-      while (candidate >= 0 && (!measurement || !virtualizer.itemSizeCache.has(measurement.key))) {
-        candidate -= 1
-        if (candidate < 0) return null
-        const fallbackGroupIndex = userGroupIndices[candidate]!
-        measurement = measurements[fallbackGroupIndex]
-        group = groups[fallbackGroupIndex]
-      }
-      if (!measurement || !group) return null
-      return getGroupId(group)
-    },
-  }), [groups, scrollRef, stopScroll, userGroupIndices, virtualizer])
+  }), [scrollRef, stopScroll])
 
   return (
-    <div
-      className="relative w-full shrink-0"
-      style={{ height: virtualizer.getTotalSize() }}
-    >
-      {virtualItems.map((item) => {
-        const group = groups[item.index]
-        if (!group) return null
+    <div className="w-full shrink-0">
+      {groups.map((group, index) => {
         const isLive = liveGroupSet.has(group)
         const isErrorGroup = group.type === 'assistant-turn'
           && group.assistantMessages.some((message) => !!message.error)
         const shouldDisableActions = isLive && !isErrorGroup
         const isLastAssistantTurn = !streaming && stoppedByUser
           && group.type === 'assistant-turn'
-          && item.index === lastAssistantTurnIndex
+          && index === lastAssistantTurnIndex
 
         return (
-          <div
-            key={item.key}
-            ref={virtualizer.measureElement}
-            data-index={item.index}
-            className="absolute left-0 top-0 w-full pb-1"
-            style={{ transform: `translateY(${item.start}px)` }}
-          >
+          <div key={getGroupId(group)} className="w-full pb-1">
             <MessageGroupRenderer
               group={group}
               allMessages={group.type === 'assistant-turn' ? allMessages : EMPTY_SDK_MESSAGES}
@@ -838,7 +733,7 @@ export const AgentMessages = React.memo(function AgentMessages({
   const channels = useAtomValue(channelsAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const historySelectionRootRef = React.useRef<HTMLDivElement>(null)
-  const historyVirtualizerRef = React.useRef<AgentTranscriptHistoryHandle>(null)
+  const historyRef = React.useRef<AgentTranscriptHistoryHandle>(null)
   const visibleGroupsRef = React.useRef<MessageGroup[]>([])
   const selectionHighlightUsesBrowserSelectionRef = React.useRef(false)
   const clearHistoryQuoteHighlight = React.useCallback((): void => {
@@ -904,7 +799,7 @@ export const AgentMessages = React.memo(function AgentMessages({
 
       const targetIndex = visibleGroupsRef.current.findIndex((group) => getGroupId(group) === messageId)
       if (targetIndex >= 0) {
-        historyVirtualizerRef.current?.scrollToMessage(messageId, applyNavigation)
+        historyRef.current?.scrollToMessage(messageId, applyNavigation)
         return
       }
 
@@ -1139,13 +1034,6 @@ export const AgentMessages = React.memo(function AgentMessages({
     return turns
   }, [visibleGroups])
 
-  const scrollToTranscriptMessage = React.useCallback((messageId: string): void => {
-    historyVirtualizerRef.current?.scrollToMessage(messageId)
-  }, [])
-  const getStickyTranscriptMessageId = React.useCallback((scrollTop: number): string | null => (
-    historyVirtualizerRef.current?.getStickyUserMessageId(scrollTop) ?? null
-  ), [])
-
   return (
     <BasePathsProvider basePaths={messageBasePaths}>
       <AgentBrowserLinkProvider sessionId={sessionId}>
@@ -1165,8 +1053,7 @@ export const AgentMessages = React.memo(function AgentMessages({
             <>
               {/* 统一消息渲染（持久化 + 实时合并为一个列表，确保 system 消息位置正确） */}
               <AgentTranscriptHistory
-                ref={historyVirtualizerRef}
-                sessionId={sessionId}
+                ref={historyRef}
                 groups={visibleGroups}
                 liveGroupSet={liveGroupSet}
                 allMessages={allSDKMessages}
@@ -1215,7 +1102,7 @@ export const AgentMessages = React.memo(function AgentMessages({
             </>
           )}
         </ConversationContent>
-        <ScrollMinimap items={minimapItems} onScrollToMessage={scrollToTranscriptMessage} />
+        <ScrollMinimap items={minimapItems} />
         <TaskProgressOverlay
           key={sessionId}
           activities={liveTaskActivities}
@@ -1225,8 +1112,6 @@ export const AgentMessages = React.memo(function AgentMessages({
         {allUserMessagesData.length > 0 && (
           <StickyUserMessage
             userMessages={allUserMessagesData}
-            getStickyMessageId={getStickyTranscriptMessageId}
-            onScrollToMessage={scrollToTranscriptMessage}
           />
         )}
           </Conversation>

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -1151,6 +1151,11 @@ export const AgentMessages = React.memo(function AgentMessages({
     return turns
   }, [visibleGroups])
 
+  const stickyLayoutSignature = React.useMemo(() => {
+    const firstGroup = visibleGroups[0]
+    return `${visibleGroups.length}:${firstGroup ? getGroupId(firstGroup) : ''}`
+  }, [visibleGroups])
+
   return (
     <BasePathsProvider basePaths={messageBasePaths}>
       <AgentBrowserLinkProvider sessionId={sessionId}>
@@ -1229,6 +1234,7 @@ export const AgentMessages = React.memo(function AgentMessages({
         {allUserMessagesData.length > 0 && (
           <StickyUserMessage
             userMessages={allUserMessagesData}
+            layoutSignature={stickyLayoutSignature}
           />
         )}
           </Conversation>

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -589,11 +589,37 @@ interface AgentTranscriptHistoryProps {
   onCompact?: () => void
 }
 
-/**
- * Agent 历史消息使用普通 DOM 列表，避免滚动期间反复挂载和测量重型消息组件。
- * 历史 group 仍通过 message-group-rendering 缓存和 MessageGroupRenderer.memo 隔离更新。
- */
-const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, AgentTranscriptHistoryProps>(function AgentTranscriptHistory({
+const EMPTY_LIVE_GROUP_SET: ReadonlySet<MessageGroup> = new Set()
+const EMPTY_MESSAGE_GROUPS: MessageGroup[] = []
+
+function areTranscriptRowsEqual(
+  previous: AgentTranscriptHistoryProps,
+  next: AgentTranscriptHistoryProps,
+): boolean {
+  if (
+    previous.groups.length !== next.groups.length
+    || previous.liveGroupSet !== next.liveGroupSet
+    || previous.taskNotificationSignature !== next.taskNotificationSignature
+    || previous.sessionPath !== next.sessionPath
+    || previous.sessionModelId !== next.sessionModelId
+    || previous.streaming !== next.streaming
+    || previous.stoppedByUser !== next.stoppedByUser
+    || previous.onFork !== next.onFork
+    || previous.onRewind !== next.onRewind
+    || previous.onAgentHistoryQuoteClick !== next.onAgentHistoryQuoteClick
+    || previous.onCreateTodo !== next.onCreateTodo
+    || previous.onRetry !== next.onRetry
+    || previous.onRetryInNewSession !== next.onRetryInNewSession
+    || previous.onRelinkProjectRoot !== next.onRelinkProjectRoot
+    || previous.onRestoreProjectRoot !== next.onRestoreProjectRoot
+    || previous.onCompact !== next.onCompact
+  ) {
+    return false
+  }
+  return previous.groups.every((group, index) => group === next.groups[index])
+}
+
+const AgentTranscriptRows = React.memo(function AgentTranscriptRows({
   groups,
   liveGroupSet,
   allMessages,
@@ -612,62 +638,14 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
   onRelinkProjectRoot,
   onRestoreProjectRoot,
   onCompact,
-}, ref): React.ReactElement {
-  const { scrollRef, isAtBottom, stopScroll } = useStickToBottomContext()
-  const previousLayoutRef = React.useRef<{
-    count: number
-    firstGroupId: string | undefined
-    scrollHeight: number
-    isAtBottom: boolean
-  } | null>(null)
-
-  React.useLayoutEffect(() => {
-    const element = scrollRef.current
-    if (!element) return
-
-    const previous = previousLayoutRef.current
-    const firstGroupId = groups[0] ? getGroupId(groups[0]) : undefined
-    if (
-      previous
-      && previous.firstGroupId !== undefined
-      && groups.length > previous.count
-      && firstGroupId !== previous.firstGroupId
-      && !previous.isAtBottom
-    ) {
-      const heightDelta = element.scrollHeight - previous.scrollHeight
-      if (heightDelta > 0) element.scrollTop += heightDelta
-    }
-
-    previousLayoutRef.current = {
-      count: groups.length,
-      firstGroupId,
-      scrollHeight: element.scrollHeight,
-      isAtBottom,
-    }
-  }, [groups, isAtBottom, scrollRef])
-
+}: AgentTranscriptHistoryProps): React.ReactElement {
   const lastAssistantTurnIndex = React.useMemo(
     () => groups.findLastIndex((group) => group.type === 'assistant-turn'),
     [groups],
   )
 
-  React.useImperativeHandle(ref, () => ({
-    scrollToMessage: (messageId, onMounted) => {
-      const target = Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-message-id]') ?? [])
-        .find((element) => element.dataset.messageId === messageId)
-      if (!target) return
-
-      stopScroll()
-      if (onMounted) {
-        onMounted(target)
-        return
-      }
-      target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
-    },
-  }), [scrollRef, stopScroll])
-
   return (
-    <div className="w-full shrink-0">
+    <>
       {groups.map((group, index) => {
         const isLive = liveGroupSet.has(group)
         const isErrorGroup = group.type === 'assistant-turn'
@@ -701,6 +679,145 @@ const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, Ag
           </div>
         )
       })}
+    </>
+  )
+}, areTranscriptRowsEqual)
+
+/**
+ * Agent 历史消息使用普通 DOM 列表，避免滚动期间反复挂载和测量重型消息组件。
+ * 稳定历史前缀与实时 tail 分开 memo，token 更新时不重新协调整个历史 DOM。
+ */
+const AgentTranscriptHistory = React.forwardRef<AgentTranscriptHistoryHandle, AgentTranscriptHistoryProps>(function AgentTranscriptHistory({
+  groups,
+  liveGroupSet,
+  allMessages,
+  taskNotificationSignature,
+  sessionPath,
+  sessionModelId,
+  groupHistoryTurns,
+  streaming,
+  stoppedByUser,
+  onFork,
+  onRewind,
+  onAgentHistoryQuoteClick,
+  onCreateTodo,
+  onRetry,
+  onRetryInNewSession,
+  onRelinkProjectRoot,
+  onRestoreProjectRoot,
+  onCompact,
+}, ref): React.ReactElement {
+  const { scrollRef, isAtBottom, stopScroll } = useStickToBottomContext()
+  const previousLayoutRef = React.useRef<{
+    count: number
+    firstGroupId: string | undefined
+    scrollHeight: number
+    isAtBottom: boolean
+  } | null>(null)
+
+  const firstGroupId = groups[0] ? getGroupId(groups[0]) : undefined
+  const groupCount = groups.length
+
+  React.useLayoutEffect(() => {
+    const element = scrollRef.current
+    if (!element) return
+
+    const previous = previousLayoutRef.current
+    if (
+      previous
+      && previous.firstGroupId !== undefined
+      && groupCount > previous.count
+      && firstGroupId !== previous.firstGroupId
+      && !previous.isAtBottom
+    ) {
+      const heightDelta = element.scrollHeight - previous.scrollHeight
+      if (heightDelta > 0) element.scrollTop += heightDelta
+    }
+
+    previousLayoutRef.current = {
+      count: groupCount,
+      firstGroupId,
+      scrollHeight: element.scrollHeight,
+      isAtBottom,
+    }
+  }, [firstGroupId, groupCount, isAtBottom, scrollRef])
+
+  const firstLiveIndex = groups.findIndex((group) => liveGroupSet.has(group))
+  const historyEnd = firstLiveIndex >= 0 ? firstLiveIndex : groups.length
+  const stableHistoryGroupsRef = React.useRef<MessageGroup[]>([])
+  const historyGroups = React.useMemo(() => {
+    const previous = stableHistoryGroupsRef.current
+    if (
+      previous.length === historyEnd
+      && previous.every((group, index) => group === groups[index])
+    ) {
+      return previous
+    }
+    const next = groups.slice(0, historyEnd)
+    stableHistoryGroupsRef.current = next
+    return next
+  }, [groups, historyEnd])
+  const liveGroups = historyEnd < groups.length ? groups.slice(historyEnd) : EMPTY_MESSAGE_GROUPS
+
+  React.useImperativeHandle(ref, () => ({
+    scrollToMessage: (messageId, onMounted) => {
+      const target = Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-message-id]') ?? [])
+        .find((element) => element.dataset.messageId === messageId)
+      if (!target) return
+
+      stopScroll()
+      if (onMounted) {
+        onMounted(target)
+        return
+      }
+      target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
+    },
+  }), [scrollRef, stopScroll])
+
+  return (
+    <div className="w-full shrink-0">
+      <AgentTranscriptRows
+        groups={historyGroups}
+        liveGroupSet={EMPTY_LIVE_GROUP_SET}
+        allMessages={allMessages}
+        taskNotificationSignature={taskNotificationSignature}
+        sessionPath={sessionPath}
+        sessionModelId={sessionModelId}
+        groupHistoryTurns={groupHistoryTurns}
+        streaming={false}
+        stoppedByUser={liveGroups.length === 0 ? stoppedByUser : undefined}
+        onFork={onFork}
+        onRewind={onRewind}
+        onAgentHistoryQuoteClick={onAgentHistoryQuoteClick}
+        onCreateTodo={onCreateTodo}
+        onRetry={onRetry}
+        onRetryInNewSession={onRetryInNewSession}
+        onRelinkProjectRoot={onRelinkProjectRoot}
+        onRestoreProjectRoot={onRestoreProjectRoot}
+        onCompact={onCompact}
+      />
+      {liveGroups.length > 0 && (
+        <AgentTranscriptRows
+          groups={liveGroups}
+          liveGroupSet={liveGroupSet}
+          allMessages={allMessages}
+          taskNotificationSignature={taskNotificationSignature}
+          sessionPath={sessionPath}
+          sessionModelId={sessionModelId}
+          groupHistoryTurns={groupHistoryTurns}
+          streaming={streaming}
+          stoppedByUser={stoppedByUser}
+          onFork={onFork}
+          onRewind={onRewind}
+          onAgentHistoryQuoteClick={onAgentHistoryQuoteClick}
+          onCreateTodo={onCreateTodo}
+          onRetry={onRetry}
+          onRetryInNewSession={onRetryInNewSession}
+          onRelinkProjectRoot={onRelinkProjectRoot}
+          onRestoreProjectRoot={onRestoreProjectRoot}
+          onCompact={onCompact}
+        />
+      )}
     </div>
   )
 })

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -30,7 +30,6 @@ export interface MinimapItem {
 
 interface ScrollMinimapProps {
   items: MinimapItem[]
-  onScrollToMessage?: (id: string) => void
 }
 
 /** 最少消息数才显示迷你地图 */
@@ -75,7 +74,7 @@ function escapeRegExp(str: string): string {
 
 // ── 主组件 ──
 
-export function ScrollMinimap({ items, onScrollToMessage }: ScrollMinimapProps): React.ReactElement | null {
+export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement | null {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const [hovered, setHovered] = React.useState(false)
   const [isLeaving, setIsLeaving] = React.useState(false)
@@ -352,14 +351,9 @@ export function ScrollMinimap({ items, onScrollToMessage }: ScrollMinimapProps):
   const scrollToMessage = React.useCallback((id: string) => {
     const el = scrollRef.current
     if (!el) return
-    if (onScrollToMessage) {
-      onScrollToMessage(id)
-      setHovered(false)
-      return
-    }
 
     const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
-      (node) => node.getAttribute('data-message-id') === id
+      (node) => node.getAttribute('data-message-id') === id,
     )
     if (!target) return
 
@@ -377,7 +371,7 @@ export function ScrollMinimap({ items, onScrollToMessage }: ScrollMinimapProps):
     el.scrollTo({ top: Math.max(0, scrollTarget), behavior: 'smooth' })
 
     setHovered(false)
-  }, [onScrollToMessage, scrollRef, stopScroll, stickyState])
+  }, [scrollRef, stopScroll, stickyState])
 
   // ── 搜索过滤 ──
 

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -152,12 +152,10 @@ export function StickyUserMessage({
       }
       if (entries.some((entry) => entry.target !== el)) scheduleMeasure()
     })
-    const contentRoot = el.firstElementChild
-    if (contentRoot && contentRoot !== el) resizeObserver.observe(contentRoot)
+    // 只观察滚动容器尺寸和用户消息节点：assistant 流式内容位于最后一个用户消息之后，
+    // 它的高度变化不会改变已记录的用户消息位置。
+    resizeObserver.observe(el)
 
-    // 只有最后一条用户消息及其之前的内容会改变用户消息的绝对位置。
-    // 当前流式 assistant 位于它之后，不需要监听每个子树 mutation；内容根节点的高度变化
-    // 已由 ResizeObserver 捕获，并会在下一帧重新收集用户消息位置。
     const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
     const lastUserMessageIndex = messageElements.findLastIndex(
       (message) => message.dataset.messageRole === 'user',

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -42,8 +42,6 @@ interface UserMessageData {
 
 interface StickyUserMessageProps {
   userMessages: UserMessageData[]
-  getStickyMessageId?: (scrollTop: number) => string | null
-  onScrollToMessage?: (id: string) => void
 }
 
 interface UserMessagePosition {
@@ -53,8 +51,6 @@ interface UserMessagePosition {
 
 export function StickyUserMessage({
   userMessages,
-  getStickyMessageId,
-  onScrollToMessage,
 }: StickyUserMessageProps): React.ReactElement {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const userProfile = useAtomValue(userProfileAtom)
@@ -93,13 +89,6 @@ export function StickyUserMessage({
 
     const updateStickyMessage = (): void => {
       const scrollTop = el.scrollTop
-      if (getStickyMessageId) {
-        const id = getStickyMessageId(scrollTop)
-        const found = id ? messageMap.get(id) ?? null : null
-        setStickyMessage((previous) => previous?.id === found?.id ? previous : found)
-        return
-      }
-
       const positions = positionsRef.current
       let low = 0
       let high = positions.length - 1
@@ -128,14 +117,12 @@ export function StickyUserMessage({
         positions.push({ id, bottom: rect.bottom - containerRect.top + el.scrollTop })
       }
       positionsRef.current = positions
-      if (!getStickyMessageId) {
-        const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
-        const lastUserMessageIndex = messageElements.findLastIndex(
-          (message) => message.dataset.messageRole === 'user',
-        )
-        for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
-          resizeObserver.observe(message)
-        }
+      const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+      const lastUserMessageIndex = messageElements.findLastIndex(
+        (message) => message.dataset.messageRole === 'user',
+      )
+      for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
+        resizeObserver.observe(message)
       }
       updateStickyMessage()
     }
@@ -165,34 +152,28 @@ export function StickyUserMessage({
       }
       if (entries.some((entry) => entry.target !== el)) scheduleMeasure()
     })
-    const virtualContent = el.querySelector<HTMLElement>('[data-index]')?.parentElement
-      ?? el.firstElementChild
-    if (virtualContent && virtualContent !== el) resizeObserver.observe(virtualContent)
+    const contentRoot = el.firstElementChild
+    if (contentRoot && contentRoot !== el) resizeObserver.observe(contentRoot)
 
-    const mutationObserver = getStickyMessageId ? null : new MutationObserver(scheduleMeasure)
     // 只有最后一条用户消息及其之前的内容会改变用户消息的绝对位置。
-    // 当前流式 assistant 位于它之后，不纳入观察，避免每个流式高度更新重测整段历史。
-    if (!getStickyMessageId) {
-      const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
-      const lastUserMessageIndex = messageElements.findLastIndex(
-        (message) => message.dataset.messageRole === 'user',
-      )
-      for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
-        resizeObserver.observe(message)
-      }
-      mutationObserver?.observe(el, { childList: true, subtree: true })
+    // 当前流式 assistant 位于它之后，不需要监听每个子树 mutation；内容根节点的高度变化
+    // 已由 ResizeObserver 捕获，并会在下一帧重新收集用户消息位置。
+    const messageElements = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+    const lastUserMessageIndex = messageElements.findLastIndex(
+      (message) => message.dataset.messageRole === 'user',
+    )
+    for (const message of messageElements.slice(0, lastUserMessageIndex + 1)) {
+      resizeObserver.observe(message)
     }
-
     scheduleMeasure()
 
     return () => {
       if (scrollFrame !== null) cancelAnimationFrame(scrollFrame)
       if (measureFrame !== null) cancelAnimationFrame(measureFrame)
       el.removeEventListener('scroll', scheduleScrollUpdate)
-      mutationObserver?.disconnect()
       resizeObserver.disconnect()
     }
-  }, [getStickyMessageId, scrollRef, userMessageSignature, messageMap, stickyEnabled])
+  }, [scrollRef, userMessageSignature, messageMap, stickyEnabled])
 
   // 点击回滚到原始消息
   const scrollToOriginal = React.useCallback(() => {
@@ -202,10 +183,7 @@ export function StickyUserMessage({
     const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
       (node) => node.getAttribute('data-message-id') === stickyMessage.id
     )
-    if (!target) {
-      onScrollToMessage?.(stickyMessage.id)
-      return
-    }
+    if (!target) return
 
     stopScroll()
     stickyState.animation = undefined
@@ -216,7 +194,7 @@ export function StickyUserMessage({
     const targetRect = target.getBoundingClientRect()
     const targetScrollTop = el.scrollTop + (targetRect.top - containerRect.top)
     el.scrollTo({ top: Math.max(0, targetScrollTop - 24), behavior: 'smooth' })
-  }, [onScrollToMessage, scrollRef, stopScroll, stickyState, stickyMessage])
+  }, [scrollRef, stopScroll, stickyState, stickyMessage])
 
   const isSticky = stickyMessage !== null
   const hasContent = stickyMessage && (stickyMessage.text || stickyMessage.attachments.length > 0)

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -42,6 +42,8 @@ interface UserMessageData {
 
 interface StickyUserMessageProps {
   userMessages: UserMessageData[]
+  /** 历史结构变化签名，用于 prepend 非用户消息时刷新用户位置缓存。 */
+  layoutSignature?: string
 }
 
 interface UserMessagePosition {
@@ -51,6 +53,7 @@ interface UserMessagePosition {
 
 export function StickyUserMessage({
   userMessages,
+  layoutSignature,
 }: StickyUserMessageProps): React.ReactElement {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const userProfile = useAtomValue(userProfileAtom)
@@ -171,7 +174,7 @@ export function StickyUserMessage({
       el.removeEventListener('scroll', scheduleScrollUpdate)
       resizeObserver.disconnect()
     }
-  }, [scrollRef, userMessageSignature, messageMap, stickyEnabled])
+  }, [scrollRef, userMessageSignature, messageMap, layoutSignature, stickyEnabled])
 
   // 点击回滚到原始消息
   const scrollToOriginal = React.useCallback(() => {


### PR DESCRIPTION
## Summary
- remove virtualization from the Agent transcript history area
- keep message group caching and memoized rendering intact
- route minimap and sticky user message navigation through the normal DOM path
- retain virtualization for the left sidebar session lists

## Verification
- bun run typecheck
- bun test apps/electron/src/renderer/components/agent
- bun run --filter=@proma/electron build:renderer

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)