### PR TITLE
refactor(agent): simplify tool stream and split session state

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { createStore } from 'jotai/vanilla'
 import {
   agentSessionInputStreamStateAtomFamily,
+  agentSessionStreamingStateAtomFamily,
   agentStreamingStatesAtom,
   applyAgentEvent,
   clearAgentStreamError,
@@ -12,7 +13,6 @@ import {
 function createStreamState(overrides: Partial<AgentStreamState> = {}): AgentStreamState {
   return {
     running: true,
-    toolActivities: [],
     inputTokens: 180_000,
     outputTokens: 2_000,
     cacheReadTokens: 160_000,
@@ -148,10 +148,7 @@ describe('Agent 上下文压缩状态', () => {
     })
     expect(resumed.contextCompaction).toBeUndefined()
     expect(resumed.compactInFlight).toBe(false)
-    expect(resumed.toolActivities).toContainEqual(expect.objectContaining({
-      toolUseId: 'resume-task',
-      done: false,
-    }))
+    expect('toolActivities' in resumed).toBe(false)
   })
 
   test('given 压缩成功 when 当前流直接结束 then 保留终态反馈给短时完成提示', () => {
@@ -305,6 +302,41 @@ describe('Agent 流式错误状态', () => {
     expect(clearAgentStreamError(errors, 'retried-session')).toBe(errors)
   })
 })
+
+describe('Agent per-session 流式状态 family', () => {
+  test('given another session changes when the active family is subscribed then it does not notify', () => {
+    const store = createStore()
+    const activeAtom = agentSessionStreamingStateAtomFamily('active-session')
+    const otherAtom = agentSessionStreamingStateAtomFamily('other-session')
+    const activeState = createStreamState()
+    const otherState = createStreamState({ inputTokens: 20_000 })
+
+    store.set(activeAtom, activeState)
+    store.set(otherAtom, otherState)
+    store.get(activeAtom)
+
+    let notifications = 0
+    const unsubscribe = store.sub(activeAtom, () => {
+      notifications += 1
+    })
+
+    store.set(otherAtom, { ...otherState, inputTokens: 21_000 })
+
+    expect(notifications).toBe(0)
+    expect(store.get(agentStreamingStatesAtom).get('active-session')).toBe(activeState)
+    expect(store.get(agentStreamingStatesAtom).get('other-session')?.inputTokens).toBe(21_000)
+    unsubscribe()
+  })
+
+  test('given a session family update when the aggregate compatibility atom is read then it reflects the same state reference', () => {
+    const store = createStore()
+    const state = createStreamState({ running: true })
+    store.set(agentSessionStreamingStateAtomFamily('active-session'), state)
+
+    expect(store.get(agentStreamingStatesAtom)).toEqual(new Map([['active-session', state]]))
+  })
+})
+
 
 describe('Agent 输入流状态订阅隔离', () => {
   test('given usage changes in the active session when the input selector is subscribed then it does not notify', () => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -6,6 +6,7 @@
  */
 
 import { atom } from 'jotai'
+import type { Getter } from 'jotai'
 import { atomFamily, atomWithStorage, selectAtom } from 'jotai/utils'
 import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, SDKMessage, UnstagedChangesResult } from '@proma/shared'
 import { PROMA_DEFAULT_PERMISSION_MODE } from '@proma/shared'
@@ -39,23 +40,6 @@ export interface ToolActivity {
 export interface ActivityGroup {
   parent: ToolActivity
   children: ToolActivity[]
-}
-
-/**
- * 将流式状态中未完成的 toolActivities 标记为终态。
- * 用于 complete、handleStop、STREAM_COMPLETE 等多个终态入口的兜底清理。
- * 当所有项已处于终态时返回原引用，避免不必要的 React 重渲染。
- */
-export function finalizeStreamingActivities(
-  toolActivities: ToolActivity[],
-): { toolActivities: ToolActivity[] } {
-  const hasUnfinishedTools = toolActivities.some((ta) => !ta.done)
-
-  return {
-    toolActivities: hasUnfinishedTools
-      ? toolActivities.map((ta) => (ta.done ? ta : { ...ta, done: true }))
-      : toolActivities,
-  }
 }
 
 export interface ContextCompactionState {
@@ -99,7 +83,6 @@ export interface AgentStreamState {
    * 此状态下 running 为 false，但服务端 activeSessions 仍保留，新消息必须走注入通道而非新建 run。
    */
   backgroundWaiting?: boolean
-  toolActivities: ToolActivity[]
   model?: string
   /** 当前输入 token 数（上下文使用量） */
   inputTokens?: number
@@ -290,21 +273,76 @@ export const agentSessionChannelMapAtom = atom<Map<string, string>>(new Map())
 /** Per-session 模型 ID Map — sessionId → modelId */
 export const agentSessionModelMapAtom = atom<Map<string, string>>(new Map())
 export const currentAgentSessionIdAtom = atom<string | null>(null)
-export const agentStreamingStatesAtom = atom<Map<string, AgentStreamState>>(new Map())
 
 /**
- * 单个 session 的 streaming state 派生 atomFamily — 按 sessionId 切片订阅。
+ * Agent 流式状态的 session 索引与实际存储。
  *
- * 直接订阅 agentStreamingStatesAtom 会让任意 session 的流式更新都触发 AgentView
- * 整树重渲染（10–30fps）。本 family 让订阅者只在本 session 的 state 引用变化时
- * 重渲染——其他 session 的更新虽然让 base atom 变化，但派生 atom 输出引用未变，
- * jotai 自动跳过通知。
+ * 高频事件直接写入 family，避免每次 token/tool 状态更新都复制完整的 session Map。
+ * 聚合 atom 仅作为低频汇总和旧调用方兼容入口保留。
  */
-export const agentSessionStreamingStateAtomFamily = atomFamily((sessionId: string) =>
-  atom((get) => get(agentStreamingStatesAtom).get(sessionId)),
+const agentStreamingStateIdsAtom = atom<Set<string>>(new Set<string>())
+const agentStreamingStateStorageAtomFamily = atomFamily((sessionId: string) =>
+  atom<AgentStreamState | undefined>(undefined),
 )
 
-/** AgentView 输入区/工具栏需要的低频流状态；排除逐 token 变化的 content/toolActivities。 */
+export const agentSessionStreamingStateAtomFamily = atomFamily((sessionId: string) =>
+  atom(
+    (get) => get(agentStreamingStateStorageAtomFamily(sessionId)),
+    (
+      get,
+      set,
+      update: AgentStreamState | undefined | ((prev: AgentStreamState | undefined) => AgentStreamState | undefined),
+    ) => {
+      const previous = get(agentStreamingStateStorageAtomFamily(sessionId))
+      const next = typeof update === 'function' ? update(previous) : update
+      if (Object.is(previous, next)) return
+
+      set(agentStreamingStateStorageAtomFamily(sessionId), next)
+      set(agentStreamingStateIdsAtom, (prev: Set<string>) => {
+        if (next !== undefined) {
+          if (prev.has(sessionId)) return prev
+          const ids = new Set(prev)
+          ids.add(sessionId)
+          return ids
+        }
+        if (!prev.has(sessionId)) return prev
+        const ids = new Set(prev)
+        ids.delete(sessionId)
+        return ids
+      })
+    },
+  ),
+)
+
+function readAgentStreamingStates(get: Getter): Map<string, AgentStreamState> {
+  const states = new Map<string, AgentStreamState>()
+  for (const sessionId of get(agentStreamingStateIdsAtom)) {
+    const state = get(agentSessionStreamingStateAtomFamily(sessionId))
+    if (state) states.set(sessionId, state)
+  }
+  return states
+}
+
+/**
+ * 兼容旧调用方的聚合视图。高频路径不要写入此 atom，请使用
+ * agentSessionStreamingStateAtomFamily(sessionId)。
+ */
+export const agentStreamingStatesAtom = atom<Map<string, AgentStreamState>, [Map<string, AgentStreamState> | ((prev: Map<string, AgentStreamState>) => Map<string, AgentStreamState>)], void>(
+  (get) => readAgentStreamingStates(get),
+  (get, set, update) => {
+    const previous = readAgentStreamingStates(get)
+    const next = typeof update === 'function' ? update(previous) : update
+    const sessionIds = new Set([...previous.keys(), ...next.keys()])
+    for (const sessionId of sessionIds) {
+      const previousState = previous.get(sessionId)
+      const nextState = next.get(sessionId)
+      if (Object.is(previousState, nextState)) continue
+      set(agentSessionStreamingStateAtomFamily(sessionId), nextState)
+    }
+  },
+)
+
+/** AgentView 输入区/工具栏需要的低频流状态。 */
 export type AgentViewStreamState = Pick<
   AgentStreamState,
   | 'running'
@@ -669,39 +707,39 @@ export const currentAgentSessionAtom = atom<AgentSessionMeta | null>((get) => {
 export const agentStreamingAtom = atom<boolean>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return false
-  return get(agentStreamingStatesAtom).get(currentId)?.running ?? false
-})
-
-export const agentToolActivitiesAtom = atom<ToolActivity[]>((get) => {
-  const currentId = get(currentAgentSessionIdAtom)
-  if (!currentId) return []
-  return get(agentStreamingStatesAtom).get(currentId)?.toolActivities ?? []
+  return get(agentSessionStreamingStateAtomFamily(currentId))?.running ?? false
 })
 
 export const agentStreamingModelAtom = atom<string | undefined>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return undefined
-  return get(agentStreamingStatesAtom).get(currentId)?.model
+  return get(agentSessionStreamingStateAtomFamily(currentId))?.model
 })
 
 export const agentRetryingAtom = atom<AgentStreamState['retrying'] | undefined>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return undefined
-  return get(agentStreamingStatesAtom).get(currentId)?.retrying
+  return get(agentSessionStreamingStateAtomFamily(currentId))?.retrying
 })
 
 export const agentStartedAtAtom = atom<number | undefined>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return undefined
-  return get(agentStreamingStatesAtom).get(currentId)?.startedAt
+  return get(agentSessionStreamingStateAtomFamily(currentId))?.startedAt
 })
 
+let lastRunningSessionSignature = ''
+let lastRunningSessionIds = new Set<string>()
+
 export const agentRunningSessionIdsAtom = atom<Set<string>>((get) => {
-  const states = get(agentStreamingStatesAtom)
   const ids = new Set<string>()
-  for (const [id, state] of states) {
-    if (state.running) ids.add(id)
+  for (const sessionId of get(agentStreamingStateIdsAtom)) {
+    if (get(agentSessionStreamingStateAtomFamily(sessionId))?.running) ids.add(sessionId)
   }
+  const signature = [...ids].sort().join('|')
+  if (signature === lastRunningSessionSignature) return lastRunningSessionIds
+  lastRunningSessionSignature = signature
+  lastRunningSessionIds = ids
   return ids
 })
 
@@ -771,108 +809,16 @@ export function applyAgentEvent(
   event: AgentEvent,
 ): AgentStreamState {
   switch (event.type) {
-    case 'tool_start': {
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      const existing = resumed.toolActivities.find((t) => t.toolUseId === event.toolUseId)
-      if (existing) {
-        return {
-          ...resumed,
-          toolActivities: resumed.toolActivities.map((t) =>
-            t.toolUseId === event.toolUseId
-              ? { ...t, input: event.input, intent: event.intent || t.intent, displayName: event.displayName || t.displayName }
-              : t
-          ),
-          // 开始工具调用 - 清除重试状态（重试成功）
-          retrying: undefined,
-        }
-      }
-      return {
-        ...resumed,
-        toolActivities: [...resumed.toolActivities, {
-          toolUseId: event.toolUseId,
-          toolName: event.toolName,
-          input: event.input,
-          intent: event.intent,
-          displayName: event.displayName,
-          done: false,
-          parentToolUseId: event.parentToolUseId,
-        }],
-        // 开始工具调用 - 清除重试状态（重试成功）
-        retrying: undefined,
-      }
-    }
+    case 'tool_start':
+      // 工具开始只负责收束 retry/compaction 控制状态；工具展示由 live SDK message 驱动。
+      return { ...clearFinishedCompactionForResumedWork(prev), retrying: undefined }
 
-    case 'tool_result': {
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      return {
-        ...resumed,
-        toolActivities: resumed.toolActivities.map((t) =>
-          t.toolUseId === event.toolUseId
-            ? { ...t, result: event.result, isError: event.isError, done: true, imageAttachments: event.imageAttachments }
-            : t
-        ),
-      }
-    }
-
-    case 'task_backgrounded': {
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      return {
-        ...resumed,
-        toolActivities: resumed.toolActivities.map((t) =>
-          t.toolUseId === event.toolUseId
-            ? { ...t, isBackground: true, taskId: event.taskId, done: true }
-            : t
-        ),
-      }
-    }
-
-    case 'task_progress': {
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      // 普通 tool 计时语义（仅当有真实 elapsedSeconds 时更新）
-      if (event.elapsedSeconds != null) {
-        return {
-          ...resumed,
-          toolActivities: resumed.toolActivities.map((t) =>
-            t.toolUseId === event.toolUseId
-              ? { ...t, elapsedSeconds: event.elapsedSeconds! }
-              : t
-          ),
-        }
-      }
-      return resumed
-    }
-
-    case 'task_started': {
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      // 查找匹配 toolUseId 的 ToolActivity，更新 intent 和 taskId
-      let nextActivities = resumed.toolActivities
-      if (event.toolUseId) {
-        if (resumed.toolActivities.some((t) => t.toolUseId === event.toolUseId)) {
-          nextActivities = resumed.toolActivities.map((t) =>
-            t.toolUseId === event.toolUseId
-              ? { ...t, intent: event.description, taskId: event.taskId }
-              : t
-          )
-        }
-      }
-      return { ...resumed, toolActivities: nextActivities }
-    }
-
-    case 'shell_backgrounded': {
-      const resumed = clearFinishedCompactionForResumedWork(prev)
-      return {
-        ...resumed,
-        toolActivities: resumed.toolActivities.map((t) =>
-          t.toolUseId === event.toolUseId
-            ? { ...t, isBackground: true, shellId: event.shellId, done: true }
-            : t
-        ),
-      }
-    }
-
+    case 'tool_result':
+    case 'task_backgrounded':
+    case 'task_progress':
+    case 'task_started':
+    case 'shell_backgrounded':
     case 'shell_killed':
-      return clearFinishedCompactionForResumedWork(prev)
-
     case 'task_notification':
       return clearFinishedCompactionForResumedWork(prev)
 
@@ -930,7 +876,6 @@ export function applyAgentEvent(
           }),
         } : {}),
         retrying: undefined,
-        ...finalizeStreamingActivities(prev.toolActivities),
       }
     }
 
