### PR TITLE
fix(browser): reduce in-app browser rendering jank

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.29",
+  "version": "0.17.30",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -54,6 +54,8 @@ type BrowserTabRecord = {
   lastActivityAt: number
   highlightTimer?: ReturnType<typeof setTimeout>
   lastBounds?: BrowserViewLayout['bounds']
+  /** 仅记录当前实际挂载的 owner；隐藏时 detach，但保留 WebContents 及页面状态。 */
+  attachedOwner: BrowserWindow | null
 }
 type BrowserTabOptions = {
   isLocalPreview?: boolean
@@ -557,8 +559,8 @@ export class BrowserController {
       popupInitialUrl,
       popupInitialNavigationPending: popupInitialUrl !== null && isTransientBrowserPopupUrl(popupInitialUrl),
       lastActivityAt: Date.now(),
+      attachedOwner: null,
     }
-    this.owner.contentView.addChildView(view)
     view.setVisible(false)
     view.webContents.setWindowOpenHandler(({ url }) => {
       if (!isSupportedBrowserPopupUrl(url)) {
@@ -613,7 +615,7 @@ export class BrowserController {
       this.disposePopupChildren(browserSession, tab.tabId)
       browserSession.tabs.delete(tab.tabId)
       this.clearAgentTargetHighlight(tab)
-      try { this.owner?.contentView.removeChildView(tab.view) } catch { /* owner 已销毁 */ }
+      this.detachTabView(tab)
       this.repairTabSelection(browserSession, tab.tabId)
       if (browserSession.tabs.size === 0) {
         this.sessions.delete(browserSession.sessionId)
@@ -726,11 +728,7 @@ export class BrowserController {
     for (const browserSession of this.sessions.values()) {
       for (const tab of browserSession.tabs.values()) {
         if (browserSession.sessionId === targetSessionId && tab.tabId === targetTabId) continue
-        tab.view.setVisible(false)
-        if (tab.state.visible) {
-          tab.state.visible = false
-          changedSessions.add(browserSession)
-        }
+        if (this.hideTabView(tab)) changedSessions.add(browserSession)
       }
     }
     return changedSessions
@@ -738,6 +736,50 @@ export class BrowserController {
 
   private emitChangedSessions(changedSessions: Set<BrowserSessionRecord>): void {
     for (const browserSession of changedSessions) this.emit(browserSession)
+  }
+
+  /** 隐藏时从原生 View 树移除，避免 Chromium 继续按前台 WebContentsView 调度。 */
+  private detachTabView(tab: BrowserTabRecord): void {
+    try { tab.view.setVisible(false) } catch { /* WebContents/View 已销毁 */ }
+    const attachedOwner = tab.attachedOwner
+    if (!attachedOwner) return
+    tab.attachedOwner = null
+    try {
+      if (!attachedOwner.isDestroyed()) attachedOwner.contentView.removeChildView(tab.view)
+    } catch { /* owner 或 View 已销毁/已被 Electron 移除 */ }
+  }
+
+  /** 重新展示时只恢复原生挂载、bounds 和 visible，不重建 WebContents。 */
+  private attachTabView(tab: BrowserTabRecord): boolean {
+    const owner = this.owner
+    if (!owner || owner.isDestroyed() || tab.view.webContents.isDestroyed()) {
+      this.detachTabView(tab)
+      return false
+    }
+    if (tab.attachedOwner !== owner) {
+      this.detachTabView(tab)
+      try {
+        owner.contentView.addChildView(tab.view)
+        tab.attachedOwner = owner
+      } catch {
+        return false
+      }
+    }
+    try {
+      if (tab.lastBounds) tab.view.setBounds(tab.lastBounds)
+      tab.view.setVisible(true)
+      return true
+    } catch {
+      this.detachTabView(tab)
+      return false
+    }
+  }
+
+  private hideTabView(tab: BrowserTabRecord): boolean {
+    this.detachTabView(tab)
+    if (!tab.state.visible) return false
+    tab.state.visible = false
+    return true
   }
 
   setLayout(layout: BrowserViewLayout): void {
@@ -753,12 +795,9 @@ export class BrowserController {
     const bounds = layout.bounds
     const visible = layout.visible && bounds.width > 4 && bounds.height > 4 && !!this.owner && !this.owner.isDestroyed() && this.owner.isVisible()
     if (!visible) {
-      tab.view.setVisible(false)
+      this.latestPresentationRevision = Math.max(this.latestPresentationRevision, layout.revision)
       const changedSessions = new Set<BrowserSessionRecord>()
-      if (tab.state.visible) {
-        tab.state.visible = false
-        changedSessions.add(browserSession)
-      }
+      if (this.hideTabView(tab)) changedSessions.add(browserSession)
       if (this.presentation?.sessionId === browserSession.sessionId && this.presentation.tabId === tab.tabId) {
         this.presentation = null
       }
@@ -779,15 +818,14 @@ export class BrowserController {
     }
     const changedSessions = this.hideAllViewsExcept(browserSession.sessionId, tab.tabId)
     if (!tab.lastBounds || Object.entries(adjustedBounds).some(([key, value]) => tab.lastBounds?.[key as keyof typeof adjustedBounds] !== value)) {
-      tab.view.setBounds(adjustedBounds)
       tab.lastBounds = { ...adjustedBounds }
     }
-    tab.view.setVisible(true)
-    if (!tab.state.visible) {
-      tab.state.visible = true
+    const shown = this.attachTabView(tab)
+    if (tab.state.visible !== shown) {
+      tab.state.visible = shown
       changedSessions.add(browserSession)
     }
-    this.presentation = { sessionId: browserSession.sessionId, tabId: tab.tabId, revision: layout.revision }
+    this.presentation = shown ? { sessionId: browserSession.sessionId, tabId: tab.tabId, revision: layout.revision } : null
     this.latestPresentationRevision = layout.revision
     this.emitChangedSessions(changedSessions)
   }
@@ -801,22 +839,24 @@ export class BrowserController {
     tab.lastActivityAt = Date.now()
     browserSession.activeTabId = tab.tabId
     if (this.presentation?.sessionId !== browserSession.sessionId) {
+      // 后台 Session 的 tab 切换只更新逻辑状态，所有原生 View 都保持 detach。
+      for (const candidate of browserSession.tabs.values()) this.hideTabView(candidate)
       this.emit(browserSession)
       return
     }
 
     if (!tab.lastBounds && previous?.lastBounds) {
-      tab.view.setBounds(previous.lastBounds)
       tab.lastBounds = { ...previous.lastBounds }
     }
     const changedSessions = this.hideAllViewsExcept(browserSession.sessionId, tab.tabId)
-    const visible = !!tab.lastBounds && !!this.owner && !this.owner.isDestroyed() && this.owner.isVisible()
-    tab.view.setVisible(visible)
+    const shouldShow = !!tab.lastBounds && !!this.owner && !this.owner.isDestroyed() && this.owner.isVisible()
+    const visible = shouldShow && this.attachTabView(tab)
+    if (!visible) this.detachTabView(tab)
     if (tab.state.visible !== visible) {
       tab.state.visible = visible
       changedSessions.add(browserSession)
     }
-    this.presentation = { ...this.presentation, tabId: tab.tabId }
+    this.presentation = visible ? { ...this.presentation, tabId: tab.tabId } : null
     this.emitChangedSessions(changedSessions)
   }
 
@@ -842,7 +882,7 @@ export class BrowserController {
     browserSession.tabs.delete(tab.tabId)
     this.clearAgentTargetHighlight(tab)
     try { if (tab.view.webContents.debugger.isAttached()) tab.view.webContents.debugger.detach() } catch { /* 已销毁 */ }
-    try { this.owner?.contentView.removeChildView(tab.view) } catch { /* owner 已销毁 */ }
+    this.detachTabView(tab)
     if (!tab.view.webContents.isDestroyed()) tab.view.webContents.close()
   }
 
@@ -1307,10 +1347,11 @@ export class BrowserController {
     const browserSession = this.sessions.get(sessionId)
     if (!browserSession) return
     this.sessions.delete(sessionId)
+    if (this.presentation?.sessionId === sessionId) this.presentation = null
     for (const tab of browserSession.tabs.values()) {
       this.clearAgentTargetHighlight(tab)
       try { if (tab.view.webContents.debugger.isAttached()) tab.view.webContents.debugger.detach() } catch { /* 已销毁 */ }
-      try { this.owner?.contentView.removeChildView(tab.view) } catch { /* owner 已销毁 */ }
+      this.detachTabView(tab)
       if (!tab.view.webContents.isDestroyed()) tab.view.webContents.close()
     }
     browserSession.tabs.clear()
@@ -1319,6 +1360,8 @@ export class BrowserController {
   dispose(): void {
     for (const sessionId of [...this.sessions.keys()]) void this.close(sessionId)
     this.configurations.clear()
+    this.presentation = null
+    this.latestPresentationRevision = 0
     this.owner = null
   }
 }

--- a/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
@@ -13,6 +13,7 @@ const APP_OVERLAY_LIFECYCLE_SELECTOR = [
   '[role="dialog"]',
   '[role="alertdialog"]',
   '[data-sonner-toast]',
+  '[data-sonner-toaster]',
   '[data-radix-popper-content-wrapper]',
 ].join(', ')
 
@@ -28,23 +29,69 @@ function hasBlockingAppOverlay(): boolean {
     })
 }
 
-/** 只跟踪 portal/toast 生命周期，避免 Agent 流式渲染触发无意义的 layout IPC。 */
-function mutationsAffectAppOverlay(mutations: MutationRecord[]): boolean {
-  return mutations.some((mutation) => {
-    if (mutation.type === 'attributes') {
-      const target = mutation.target instanceof Element ? mutation.target : null
-      return !!target?.closest(APP_OVERLAY_LIFECYCLE_SELECTOR)
+function isAppOverlayElement(element: Element): boolean {
+  return element.matches(APP_OVERLAY_LIFECYCLE_SELECTOR)
+}
+
+function findAppOverlayElements(node: Node): Element[] {
+  if (!(node instanceof Element)) return []
+  const elements = isAppOverlayElement(node) ? [node] : []
+  return elements.concat(Array.from(node.querySelectorAll(APP_OVERLAY_LIFECYCLE_SELECTOR)))
+}
+
+/**
+ * 只跟踪 portal/toast 生命周期，避免 Agent 流式渲染触发无意义的 layout IPC。
+ *
+ * body 只监听直接子节点：Radix/Toast portal 都挂在这里，普通消息 DOM 的深层
+ * 更新不会进入 observer。识别出浮层根节点后，再把 attributes/subtree 监听限制
+ * 在该浮层内部，以便捕获 data-state 等开关变化。
+ */
+function observeAppOverlayLifecycle(onChange: () => void): () => void {
+  const overlayRoots = new Set<Element>()
+  const overlayObserver = new MutationObserver((mutations) => {
+    if (mutations.length > 0) onChange()
+  })
+  const bodyObserver = new MutationObserver((mutations) => {
+    let changed = false
+    for (const mutation of mutations) {
+      for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
+        const overlayElements = findAppOverlayElements(node)
+        if (overlayElements.length > 0) changed = true
+        for (const element of overlayElements) overlayRoots.add(element)
+      }
+    }
+    syncOverlayRoots()
+    if (changed) onChange()
+  })
+
+  function syncOverlayRoots(): void {
+    for (const root of overlayRoots) {
+      if (!root.isConnected) overlayRoots.delete(root)
     }
 
-    const nodes = [...mutation.addedNodes, ...mutation.removedNodes]
-    if (nodes.some((node) => (
-      node instanceof Element
-      && (node.matches(APP_OVERLAY_LIFECYCLE_SELECTOR) || !!node.querySelector(APP_OVERLAY_LIFECYCLE_SELECTOR))
-    ))) return true
+    for (const root of Array.from(document.body.children)) {
+      for (const element of findAppOverlayElements(root)) overlayRoots.add(element)
+    }
 
-    const parent = mutation.target instanceof Element ? mutation.target : null
-    return !!parent?.closest(APP_OVERLAY_LIFECYCLE_SELECTOR)
-  })
+    overlayObserver.disconnect()
+    for (const root of overlayRoots) {
+      overlayObserver.observe(root, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['data-mounted', 'data-state', 'data-visible', 'role'],
+      })
+    }
+  }
+
+  syncOverlayRoots()
+  bodyObserver.observe(document.body, { childList: true })
+
+  return () => {
+    bodyObserver.disconnect()
+    overlayObserver.disconnect()
+    overlayRoots.clear()
+  }
 }
 
 export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: string }): React.ReactElement {
@@ -73,22 +120,14 @@ export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: st
     }
     const publishCurrentVisibility = () => publish(!hasBlockingAppOverlay())
     const observer = new ResizeObserver(publishCurrentVisibility)
-    const overlayObserver = new MutationObserver((mutations) => {
-      if (mutationsAffectAppOverlay(mutations)) publishCurrentVisibility()
-    })
+    const disconnectOverlayObserver = observeAppOverlayLifecycle(publishCurrentVisibility)
     const publishBounded = () => publishCurrentVisibility()
     observer.observe(element)
-    overlayObserver.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['class', 'data-mounted', 'data-state', 'data-visible', 'style'],
-    })
     window.addEventListener('resize', publishBounded)
     publishCurrentVisibility()
     return () => {
       observer.disconnect()
-      overlayObserver.disconnect()
+      disconnectOverlayObserver()
       window.removeEventListener('resize', publishBounded)
       if (frame) cancelAnimationFrame(frame)
       void setLayout({ sessionId, tabId, revision: nextBrowserLayoutRevision(), visible: false, bounds: { x: 0, y: 0, width: 0, height: 0 } })


### PR DESCRIPTION
## Summary

- Reduce renderer MutationObserver scope for the managed browser overlay lifecycle.
- Detach hidden WebContentsView instances while preserving their WebContents.
- Reject stale cross-session browser layout revisions.

## Validation

- `bun run --cwd apps/electron typecheck`
- `bun run --cwd apps/electron build:main`
- `bun run --cwd apps/electron build:renderer`
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)