### PR TITLE
feat(model): GLM-5.3 加入 1M 上下文白名单

### DIFF
--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -52,8 +52,8 @@ const ONE_MILLION_CONTEXT_RULES = {
   ],
   // DeepSeek
   deepseek: ['deepseek-v4'],
-  // 智谱 GLM
-  glm: ['glm-5.2'],
+  // 智谱 GLM（GLM-5.2 起支持 1M；GLM-5.3 官方文档同样标注 1M，#1658 已进预设但缺此白名单）
+  glm: ['glm-5.2', 'glm-5.3'],
   // 小米 MiMo
   mimo: ['mimo-v2.5'],
   // MiniMax


### PR DESCRIPTION
## 背景

#1658 把 `glm-5.3` 加进了智谱三个渠道（zhipu / zhipu-coding / zhipu-coding-team）的预设并默认启用，同时补了 128K 输出上限，但 `ONE_MILLION_CONTEXT_RULES` 白名单仍只有 `glm-5.2`。

## 问题

GLM-5.3 未命中 1M 白名单时：

- UI 的 ContextUsageBadge 按 200K 默认窗口显示
- `pi-model-registry` 的 `resolvePiModelDefaults` 走 `Math.max(catalogContextWindow, inferredContextWindow)`，catalog 缺失分支回落 200K，运行时注册的 contextWindow 同样偏小

智谱官方模型文档标注 GLM-5.3 上下文窗口 1M、最大输出 128K（与 GLM-5.2 同基座）。

## 改动

`packages/shared/src/utils/context-window.ts` 的 `glm` 数组追加 `'glm-5.3'`。

- substring 匹配自动覆盖 `[1m]` 后缀变体（pi 模式统一剥后缀后发送裸 ID，与 glm-5.2 的既有处理一致）
- 不涉及任何 beta header（文件头已注明 1M 随各家模型转正为默认能力）

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)