### PR TITLE
feat(agent): smooth streamed output

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.30",
+  "version": "0.17.31",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.33",
+  "version": "0.17.34",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.31",
+  "version": "0.17.32",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.32",
+  "version": "0.17.33",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -26,6 +26,7 @@ import { PreviewOpenButton } from './tool-result-renderers/preview-open-button'
 import { getTaskGetStatusLabel, parseTaskGetResult, type ParsedTaskGetResult } from './tool-result-renderers/task-get-result'
 import { parseTaskListResult, type ParsedTaskListItem } from './tool-result-renderers/task-list-result'
 import { formatDuration } from './AgentMessages'
+import { useSmoothStream } from '@proma/ui'
 import type {
   SDKContentBlock,
   SDKMessage,
@@ -649,6 +650,25 @@ function ThinkingBlock({ block, dimmed = false }: ThinkingBlockProps): React.Rea
   )
 }
 
+function StreamingTextBlock({
+  text,
+  isStreaming,
+  basePath,
+  basePaths,
+}: {
+  text: string
+  isStreaming?: boolean
+  basePath?: string
+  basePaths?: string[]
+}): React.ReactElement {
+  const { displayedContent } = useSmoothStream({
+    content: text,
+    isStreaming: isStreaming ?? false,
+  })
+
+  return <MessageResponse basePath={basePath} basePaths={basePaths}>{displayedContent}</MessageResponse>
+}
+
 // ===== ContentBlock 主组件 =====
 
 export function ContentBlock({ block, allMessages, basePath, basePaths, animate = false, index = 0, dimmed = false, childBlocks, isStreaming }: ContentBlockProps): React.ReactElement | null {
@@ -657,7 +677,12 @@ export function ContentBlock({ block, allMessages, basePath, basePaths, animate 
     const textBlock = block as SDKTextBlock
     if (!textBlock.text) return null
     return (
-      <MessageResponse basePath={basePath} basePaths={basePaths}>{textBlock.text}</MessageResponse>
+      <StreamingTextBlock
+        text={textBlock.text}
+        isStreaming={isStreaming}
+        basePath={basePath}
+        basePaths={basePaths}
+      />
     )
   }
 

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
@@ -22,6 +22,7 @@ interface ProcessBlockGroupProps {
 
 const MAX_PROCESS_GROUP_ICONS = 4
 const PROCESS_GROUP_VIEWPORT_HEIGHT = 320
+const PROCESS_GROUP_LIVE_CHILD_WINDOW = 4
 const PROCESS_GROUP_COLLAPSE_DURATION_MS = 500
 const PROCESS_GROUP_AUTO_COLLAPSE_SOUND_DELAY_MS = 900
 const PROCESS_GROUP_AUTO_COLLAPSE_COUNTDOWN_SECONDS = 3
@@ -180,6 +181,13 @@ function getProcessChildKey(child: React.ReactNode, index: number): string {
   return `process-child-${index}`
 }
 
+const StableProcessChild = React.memo(
+  function StableProcessChild({ child }: { child: React.ReactNode }): React.ReactElement {
+    return <>{child}</>
+  },
+  (previous, next) => previous.child === next.child,
+)
+
 export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessageTail = false }: ProcessBlockGroupProps): React.ReactElement {
   const initialDisplayMode: ProcessGroupDisplayMode = !isStreaming
     ? 'collapsed'
@@ -196,6 +204,8 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
   const autoCollapseTimersRef = React.useRef<number[]>([])
   const contentRef = React.useRef<HTMLDivElement>(null)
   const contentInnerRef = React.useRef<HTMLDivElement>(null)
+  const stableChildrenRef = React.useRef(new Map<string, React.ReactNode>())
+  const collapseFrameRef = React.useRef<number | null>(null)
   const [measuredHeight, setMeasuredHeight] = React.useState<number | undefined>(undefined)
 
   const isContentExpanded = displayMode === 'expanded'
@@ -339,6 +349,10 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
   // 折叠前测量实际高度，用于丝滑的 height 过渡（子元素不 reflow，只裁剪边界）
   React.useEffect(() => {
     if (isContentExpanded) {
+      if (collapseFrameRef.current !== null) {
+        cancelAnimationFrame(collapseFrameRef.current)
+        collapseFrameRef.current = null
+      }
       setShouldRenderContent(true)
       setMeasuredHeight(undefined)
       return
@@ -349,12 +363,20 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
     if (el) {
       const h = el.clientHeight
       setMeasuredHeight(h)
-      // 强制浏览器在下一帧开始从 h → 0 的过渡
-      requestAnimationFrame(() => setMeasuredHeight(0))
+      collapseFrameRef.current = requestAnimationFrame(() => {
+        collapseFrameRef.current = null
+        setMeasuredHeight(0)
+      })
     }
 
     const timer = window.setTimeout(() => setShouldRenderContent(false), PROCESS_GROUP_COLLAPSE_DURATION_MS)
-    return () => window.clearTimeout(timer)
+    return () => {
+      window.clearTimeout(timer)
+      if (collapseFrameRef.current !== null) {
+        cancelAnimationFrame(collapseFrameRef.current)
+        collapseFrameRef.current = null
+      }
+    }
   }, [isContentExpanded])
 
   const summary = React.useMemo(
@@ -365,24 +387,33 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
   const visibleToolNames = toolNames.slice(0, MAX_PROCESS_GROUP_ICONS)
   const hiddenToolCount = Math.max(0, toolNames.length - visibleToolNames.length)
 
-  // 内容区子项渲染策略：
-  // - 流式中：每个新块有入场动画，最新一段（消息末尾过程组的最后一个 child）保持正常显示，
-  //   其余步骤轻微弱化以引导视觉重心到最下方。
-  // - 流式结束后用户展开：所有内容以正常颜色显示，无动画。
+  // 只让最近几项参与高频更新；旧项保留在 DOM 中供用户滚动查看，但冻结其 React 子树。
   const renderContentChildren = (): React.ReactNode => {
     const childArray = React.Children.toArray(visibleChildren)
-    return childArray.map((child, i) => {
+    const liveStart = Math.max(0, childArray.length - PROCESS_GROUP_LIVE_CHILD_WINDOW)
+    const activeKeys = new Set<string>()
+
+    const rendered = childArray.map((child, i) => {
+      const key = getProcessChildKey(child, i)
+      activeKeys.add(key)
+      const cachedChild = stableChildrenRef.current.get(key)
+      const shouldFreeze = !!isStreaming && i < liveStart
+      const stableChild = shouldFreeze && cachedChild ? cachedChild : child
+      if (!shouldFreeze || !cachedChild) stableChildrenRef.current.set(key, child)
+
       const isLast = i === childArray.length - 1
       const dimmed = isStreaming && !(isMessageTail && isLast)
       return (
-        <div
-          key={getProcessChildKey(child, i)}
-          className={cn(dimmed && 'opacity-80')}
-        >
-          {child}
+        <div key={key} className={cn(dimmed && 'opacity-80')}>
+          <StableProcessChild child={stableChild} />
         </div>
       )
     })
+
+    for (const key of stableChildrenRef.current.keys()) {
+      if (!activeKeys.has(key)) stableChildrenRef.current.delete(key)
+    }
+    return rendered
   }
 
   return (

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
@@ -8,6 +8,8 @@ import type {
   SDKToolResultBlock,
   SDKToolUseBlock,
   SDKUserMessage,
+  SDKTextBlock,
+  SDKThinkingBlock,
 } from '@proma/shared'
 
 interface ProcessBlockGroupProps {
@@ -181,6 +183,25 @@ function getProcessChildKey(child: React.ReactNode, index: number): string {
   return `process-child-${index}`
 }
 
+interface StableProcessChildCacheEntry {
+  child: React.ReactNode
+  snapshot: string
+}
+
+function getProcessChildSnapshot(child: React.ReactNode): string | null {
+  if (!React.isValidElement(child) || child.type !== React.Fragment) return null
+  const fragmentProps = child.props as { children?: React.ReactNode }
+  const content = fragmentProps.children
+  if (!React.isValidElement(content)) return null
+  const contentProps = content.props as { block?: SDKContentBlock }
+  const block = contentProps.block
+  if (!block || (block.type !== 'text' && block.type !== 'thinking')) return null
+  const text = block.type === 'text'
+    ? (block as SDKTextBlock).text
+    : (block as SDKThinkingBlock).thinking
+  return `${block.type}:${text}`
+}
+
 const StableProcessChild = React.memo(
   function StableProcessChild({ child }: { child: React.ReactNode }): React.ReactElement {
     return <>{child}</>
@@ -204,7 +225,7 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
   const autoCollapseTimersRef = React.useRef<number[]>([])
   const contentRef = React.useRef<HTMLDivElement>(null)
   const contentInnerRef = React.useRef<HTMLDivElement>(null)
-  const stableChildrenRef = React.useRef(new Map<string, React.ReactNode>())
+  const stableChildrenRef = React.useRef(new Map<string, StableProcessChildCacheEntry>())
   const collapseFrameRef = React.useRef<number | null>(null)
   const [measuredHeight, setMeasuredHeight] = React.useState<number | undefined>(undefined)
 
@@ -396,10 +417,15 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
     const rendered = childArray.map((child, i) => {
       const key = getProcessChildKey(child, i)
       activeKeys.add(key)
-      const cachedChild = stableChildrenRef.current.get(key)
-      const shouldFreeze = !!isStreaming && i < liveStart
-      const stableChild = shouldFreeze && cachedChild ? cachedChild : child
-      if (!shouldFreeze || !cachedChild) stableChildrenRef.current.set(key, child)
+      const cachedEntry = stableChildrenRef.current.get(key)
+      const snapshot = getProcessChildSnapshot(child)
+      const shouldFreeze = !!isStreaming && i < liveStart && snapshot !== null
+      const stableChild = shouldFreeze && cachedEntry?.snapshot === snapshot
+        ? cachedEntry.child
+        : child
+      if (!shouldFreeze || !cachedEntry || cachedEntry.snapshot !== snapshot) {
+        stableChildrenRef.current.set(key, { child, snapshot: snapshot ?? '' })
+      }
 
       const isLast = i === childArray.length - 1
       const dimmed = isStreaming && !(isMessageTail && isLast)

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
@@ -13,15 +13,15 @@ import type {
 interface ProcessBlockGroupProps {
   blocks: SDKContentBlock[]
   isStreaming?: boolean
-  /** 按当前显示模式惰性生成过程项，避免流式中提前构造完整历史。 */
-  renderChildren: (mode: 'preview' | 'full') => React.ReactNode
+  /** 惰性生成过程项；流式与历史态均渲染完整内容。 */
+  renderChildren: () => React.ReactNode
   // 该过程组是否为整条消息的末尾项：是则流式中保留最后一段为正常显示，
   // 否则（最终答案已作为后续兄弟块外置）整组统一弱化。
   isMessageTail?: boolean
 }
 
 const MAX_PROCESS_GROUP_ICONS = 4
-export const MAX_EXPANDED_PROCESS_BLOCKS = 10
+const PROCESS_GROUP_VIEWPORT_HEIGHT = 320
 const PROCESS_GROUP_COLLAPSE_DURATION_MS = 500
 const PROCESS_GROUP_AUTO_COLLAPSE_SOUND_DELAY_MS = 900
 const PROCESS_GROUP_AUTO_COLLAPSE_COUNTDOWN_SECONDS = 3
@@ -172,35 +172,34 @@ export function buildProcessGroupToolNames(blocks: SDKContentBlock[]): string[] 
   return toolNames
 }
 
-type ProcessGroupDisplayMode = 'collapsed' | 'partial' | 'expanded'
+type ProcessGroupDisplayMode = 'collapsed' | 'expanded'
+
+function getProcessChildKey(child: React.ReactNode, index: number): string {
+  if (React.isValidElement(child) && child.key != null) return String(child.key)
+  return `process-child-${index}`
+}
 
 export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessageTail = false }: ProcessBlockGroupProps): React.ReactElement {
-  const hasStreamingPreview = !!isStreaming && blocks.length > MAX_EXPANDED_PROCESS_BLOCKS
   const initialDisplayMode: ProcessGroupDisplayMode = !isStreaming
     ? 'collapsed'
-    : hasStreamingPreview
-      ? 'partial'
-      : 'expanded'
+    : 'expanded'
   const [displayMode, setDisplayMode] = React.useState<ProcessGroupDisplayMode>(initialDisplayMode)
   const [shouldRenderContent, setShouldRenderContent] = React.useState(initialDisplayMode !== 'collapsed')
+  const [keepProgressViewport, setKeepProgressViewport] = React.useState(!!isStreaming)
   const [collapseCountdown, setCollapseCountdown] = React.useState<number | null>(null)
   const userToggledRef = React.useRef(false)
+  const followLatestRef = React.useRef(true)
+  const smoothScrollTargetRef = React.useRef<number | null>(null)
+  const scrollFrameRef = React.useRef<number | null>(null)
   const wasStreamingRef = React.useRef(!!isStreaming)
   const autoCollapseTimersRef = React.useRef<number[]>([])
   const contentRef = React.useRef<HTMLDivElement>(null)
+  const contentInnerRef = React.useRef<HTMLDivElement>(null)
   const [measuredHeight, setMeasuredHeight] = React.useState<number | undefined>(undefined)
 
-  const isPreviewMode = displayMode === 'partial' && !!isStreaming && hasStreamingPreview
-  const isContentExpanded = displayMode !== 'collapsed'
-  const renderMode = isPreviewMode ? 'preview' : 'full'
-  const collapsingRenderModeRef = React.useRef<'preview' | 'full'>(renderMode)
-  if (isContentExpanded) {
-    collapsingRenderModeRef.current = renderMode
-  }
+  const isContentExpanded = displayMode === 'expanded'
   const shouldShowContent = isContentExpanded || shouldRenderContent
-  const visibleChildren = shouldShowContent
-    ? renderChildren(isContentExpanded ? renderMode : collapsingRenderModeRef.current)
-    : null
+  const visibleChildren = shouldShowContent ? renderChildren() : null
 
   const clearAutoCollapseTimers = React.useCallback(() => {
     for (const timer of autoCollapseTimersRef.current) window.clearTimeout(timer)
@@ -212,13 +211,18 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
 
     if (isStreaming) {
       setCollapseCountdown(null)
-      if (isStreaming && !wasStreamingRef.current) {
+      setKeepProgressViewport(true)
+      if (!wasStreamingRef.current) {
         userToggledRef.current = false
+        followLatestRef.current = true
+        smoothScrollTargetRef.current = null
+        if (scrollFrameRef.current !== null) {
+          cancelAnimationFrame(scrollFrameRef.current)
+          scrollFrameRef.current = null
+        }
       }
-      if (!userToggledRef.current) {
-        setDisplayMode(hasStreamingPreview ? 'partial' : 'expanded')
-      }
-      wasStreamingRef.current = !!isStreaming
+      if (!userToggledRef.current) setDisplayMode('expanded')
+      wasStreamingRef.current = true
       return
     }
 
@@ -226,9 +230,8 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
     wasStreamingRef.current = false
 
     if (!shouldAutoCollapseAfterCompletion) {
-      if (!userToggledRef.current) {
-        setDisplayMode('collapsed')
-      }
+      setKeepProgressViewport(false)
+      if (!userToggledRef.current) setDisplayMode('collapsed')
       return
     }
 
@@ -243,12 +246,90 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
       autoCollapseTimersRef.current.push(window.setTimeout(() => {
         setCollapseCountdown(null)
         setDisplayMode('collapsed')
+        autoCollapseTimersRef.current.push(window.setTimeout(
+          () => setKeepProgressViewport(false),
+          PROCESS_GROUP_COLLAPSE_DURATION_MS,
+        ))
       }, PROCESS_GROUP_AUTO_COLLAPSE_COUNTDOWN_SECONDS * 1000))
     }, PROCESS_GROUP_AUTO_COLLAPSE_SOUND_DELAY_MS)
     autoCollapseTimersRef.current.push(soundDelayTimer)
 
     return clearAutoCollapseTimers
-  }, [clearAutoCollapseTimers, hasStreamingPreview, isStreaming])
+  }, [clearAutoCollapseTimers, isStreaming])
+
+  const scrollToLatest = React.useCallback(() => {
+    if (!followLatestRef.current) return
+    const viewport = contentRef.current
+    if (!viewport) return
+
+    smoothScrollTargetRef.current = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+    if (scrollFrameRef.current !== null) return
+
+    const advanceScroll = (): void => {
+      const target = smoothScrollTargetRef.current
+      const activeViewport = contentRef.current
+      if (!followLatestRef.current || target == null || !activeViewport) {
+        scrollFrameRef.current = null
+        return
+      }
+
+      const distance = target - activeViewport.scrollTop
+      if (Math.abs(distance) <= 1) {
+        activeViewport.scrollTop = target
+        smoothScrollTargetRef.current = null
+        scrollFrameRef.current = null
+        return
+      }
+
+      // 内容突增时快速追近，正常增量则保持低成本的连续插值。
+      const nextTop = distance > 72
+        ? target - 48
+        : activeViewport.scrollTop + distance * 0.32
+      activeViewport.scrollTop = nextTop
+      scrollFrameRef.current = requestAnimationFrame(advanceScroll)
+    }
+
+    scrollFrameRef.current = requestAnimationFrame(advanceScroll)
+  }, [])
+
+  React.useLayoutEffect(() => {
+    if (!isStreaming || !keepProgressViewport) return
+    const content = contentInnerRef.current
+    if (!content) return
+
+    const frame = requestAnimationFrame(scrollToLatest)
+    const observer = new ResizeObserver(scrollToLatest)
+    observer.observe(content)
+    return () => {
+      cancelAnimationFrame(frame)
+      if (scrollFrameRef.current !== null) {
+        cancelAnimationFrame(scrollFrameRef.current)
+        scrollFrameRef.current = null
+      }
+      observer.disconnect()
+    }
+  }, [isStreaming, keepProgressViewport, scrollToLatest])
+
+  React.useLayoutEffect(() => {
+    if (isStreaming && keepProgressViewport) scrollToLatest()
+  }, [blocks, isStreaming, keepProgressViewport, scrollToLatest])
+
+  const handleProgressScroll = React.useCallback((event: React.UIEvent<HTMLDivElement>): void => {
+    if (scrollFrameRef.current !== null) return
+    const { clientHeight, scrollHeight, scrollTop } = event.currentTarget
+    if (scrollHeight - scrollTop - clientHeight <= 24) {
+      followLatestRef.current = true
+    }
+  }, [])
+
+  const handleProgressScrollIntent = React.useCallback((): void => {
+    smoothScrollTargetRef.current = null
+    followLatestRef.current = false
+    if (scrollFrameRef.current !== null) {
+      cancelAnimationFrame(scrollFrameRef.current)
+      scrollFrameRef.current = null
+    }
+  }, [])
 
   // 折叠前测量实际高度，用于丝滑的 height 过渡（子元素不 reflow，只裁剪边界）
   React.useEffect(() => {
@@ -261,7 +342,7 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
     // 折叠时：先测量当前高度，触发 height 过渡动画，动画结束后卸载 DOM
     const el = contentRef.current
     if (el) {
-      const h = el.scrollHeight
+      const h = el.clientHeight
       setMeasuredHeight(h)
       // 强制浏览器在下一帧开始从 h → 0 的过渡
       requestAnimationFrame(() => setMeasuredHeight(0))
@@ -290,11 +371,8 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
       const dimmed = isStreaming && !(isMessageTail && isLast)
       return (
         <div
-          key={i}
-          className={cn(
-            dimmed && 'opacity-80',
-            isStreaming && 'animate-in fade-in slide-in-from-top-1 duration-200',
-          )}
+          key={getProcessChildKey(child, i)}
+          className={cn(dimmed && 'opacity-80')}
         >
           {child}
         </div>
@@ -314,14 +392,8 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
           userToggledRef.current = true
           clearAutoCollapseTimers()
           setCollapseCountdown(null)
-          setDisplayMode((previous) => {
-            if (hasStreamingPreview) {
-              if (previous === 'partial') return 'collapsed'
-              if (previous === 'collapsed') return 'expanded'
-              return 'collapsed'
-            }
-            return previous === 'collapsed' ? 'expanded' : 'collapsed'
-          })
+          if (!isStreaming) setKeepProgressViewport(false)
+          setDisplayMode((previous) => previous === 'collapsed' ? 'expanded' : 'collapsed')
         }}
       >
         <ChevronRight
@@ -361,8 +433,15 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
         <div
           ref={contentRef}
           data-agent-history-selection-excluded={isContentExpanded ? undefined : 'true'}
-          className="overflow-hidden"
+          className={cn(
+            'overflow-hidden',
+            keepProgressViewport && 'overflow-y-auto overscroll-contain scrollbar-none',
+          )}
+          onScroll={keepProgressViewport ? handleProgressScroll : undefined}
+          onWheel={keepProgressViewport ? handleProgressScrollIntent : undefined}
+          onTouchStart={keepProgressViewport ? handleProgressScrollIntent : undefined}
           style={{
+            maxHeight: keepProgressViewport ? `${PROCESS_GROUP_VIEWPORT_HEIGHT}px` : undefined,
             height: measuredHeight !== undefined ? `${measuredHeight}px` : 'auto',
             opacity: isContentExpanded ? 1 : 0,
             transition: measuredHeight !== undefined
@@ -370,7 +449,7 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
               : `opacity ${PROCESS_GROUP_COLLAPSE_DURATION_MS}ms ease-in-out`,
           }}
         >
-          <div className="space-y-2">
+          <div ref={contentInnerRef} className="space-y-2">
             {renderContentChildren()}
           </div>
         </div>

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
@@ -25,6 +25,7 @@ const PROCESS_GROUP_VIEWPORT_HEIGHT = 320
 const PROCESS_GROUP_COLLAPSE_DURATION_MS = 500
 const PROCESS_GROUP_AUTO_COLLAPSE_SOUND_DELAY_MS = 900
 const PROCESS_GROUP_AUTO_COLLAPSE_COUNTDOWN_SECONDS = 3
+const PROGRESS_SCROLL_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '])
 
 interface IndexedContentBlock {
   block: SDKContentBlock
@@ -331,6 +332,10 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
     }
   }, [])
 
+  const handleProgressKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (PROGRESS_SCROLL_KEYS.has(event.key)) handleProgressScrollIntent()
+  }, [handleProgressScrollIntent])
+
   // 折叠前测量实际高度，用于丝滑的 height 过渡（子元素不 reflow，只裁剪边界）
   React.useEffect(() => {
     if (isContentExpanded) {
@@ -434,12 +439,15 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
           ref={contentRef}
           data-agent-history-selection-excluded={isContentExpanded ? undefined : 'true'}
           className={cn(
-            'overflow-hidden',
+            'overflow-hidden focus:outline-none',
             keepProgressViewport && 'overflow-y-auto overscroll-contain scrollbar-none',
           )}
+          tabIndex={keepProgressViewport ? 0 : undefined}
           onScroll={keepProgressViewport ? handleProgressScroll : undefined}
+          onPointerDown={keepProgressViewport ? handleProgressScrollIntent : undefined}
           onWheel={keepProgressViewport ? handleProgressScrollIntent : undefined}
           onTouchStart={keepProgressViewport ? handleProgressScrollIntent : undefined}
+          onKeyDown={keepProgressViewport ? handleProgressKeyDown : undefined}
           style={{
             maxHeight: keepProgressViewport ? `${PROCESS_GROUP_VIEWPORT_HEIGHT}px` : undefined,
             height: measuredHeight !== undefined ? `${measuredHeight}px` : 'auto',

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -19,7 +19,7 @@ import { ImageLightbox, type LightboxImage } from '@/components/ui/image-lightbo
 import { ContentBlock } from './ContentBlock'
 import { TurnFileChangesSummary, buildTurnFileNameMap } from './TurnFileChangesSummary'
 import { TurnSkillUsageSummary } from './TurnSkillUsageSummary'
-import { ProcessBlockGroup, buildAssistantTurnRenderItems, buildCompletedToolResultIds, MAX_EXPANDED_PROCESS_BLOCKS } from './ProcessBlockGroup'
+import { ProcessBlockGroup, buildAssistantTurnRenderItems, buildCompletedToolResultIds } from './ProcessBlockGroup'
 import { extractToolResultText, TASK_TOOL_NAMES } from './task-progress'
 import { normalizeThinkTagsInContentBlocks } from './thinking-tag-parser'
 // 会话转录的纯逻辑(Turn 分组 / 快照去重 / 预览)已下沉到 @proma/session-core 作为唯一真源。
@@ -551,16 +551,11 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
                 key={groupKey}
                 blocks={groupBlocks}
                 isStreaming={isStreaming}
-                renderChildren={(mode) => {
-                  const groupItems = mode === 'preview'
-                    ? item.items.slice(-MAX_EXPANDED_PROCESS_BLOCKS)
-                    : item.items
-                  return groupItems.map((groupItem) => (
-                    <React.Fragment key={groupItem.index}>
-                      {renderProcessGroupBlock(groupItem.block, groupItem.index)}
-                    </React.Fragment>
-                  ))
-                }}
+                renderChildren={() => item.items.map((groupItem) => (
+                  <React.Fragment key={groupItem.index}>
+                    {renderProcessGroupBlock(groupItem.block, groupItem.index)}
+                  </React.Fragment>
+                ))}
                 isMessageTail={itemIndex === renderItems.length - 1}
               />
             )

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/ui",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "AGPL-3.0-only",
   "description": "Shared UI components for proma",
   "type": "module",

--- a/packages/ui/src/hooks/useSmoothStream.ts
+++ b/packages/ui/src/hooks/useSmoothStream.ts
@@ -61,6 +61,7 @@ export function useSmoothStream({
   minDelay = 10,
 }: UseSmoothStreamOptions): UseSmoothStreamReturn {
   const [displayedContent, setDisplayedContent] = useState(content)
+  const [queueVersion, setQueueVersion] = useState(0)
 
   // 字符队列（待渲染的字符）
   const chunkQueueRef = useRef<string[]>([])
@@ -94,6 +95,7 @@ export function useSmoothStream({
       if (delta) {
         const chars = segmentText(delta)
         chunkQueueRef.current.push(...chars)
+        setQueueVersion((version) => version + 1)
       }
     } else {
       // 内容重置（用户重新发送等场景）
@@ -138,8 +140,8 @@ export function useSmoothStream({
         rafRef.current = null
         return
       }
-      // 流未结束但队列空 → 等下一帧
-      rafRef.current = requestAnimationFrame(renderLoop)
+      // 流未结束但暂无增量：停止空转，下一次内容入队时再唤醒。
+      rafRef.current = null
       return
     }
 
@@ -160,32 +162,34 @@ export function useSmoothStream({
     displayedRef.current += chars.join('')
     setDisplayedContent(displayedRef.current)
 
-    // 队列未空或流未结束 → 继续
-    if (queue.length > 0 || !streamDoneRef.current) {
+    // 队列未空 → 继续；流未结束但队列排空时休眠，等待下一段 delta 唤醒。
+    if (queue.length > 0) {
       rafRef.current = requestAnimationFrame(renderLoop)
-    } else {
+    } else if (streamDoneRef.current) {
       // 队列刚排空 + 流已结束 → 同步最终内容并停止
       if (displayedRef.current !== prevContentRef.current) {
         displayedRef.current = prevContentRef.current
         setDisplayedContent(displayedRef.current)
       }
       rafRef.current = null
+    } else {
+      rafRef.current = null
     }
   }, [minDelay])
 
-  // 启动/重启渲染循环（流结束后也继续运行直到队列排空）
+  // 内容入队或流结束时启动循环；空队列的流式空档不保留 rAF。
   useEffect(() => {
-    if ((isStreaming || chunkQueueRef.current.length > 0) && !rafRef.current) {
+    if (chunkQueueRef.current.length > 0 && !rafRef.current) {
       rafRef.current = requestAnimationFrame(renderLoop)
     }
+  }, [isStreaming, queueVersion, renderLoop])
 
-    return () => {
-      if (rafRef.current) {
-        cancelAnimationFrame(rafRef.current)
-        rafRef.current = null
-      }
+  useEffect(() => () => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
     }
-  }, [isStreaming, renderLoop])
+  }, [])
 
   return { displayedContent }
 }


### PR DESCRIPTION
## Summary

- Agent 正文复用 Chat 的 useSmoothStream，实现平滑流式输出。
- 工具过程改为无边框、自动跟随最新进度的内部滚动区；结束后自动收起，点击摘要可展开完整历史。
- 稳定过程项 key 并移除重复入场动画，减少流式重排闪烁。

## Test plan

- [x] `bun run --filter=@proma/electron typecheck`
- [x] `bun test apps/electron/src/renderer/components/agent`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)