### PR TITLE
fix(agent): preserve queued run state

### DIFF
--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -80,7 +80,7 @@ import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/a
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
 import { detectIsWindows } from '@/lib/platform'
 import { getSessionFileChangeKind, arePathsEqual, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
-import { removeQueuedMessage } from '@/lib/agent-message-queue'
+import { removeQueuedMessage, createQueuedAgentStreamState } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
@@ -560,6 +560,17 @@ export function useGlobalAgentListeners(): void {
 
     const cleanupQueuedMessageStatus = window.electronAPI.onAgentQueuedMessageStatus((status) => {
       unstable_batchedUpdates(() => {
+        // 主进程在启动 deferred run 前先发送 started 投影。这里必须先建立完整的
+        // 当前 run 状态，否则首个 SDK/tool 事件到达前会被当成空闲；后续事件只能
+        // 隐式创建一个没有 startedAt 的状态，导致续跑的运行计时和 run 边界丢失。
+        store.set(agentStreamingStatesAtom, (prev) => {
+          const current = prev.get(status.sessionId)
+          // 不让迟到的队列状态覆盖已经开始的新一轮 run。
+          if (current?.startedAt != null && current.startedAt > status.startedAt) return prev
+          const map = new Map(prev)
+          map.set(status.sessionId, createQueuedAgentStreamState(current, status.startedAt))
+          return map
+        })
         store.set(agentSessionMessageQueueAtom, (prev) => {
           const current = prev.get(status.sessionId) ?? []
           const next = removeQueuedMessage(current, status.messageId)
@@ -571,7 +582,7 @@ export function useGlobalAgentListeners(): void {
         })
         store.set(liveMessagesMapAtom, (prev) => {
           const current = prev.get(status.sessionId) ?? []
-          const uuid = `queued-`
+          const uuid = `queued-${status.messageId}`
           if (current.some((message) => (message as unknown as { uuid?: string }).uuid === uuid)) return prev
           const optimisticMessage: SDKMessage = {
             type: "user",

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -1,3 +1,4 @@
+import type { AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   buildAgentHistoryQuoteLabel,
@@ -69,19 +70,10 @@ export function createAgentQueuedMessage(
   return message
 }
 
-export interface AgentQueuedRunStateSeed {
-  running: true
-  backgroundWaiting: false
-  model?: string
-  startedAt: number
-  inputTokens?: number
-  contextWindow?: number
-}
-
 export function createQueuedAgentStreamState(
-  previous: Pick<AgentQueuedRunStateSeed, 'model' | 'inputTokens' | 'contextWindow'> | undefined,
+  previous: Pick<AgentStreamState, 'model' | 'inputTokens' | 'contextWindow'> | undefined,
   startedAt: number,
-): AgentQueuedRunStateSeed {
+): AgentStreamState {
   return {
     running: true,
     backgroundWaiting: false,

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -69,6 +69,29 @@ export function createAgentQueuedMessage(
   return message
 }
 
+export interface AgentQueuedRunStateSeed {
+  running: true
+  backgroundWaiting: false
+  model?: string
+  startedAt: number
+  inputTokens?: number
+  contextWindow?: number
+}
+
+export function createQueuedAgentStreamState(
+  previous: Pick<AgentQueuedRunStateSeed, 'model' | 'inputTokens' | 'contextWindow'> | undefined,
+  startedAt: number,
+): AgentQueuedRunStateSeed {
+  return {
+    running: true,
+    backgroundWaiting: false,
+    model: previous?.model,
+    startedAt,
+    inputTokens: previous?.inputTokens,
+    contextWindow: previous?.contextWindow,
+  }
+}
+
 export function removeQueuedMessage(
   queue: AgentQueuedMessage[],
   messageId: string,


### PR DESCRIPTION
## Summary
- initialize renderer run state when a deferred queue message starts
- preserve startedAt and context usage for queued continuation
- use per-message optimistic UUIDs for consecutive queued messages

## Verification
- `bun test ./apps/electron/src/renderer/lib/agent-message-queue.test.ts` (5 passed)
- `git diff --check`
- typecheck/renderer build could not run because this worktree lacks `tsc`, `vite`, and `jotai` dependencies

## Performance
Low-frequency renderer state update once per queued run; no token-level or IPC hot-path increase.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)