### PR TITLE
perf(agent): move deferred queue scheduling to main process

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -279,7 +279,7 @@ import {
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, promoteAgentQueuedMessage, listAgentQueuedMessages, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, promoteAgentQueuedMessage, bindAgentQueuedMessageWebContents, onAgentQueueBlockingRequestResolved, listAgentQueuedMessages, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -2889,7 +2889,8 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_QUEUED_MESSAGES,
-    async (_, sessionId?: string): Promise<import('@proma/shared').AgentQueuedMessage[]> => {
+    async (event, sessionId?: string): Promise<import('@proma/shared').AgentQueuedMessage[]> => {
+      if (sessionId) bindAgentQueuedMessageWebContents(sessionId, event.sender)
       return listAgentQueuedMessages(sessionId)
     },
   )
@@ -2922,6 +2923,7 @@ export function registerIpcHandlers(): void {
     async (event, response: PermissionResponse): Promise<void> => {
       const { requestId, behavior, alwaysAllow } = response
       const sessionId = permissionService.respondToPermission(requestId, behavior, alwaysAllow)
+      if (sessionId) onAgentQueueBlockingRequestResolved(sessionId)
 
       // 发送 permission_resolved 事件给渲染进程
       if (sessionId) {
@@ -3147,6 +3149,7 @@ export function registerIpcHandlers(): void {
     async (event, response: AskUserResponse): Promise<void> => {
       const { requestId, answers } = response
       const sessionId = askUserService.respondToAskUser(requestId, answers)
+      if (sessionId) onAgentQueueBlockingRequestResolved(sessionId)
 
       if (sessionId) {
         event.sender.send(AGENT_IPC_CHANNELS.STREAM_EVENT, {
@@ -3164,6 +3167,7 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.EXIT_PLAN_MODE_RESPOND,
     async (event, response: ExitPlanModeResponse): Promise<void> => {
       const result = exitPlanService.respondToExitPlanMode(response)
+      if (result) onAgentQueueBlockingRequestResolved(result.sessionId)
 
       if (result) {
         const { sessionId, targetMode } = result

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -279,7 +279,7 @@ import {
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, promoteAgentQueuedMessage, listAgentQueuedMessages, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -2234,6 +2234,7 @@ export function registerIpcHandlers(): void {
       askUserService.clearSessionPending(id)
       // 清理 ExitPlanMode 服务中的待处理请求
       exitPlanService.clearSessionPending(id)
+      clearAgentQueuedMessages(id)
       await browserController.close(id)
       deleteAgentSession(id)
       releaseAttachedFileWatchers(attachedFiles)
@@ -2855,6 +2856,42 @@ export function registerIpcHandlers(): void {
     async (event, input: import('@proma/shared').AgentQueueMessageInput): Promise<string> => {
       return queueAgentMessage(input, event.sender)
     }
+  )
+
+  // 将等待当前 run 结束的消息交给主进程调度器
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.ENQUEUE_QUEUED_MESSAGE,
+    async (event, input: import('@proma/shared').AgentDeferredQueueMessageInput): Promise<void> => {
+      enqueueAgentQueuedMessage(input, event.sender)
+    },
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.CANCEL_QUEUED_MESSAGE,
+    async (_, input: import('@proma/shared').AgentQueuedMessageControlInput): Promise<boolean> => {
+      return cancelAgentQueuedMessage(input)
+    },
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.MOVE_QUEUED_MESSAGE,
+    async (_, input: import('@proma/shared').AgentMoveQueuedMessageInput): Promise<boolean> => {
+      return moveAgentQueuedMessage(input)
+    },
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.PROMOTE_QUEUED_MESSAGE,
+    async (_, input: import('@proma/shared').AgentQueuedMessageControlInput & { interrupt?: boolean }): Promise<boolean> => {
+      return promoteAgentQueuedMessage(input)
+    },
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.LIST_QUEUED_MESSAGES,
+    async (_, sessionId?: string): Promise<import('@proma/shared').AgentQueuedMessage[]> => {
+      return listAgentQueuedMessages(sessionId)
+    },
   )
 
   // ===== Agent 后台任务管理 =====

--- a/apps/electron/src/main/lib/agent-ask-user-service.ts
+++ b/apps/electron/src/main/lib/agent-ask-user-service.ts
@@ -101,6 +101,13 @@ export class AgentAskUserService {
     return sessionId
   }
 
+  hasPendingRequests(sessionId: string): boolean {
+    for (const pending of this.pendingRequests.values()) {
+      if (pending.request.sessionId === sessionId) return true
+    }
+    return false
+  }
+
   /**
    * 获取当前所有待处理的 AskUser 请求（用于渲染进程重载后恢复状态）
    */

--- a/apps/electron/src/main/lib/agent-exit-plan-service.ts
+++ b/apps/electron/src/main/lib/agent-exit-plan-service.ts
@@ -135,6 +135,13 @@ export class AgentExitPlanService {
     }
   }
 
+  hasPendingRequests(sessionId: string): boolean {
+    for (const pending of this.pendingRequests.values()) {
+      if (pending.request.sessionId === sessionId) return true
+    }
+    return false
+  }
+
   /**
    * 获取当前所有待处理的 ExitPlanMode 请求（用于渲染进程重载后恢复状态）
    */

--- a/apps/electron/src/main/lib/agent-permission-service.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.ts
@@ -214,6 +214,13 @@ export class AgentPermissionService {
     return sessionId
   }
 
+  hasPendingRequests(sessionId: string): boolean {
+    for (const pending of this.pendingPermissions.values()) {
+      if (pending.request.sessionId === sessionId) return true
+    }
+    return false
+  }
+
   /**
    * 清除指定会话的所有待处理请求（会话结束或中止时调用）
    */

--- a/apps/electron/src/main/lib/agent-queue-coordinator.ts
+++ b/apps/electron/src/main/lib/agent-queue-coordinator.ts
@@ -10,7 +10,7 @@ import type {
 
 interface DeferredQueueEntry {
   input: AgentDeferredQueueMessageInput
-  webContents: WebContents
+  webContents: WebContents | null
 }
 
 export interface AgentQueueCoordinatorOptions {
@@ -20,6 +20,7 @@ export interface AgentQueueCoordinatorOptions {
     input: AgentQueueMessageInput,
     webContents: WebContents,
   ) => Promise<string>
+  canDispatch?: (sessionId: string) => boolean
   sendStatus: (webContents: WebContents, status: AgentQueuedMessageStatus) => void
 }
 
@@ -31,11 +32,35 @@ export interface AgentQueueCoordinatorOptions {
  */
 export class AgentQueueCoordinator {
   private readonly queues = new Map<string, DeferredQueueEntry[]>()
-  private readonly dispatching = new Set<string>()
+  private readonly dispatching = new Map<string, string>()
+  private readonly inFlight = new Map<string, DeferredQueueEntry>()
+  private readonly backgroundWaiting = new Set<string>()
+  private readonly stopped = new Set<string>()
+  private readonly failed = new Set<string>()
   private readonly options: AgentQueueCoordinatorOptions
 
   constructor(options: AgentQueueCoordinatorOptions) {
     this.options = options
+  }
+
+  bindWebContents(sessionId: string, webContents: WebContents): void {
+    for (const entry of this.queues.get(sessionId) ?? []) {
+      entry.webContents = webContents
+    }
+    const inFlight = this.inFlight.get(sessionId)
+    if (inFlight) inFlight.webContents = webContents
+    this.tryDispatch(sessionId)
+  }
+
+  detachWebContents(webContents: WebContents): void {
+    for (const queue of this.queues.values()) {
+      for (const entry of queue) {
+        if (entry.webContents === webContents) entry.webContents = null
+      }
+    }
+    for (const entry of this.inFlight.values()) {
+      if (entry.webContents === webContents) entry.webContents = null
+    }
   }
 
   enqueue(input: AgentDeferredQueueMessageInput, webContents: WebContents): void {
@@ -58,7 +83,9 @@ export class AgentQueueCoordinator {
     if (!entry) return false
     queue.splice(index, 1)
     this.deleteEmptyQueue(input.sessionId)
+    this.failed.delete(input.sessionId)
     this.emit(entry.webContents, entry.input, 'cancelled')
+    this.tryDispatch(input.sessionId)
     return true
   }
 
@@ -91,7 +118,12 @@ export class AgentQueueCoordinator {
     if (this.dispatching.has(input.sessionId)) return false
     const entry = this.removeEntry(input)
     if (!entry) return false
+    if (!entry.webContents) {
+      this.restoreEntry(input.sessionId, entry)
+      return false
+    }
 
+    this.failed.delete(input.sessionId)
     this.emit(entry.webContents, entry.input, 'started')
     if (this.options.isActive(input.sessionId)) {
       const queueInput: AgentQueueMessageInput = {
@@ -110,29 +142,64 @@ export class AgentQueueCoordinator {
         await this.options.injectMessage(queueInput, entry.webContents)
       } catch (error) {
         this.restoreEntry(input.sessionId, entry)
+        this.failed.add(input.sessionId)
         this.emit(entry.webContents, entry.input, 'failed', error)
       }
       return true
     }
 
-    this.dispatching.add(input.sessionId)
+    this.dispatching.set(input.sessionId, entry.input.queueMessageId)
+    this.inFlight.set(input.sessionId, entry)
     void this.options.startRun({
       ...entry.input,
       startedAt: Date.now(),
     }, entry.webContents)
       .catch((error) => {
-        this.restoreEntry(input.sessionId, entry)
-        this.emit(entry.webContents, entry.input, 'failed', error)
+        this.failDispatch(input.sessionId, entry, error)
       })
       .finally(() => {
-        this.dispatching.delete(input.sessionId)
+        this.releaseDispatch(input.sessionId, entry.input.queueMessageId)
       })
     return true
   }
 
-  onRunComplete(sessionId: string, backgroundTasksPending: boolean): void {
-    this.dispatching.delete(sessionId)
-    if (backgroundTasksPending) return
+  onRunError(sessionId: string, messageId: string, error: unknown): void {
+    if (this.dispatching.get(sessionId) !== messageId) return
+    const entry = this.inFlight.get(sessionId)
+    if (!entry || entry.input.queueMessageId !== messageId) return
+    this.releaseDispatch(sessionId, messageId)
+    this.restoreEntry(sessionId, entry)
+    this.failed.add(sessionId)
+    this.emit(entry.webContents, entry.input, 'failed', error)
+  }
+
+  onRunComplete(
+    sessionId: string,
+    options: {
+      queueMessageId?: string
+      backgroundTasksPending: boolean
+      stoppedByUser: boolean
+    },
+  ): void {
+    if (options.queueMessageId) {
+      this.releaseDispatch(sessionId, options.queueMessageId)
+    }
+    if (options.stoppedByUser) {
+      this.stopped.add(sessionId)
+      return
+    }
+    this.stopped.delete(sessionId)
+    if (this.failed.has(sessionId)) return
+    if (options.backgroundTasksPending) {
+      this.backgroundWaiting.add(sessionId)
+      return
+    }
+    this.backgroundWaiting.delete(sessionId)
+    this.tryDispatch(sessionId)
+  }
+
+  onBackgroundTaskComplete(sessionId: string): void {
+    this.backgroundWaiting.delete(sessionId)
     this.tryDispatch(sessionId)
   }
 
@@ -146,29 +213,55 @@ export class AgentQueueCoordinator {
   clear(sessionId: string): void {
     this.queues.delete(sessionId)
     this.dispatching.delete(sessionId)
+    this.inFlight.delete(sessionId)
+    this.backgroundWaiting.delete(sessionId)
+    this.stopped.delete(sessionId)
+    this.failed.delete(sessionId)
   }
 
   private tryDispatch(sessionId: string): void {
-    if (this.dispatching.has(sessionId) || this.options.isActive(sessionId)) return
+    if (
+      this.dispatching.has(sessionId)
+      || this.options.isActive(sessionId)
+      || this.backgroundWaiting.has(sessionId)
+      || this.stopped.has(sessionId)
+      || this.failed.has(sessionId)
+      || this.options.canDispatch?.(sessionId) === false
+    ) return
     const queue = this.queues.get(sessionId)
     const entry = queue?.[0]
-    if (!entry) return
+    if (!entry || !entry.webContents) return
 
     queue!.shift()
     this.deleteEmptyQueue(sessionId)
-    this.dispatching.add(sessionId)
+    this.dispatching.set(sessionId, entry.input.queueMessageId)
+    this.inFlight.set(sessionId, entry)
     this.emit(entry.webContents, entry.input, 'started')
     void this.options.startRun({
       ...entry.input,
       startedAt: Date.now(),
     }, entry.webContents)
       .catch((error) => {
-        this.restoreEntry(sessionId, entry)
-        this.emit(entry.webContents, entry.input, 'failed', error)
+        this.failDispatch(sessionId, entry, error)
       })
       .finally(() => {
-        this.dispatching.delete(sessionId)
+        this.releaseDispatch(sessionId, entry.input.queueMessageId)
       })
+  }
+
+  private failDispatch(sessionId: string, entry: DeferredQueueEntry, error: unknown): void {
+    if (this.dispatching.get(sessionId) !== entry.input.queueMessageId) return
+    this.releaseDispatch(sessionId, entry.input.queueMessageId)
+    this.restoreEntry(sessionId, entry)
+    this.failed.add(sessionId)
+    this.emit(entry.webContents, entry.input, 'failed', error)
+  }
+
+  private releaseDispatch(sessionId: string, messageId: string): void {
+    if (this.dispatching.get(sessionId) !== messageId) return
+    this.dispatching.delete(sessionId)
+    const entry = this.inFlight.get(sessionId)
+    if (entry?.input.queueMessageId === messageId) this.inFlight.delete(sessionId)
   }
 
   private removeEntry(input: AgentQueuedMessageControlInput): DeferredQueueEntry | undefined {
@@ -197,11 +290,12 @@ export class AgentQueueCoordinator {
   }
 
   private emit(
-    webContents: WebContents,
+    webContents: WebContents | null,
     input: AgentDeferredQueueMessageInput,
     status: AgentQueuedMessageStatus['status'],
     error?: unknown,
   ): void {
+    if (!webContents || webContents.isDestroyed()) return
     this.options.sendStatus(webContents, {
       sessionId: input.sessionId,
       messageId: input.queueMessageId,

--- a/apps/electron/src/main/lib/agent-queue-coordinator.ts
+++ b/apps/electron/src/main/lib/agent-queue-coordinator.ts
@@ -151,6 +151,7 @@ export class AgentQueueCoordinator {
         this.emit(entry.webContents, entry.input, 'failed', error)
         return false
       }
+      return true
     }
 
     this.dispatching.set(input.sessionId, entry.input.queueMessageId)

--- a/apps/electron/src/main/lib/agent-queue-coordinator.ts
+++ b/apps/electron/src/main/lib/agent-queue-coordinator.ts
@@ -1,0 +1,213 @@
+import type { WebContents } from 'electron'
+import type {
+  AgentDeferredQueueMessageInput,
+  AgentMoveQueuedMessageInput,
+  AgentQueuedMessage,
+  AgentQueuedMessageControlInput,
+  AgentQueuedMessageStatus,
+  AgentQueueMessageInput,
+} from '@proma/shared'
+
+interface DeferredQueueEntry {
+  input: AgentDeferredQueueMessageInput
+  webContents: WebContents
+}
+
+export interface AgentQueueCoordinatorOptions {
+  isActive: (sessionId: string) => boolean
+  startRun: (input: AgentDeferredQueueMessageInput, webContents: WebContents) => Promise<void>
+  injectMessage: (
+    input: AgentQueueMessageInput,
+    webContents: WebContents,
+  ) => Promise<string>
+  sendStatus: (webContents: WebContents, status: AgentQueuedMessageStatus) => void
+}
+
+/**
+ * 管理等待当前 Agent run 结束后发送的用户消息。
+ *
+ * 这里保存的是一次性的发送参数和 UI 快照，不保存流式消息，也不写磁盘。
+ * renderer 只负责展示投影；真正的“何时启动下一轮”由主进程 active slot 决定。
+ */
+export class AgentQueueCoordinator {
+  private readonly queues = new Map<string, DeferredQueueEntry[]>()
+  private readonly dispatching = new Set<string>()
+  private readonly options: AgentQueueCoordinatorOptions
+
+  constructor(options: AgentQueueCoordinatorOptions) {
+    this.options = options
+  }
+
+  enqueue(input: AgentDeferredQueueMessageInput, webContents: WebContents): void {
+    const current = this.queues.get(input.sessionId) ?? []
+    if (current.some((entry) => entry.input.queueMessageId === input.queueMessageId)) return
+
+    current.push({ input, webContents })
+    this.queues.set(input.sessionId, current)
+    this.emit(webContents, input, 'queued')
+    this.tryDispatch(input.sessionId)
+  }
+
+  cancel(input: AgentQueuedMessageControlInput): boolean {
+    const queue = this.queues.get(input.sessionId)
+    if (!queue) return false
+    const index = queue.findIndex((entry) => entry.input.queueMessageId === input.messageId)
+    if (index < 0) return false
+
+    const entry = queue[index]
+    if (!entry) return false
+    queue.splice(index, 1)
+    this.deleteEmptyQueue(input.sessionId)
+    this.emit(entry.webContents, entry.input, 'cancelled')
+    return true
+  }
+
+  move(input: AgentMoveQueuedMessageInput): boolean {
+    const queue = this.queues.get(input.sessionId)
+    if (!queue || input.sourceId === input.targetId) return false
+
+    const sourceIndex = queue.findIndex((entry) => entry.input.queueMessageId === input.sourceId)
+    if (sourceIndex < 0) return false
+    const source = queue[sourceIndex]
+    if (!source) return false
+    queue.splice(sourceIndex, 1)
+    const targetIndex = queue.findIndex((entry) => entry.input.queueMessageId === input.targetId)
+    if (targetIndex < 0) {
+      queue.splice(sourceIndex, 0, source)
+      return false
+    }
+
+    const insertIndex = input.placement === 'after' ? targetIndex + 1 : targetIndex
+    queue.splice(insertIndex, 0, source)
+    return true
+  }
+
+  /**
+   * 用户点击“立即发送”时：
+   * - 当前 run 仍在执行：复用原有 SDK queue injection；
+   * - 当前 run 已结束：直接启动一轮新的 Agent。
+   */
+  async promote(input: AgentQueuedMessageControlInput & { interrupt?: boolean }): Promise<boolean> {
+    if (this.dispatching.has(input.sessionId)) return false
+    const entry = this.removeEntry(input)
+    if (!entry) return false
+
+    this.emit(entry.webContents, entry.input, 'started')
+    if (this.options.isActive(input.sessionId)) {
+      const queueInput: AgentQueueMessageInput = {
+        sessionId: entry.input.sessionId,
+        userMessage: entry.input.userMessage,
+        rawUserMessage: entry.input.rawUserMessage,
+        uuid: entry.input.queueMessageId,
+        interrupt: input.interrupt,
+        mentionedSkills: entry.input.mentionedSkills,
+        mentionedMcpServers: entry.input.mentionedMcpServers,
+        mentionedSessionIds: entry.input.mentionedSessionIds,
+        mentionedTodoIds: entry.input.mentionedTodoIds,
+        mentionedCalendarEventIds: entry.input.mentionedCalendarEventIds,
+      }
+      try {
+        await this.options.injectMessage(queueInput, entry.webContents)
+      } catch (error) {
+        this.restoreEntry(input.sessionId, entry)
+        this.emit(entry.webContents, entry.input, 'failed', error)
+      }
+      return true
+    }
+
+    this.dispatching.add(input.sessionId)
+    void this.options.startRun({
+      ...entry.input,
+      startedAt: Date.now(),
+    }, entry.webContents)
+      .catch((error) => {
+        this.restoreEntry(input.sessionId, entry)
+        this.emit(entry.webContents, entry.input, 'failed', error)
+      })
+      .finally(() => {
+        this.dispatching.delete(input.sessionId)
+      })
+    return true
+  }
+
+  onRunComplete(sessionId: string, backgroundTasksPending: boolean): void {
+    this.dispatching.delete(sessionId)
+    if (backgroundTasksPending) return
+    this.tryDispatch(sessionId)
+  }
+
+  list(sessionId?: string): AgentQueuedMessage[] {
+    if (sessionId) {
+      return (this.queues.get(sessionId) ?? []).map((entry) => entry.input.displayMessage)
+    }
+    return [...this.queues.values()].flatMap((queue) => queue.map((entry) => entry.input.displayMessage))
+  }
+
+  clear(sessionId: string): void {
+    this.queues.delete(sessionId)
+    this.dispatching.delete(sessionId)
+  }
+
+  private tryDispatch(sessionId: string): void {
+    if (this.dispatching.has(sessionId) || this.options.isActive(sessionId)) return
+    const queue = this.queues.get(sessionId)
+    const entry = queue?.[0]
+    if (!entry) return
+
+    queue!.shift()
+    this.deleteEmptyQueue(sessionId)
+    this.dispatching.add(sessionId)
+    this.emit(entry.webContents, entry.input, 'started')
+    void this.options.startRun({
+      ...entry.input,
+      startedAt: Date.now(),
+    }, entry.webContents)
+      .catch((error) => {
+        this.restoreEntry(sessionId, entry)
+        this.emit(entry.webContents, entry.input, 'failed', error)
+      })
+      .finally(() => {
+        this.dispatching.delete(sessionId)
+      })
+  }
+
+  private removeEntry(input: AgentQueuedMessageControlInput): DeferredQueueEntry | undefined {
+    const queue = this.queues.get(input.sessionId)
+    if (!queue) return undefined
+    const index = queue.findIndex((entry) => entry.input.queueMessageId === input.messageId)
+    if (index < 0) return undefined
+    const entry = queue[index]
+    if (!entry) return undefined
+    queue.splice(index, 1)
+    this.deleteEmptyQueue(input.sessionId)
+    return entry
+  }
+
+  private restoreEntry(sessionId: string, entry: DeferredQueueEntry): void {
+    const queue = this.queues.get(sessionId) ?? []
+    if (!queue.some((item) => item.input.queueMessageId === entry.input.queueMessageId)) {
+      queue.unshift(entry)
+      this.queues.set(sessionId, queue)
+    }
+  }
+
+  private deleteEmptyQueue(sessionId: string): void {
+    const queue = this.queues.get(sessionId)
+    if (queue && queue.length === 0) this.queues.delete(sessionId)
+  }
+
+  private emit(
+    webContents: WebContents,
+    input: AgentDeferredQueueMessageInput,
+    status: AgentQueuedMessageStatus['status'],
+    error?: unknown,
+  ): void {
+    this.options.sendStatus(webContents, {
+      sessionId: input.sessionId,
+      messageId: input.queueMessageId,
+      status,
+      message: input.displayMessage,
+      ...(error ? { error: error instanceof Error ? error.message : String(error) } : {}),
+    })
+  }
+}

--- a/apps/electron/src/main/lib/agent-queue-coordinator.ts
+++ b/apps/electron/src/main/lib/agent-queue-coordinator.ts
@@ -49,6 +49,9 @@ export class AgentQueueCoordinator {
     }
     const inFlight = this.inFlight.get(sessionId)
     if (inFlight) inFlight.webContents = webContents
+  }
+
+  wake(sessionId: string): void {
     this.tryDispatch(sessionId)
   }
 
@@ -106,6 +109,8 @@ export class AgentQueueCoordinator {
 
     const insertIndex = input.placement === 'after' ? targetIndex + 1 : targetIndex
     queue.splice(insertIndex, 0, source)
+    this.failed.delete(input.sessionId)
+    this.tryDispatch(input.sessionId)
     return true
   }
 
@@ -144,8 +149,8 @@ export class AgentQueueCoordinator {
         this.restoreEntry(input.sessionId, entry)
         this.failed.add(input.sessionId)
         this.emit(entry.webContents, entry.input, 'failed', error)
+        return false
       }
-      return true
     }
 
     this.dispatching.set(input.sessionId, entry.input.queueMessageId)
@@ -217,6 +222,10 @@ export class AgentQueueCoordinator {
     this.backgroundWaiting.delete(sessionId)
     this.stopped.delete(sessionId)
     this.failed.delete(sessionId)
+  }
+
+  onBlockingRequestResolved(sessionId: string): void {
+    this.tryDispatch(sessionId)
   }
 
   private tryDispatch(sessionId: string): void {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -44,6 +44,9 @@ import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
 import { AgentStreamForwarder } from './agent-stream-forwarder'
 import { AgentQueueCoordinator } from './agent-queue-coordinator'
+import { permissionService } from './agent-permission-service'
+import { askUserService } from './agent-ask-user-service'
+import { exitPlanService } from './agent-exit-plan-service'
 
 // ===== 实例创建 =====
 
@@ -92,15 +95,16 @@ function registerWebContents(sessionId: string, wc: WebContents): void {
   if (previousWebContents && previousWebContents !== wc) streamForwarder.clear(sessionId)
   // 旧 wc 的 destroyed 钩子仍由 WeakSet 持有，触发时会扫描 sessionWebContents 清理所有指向它的条目。
   sessionWebContents.set(sessionId, wc)
+  agentQueueCoordinator.bindWebContents(sessionId, wc)
   if (wcWithCleanupHook.has(wc)) return
   wcWithCleanupHook.add(wc)
   wc.once('destroyed', () => {
+    agentQueueCoordinator.detachWebContents(wc)
     // 单个 wc 可能映射到多个 sessionId（同窗口多 tab），需要清理所有指向它的条目
     for (const [sid, mappedWc] of sessionWebContents) {
       if (mappedWc === wc) {
         sessionWebContents.delete(sid)
         streamForwarder.clear(sid)
-        agentQueueCoordinator.clear(sid)
       }
     }
     visibleAgentSessionByWebContents.delete(wc)
@@ -164,6 +168,13 @@ eventBus.use((sessionId, payload, next) => {
     }
   }
   next()
+  if (
+    payload.kind === 'sdk_message'
+    && payload.message.type === 'system'
+    && payload.message.subtype === 'task_notification'
+  ) {
+    agentQueueCoordinator.onBackgroundTaskComplete(sessionId)
+  }
 })
 
 /** renderer 切换标签时更新流式优先级；切入会话立即 flush 等待中的后台快照。 */
@@ -179,6 +190,13 @@ export function setVisibleAgentSession(webContents: WebContents, sessionId: stri
 
 const agentQueueCoordinator = new AgentQueueCoordinator({
   isActive: (sessionId) => orchestrator.isActive(sessionId),
+  canDispatch: (sessionId) => {
+    const session = getAgentSessionMeta(sessionId)
+    return !session?.stoppedByUser
+      && !permissionService.hasPendingRequests(sessionId)
+      && !askUserService.hasPendingRequests(sessionId)
+      && !exitPlanService.hasPendingRequests(sessionId)
+  },
   startRun: (input, webContents) => runAgent(input, webContents),
   injectMessage: (input, webContents) => queueAgentMessage(input, webContents),
   sendStatus: (webContents, status) => {
@@ -206,6 +224,8 @@ export async function runAgent(
 ): Promise<void> {
   // 更新 webContents 映射（允许覆盖 — 由 orchestrator.activeSessions 处理真正的并发保护）
   registerWebContents(input.sessionId, webContents)
+  // deferred queue runs carry their queue id at runtime; normal renderer/bridge runs do not.
+  const deferredQueueMessageId = (input as Partial<AgentDeferredQueueMessageInput>).queueMessageId
   // 开始新一轮执行时清除"完成未确认"标记
   try {
     updateAgentSessionMeta(input.sessionId, { completedButUnconfirmed: false })
@@ -228,6 +248,9 @@ export async function runAgent(
   try {
     await orchestrator.sendMessage(input, {
       onError: (error) => {
+        if (deferredQueueMessageId) {
+          agentQueueCoordinator.onRunError(input.sessionId, deferredQueueMessageId, error)
+        }
         if (!webContents.isDestroyed()) {
           webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
             sessionId: input.sessionId,
@@ -248,8 +271,12 @@ export async function runAgent(
             // 只读取刚完成的轻量 meta，renderer 可据此增量更新列表，避免再取 5,000+ 条全量会话。
             session: getSessionMetaForRenderer(input.sessionId),
           })
-          agentQueueCoordinator.onRunComplete(input.sessionId, opts?.backgroundTasksPending === true)
         }
+        agentQueueCoordinator.onRunComplete(input.sessionId, {
+          queueMessageId: deferredQueueMessageId,
+          backgroundTasksPending: opts?.backgroundTasksPending === true,
+          stoppedByUser: opts?.stoppedByUser === true,
+        })
       },
       onRunStarted: ({ startedAt }) => {
         eventBus.emit(input.sessionId, {
@@ -273,6 +300,9 @@ export async function runAgent(
   } catch (err) {
     console.error('[Agent 服务] runAgent 未处理异常:', err)
     const errorMessage = err instanceof Error ? err.message : '未知错误'
+    if (deferredQueueMessageId) {
+      agentQueueCoordinator.onRunError(input.sessionId, deferredQueueMessageId, errorMessage)
+    }
     if (!webContents.isDestroyed()) {
       webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
         sessionId: input.sessionId,
@@ -282,8 +312,12 @@ export async function runAgent(
         messages: [],
         stoppedByUser: false,
       })
-      agentQueueCoordinator.onRunComplete(input.sessionId, false)
     }
+    agentQueueCoordinator.onRunComplete(input.sessionId, {
+      queueMessageId: deferredQueueMessageId,
+      backgroundTasksPending: false,
+      stoppedByUser: false,
+    })
   } finally {
     // 仅在 orchestrator 已完成此会话时清理映射
     // 避免被拒绝的请求误删仍在运行的会话映射
@@ -350,8 +384,11 @@ export async function runAgentHeadless(
             // 只读取刚完成的轻量 meta，renderer 可据此增量更新列表，避免再取 5,000+ 条全量会话。
             session: getSessionMetaForRenderer(runInput.sessionId),
           })
-          agentQueueCoordinator.onRunComplete(runInput.sessionId, opts?.backgroundTasksPending === true)
         }
+        agentQueueCoordinator.onRunComplete(runInput.sessionId, {
+          backgroundTasksPending: opts?.backgroundTasksPending === true,
+          stoppedByUser: opts?.stoppedByUser === true,
+        })
       },
       onTitleUpdated: (title) => {
         callbacks.onTitleUpdated(title)
@@ -396,8 +433,11 @@ export async function runAgentHeadless(
         stoppedByUser: false,
         startedAt,
       })
-      agentQueueCoordinator.onRunComplete(runInput.sessionId, false)
     }
+    agentQueueCoordinator.onRunComplete(runInput.sessionId, {
+      backgroundTasksPending: false,
+      stoppedByUser: false,
+    })
   } finally {
     if (!orchestrator.isActive(runInput.sessionId)) {
       sessionWebContents.delete(runInput.sessionId)

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -548,6 +548,15 @@ export async function promoteAgentQueuedMessage(
   return agentQueueCoordinator.promote(input)
 }
 
+export function bindAgentQueuedMessageWebContents(sessionId: string, webContents: WebContents): void {
+  agentQueueCoordinator.bindWebContents(sessionId, webContents)
+  agentQueueCoordinator.wake(sessionId)
+}
+
+export function onAgentQueueBlockingRequestResolved(sessionId: string): void {
+  agentQueueCoordinator.onBlockingRequestResolved(sessionId)
+}
+
 export function listAgentQueuedMessages(sessionId?: string) {
   return agentQueueCoordinator.list(sessionId)
 }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -25,6 +25,9 @@ import type {
   AgentStreamEvent,
   AgentStreamPayload,
   AgentQueueMessageInput,
+  AgentDeferredQueueMessageInput,
+  AgentQueuedMessageControlInput,
+  AgentMoveQueuedMessageInput,
   PromaPermissionMode,
   AgentExternalRunSource,
   AgentMessage,
@@ -40,6 +43,7 @@ import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner
 import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
 import { AgentStreamForwarder } from './agent-stream-forwarder'
+import { AgentQueueCoordinator } from './agent-queue-coordinator'
 
 // ===== 实例创建 =====
 
@@ -96,6 +100,7 @@ function registerWebContents(sessionId: string, wc: WebContents): void {
       if (mappedWc === wc) {
         sessionWebContents.delete(sid)
         streamForwarder.clear(sid)
+        agentQueueCoordinator.clear(sid)
       }
     }
     visibleAgentSessionByWebContents.delete(wc)
@@ -172,6 +177,17 @@ export function setVisibleAgentSession(webContents: WebContents, sessionId: stri
   if (sessionId) streamForwarder.promote(sessionId)
 }
 
+const agentQueueCoordinator = new AgentQueueCoordinator({
+  isActive: (sessionId) => orchestrator.isActive(sessionId),
+  startRun: (input, webContents) => runAgent(input, webContents),
+  injectMessage: (input, webContents) => queueAgentMessage(input, webContents),
+  sendStatus: (webContents, status) => {
+    if (!webContents.isDestroyed()) {
+      webContents.send(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, status)
+    }
+  },
+})
+
 // ===== IPC 薄包装函数 =====
 
 /** 仅主进程内部使用的单次运行扩展，绝不经 IPC 序列化。 */
@@ -232,6 +248,7 @@ export async function runAgent(
             // 只读取刚完成的轻量 meta，renderer 可据此增量更新列表，避免再取 5,000+ 条全量会话。
             session: getSessionMetaForRenderer(input.sessionId),
           })
+          agentQueueCoordinator.onRunComplete(input.sessionId, opts?.backgroundTasksPending === true)
         }
       },
       onRunStarted: ({ startedAt }) => {
@@ -265,6 +282,7 @@ export async function runAgent(
         messages: [],
         stoppedByUser: false,
       })
+      agentQueueCoordinator.onRunComplete(input.sessionId, false)
     }
   } finally {
     // 仅在 orchestrator 已完成此会话时清理映射
@@ -332,6 +350,7 @@ export async function runAgentHeadless(
             // 只读取刚完成的轻量 meta，renderer 可据此增量更新列表，避免再取 5,000+ 条全量会话。
             session: getSessionMetaForRenderer(runInput.sessionId),
           })
+          agentQueueCoordinator.onRunComplete(runInput.sessionId, opts?.backgroundTasksPending === true)
         }
       },
       onTitleUpdated: (title) => {
@@ -377,6 +396,7 @@ export async function runAgentHeadless(
         stoppedByUser: false,
         startedAt,
       })
+      agentQueueCoordinator.onRunComplete(runInput.sessionId, false)
     }
   } finally {
     if (!orchestrator.isActive(runInput.sessionId)) {
@@ -464,6 +484,36 @@ export async function queueAgentMessage(
     input.mentionedTodoIds,
     input.mentionedCalendarEventIds,
   )
+}
+
+/** 将等待当前 run 结束的消息交给主进程内存队列。 */
+export function enqueueAgentQueuedMessage(
+  input: AgentDeferredQueueMessageInput,
+  webContents: WebContents,
+): void {
+  agentQueueCoordinator.enqueue(input, webContents)
+}
+
+export function cancelAgentQueuedMessage(input: AgentQueuedMessageControlInput): boolean {
+  return agentQueueCoordinator.cancel(input)
+}
+
+export function moveAgentQueuedMessage(input: AgentMoveQueuedMessageInput): boolean {
+  return agentQueueCoordinator.move(input)
+}
+
+export async function promoteAgentQueuedMessage(
+  input: AgentQueuedMessageControlInput & { interrupt?: boolean },
+): Promise<boolean> {
+  return agentQueueCoordinator.promote(input)
+}
+
+export function listAgentQueuedMessages(sessionId?: string) {
+  return agentQueueCoordinator.list(sessionId)
+}
+
+export function clearAgentQueuedMessages(sessionId: string): void {
+  agentQueueCoordinator.clear(sessionId)
 }
 
 // ===== 文件操作 =====

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -110,6 +110,11 @@ import type {
   WeChatConfig,
   WeChatBridgeState,
   AgentQueueMessageInput,
+  AgentDeferredQueueMessageInput,
+  AgentQueuedMessageControlInput,
+  AgentMoveQueuedMessageInput,
+  AgentQueuedMessageStatus,
+  AgentQueuedMessage,
   PendingRequestsSnapshot,
   NativeAgentIslandSnapshot,
   Automation,
@@ -576,6 +581,18 @@ export interface ElectronAPI {
 
   /** 流式追加发送 Agent 消息（Agent 运行中） */
   queueAgentMessage: (input: AgentQueueMessageInput) => Promise<string>
+  /** 将等待当前 run 结束的消息交给主进程队列。 */
+  enqueueAgentQueuedMessage: (input: AgentDeferredQueueMessageInput) => Promise<void>
+  /** 取消主进程中的等待队列消息；返回是否仍处于 pending。 */
+  cancelAgentQueuedMessage: (input: AgentQueuedMessageControlInput) => Promise<boolean>
+  /** 调整主进程队列顺序。 */
+  moveAgentQueuedMessage: (input: AgentMoveQueuedMessageInput) => Promise<boolean>
+  /** 将队列消息提升为立即发送/注入。 */
+  promoteAgentQueuedMessage: (input: AgentQueuedMessageControlInput & { interrupt?: boolean }) => Promise<boolean>
+  /** 查询主进程当前内存队列，用于 renderer 重载后恢复 UI。 */
+  listAgentQueuedMessages: (sessionId?: string) => Promise<AgentQueuedMessage[]>
+  /** 订阅主进程队列状态变更。 */
+  onAgentQueuedMessageStatus: (callback: (status: AgentQueuedMessageStatus) => void) => () => void
 
   // ===== Agent 后台任务管理 =====
 
@@ -1790,6 +1807,26 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.QUEUE_MESSAGE, input)
   },
 
+  enqueueAgentQueuedMessage: (input: AgentDeferredQueueMessageInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ENQUEUE_QUEUED_MESSAGE, input)
+  },
+
+  cancelAgentQueuedMessage: (input: AgentQueuedMessageControlInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CANCEL_QUEUED_MESSAGE, input)
+  },
+
+  moveAgentQueuedMessage: (input: AgentMoveQueuedMessageInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.MOVE_QUEUED_MESSAGE, input)
+  },
+
+  promoteAgentQueuedMessage: (input: AgentQueuedMessageControlInput & { interrupt?: boolean }) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.PROMOTE_QUEUED_MESSAGE, input)
+  },
+
+  listAgentQueuedMessages: (sessionId?: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_QUEUED_MESSAGES, sessionId)
+  },
+
   // Agent 后台任务管理
   getTaskOutput: (input: GetTaskOutputInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_TASK_OUTPUT, input)
@@ -2022,6 +2059,12 @@ const electronAPI: ElectronAPI = {
     const listener = (_: unknown, data: AgentStreamCompletePayload): void => callback(data)
     ipcRenderer.on(AGENT_IPC_CHANNELS.STREAM_COMPLETE, listener)
     return () => { ipcRenderer.removeListener(AGENT_IPC_CHANNELS.STREAM_COMPLETE, listener) }
+  },
+
+  onAgentQueuedMessageStatus: (callback: (status: AgentQueuedMessageStatus) => void) => {
+    const listener = (_: unknown, status: AgentQueuedMessageStatus): void => callback(status)
+    ipcRenderer.on(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, listener)
+    return () => { ipcRenderer.removeListener(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, listener) }
   },
 
   onAgentStreamError: (callback: (data: { sessionId: string; error: string }) => void) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -129,7 +129,6 @@ import {
   parseQueuedMessageMentions,
   queuedTextToParagraphHtml,
   removeQueuedMessage,
-  restoreQueuedMessageToFront,
 } from '@/lib/agent-message-queue'
 import type { AgentQueuedAttachment, AgentQueuedMessage, QueueDropPlacement } from '@/lib/agent-message-queue'
 
@@ -2735,59 +2734,66 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
     queuedSendInFlightRef.current = true
     sendingQueuedMessageIdsRef.current.add(messageId)
-    void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId })
-      .then((cancelled) => {
-        if (!cancelled) return
+    clearStoppedByUser()
+    void window.electronAPI.promoteAgentQueuedMessage({
+      sessionId,
+      messageId,
+      interrupt: streaming,
+    })
+      .then((promoted) => {
+        if (!promoted) return
         setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
-        return sendPlainTextAgentMessage(message).catch((error) => {
-          console.error('[AgentView] 队列消息发送失败:', error)
-          toast.error('队列消息发送失败', { description: String(error) })
-          setQueuedMessages((prev) => restoreQueuedMessageToFront(prev, message))
-        })
       })
       .catch((error) => {
-        console.error('[AgentView] 取消主进程队列失败:', error)
-        toast.error('队列消息操作失败', { description: String(error) })
+        console.error('[AgentView] 立即发送队列消息失败:', error)
+        toast.error('队列消息发送失败', { description: String(error) })
       })
       .finally(() => {
         sendingQueuedMessageIdsRef.current.delete(messageId)
         queuedSendInFlightRef.current = false
       })
-  }, [canSendQueuedNow, queuedMessages, sendPlainTextAgentMessage, sessionId, setQueuedMessages, streaming])
+  }, [canSendQueuedNow, clearStoppedByUser, queuedMessages, sessionId, setQueuedMessages, streaming])
 
   const handleRecallQueuedMessage = React.useCallback((messageId: string): void => {
     const message = queuedMessages.find((item) => item.id === messageId)
     if (!message) return
 
-    setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
-    const recalledQuotedSelection = message.quotedSelection
-    if (recalledQuotedSelection) {
-      setQuotedSelectionMap((prev) => {
-        const map = new Map(prev)
-        map.set(sessionId, recalledQuotedSelection)
-        return map
+    void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId })
+      .then((cancelled) => {
+        if (!cancelled) return
+        setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+        const recalledQuotedSelection = message.quotedSelection
+        if (recalledQuotedSelection) {
+          setQuotedSelectionMap((prev) => {
+            const map = new Map(prev)
+            map.set(sessionId, recalledQuotedSelection)
+            return map
+          })
+        }
+        restoreQueuedAttachmentsToPending(message.attachments)
+
+        const currentDraft = store.get(agentSessionDraftsAtom).get(sessionId) ?? ''
+        const currentDraftHtml = store.get(agentSessionDraftHtmlAtom).get(sessionId) ?? ''
+        const hasDraft = currentDraft.trim().length > 0
+        const nextDraft = hasDraft
+          ? `${currentDraft.trimEnd()}\n\n${message.text}`
+          : message.text
+        setInputContent(nextDraft)
+
+        // 已有草稿时，用「原草稿 HTML + 队列文本段落 HTML」合并，保留原草稿的 mention 等富文本节点；
+        // 空草稿时留空 HTML，交给编辑器按纯文本重建（与正常输入渲染一致）。
+        if (hasDraft) {
+          const draftHtml = currentDraftHtml.trim().length > 0
+            ? currentDraftHtml
+            : queuedTextToParagraphHtml(currentDraft)
+          setInputHtmlContent(`${draftHtml}${queuedTextToParagraphHtml(message.text)}`)
+        } else {
+          setInputHtmlContent('')
+        }
       })
-    }
-    restoreQueuedAttachmentsToPending(message.attachments)
-
-    const currentDraft = store.get(agentSessionDraftsAtom).get(sessionId) ?? ''
-    const currentDraftHtml = store.get(agentSessionDraftHtmlAtom).get(sessionId) ?? ''
-    const hasDraft = currentDraft.trim().length > 0
-    const nextDraft = hasDraft
-      ? `${currentDraft.trimEnd()}\n\n${message.text}`
-      : message.text
-    setInputContent(nextDraft)
-
-    // 已有草稿时，用「原草稿 HTML + 队列文本段落 HTML」合并，保留原草稿的 mention 等富文本节点；
-    // 空草稿时留空 HTML，交给编辑器按纯文本重建（与正常输入渲染一致）。
-    if (hasDraft) {
-      const draftHtml = currentDraftHtml.trim().length > 0
-        ? currentDraftHtml
-        : queuedTextToParagraphHtml(currentDraft)
-      setInputHtmlContent(`${draftHtml}${queuedTextToParagraphHtml(message.text)}`)
-    } else {
-      setInputHtmlContent('')
-    }
+      .catch((error) => {
+        console.warn('[AgentView] 撤回主进程队列消息失败:', error)
+      })
   }, [queuedMessages, restoreQueuedAttachmentsToPending, sessionId, setInputContent, setInputHtmlContent, setQueuedMessages, setQuotedSelectionMap, store])
 
   const handleRemoveQueuedMessage = React.useCallback((messageId: string): void => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -115,7 +115,7 @@ import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
-import type { AgentSendInput, AgentPendingFile, AgentThinkingLevel, FileDialogLargeFile, FileDialogResult, ModelOption, ReasoningCapability, SDKMessage, SDKUserMessage } from '@proma/shared'
+import type { AgentDeferredQueueMessageInput, AgentSendInput, AgentPendingFile, AgentThinkingLevel, FileDialogLargeFile, FileDialogResult, ModelOption, ReasoningCapability, SDKMessage, SDKUserMessage } from '@proma/shared'
 import { inferContextWindow, inferReasoningTransport, isCodexFastModeSupportedModel, MAX_ATTACHMENT_SIZE, normalizeReasoningCapabilityLevel, normalizeReasoningLevel, resolveReasoningCapability, resolveReasoningProfile } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
 import { getFilePanelDragData, INSERT_FILE_MENTION_EVENT, type FilePanelDragItem } from '@/lib/file-panel-drag'
@@ -483,6 +483,23 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [pendingPrompt, setPendingPrompt] = useAtom(agentPendingPromptAtom)
   const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtomFamily(sessionId))
   const [queuedMessages, setQueuedMessages] = useAtom(agentMessageQueueAtomFamily(sessionId))
+  React.useEffect(() => {
+    let disposed = false
+    void window.electronAPI.listAgentQueuedMessages(sessionId)
+      .then((messages) => {
+        if (disposed) return
+        setQueuedMessages((current) => {
+          const mainIds = new Set(messages.map((message) => message.id))
+          return [...messages, ...current.filter((message) => !mainIds.has(message.id))]
+        })
+      })
+      .catch((error) => {
+        console.warn('[AgentView] 恢复主进程队列失败:', error)
+      })
+    return () => {
+      disposed = true
+    }
+  }, [sessionId, setQueuedMessages])
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const setWorkspaces = useSetAtom(agentWorkspacesAtom)
   const [restoreProjectRootDialogOpen, setRestoreProjectRootDialogOpen] = React.useState(false)
@@ -2112,17 +2129,49 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       if (pendingFilesSnapshot.length > 0 && !attachmentContext) return
 
       const quotedSelection = consumeQuotedSelection()
-      setQueuedMessages((prev) => [
-        ...prev,
-        createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now(), quotedSelection, attachmentContext
-          ? {
-              fileReferenceBlock: attachmentContext.referenceBlock,
-              attachments: attachmentContext.attachments,
-              additionalDirectories: attachmentContext.additionalDirectories,
-            }
-          : undefined),
-      ])
-      // 入队后消息会出现在队列 UI 中，用户可见；不再弹 toast 打扰。
+      const message = createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now(), quotedSelection, attachmentContext
+        ? {
+            fileReferenceBlock: attachmentContext.referenceBlock,
+            attachments: attachmentContext.attachments,
+            additionalDirectories: attachmentContext.additionalDirectories,
+          }
+        : undefined)
+      const quotedSelectionBlock = quotedSelection
+        ? buildQuotedSelectionBlock(quotedSelection)
+        : ''
+      const queuePayload = buildQueuedMessageSendPayload(message, quotedSelectionBlock)
+      const deferredInput: AgentDeferredQueueMessageInput = {
+        queueMessageId: message.id,
+        displayMessage: message,
+        sessionId,
+        userMessage: queuePayload.sdkText,
+        rawUserMessage: queuePayload.rawText,
+        channelId: agentChannelId,
+        modelId: agentModelId || undefined,
+        workspaceId: currentWorkspaceId || undefined,
+        additionalDirectories: message.additionalDirectories,
+        permissionModeOverride: permissionMode,
+        mentionedSkills: queuePayload.mentions.mentionedSkills,
+        mentionedMcpServers: queuePayload.mentions.mentionedMcpServers,
+        mentionedSessionIds: queuePayload.mentions.mentionedSessionIds,
+        mentionedTodoIds: queuePayload.mentions.mentionedTodoIds,
+        mentionedCalendarEventIds: queuePayload.mentions.mentionedCalendarEventIds,
+      }
+      setQueuedMessages((prev) => [...prev, message])
+      void window.electronAPI.enqueueAgentQueuedMessage(deferredInput).catch((error) => {
+        console.error('[AgentView] 主进程队列入队失败:', error)
+        setQueuedMessages((prev) => removeQueuedMessage(prev, message.id))
+        restoreQueuedAttachmentsToPending(message.attachments)
+        if (quotedSelection) {
+          setQuotedSelectionMap((prev) => {
+            const map = new Map(prev)
+            map.set(sessionId, quotedSelection)
+            return map
+          })
+        }
+        toast.error('消息加入队列失败', { description: String(error) })
+      })
+      // 入队后消息会出现在队列 UI 中，主进程负责在当前 run 结束后启动。
       if (overrideText === undefined || fromEditor) {
         setInputContent('')
         setInputHtmlContent('')
@@ -2686,18 +2735,25 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
     queuedSendInFlightRef.current = true
     sendingQueuedMessageIdsRef.current.add(messageId)
-    setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
-    sendPlainTextAgentMessage(message)
+    void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId })
+      .then((cancelled) => {
+        if (!cancelled) return
+        setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+        return sendPlainTextAgentMessage(message).catch((error) => {
+          console.error('[AgentView] 队列消息发送失败:', error)
+          toast.error('队列消息发送失败', { description: String(error) })
+          setQueuedMessages((prev) => restoreQueuedMessageToFront(prev, message))
+        })
+      })
       .catch((error) => {
-        console.error('[AgentView] 队列消息发送失败:', error)
-        toast.error('队列消息发送失败', { description: String(error) })
-        setQueuedMessages((prev) => restoreQueuedMessageToFront(prev, message))
+        console.error('[AgentView] 取消主进程队列失败:', error)
+        toast.error('队列消息操作失败', { description: String(error) })
       })
       .finally(() => {
         sendingQueuedMessageIdsRef.current.delete(messageId)
         queuedSendInFlightRef.current = false
       })
-  }, [canSendQueuedNow, queuedMessages, sendPlainTextAgentMessage, setQueuedMessages, streaming])
+  }, [canSendQueuedNow, queuedMessages, sendPlainTextAgentMessage, sessionId, setQueuedMessages, streaming])
 
   const handleRecallQueuedMessage = React.useCallback((messageId: string): void => {
     const message = queuedMessages.find((item) => item.id === messageId)
@@ -2735,16 +2791,22 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [queuedMessages, restoreQueuedAttachmentsToPending, sessionId, setInputContent, setInputHtmlContent, setQueuedMessages, setQuotedSelectionMap, store])
 
   const handleRemoveQueuedMessage = React.useCallback((messageId: string): void => {
+    void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId }).catch((error) => {
+      console.warn('[AgentView] 取消主进程队列失败:', error)
+    })
     setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
-  }, [setQueuedMessages])
+  }, [sessionId, setQueuedMessages])
 
   const handleMoveQueuedMessage = React.useCallback((
     sourceId: string,
     targetId: string,
     placement: QueueDropPlacement,
   ): void => {
+    void window.electronAPI.moveAgentQueuedMessage({ sessionId, sourceId, targetId, placement }).catch((error) => {
+      console.warn('[AgentView] 调整主进程队列顺序失败:', error)
+    })
     setQueuedMessages((prev) => moveQueuedMessage(prev, sourceId, targetId, placement))
-  }, [setQueuedMessages])
+  }, [sessionId, setQueuedMessages])
 
   // ===== 预览面板状态（toggle 快捷键，分屏布局在 MainArea） =====
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -81,8 +81,6 @@ import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/a
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
 import { detectIsWindows } from '@/lib/platform'
 import { getSessionFileChangeKind, arePathsEqual, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
-import { buildQueuedMessageSendPayload, removeQueuedMessage, restoreQueuedMessageToFront, shouldAutoDispatchQueuedMessage } from '@/lib/agent-message-queue'
-import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
@@ -560,208 +558,57 @@ export function useGlobalAgentListeners(): void {
     /** 正在执行的 git 突变 Bash 命令：toolUseId → sessionId（完成后触发 diff 刷新） */
     const pendingGitMutateTools = new Map<string, string>()
 
-    const queuedDispatchInFlight = new Set<string>()
-    const queuedDispatchScheduled = new Set<string>()
-    // IPC 拒绝后保留失败的队首，直到用户调整队列，避免订阅回调触发自动重试风暴。
-    const queuedDispatchSuppressedMessageIds = new Map<string, string>()
-
-    const dispatchQueuedMessage = (sessionId: string): void => {
-      if (queuedDispatchInFlight.has(sessionId)) return
-
-      const queuedMessages = store.get(agentSessionMessageQueueAtom).get(sessionId) ?? []
-      if (queuedDispatchSuppressedMessageIds.get(sessionId) === queuedMessages[0]?.id) return
-      queuedDispatchSuppressedMessageIds.delete(sessionId)
-      const streamState = store.get(agentStreamingStatesAtom).get(sessionId)
-      const session = store.get(agentSessionsAtom).find((item) => item.id === sessionId)
-      if (session?.legacyTranscript?.continuationRequired) return
-
-      const channelId = session?.channelId
-        ?? store.get(agentSessionChannelMapAtom).get(sessionId)
-        ?? store.get(agentChannelIdAtom)
-      const modelId = session?.modelId
-        ?? store.get(agentSessionModelMapAtom).get(sessionId)
-        ?? store.get(agentModelIdAtom)
-      const channels = store.get(channelsAtom)
-      const hasAvailableModel = channels.some((channel) => (
-        channel.enabled && channel.models.some((model) => model.enabled)
-      ))
-      const hasBlockingRequests =
-        (store.get(allPendingPermissionRequestsAtom).get(sessionId)?.length ?? 0) > 0 ||
-        (store.get(allPendingAskUserRequestsAtom).get(sessionId)?.length ?? 0) > 0 ||
-        (store.get(allPendingExitPlanRequestsAtom).get(sessionId)?.length ?? 0) > 0
-
-      if (!shouldAutoDispatchQueuedMessage({
-        queueLength: queuedMessages.length,
-        running: streamState?.running ?? false,
-        backgroundWaiting: streamState?.backgroundWaiting ?? false,
-        stoppedByUser: store.get(stoppedByUserSessionsAtom).has(sessionId),
-        hasBlockingRequests,
-        hasChannel: Boolean(channelId),
-        hasAvailableModel,
-      })) {
-        return
-      }
-
-      const message = queuedMessages[0]
-      if (!message || !channelId) return
-
-      const streamStartedAt = Date.now()
-      const quotedSelectionBlock = message.quotedSelection
-        ? buildQuotedSelectionBlock(message.quotedSelection)
-        : ''
-      const payload = buildQueuedMessageSendPayload(message, quotedSelectionBlock)
-      let dequeued = false
-      queuedDispatchInFlight.add(sessionId)
-      store.set(agentSessionMessageQueueAtom, (prev) => {
-        const current = prev.get(sessionId) ?? []
-        if (current[0]?.id !== message.id) return prev
-        const map = new Map(prev)
-        const next = removeQueuedMessage(current, message.id)
-        if (next.length === 0) map.delete(sessionId)
-        else map.set(sessionId, next)
-        dequeued = true
-        return map
-      })
-      if (!dequeued) {
-        queuedDispatchInFlight.delete(sessionId)
-        return
-      }
-
-      const optimisticMessageUuid = `queued-${message.id}`
-      const optimisticMessage: SDKMessage = {
-        type: 'user',
-        uuid: optimisticMessageUuid,
-        message: { content: [{ type: 'text', text: payload.rawText }] },
-        parent_tool_use_id: null,
-        _createdAt: streamStartedAt,
-        _promaLiveRunStartedAt: streamStartedAt,
-      } as unknown as SDKMessage
-      store.set(liveMessagesMapAtom, (prev) => {
-        const map = new Map(prev)
-        map.set(sessionId, [...(map.get(sessionId) ?? []), optimisticMessage])
-        return map
-      })
-      store.set(agentStreamErrorsAtom, (prev) => {
-        if (!prev.has(sessionId)) return prev
-        const map = new Map(prev)
-        map.delete(sessionId)
-        return map
-      })
-      store.set(agentStreamingStatesAtom, (prev) => {
-        const map = new Map(prev)
-        map.set(sessionId, {
-          running: true,
-          toolActivities: [],
-          model: modelId || undefined,
-          startedAt: streamStartedAt,
-          inputTokens: prev.get(sessionId)?.inputTokens,
-          contextWindow: prev.get(sessionId)?.contextWindow,
-        })
-        return map
-      })
-
-      const rollbackFailedDispatch = (): void => {
-        queuedDispatchSuppressedMessageIds.set(sessionId, message.id)
+    const cleanupQueuedMessageStatus = window.electronAPI.onAgentQueuedMessageStatus((status) => {
+      unstable_batchedUpdates(() => {
         store.set(agentSessionMessageQueueAtom, (prev) => {
+          const current = prev.get(status.sessionId) ?? []
+          const existing = current.some((message) => message.id === status.messageId)
+          const next = status.status === 'queued' && status.message && !existing
+            ? [...current, status.message]
+            : status.status === 'failed' && status.message && !existing
+              ? [status.message, ...current]
+              : status.status === 'started' || status.status === 'cancelled'
+                ? current.filter((message) => message.id !== status.messageId)
+                : current
+          if (next.length === current.length && next.every((message, index) => message === current[index])) return prev
           const map = new Map(prev)
-          map.set(sessionId, restoreQueuedMessageToFront(map.get(sessionId) ?? [], message))
+          if (next.length === 0) map.delete(status.sessionId)
+          else map.set(status.sessionId, next)
           return map
         })
-        store.set(liveMessagesMapAtom, (prev) => {
-          const current = prev.get(sessionId) ?? []
-          const next = current.filter((item) => (item as unknown as { uuid?: string }).uuid !== optimisticMessageUuid)
-          if (next.length === current.length) return prev
-          const map = new Map(prev)
-          if (next.length === 0) map.delete(sessionId)
-          else map.set(sessionId, next)
-          return map
-        })
-        store.set(agentStreamingStatesAtom, (prev) => {
-          const current = prev.get(sessionId)
-          if (!current || current.startedAt !== streamStartedAt) return prev
-          const map = new Map(prev)
-          map.set(sessionId, { ...current, running: false })
-          return map
-        })
-      }
-
-      const queuedAdditionalDirectories = message.additionalDirectories ?? []
-      const workspaceId = session?.workspaceId ?? store.get(currentAgentWorkspaceIdAtom) ?? undefined
-      const attachedDirectories = store.get(agentAttachedDirectoriesMapAtom).get(sessionId)
-        ?? session?.attachedDirectories
-        ?? []
-      const attachedFiles = store.get(agentAttachedFilesMapAtom).get(sessionId)
-        ?? session?.attachedFiles
-        ?? []
-      const workspaceAttachedFiles = workspaceId
-        ? (store.get(workspaceAttachedFilesMapAtom).get(workspaceId) ?? [])
-        : []
-      const additionalDirectories = Array.from(new Set([
-        ...attachedDirectories,
-        ...[...attachedFiles, ...workspaceAttachedFiles].map(getParentDir).filter(Boolean),
-        ...queuedAdditionalDirectories,
-      ]))
-      const permissionMode = store.get(agentPermissionModeMapAtom).get(sessionId)
-        ?? session?.permissionMode
-        ?? store.get(agentDefaultPermissionModeAtom)
-
-      try {
-        const sendPromise = window.electronAPI.sendAgentMessage({
-          sessionId,
-          userMessage: payload.sdkText,
-          rawUserMessage: payload.rawText,
-          channelId,
-          modelId: modelId || undefined,
-          workspaceId,
-          startedAt: streamStartedAt,
-          permissionModeOverride: permissionMode,
-          ...(additionalDirectories.length > 0 && { additionalDirectories }),
-          ...(payload.mentions.mentionedSkills.length > 0 && { mentionedSkills: payload.mentions.mentionedSkills }),
-          ...(payload.mentions.mentionedMcpServers.length > 0 && { mentionedMcpServers: payload.mentions.mentionedMcpServers }),
-          ...(payload.mentions.mentionedSessionIds.length > 0 && { mentionedSessionIds: payload.mentions.mentionedSessionIds }),
-          ...(payload.mentions.mentionedTodoIds.length > 0 && { mentionedTodoIds: payload.mentions.mentionedTodoIds }),
-          ...(payload.mentions.mentionedCalendarEventIds.length > 0 && { mentionedCalendarEventIds: payload.mentions.mentionedCalendarEventIds }),
-        })
-        queuedDispatchInFlight.delete(sessionId)
-        void sendPromise.catch((error) => {
-          console.error('[GlobalAgentListeners] 自动发送队列消息失败:', error)
-          rollbackFailedDispatch()
-          toast.error('自动发送队列消息失败', { description: String(error) })
-        })
-      } catch (error) {
-        queuedDispatchInFlight.delete(sessionId)
-        console.error('[GlobalAgentListeners] 自动发送队列消息初始化失败:', error)
-        rollbackFailedDispatch()
-        toast.error('自动发送队列消息失败', { description: String(error) })
-      }
-    }
-
-    const scheduleQueuedMessageDispatch = (sessionId: string): void => {
-      if (queuedDispatchScheduled.has(sessionId)) return
-      queuedDispatchScheduled.add(sessionId)
-      queueMicrotask(() => {
-        queuedDispatchScheduled.delete(sessionId)
-        dispatchQueuedMessage(sessionId)
+        const statusMessage = status.message
+        if (status.status === 'started' && statusMessage) {
+          store.set(liveMessagesMapAtom, (prev) => {
+            const current = prev.get(status.sessionId) ?? []
+            if (current.some((message) => (message as unknown as { uuid?: string }).uuid === status.messageId)) return prev
+            const optimisticMessage: SDKMessage = {
+              type: 'user',
+              uuid: status.messageId,
+              message: { content: [{ type: 'text', text: statusMessage.text }] },
+              parent_tool_use_id: null,
+              _createdAt: statusMessage.createdAt,
+            } as unknown as SDKMessage
+            const map = new Map(prev)
+            map.set(status.sessionId, [...current, optimisticMessage])
+            return map
+          })
+        }
+        if (status.status === 'failed') {
+          store.set(liveMessagesMapAtom, (prev) => {
+            const current = prev.get(status.sessionId) ?? []
+            const next = current.filter((message) => (message as unknown as { uuid?: string }).uuid !== status.messageId)
+            if (next.length === current.length) return prev
+            const map = new Map(prev)
+            if (next.length === 0) map.delete(status.sessionId)
+            else map.set(status.sessionId, next)
+            return map
+          })
+        }
+        if (status.status === 'failed' && status.error) {
+          toast.error('队列消息发送失败', { description: status.error })
+        }
       })
-    }
-
-    const scheduleAllQueuedMessageDispatches = (): void => {
-      for (const sessionId of store.get(agentSessionMessageQueueAtom).keys()) {
-        scheduleQueuedMessageDispatch(sessionId)
-      }
-    }
-
-    const queuedDispatchUnsubscribers = [
-      store.sub(agentSessionMessageQueueAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(agentStreamingStatesAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(agentSessionsAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(agentSessionChannelMapAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(agentChannelIdAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(allPendingPermissionRequestsAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(allPendingAskUserRequestsAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(allPendingExitPlanRequestsAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(channelsAtom, scheduleAllQueuedMessageDispatches),
-    ]
+    })
 
     /** 构建导航到指定会话的回调 */
     const makeNavigateToSession = (sessionId: string, sessionTitle: string) => () => {
@@ -1701,9 +1548,7 @@ export function useGlobalAgentListeners(): void {
           return prev
         })
 
-        if (!backgroundTasksPending) {
-          scheduleQueuedMessageDispatch(data.sessionId)
-        }
+        // 主进程队列协调器已在 active slot 释放后直接启动下一条消息。
 
         // 非正常结束时显示截断提示
         if (data.resultSubtype && data.resultSubtype !== 'success' && !data.stoppedByUser) {
@@ -1976,7 +1821,7 @@ export function useGlobalAgentListeners(): void {
       cleanupTitleUpdated()
       cleanupPlaySound()
       cleanupWatchedFileChanges()
-      queuedDispatchUnsubscribers.forEach((unsubscribe) => unsubscribe())
+      cleanupQueuedMessageStatus()
       clearInterval(pruneTimer)
       window.removeEventListener('focus', onWindowFocus)
     }

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -1,3 +1,4 @@
+import type { AgentQueuedAttachment as SharedAgentQueuedAttachment, AgentQueuedMessage as SharedAgentQueuedMessage } from '@proma/shared'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   buildAgentHistoryQuoteLabel,
@@ -7,22 +8,9 @@ import {
 
 export type QueueDropPlacement = 'before' | 'after'
 
-export interface AgentQueuedAttachment {
-  filename: string
-  mediaType: string
-  size: number
-  targetPath: string
-}
+export type AgentQueuedAttachment = SharedAgentQueuedAttachment
 
-export interface AgentQueuedMessage {
-  id: string
-  text: string
-  createdAt: number
-  quotedSelection?: QuotedSelection
-  fileReferenceBlock?: string
-  attachments?: AgentQueuedAttachment[]
-  additionalDirectories?: string[]
-}
+export type AgentQueuedMessage = SharedAgentQueuedMessage
 
 /**
  * 队列的自动消费必须由常驻调度器执行，不能依赖某个 AgentView 是否仍挂载。

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1186,6 +1186,69 @@ export interface AgentSendInput {
 
 // ===== Agent 队列消息 =====
 
+/** 队列 UI 使用的附件元数据；只传路径和文件信息，不传文件内容。 */
+export interface AgentQueuedAttachment {
+  filename: string
+  mediaType: string
+  size: number
+  targetPath: string
+}
+
+/** 队列消息中可恢复的引用选区。 */
+export interface AgentQueuedSelection {
+  text: string
+  filePath: string
+  sourceType?: 'file' | 'agent-history' | 'scratch-pad'
+  sourceLabel?: string
+  messageId?: string
+  messageRole?: 'user' | 'assistant' | 'system'
+  startLine?: number
+  endLine?: number
+  selectionStart?: number
+  selectionEnd?: number
+  turn?: number
+  capturedAt: number
+}
+
+/** renderer 与主进程共享的队列消息快照。 */
+export interface AgentQueuedMessage {
+  id: string
+  text: string
+  createdAt: number
+  quotedSelection?: AgentQueuedSelection
+  fileReferenceBlock?: string
+  attachments?: AgentQueuedAttachment[]
+  additionalDirectories?: string[]
+}
+
+/** 流式结束后由主进程自动启动的 deferred Agent 消息。 */
+export interface AgentDeferredQueueMessageInput extends AgentSendInput {
+  queueMessageId: string
+  displayMessage: AgentQueuedMessage
+}
+
+export type AgentQueuedMessagePlacement = 'before' | 'after'
+
+export interface AgentQueuedMessageControlInput {
+  sessionId: string
+  messageId: string
+}
+
+export interface AgentMoveQueuedMessageInput {
+  sessionId: string
+  sourceId: string
+  targetId: string
+  placement: AgentQueuedMessagePlacement
+}
+
+export interface AgentQueuedMessageStatus {
+  sessionId: string
+  messageId: string
+  status: 'queued' | 'started' | 'cancelled' | 'failed'
+  message?: AgentQueuedMessage
+  error?: string
+}
+
 /** 流式追加消息的输入参数（Agent 流式中发送新消息） */
 export interface AgentQueueMessageInput {
   /** 会话 ID */
@@ -1894,13 +1957,19 @@ export const AGENT_IPC_CHANNELS = {
   /** ExitPlanMode 响应（渲染进程 → 主进程） */
   EXIT_PLAN_MODE_RESPOND: 'agent:exit-plan-mode:respond',
 
-  // 队列消息（Agent 运行中排队发送）
-  /** 排队发送消息 */
+    // 队列消息（Agent 运行中排队发送）
+  /** 排队发送消息并在当前 run 结束后由主进程自动启动 */
+  ENQUEUE_QUEUED_MESSAGE: 'agent:enqueue-queued-message',
+  /** 排队发送消息（当前运行中的 SDK 注入） */
   QUEUE_MESSAGE: 'agent:queue-message',
   /** 取消队列消息 */
   CANCEL_QUEUED_MESSAGE: 'agent:cancel-queued-message',
+  /** 调整队列消息顺序 */
+  MOVE_QUEUED_MESSAGE: 'agent:move-queued-message',
   /** 提升队列消息为立即发送 */
   PROMOTE_QUEUED_MESSAGE: 'agent:promote-queued-message',
+  /** 查询主进程内存队列 */
+  LIST_QUEUED_MESSAGES: 'agent:list-queued-messages',
   /** 队列消息状态变更通知（主进程 → 渲染进程推送） */
   QUEUED_MESSAGE_STATUS: 'agent:queued-message-status',
 


### PR DESCRIPTION
## Summary

- move deferred per-session queue ownership and scheduling into the Electron main process
- keep renderer queue state as a local projection for display, removal, ordering, and reload recovery
- preserve SDK queue injection for messages added while a run is active
- avoid renderer-wide queue scans on streaming state updates
- remove the temporary coordinator test file as requested

## Verification

- renderer queue tests passed
- Electron TypeScript check passed
- main, preload, and renderer builds passed
- git diff --check passed

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)