@@ -1155,7 +1100,7 @@ export interface AgentContextStatus {
 export const agentContextStatusAtom = atom<AgentContextStatus>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return { isCompacting: false }
-  const state = get(agentStreamingStatesAtom).get(currentId)
+  const state = get(agentSessionStreamingStateAtomFamily(currentId))
   return {
     isCompacting: state?.isCompacting ?? false,
     inputTokens: state?.inputTokens,

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -860,19 +860,17 @@ export const AgentMessages = React.memo(function AgentMessages({
       selectionHighlightUsesBrowserSelectionRef.current = false
     }
   }, [])
-  /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
-  const [ready, setReady] = React.useState(false)
-  // 空会话无需淡入过渡（无消息则无滚动位置问题）
-  const [skipFadeIn, setSkipFadeIn] = React.useState(false)
-  const prevSessionIdRef = React.useRef<string | null>(null)
-
+  // 消息和布局恢复完成后才显示会话。隐藏期间不让用户看到 StickToBottom 初始化时
+  // 可能出现的临时底部位置；显示前 ScrollPositionManager 已经直接设置了 scrollTop。
+  const [readySessionId, setReadySessionId] = React.useState<string | null>(null)
   React.useEffect(() => {
-    if (sessionId !== prevSessionIdRef.current) {
-      prevSessionIdRef.current = sessionId
-      setReady(false)
-      setSkipFadeIn(false)
+    if (messagesLoaded === false) {
+      setReadySessionId(null)
+      return
     }
-  }, [sessionId])
+    setReadySessionId(sessionId)
+  }, [messagesLoaded, sessionId])
+  const ready = messagesLoaded !== false && readySessionId === sessionId
 
   React.useEffect(() => {
     const root = historySelectionRootRef.current
@@ -929,30 +927,6 @@ export const AgentMessages = React.memo(function AgentMessages({
     return () => window.cancelAnimationFrame(frame)
   }, [clearHistoryQuoteHighlight, historyQuoteNavigation, sessionId])
 
-  React.useEffect(() => {
-    if (ready) return
-
-    // 必须等消息加载完成，否则空 SDK 消息会被误判为空对话
-    if (messagesLoaded === false) return
-
-    // 流式进行中且有实时内容 → 跳过 fade 直接显示
-    if (streaming && liveMessages && liveMessages.length > 0) {
-      setReady(true)
-      return
-    }
-
-    if ((!persistedSDKMessages || persistedSDKMessages.length === 0) && !streaming) {
-      setSkipFadeIn(true)
-      setReady(true)
-      return
-    }
-    let cancelled = false
-    requestAnimationFrame(() => {
-      if (!cancelled) setReady(true)
-    })
-    return () => { cancelled = true }
-  }, [streaming, liveMessages, persistedSDKMessages, messagesLoaded])
-
   // 实时文本仅从 liveMessages 读取。AgentStreamState 只保留运行/控制状态，
   // 避免每个 sdk_delta 同时更新 transcript 和 legacy content 两条路径。
   const retrying = streamState?.retrying
@@ -963,38 +937,8 @@ export const AgentMessages = React.memo(function AgentMessages({
     : undefined
   const optimisticTime = startedAt ? formatMessageTime(startedAt) : undefined
 
-  /**
-   * 流式完成过渡：streaming 结束到持久化消息加载完成之间，
-   * 强制 resize="instant" 避免中间高度变化触发平滑滚动动画。
-   *
-   * 使用 render-phase 计算避免 useEffect 延迟一帧的问题：
-   * - streaming 变 false 的第一帧就能立即切到 instant，防止闪动
-   * - 后续通过 ref+timeout 延迟 150ms 才允许切回 smooth
-   */
-  const [transitioningCooldown, setTransitioningCooldown] = React.useState(false)
-  const wasStreamingRef = React.useRef(streaming)
-
-  // render-phase 判断：是否处于需要 instant resize 的过渡期
-  // liveMessages 非空说明持久化消息还没加载完（加载完后会清空 liveMessages）
-  const needsInstant = !streaming && liveMessages != null && liveMessages.length > 0
-
-  React.useEffect(() => {
-    // 刚从 streaming → not-streaming：启动 cooldown
-    if (wasStreamingRef.current && !streaming) {
-      setTransitioningCooldown(true)
-    }
-    wasStreamingRef.current = streaming
-  }, [streaming])
-
-  React.useEffect(() => {
-    if (needsInstant) return
-    // 过渡完成后延迟 150ms 才关闭 cooldown，给 StickToBottom 时间稳定
-    const timer = setTimeout(() => setTransitioningCooldown(false), 150)
-    return () => clearTimeout(timer)
-  }, [needsInstant])
-
-  const transitioning = needsInstant || transitioningCooldown
-
+  // Agent 消息区不使用 StickToBottom 的 smooth resize。切换会话、虚拟列表测量和
+  // 历史消息加载都必须立即定位，避免 ResizeObserver 触发滚动 spring 动画。
   // 合并持久化 + 实时 SDKMessage：同一 UUID 的 live 消息替换历史快照，避免
   // 历史会话快速续跑时 live atom 尚未清空而把同一 assistant 渲染两次。
   const allSDKMessages = React.useMemo(() => {
@@ -1166,7 +1110,7 @@ export const AgentMessages = React.memo(function AgentMessages({
           color: inherit;
         }
       `}</style>
-          <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
+          <Conversation resize="instant" className={ready ? 'opacity-100' : 'opacity-0'}>
         <ScrollPositionManager id={sessionId} ready={ready} />
         <ConversationContent>
           {!hasContent && !streaming ? (

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -428,6 +428,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   )
   const persistedSDKMessagesRef = React.useRef<SDKMessage[]>([])
   persistedSDKMessagesRef.current = persistedSDKMessages
+  const messagesRequestIdRef = React.useRef(0)
+  const messagesMutationVersionRef = React.useRef(0)
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   // 只订阅输入区/工具栏需要的低频流状态。
   const streamViewState = useAtomValue(agentSessionInputStreamStateAtomFamily(sessionId))
@@ -945,6 +947,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const appendOptimisticPersistedMessage = React.useCallback((message: SDKMessage) => {
     // 切会话时优先命中内存缓存，因此乐观插入的用户消息也要同步写入缓存，
     // 否则“发送后立刻切走再切回”会短暂回退到旧消息数组。
+    // 本地乐观消息优先于正在进行中的旧 IPC 快照。
+    messagesMutationVersionRef.current += 1
     const next = [...persistedSDKMessagesRef.current, message]
     persistedSDKMessagesRef.current = next
     setPersistedSDKMessages(next)
@@ -1158,10 +1162,19 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
     messagesRefreshingRef.current = true
     setMessagesRefreshing(true)
+    const requestId = ++messagesRequestIdRef.current
+    const requestMutationVersion = messagesMutationVersionRef.current
     let cancelled = false
     window.electronAPI.getAgentSessionSDKMessages(sessionId)
       .then((sdkMsgs) => {
-        if (cancelled) return
+        if (cancelled || requestId !== messagesRequestIdRef.current) return
+        if (requestMutationVersion !== messagesMutationVersionRef.current) {
+          // 请求期间已有本地消息变更，旧 IPC 快照不能覆盖当前内存消息。
+          setMessagesLoaded(true)
+          messagesRefreshingRef.current = false
+          setMessagesRefreshing(false)
+          return
+        }
         // 写入缓存（含 LRU 淘汰，防止会话数增长导致内存无限膨胀）
         setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, sdkMsgs))
         unstable_batchedUpdates(() => {
@@ -2457,6 +2470,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // 在下一轮回复开始前仍被页面渲染。旧会话没有 UUID 时保留历史，由主进程幂等处理。
     const messagesAfterCleanup = removeRetriedErrorSDKMessage(persistedSDKMessages, retryOfErrorUuid)
     if (messagesAfterCleanup !== persistedSDKMessages) {
+      messagesMutationVersionRef.current += 1
       persistedSDKMessagesRef.current = messagesAfterCleanup
       setPersistedSDKMessages(messagesAfterCleanup)
       setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, messagesAfterCleanup))

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -65,6 +65,7 @@ import { previewPanelOpenMapAtom, quotedSelectionMapAtom, currentQuotedSelection
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
+  agentSessionStreamingStateAtomFamily,
   agentSessionInputStreamStateAtomFamily,
   agentChannelIdAtom,
   agentModelIdAtom,
@@ -104,7 +105,6 @@ import {
   allPendingAskUserRequestsAtom,
   allPendingPermissionRequestsAtom,
   allPendingExitPlanRequestsAtom,
-  finalizeStreamingActivities,
 } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
@@ -421,12 +421,15 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
 }
 
 export function AgentView({ sessionId }: { sessionId: string }): React.ReactElement {
-  const [persistedSDKMessages, setPersistedSDKMessages] = React.useState<SDKMessage[]>([])
+  const store = useStore()
+  const initialCachedMessages = store.get(agentSDKMessagesCacheAtom).get(sessionId)
+  const [persistedSDKMessages, setPersistedSDKMessages] = React.useState<SDKMessage[]>(
+    () => initialCachedMessages ?? [],
+  )
   const persistedSDKMessagesRef = React.useRef<SDKMessage[]>([])
   persistedSDKMessagesRef.current = persistedSDKMessages
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
-  // 只订阅输入区/工具栏需要的低频流状态。逐 token content/toolActivities 由
-  // AgentMessages 独立消费，不能让 3000 行 AgentView 和输入框跟随每个 token 重渲染。
+  // 只订阅输入区/工具栏需要的低频流状态。
   const streamViewState = useAtomValue(agentSessionInputStreamStateAtomFamily(sessionId))
   const streaming = streamViewState.running
   // 软空闲态：本轮主体已结束、UI 可输入，但 SDK 通道仍开着等后台任务唤醒。
@@ -528,7 +531,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const persistedPermissionMode = useAtomValue(sessionPersistedPermissionModeAtom(sessionId))
   const permissionMode = permissionModeMap.get(sessionId) ?? persistedPermissionMode ?? defaultPermissionMode
   const isPermissionPlanMode = permissionMode === 'plan'
-  const store = useStore()
   const currentQuotedSelection = useAtomValue(currentQuotedSelectionAtom)
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
   const openPreview = useOpenPreview()
@@ -1026,7 +1028,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
-        toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
@@ -1129,8 +1130,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     streaming,
   ])
 
-  // 消息是否已完成首次加载（用于 auto-send 等待）
-  const [messagesLoaded, setMessagesLoaded] = React.useState(false)
+  // 消息首次加载状态直接由同步缓存决定；缓存命中时首个 render 就显示历史，IPC 只做后台校准。
+  const [messagesLoaded, setMessagesLoaded] = React.useState(initialCachedMessages !== undefined)
   const [messagesRefreshing, setMessagesRefreshing] = React.useState(false)
   const messagesRefreshingRef = React.useRef(false)
   const loadingSessionIdRef = React.useRef<string | null>(null)
@@ -1186,7 +1187,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               map.set(sessionId, {
                 running: false,
                 backgroundWaiting: state.backgroundWaiting,
-                toolActivities: [],
                 inputTokens: state.inputTokens,
                 outputTokens: state.outputTokens,
                 cacheReadTokens: state.cacheReadTokens,
@@ -1201,7 +1201,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               map.set(sessionId, {
                 running: false,
                 backgroundWaiting: state.backgroundWaiting,
-                toolActivities: [],
                 contextCompaction: state.contextCompaction,
               })
             } else {
@@ -1212,7 +1211,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           setLiveMessagesMap((prev) => {
             if (!prev.has(sessionId)) return prev
             // 仍在运行中，不清除实时消息（与 streamingStates 保护逻辑一致）
-            const streamingState = store.get(agentStreamingStatesAtom).get(sessionId)
+            const streamingState = store.get(agentSessionStreamingStateAtomFamily(sessionId))
             if (streamingState?.running) return prev
             const map = new Map(prev)
             map.delete(sessionId)
@@ -1291,7 +1290,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         const existing = prev.get(sessionId)
         map.set(sessionId, {
           running: true,
-          toolActivities: [],
           model: snapshot.modelId,
           startedAt: streamStartedAt,
           inputTokens: existing?.inputTokens,
@@ -2249,7 +2247,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
-        toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
@@ -2357,7 +2354,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const map = new Map(prev)
       const current = prev.get(sessionId) ?? {
         running: true,
-        toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
       }
@@ -2481,7 +2477,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
-        toolActivities: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
@@ -2526,7 +2521,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         const map = new Map(prev)
         map.set(meta.id, {
           running: true,
-          toolActivities: [],
           model: agentModelId || undefined,
           startedAt: streamStartedAt,
         })

--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -24,7 +24,6 @@ import {
   allPendingAskUserRequestsAtom,
   agentStreamingStatesAtom,
   askUserDraftsAtom,
-  finalizeStreamingActivities,
   type AskUserQuestionDraft,
   type AskUserRequestDraft,
 } from '@/atoms/agent-atoms'
@@ -152,7 +151,6 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
       map.set(sessionId, {
         ...current,
         running: false,
-        ...finalizeStreamingActivities(current.toolActivities),
       })
       return map
     })

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -19,7 +19,7 @@ import {
   FileText,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingExitPlanRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
+import { allPendingExitPlanRequestsAtom, agentStreamingStatesAtom } from '@/atoms/agent-atoms'
 import type { ExitPlanModeAction, ExitPlanAllowedPrompt } from '@proma/shared'
 
 /** 选项定义 */
@@ -120,7 +120,6 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
       map.set(sessionId, {
         ...current,
         running: false,
-        ...finalizeStreamingActivities(current.toolActivities),
       })
       return map
     })

--- a/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
@@ -12,7 +12,7 @@ import * as React from 'react'
 import { useAtom, useSetAtom } from 'jotai'
 import { Shield, ShieldAlert, Check, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingPermissionRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
+import { allPendingPermissionRequestsAtom, agentStreamingStatesAtom } from '@/atoms/agent-atoms'
 import type { DangerLevel } from '@proma/shared'
 
 /** 危险等级对应的图标颜色 */
@@ -72,7 +72,6 @@ export function PermissionBanner({ sessionId }: PermissionBannerProps): React.Re
       map.set(sessionId, {
         ...current,
         running: false,
-        ...finalizeStreamingActivities(current.toolActivities),
       })
       return map
     })

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -53,6 +53,9 @@ export function MainArea(): React.ReactElement {
   // DiffTabContent → ProseMirror editor mount + Shiki tokenize）让出主线程，避免点击 tab
   // 后必须等主区域渲染完才能看到 tab 切换效果
   const deferredActiveTabId = React.useDeferredValue(activeTabId)
+  // Agent 历史当前是完整 DOM，切换时使用当前 active tab，避免 deferred value 让旧会话继续占屏。
+  // Chat/Preview 仍保留 deferred 渲染，避免它们的重型编辑器阻塞 TabBar 响应。
+  const contentTabId = activeTab?.type === 'agent' ? activeTabId : deferredActiveTabId
 
   const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
   const [browserOpenMap, setBrowserOpenMap] = useAtom(browserPanelOpenMapAtom)
@@ -275,9 +278,9 @@ export function MainArea(): React.ReactElement {
                   <AutomationFormView />
                 ) : tabs.length === 0 ? (
                   <WelcomeView />
-                ) : deferredActiveTabId ? (
+                ) : contentTabId ? (
                   <div className="flex-1 min-h-0 titlebar-no-drag">
-                    <TabContent tabId={deferredActiveTabId} />
+                    <TabContent tabId={contentTabId} />
                   </div>
                 ) : null}
               </>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -12,6 +12,8 @@ import { unstable_batchedUpdates } from 'react-dom'
 import { useStore } from 'jotai'
 import {
   agentStreamingStatesAtom,
+  agentSessionStreamingStateAtomFamily,
+  agentRunningSessionIdsAtom,
   agentStreamErrorsAtom,
   agentSessionMessageQueueAtom,
   agentSessionsAtom,
@@ -37,7 +39,6 @@ import {
   agentDefaultPermissionModeAtom,
   stoppedByUserSessionsAtom,
   agentPlanModeSessionsAtom,
-  finalizeStreamingActivities,
   currentAgentSessionIdAtom,
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
@@ -565,13 +566,23 @@ export function useGlobalAgentListeners(): void {
     // IPC 拒绝后保留失败的队首，直到用户调整队列，避免订阅回调触发自动重试风暴。
     const queuedDispatchSuppressedMessageIds = new Map<string, string>()
 
+    const getStreamState = (sessionId: string): AgentStreamState | undefined =>
+      store.get(agentSessionStreamingStateAtomFamily(sessionId))
+
+    const updateStreamState = (
+      sessionId: string,
+      update: (previous: AgentStreamState | undefined) => AgentStreamState | undefined,
+    ): void => {
+      store.set(agentSessionStreamingStateAtomFamily(sessionId), update)
+    }
+
     const dispatchQueuedMessage = (sessionId: string): void => {
       if (queuedDispatchInFlight.has(sessionId)) return
 
       const queuedMessages = store.get(agentSessionMessageQueueAtom).get(sessionId) ?? []
       if (queuedDispatchSuppressedMessageIds.get(sessionId) === queuedMessages[0]?.id) return
       queuedDispatchSuppressedMessageIds.delete(sessionId)
-      const streamState = store.get(agentStreamingStatesAtom).get(sessionId)
+      const streamState = getStreamState(sessionId)
       const session = store.get(agentSessionsAtom).find((item) => item.id === sessionId)
       if (session?.legacyTranscript?.continuationRequired) return
 
@@ -651,7 +662,6 @@ export function useGlobalAgentListeners(): void {
         const map = new Map(prev)
         map.set(sessionId, {
           running: true,
-          toolActivities: [],
           model: modelId || undefined,
           startedAt: streamStartedAt,
           inputTokens: prev.get(sessionId)?.inputTokens,
@@ -753,7 +763,7 @@ export function useGlobalAgentListeners(): void {
 
     const queuedDispatchUnsubscribers = [
       store.sub(agentSessionMessageQueueAtom, scheduleAllQueuedMessageDispatches),
-      store.sub(agentStreamingStatesAtom, scheduleAllQueuedMessageDispatches),
+      store.sub(agentRunningSessionIdsAtom, scheduleAllQueuedMessageDispatches),
       store.sub(agentSessionsAtom, scheduleAllQueuedMessageDispatches),
       store.sub(agentSessionChannelMapAtom, scheduleAllQueuedMessageDispatches),
       store.sub(agentChannelIdAtom, scheduleAllQueuedMessageDispatches),
@@ -786,7 +796,7 @@ export function useGlobalAgentListeners(): void {
 
     const activateExternalAgentRun = (event: Extract<PromaEvent, { type: 'external_run_started' }>): void => {
       const applyActivation = (sessions: AgentSessionMeta[]): void => {
-        const currentStreamState = store.get(agentStreamingStatesAtom).get(event.sessionId)
+        const currentStreamState = getStreamState(event.sessionId)
         if (!shouldActivateExternalAgentRun(currentStreamState, event.startedAt)) {
           return
         }
@@ -1106,7 +1116,7 @@ export function useGlobalAgentListeners(): void {
         // Phase 2: 直接累积 SDKMessage 到 liveMessagesMapAtom（跳过 replay 消息，避免与持久化消息重复）
         if (payload.kind === 'sdk_delta') {
           const deltaPayload = payload.delta
-          const currentRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+          const currentRunStartedAt = getStreamState(sessionId)?.startedAt
           // Delta 必须携带产生它的 run 标识。迟到的旧 run Delta 不能借用当前 run，
           // 否则会被 live-group-set 误判为新一轮消息；无标识的旧协议事件也不强行归类。
           if (currentRunStartedAt != null && deltaPayload.runStartedAt !== currentRunStartedAt) return
@@ -1154,15 +1164,12 @@ export function useGlobalAgentListeners(): void {
           // 不会触碰 AgentStreamState，从而避免重新引入逐 token 的第二次 Map 更新。
           const hasAssistantActivity = deltaPayload.deltas.some((delta) => delta.type !== 'start')
           if (hasAssistantActivity) {
-            store.set(agentStreamingStatesAtom, (prev) => {
-              const current = prev.get(sessionId)
+            updateStreamState(sessionId, (current) => {
               const shouldResume = current?.retrying !== undefined
                 || current?.contextCompaction?.status === 'success'
                 || current?.contextCompaction?.status === 'noop'
-              if (!current || !shouldResume) return prev
-              const map = new Map(prev)
-              map.set(sessionId, resumeAgentStreamState(current))
-              return map
+              if (!current || !shouldResume) return current
+              return resumeAgentStreamState(current)
             })
           }
         }
@@ -1177,7 +1184,7 @@ export function useGlobalAgentListeners(): void {
             // thinking_tokens 是高频进度估算，只更新流式状态，不进入消息转录。
           } else if (!msgRecord.isReplay) {
             // 当前 run 的 assistant 消息沿用 run 起始时间，与首个 Delta 预览和乐观 header 保持一致。
-            const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+            const activeRunStartedAt = getStreamState(sessionId)?.startedAt
             // 为实时消息补充 _createdAt 时间戳（与持久化时的逻辑一致），
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
             if (typeof msgRecord._createdAt !== 'number') {
@@ -1246,7 +1253,7 @@ export function useGlobalAgentListeners(): void {
         for (const event of legacyEvents) {
           // 带 run 标识的 retry 事件必须在所有外围副作用前严格匹配当前流；
           // 否则旧 IPC 事件会复活已结束的 stream，或错误清掉新 run 的完成提醒。
-          const eventStreamState = store.get(agentStreamingStatesAtom).get(sessionId)
+          const eventStreamState = getStreamState(sessionId)
           if (isRunScopedRetryEvent(event) && event.runStartedAt != null && (
             !eventStreamState || !isRetryEventForCurrentStream(eventStreamState, event)
           )) {
@@ -1255,7 +1262,7 @@ export function useGlobalAgentListeners(): void {
 
           // 会话首次进入 running 时，清除旧的完成提醒状态
           if (event.type !== 'prompt_suggestion') {
-            const prevState = store.get(agentStreamingStatesAtom).get(sessionId)
+            const prevState = getStreamState(sessionId)
             if (!prevState || !prevState.running) {
               store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
                 if (!prev.has(sessionId)) return prev
@@ -1268,29 +1275,24 @@ export function useGlobalAgentListeners(): void {
 
           // 更新流式状态（prompt_suggestion 不影响流式状态，跳过以避免在 session 结束后用默认值 running:true 重新激活）
           if (event.type !== 'prompt_suggestion') {
-            store.set(agentStreamingStatesAtom, (prev) => {
-              const existing = prev.get(sessionId)
+            updateStreamState(sessionId, (existing) => {
               // 再做一次 scope 校验，防止同一 batch 内其它回调更新流状态后旧事件落入。
               if (isRunScopedRetryEvent(event) && event.runStartedAt != null && (
                 !existing || !isRetryEventForCurrentStream(existing, event)
               )) {
-                return prev
+                return existing
               }
               const current: AgentStreamState = existing ?? {
                 running: true,
-                toolActivities: [],
                 model: undefined,
                 // 无 run 标识的历史事件才允许 fallback；带标识的 retry 必须已在上方匹配。
                 startedAt: undefined,
               }
-              const next = applyAgentEvent(current, event)
-              const map = new Map(prev)
-              map.set(sessionId, next)
-              return map
+              return applyAgentEvent(current, event)
             })
           }
 
-          const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+          const activeRunStartedAt = getStreamState(sessionId)?.startedAt
           if (activeRunStartedAt != null) {
             const activeRunId = String(activeRunStartedAt)
             store.set(agentFileChangesCurrentRunAtom, (prev) => {
@@ -1304,7 +1306,7 @@ export function useGlobalAgentListeners(): void {
           // Pi 原生重试成功后仍会沿用同一会话；仅在事件属于当前 stream run 时
           // 清掉过期错误，避免迟到的旧 retry_cleared 掩盖新一轮真实失败。
           if (event.type === 'retry_cleared') {
-            const current = store.get(agentStreamingStatesAtom).get(sessionId)
+            const current = getStreamState(sessionId)
             if (current && isRetryEventForCurrentStream(current, event)) {
               store.set(agentStreamErrorsAtom, (prev) => clearAgentStreamError(prev, sessionId))
             }
@@ -1320,7 +1322,7 @@ export function useGlobalAgentListeners(): void {
               ?? (input?.path as string | undefined)
               ?? (input?.notebook_path as string | undefined)
             const runId = store.get(agentFileChangesCurrentRunAtom).get(sessionId)
-              ?? String(store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt ?? event.turnId ?? Date.now())
+              ?? String(getStreamState(sessionId)?.startedAt ?? event.turnId ?? Date.now())
             const entry = {
               path: targetPath || '',
               sessionId,
@@ -1659,7 +1661,6 @@ export function useGlobalAgentListeners(): void {
             // backgroundTasksPending=true → 进入/保持软空闲态（通道仍开着，handleSend 走注入路径）；
             // false → 真正结束，清除软空闲态，新消息回到新建 run 路径。
             backgroundWaiting: backgroundTasksPending,
-            ...finalizeStreamingActivities(current.toolActivities),
           })
           return map
         })
@@ -1733,7 +1734,7 @@ export function useGlobalAgentListeners(): void {
 
         /** 竞态保护：检查该会话是否已有新的流式请求正在运行 */
         const isNewStreamRunning = (): boolean => {
-          const state = store.get(agentStreamingStatesAtom).get(data.sessionId)
+          const state = getStreamState(data.sessionId)
           return state?.running === true
         }
 
@@ -1802,7 +1803,7 @@ export function useGlobalAgentListeners(): void {
         })
 
         // 递增消息刷新版本号，通知 AgentView 重新加载消息
-        const state = store.get(agentStreamingStatesAtom).get(data.sessionId)
+        const state = getStreamState(data.sessionId)
         if (!state?.running) {
           store.set(agentMessageRefreshAtom, (prev) => {
             const map = new Map(prev)

--- a/apps/electron/src/renderer/lib/external-agent-run.test.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.test.ts
@@ -34,18 +34,12 @@ describe('外部 Agent 运行激活', () => {
     })
   })
 
-  test('Given 会话标签已存在 When 再次收到外部运行开始事件 Then 复用原标签并保留已有工具活动', () => {
+  test('Given 会话标签已存在 When 再次收到外部运行开始事件 Then 复用原标签并保留已有流状态', () => {
     const tabs: ExternalAgentRunTab[] = [
       { id: session.id, type: 'agent', sessionId: session.id, title: session.title },
     ]
     const currentStreamState = {
       running: true,
-      toolActivities: [{
-        toolUseId: 'tool-1',
-        toolName: 'Bash',
-        input: {},
-        done: false,
-      }],
       model: 'old-model',
     }
 
@@ -59,7 +53,7 @@ describe('外部 Agent 运行激活', () => {
 
     expect(result.tabs).toBe(tabs)
     expect(result.activeTabId).toBe(session.id)
-    expect(result.streamState.toolActivities).toBe(currentStreamState.toolActivities)
+    expect(result.streamState.model).toBe('old-model')
     expect(result.streamState.startedAt).toBe(200)
   })
 
@@ -100,7 +94,6 @@ describe('外部 Agent 运行激活', () => {
   test('Given the same run has already completed When a delayed start event arrives Then keep it terminal', () => {
     expect(shouldActivateExternalAgentRun({
       running: false,
-      toolActivities: [],
       startedAt: 500,
     }, 500)).toBeFalse()
   })
@@ -108,7 +101,6 @@ describe('外部 Agent 运行激活', () => {
   test('Given a newer run is active When an older start event arrives Then ignore the old event', () => {
     expect(shouldActivateExternalAgentRun({
       running: true,
-      toolActivities: [],
       startedAt: 700,
     }, 600)).toBeFalse()
   })
@@ -122,7 +114,6 @@ describe('外部 Agent 运行激活', () => {
     })
 
     expect(result.streamState.running).toBe(true)
-    expect(result.streamState.toolActivities).toEqual([])
     expect(result.streamState.model).toBeUndefined()
     expect(result.streamState.startedAt).toBe(400)
   })

--- a/apps/electron/src/renderer/lib/external-agent-run.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.ts
@@ -62,7 +62,6 @@ export function buildExternalAgentRunActivation(
     streamState: {
       ...input.currentStreamState,
       running: true,
-      toolActivities: input.currentStreamState?.toolActivities ?? [],
       model: input.modelId ?? input.currentStreamState?.model,
       startedAt: input.startedAt,
     },


### PR DESCRIPTION
## Summary
- remove renderer-side duplicate tool activity materialization
- store high-frequency streaming state per Agent session
- make Agent session switching use the active tab and cached SDK messages
- remove the ineffective scroll-position test/code additions

## Validation
- bun run typecheck
- bun test ./src/renderer
- bun run build:renderer
- git diff --check

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)