### PR TITLE
fix(channel): restore GLM-5.3 reasoning compatibility

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -52,7 +52,12 @@ interface PiModelDefaults {
 const ZERO_MODEL_COST: PiModelCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 const DEFAULT_MAX_TOKENS = 64_000
-const VOLCENGINE_GLM_52_MAX_TOKENS = 128_000
+const VOLCENGINE_GLM_MAX_TOKENS = 128_000
+/**
+ * 当 Pi catalog 尚未包含 GLM-5.3 时，补回其官方最大输出上限，避免落到默认 64K。
+ * 智谱官方文档标注 GLM-5.3 最大输出 128K，与目录中 GLM-5.2 的 131072 同一口径。
+ */
+const GLM_53_MAX_TOKENS = 131_072
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api'
 const CODEX_MAX_TOKENS = 128_000
 /**
@@ -117,6 +122,18 @@ function compilePiReasoningCapabilities(
         },
         thinkingLevelMap,
       }
+    case 'zai-toggle':
+      return {
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          thinkingFormat: 'zai',
+          zaiToolStream: true,
+        },
+        thinkingLevelMap,
+      }
+    case 'anthropic-manual':
+      return { thinkingLevelMap }
   }
 }
 
@@ -339,6 +356,7 @@ function candidatePiProviders(provider: ProviderType): KnownProvider[] {
     case 'zhipu':
       return ['zai']
     case 'zhipu-coding':
+    case 'zhipu-coding-team':
       return ['zai-coding-cn', 'zai']
     case 'minimax':
       return ['minimax', 'minimax-cn']
@@ -532,8 +550,10 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const codexAlignedCapabilities = getCodexAlignedGPT5Capabilities(input.model)
   const api = normalizePiApi(input.provider)
   const providerSpecificCapabilities = compilePiReasoningCapabilities(api, input.model)
-  const isVolcengineGlm52 = (input.provider === 'doubao' || input.provider === 'ark-coding-plan')
-    && input.model?.toLowerCase() === 'glm-5.2'
+  const glmModelId = input.model?.toLowerCase()
+  const isVolcengineGlm5x = (input.provider === 'doubao' || input.provider === 'ark-coding-plan')
+    && (glmModelId === 'glm-5.2' || glmModelId === 'glm-5.3')
+  const isCatalogMissingGlm53 = !catalogModel && glmModelId === 'glm-5.3'
   const catalogContextWindow = catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
   const inferredContextWindow = inferContextWindow(input.model) ?? DEFAULT_CONTEXT_WINDOW
   return {
@@ -545,10 +565,10 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
     cost: catalogModel ? { ...catalogModel.cost } : { ...ZERO_MODEL_COST },
     // Codex 对齐策略优先；其他模型仍保留 catalog 与 shared inference 中更大的已验证能力。
     contextWindow: codexAlignedCapabilities?.contextWindow ?? Math.max(catalogContextWindow, inferredContextWindow),
-    // Pi 的智谱目录将 GLM-5.2 标为 131072，但火山方舟兼容端点上限为 128000。
-    maxTokens: isVolcengineGlm52
-      ? VOLCENGINE_GLM_52_MAX_TOKENS
-      : (catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS),
+    // Pi 的智谱目录将 GLM-5.2 标为 131072，但火山方舟兼容端点上限为 128000；GLM-5.3 同理。
+    maxTokens: isVolcengineGlm5x
+      ? VOLCENGINE_GLM_MAX_TOKENS
+      : (catalogModel?.maxTokens ?? (isCatalogMissingGlm53 ? GLM_53_MAX_TOKENS : DEFAULT_MAX_TOKENS)),
   }
 }
 

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -87,6 +87,7 @@ const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
   { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
   { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
   { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
+  { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
   { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
   { id: 'k3', name: 'Kimi K3', enabled: true },
   { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -419,6 +419,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
       } else if (p === 'opencode-go-openai') {
         setModels([
           { id: 'grok-4.5', name: 'Grok 4.5', enabled: true },
+          { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
           { id: 'glm-5.1', name: 'GLM-5.1', enabled: true },
           { id: 'kimi-k3', name: 'Kimi K3', enabled: true },
@@ -431,14 +432,18 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         ])
       } else if (p === 'zhipu' || p === 'zhipu-coding' || p === 'zhipu-coding-team') {
         setModels([
+          { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
           { id: 'glm-5.1', name: 'GLM-5.1', enabled: false },
         ])
       } else if (p === 'ark-coding-plan') {
         setModels([
+          { id: 'doubao-seed-2.1-pro', name: 'Doubao Seed 2.1 Pro', enabled: true },
+          { id: 'doubao-seed-2.1-turbo', name: 'Doubao Seed 2.1 Turbo', enabled: true },
           { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
           { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
           { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
+          { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
           { id: 'k3', name: 'Kimi K3', enabled: true },
           { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -40,6 +40,8 @@ export type ReasoningEncodingKind =
   | 'deepseek-output-effort'
   | 'openai-reasoning-effort'
   | 'zai-thinking-effort'
+  | 'zai-toggle'
+  | 'anthropic-manual'
 
 /** 每个产品等级映射为目标协议可接受的 effort 值。 */
 export type ReasoningEffortMap = Partial<Record<AgentThinkingLevel, string | null>>
@@ -50,7 +52,7 @@ export interface ReasoningEncoding {
 }
 
 export interface ReasoningProfile {
-  id: 'deepseek-v4-flash' | 'deepseek-v4-pro' | 'kimi-k3' | 'glm-5.2' | 'openai-reasoning-standard' | 'openai-reasoning-max'
+  id: 'deepseek-v4-flash' | 'deepseek-v4-pro' | 'kimi-k3' | 'glm-5.2' | 'glm-5.3' | 'openai-reasoning-standard' | 'openai-reasoning-max'
   levels: readonly AgentThinkingLevel[]
   defaultLevel: AgentThinkingLevel
   normalize(level: AgentThinkingLevel | undefined): AgentThinkingLevel
@@ -87,6 +89,15 @@ export interface ResolveReasoningProfileInput {
 const DEEPSEEK_V4_LEVELS = ['off', 'low', 'high', 'xhigh', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const K3_LEVELS = ['off', 'low', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const GLM_52_LEVELS = ['off', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
+const GLM_53_LEVELS = ['off', 'high'] as const satisfies readonly AgentThinkingLevel[]
+/** GLM-5.3 官方端点只支持思考开关，不接受 reasoning_effort；其余档位必须从 UI 隐藏。 */
+const GLM_53_THINKING_LEVEL_MAP: ReasoningEffortMap = {
+  minimal: null,
+  low: null,
+  medium: null,
+  xhigh: null,
+  max: null,
+}
 const OPENAI_STANDARD_LEVELS = ['off', 'low', 'medium', 'high', 'xhigh'] as const satisfies readonly AgentThinkingLevel[]
 const OPENAI_MAX_LEVELS = [...OPENAI_STANDARD_LEVELS, 'max'] as const satisfies readonly AgentThinkingLevel[]
 
@@ -191,6 +202,10 @@ function normalizeGlm52Level(level: AgentThinkingLevel | undefined): AgentThinki
   return level === 'xhigh' || level === 'max' ? 'max' : 'high'
 }
 
+function normalizeGlm53Level(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
+  return level === 'off' ? 'off' : 'high'
+}
+
 function normalizeOpenAIStandardLevel(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
   if (level === 'off') return 'off'
   if (level === 'minimal') return 'low'
@@ -234,6 +249,17 @@ const K3_PROFILE: ReasoningProfile = {
   },
 }
 
+const GLM_53_PROFILE: ReasoningProfile = {
+  id: 'glm-5.3',
+  levels: GLM_53_LEVELS,
+  defaultLevel: 'high',
+  normalize: normalizeGlm53Level,
+  encodings: {
+    'anthropic-messages': { kind: 'anthropic-manual', effortMap: GLM_53_THINKING_LEVEL_MAP },
+    'openai-completions': { kind: 'zai-toggle', effortMap: GLM_53_THINKING_LEVEL_MAP },
+  },
+}
+
 const GLM_52_PROFILE: ReasoningProfile = {
   id: 'glm-5.2',
   levels: GLM_52_LEVELS,
@@ -272,6 +298,7 @@ export const REASONING_PROFILES: readonly ReasoningProfile[] = [
   DEEPSEEK_V4_PRO_PROFILE,
   K3_PROFILE,
   GLM_52_PROFILE,
+  GLM_53_PROFILE,
   OPENAI_STANDARD_PROFILE,
   OPENAI_MAX_PROFILE,
 ]
@@ -290,11 +317,13 @@ export function resolveReasoningProfile(input: ResolveReasoningProfileInput): Re
       ? DEEPSEEK_V4_PRO_PROFILE
       : /^(?:k3(?:-256k)?|kimi-k3)$/.test(modelId)
         ? K3_PROFILE
-        : modelId === 'glm-5.2'
-          ? GLM_52_PROFILE
-          : isOpenAITransport && isOpenAIReasoningModel
-            ? /^gpt-5\.6(?:-|$)/.test(modelId) ? OPENAI_MAX_PROFILE : OPENAI_STANDARD_PROFILE
-            : undefined
+        : modelId === 'glm-5.3'
+          ? GLM_53_PROFILE
+          : modelId === 'glm-5.2'
+            ? GLM_52_PROFILE
+            : isOpenAITransport && isOpenAIReasoningModel
+              ? /^gpt-5\.6(?:-|$)/.test(modelId) ? OPENAI_MAX_PROFILE : OPENAI_STANDARD_PROFILE
+              : undefined
 
   return profile?.encodings[input.transport] ? profile : undefined
 }

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -53,7 +53,7 @@ const ONE_MILLION_CONTEXT_RULES = {
   // DeepSeek
   deepseek: ['deepseek-v4'],
   // 智谱 GLM
-  glm: ['glm-5.2'],
+  glm: ['glm-5.3', 'glm-5.2'],
   // 小米 MiMo
   mimo: ['mimo-v2.5'],
   // MiniMax


### PR DESCRIPTION
## Summary
- Restore GLM-5.3 presets for Zhipu, Zhipu Coding Plan, Zhipu team plan, OpenCode Go, and Ark Coding Plan.
- Keep GLM 5.2 on the existing `off/high/max` effort profile.
- Match the Pi ZAI catalog for GLM-5.3: expose `off/high` and send the official thinking toggle without `reasoning_effort`.
- Add the missing Zhipu team-plan catalog route.

## Validation
- `bun run --filter @proma/shared typecheck`
- `bun run --filter @proma/electron typecheck`
- `bun run --filter @proma/electron build:main`
- 76 existing shared/Pi tests passed
- `git diff --check`

## Performance
No material performance impact. This changes static model metadata, request compatibility settings, and channel preset resolution; it does not add a high-frequency render, IPC, or streaming path.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)