### PR TITLE
perf(sidebar): lazy load archived agent sessions

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.35",
+  "version": "0.17.36",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -266,6 +266,9 @@ import {
 import { runPlanningNativeSync } from './lib/planning-native-sync-coordinator'
 import {
   listAgentSessions,
+  listActiveAgentSessions,
+  listArchivedAgentSessions,
+  countArchivedAgentSessions,
   createAgentSession,
   getAgentSessionMeta,
   getAgentSessionSDKMessages,
@@ -2054,6 +2057,24 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_SESSIONS,
     async (): Promise<AgentSessionMeta[]> => listAgentSessions()
+  )
+
+  // 获取未归档会话列表（侧栏 active 视图）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.LIST_ACTIVE_SESSIONS,
+    async (): Promise<AgentSessionMeta[]> => listActiveAgentSessions(),
+  )
+
+  // 获取归档会话列表（进入归档视图时按需加载）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.LIST_ARCHIVED_SESSIONS,
+    async (): Promise<AgentSessionMeta[]> => listArchivedAgentSessions(),
+  )
+
+  // 获取归档会话数量（active 视图只展示计数）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.COUNT_ARCHIVED_SESSIONS,
+    async (): Promise<number> => countArchivedAgentSessions(),
   )
 
   // 创建 Agent 会话

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -251,12 +251,33 @@ function writeIndex(index: AgentSessionsIndex): void {
   }
 }
 
-/**
- * 获取所有会话（按 updatedAt 降序）
- */
+/** 按最近更新时间排序会话副本，避免修改索引数组本身。 */
+function sortSessionsByUpdatedAtDesc(sessions: AgentSessionMeta[]): AgentSessionMeta[] {
+  return [...sessions].sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+/** 获取所有会话（按 updatedAt 降序） */
 export function listAgentSessions(): AgentSessionMeta[] {
   const index = readIndex()
-  return index.sessions.sort((a, b) => b.updatedAt - a.updatedAt)
+  return sortSessionsByUpdatedAtDesc(index.sessions)
+}
+
+/** 获取未归档会话，供侧栏 active 视图按需读取。 */
+export function listActiveAgentSessions(): AgentSessionMeta[] {
+  const index = readIndex()
+  return sortSessionsByUpdatedAtDesc(index.sessions.filter((session) => !session.archived))
+}
+
+/** 获取归档会话，只有用户进入归档视图时才调用。 */
+export function listArchivedAgentSessions(): AgentSessionMeta[] {
+  const index = readIndex()
+  return sortSessionsByUpdatedAtDesc(index.sessions.filter((session) => session.archived))
+}
+
+/** 获取归档数量，不把归档会话元数据传到 renderer。 */
+export function countArchivedAgentSessions(): number {
+  const index = readIndex()
+  return index.sessions.reduce((count, session) => count + (session.archived ? 1 : 0), 0)
 }
 
 /**

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -508,6 +508,15 @@ export interface ElectronAPI {
   /** 获取 Agent 会话列表 */
   listAgentSessions: () => Promise<AgentSessionMeta[]>
 
+  /** 获取未归档会话列表，供左侧 active 视图使用 */
+  listActiveAgentSessions: () => Promise<AgentSessionMeta[]>
+
+  /** 获取归档会话列表，进入归档视图时按需调用 */
+  listArchivedAgentSessions: () => Promise<AgentSessionMeta[]>
+
+  /** 获取归档会话数量，不返回归档元数据 */
+  countArchivedAgentSessions: () => Promise<number>
+
   /** 创建 Agent 会话 */
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => Promise<AgentSessionMeta>
 
@@ -1702,6 +1711,18 @@ const electronAPI: ElectronAPI = {
   // Agent 会话管理
   listAgentSessions: () => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_SESSIONS)
+  },
+
+  listActiveAgentSessions: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_ACTIVE_SESSIONS)
+  },
+
+  listArchivedAgentSessions: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_ARCHIVED_SESSIONS)
+  },
+
+  countArchivedAgentSessions: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.COUNT_ARCHIVED_SESSIONS)
   },
 
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => {

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -178,7 +178,7 @@ export function WorkspaceSelector(): React.ReactElement {
       await window.electronAPI.deleteAgentWorkspace(deleteTargetId)
       const [remaining, sessions] = await Promise.all([
         window.electronAPI.listAgentWorkspaces(),
-        window.electronAPI.listAgentSessions(),
+        window.electronAPI.listActiveAgentSessions(),
       ])
       setWorkspaces(remaining)
       setAgentSessions(sessions)

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -776,6 +776,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
   // Agent 模式状态
   const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
+  const [archivedAgentSessionCount, setArchivedAgentSessionCount] = React.useState(0)
   const [currentAgentSessionId, setCurrentAgentSessionId] = useAtom(currentAgentSessionIdAtom)
   const agentIndicatorMap = useAtomValue(agentSessionIndicatorMapAtom)
   const unviewedCompletedSessionIds = useAtomValue(unviewedCompletedSessionIdsAtom)
@@ -818,9 +819,28 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setSearchDialogOpen = useSetAtom(searchDialogOpenAtom)
   const newChatShortcutLabel = getAcceleratorDisplay(getActiveAccelerator('new-session'))
 
+  /** 归档会话只在用户打开归档视图时加载；active 视图只保留未归档元数据。 */
+  const refreshAgentSidebarSessions = React.useCallback(async (includeArchived: boolean): Promise<void> => {
+    const [activeSessions, archivedCount] = await Promise.all([
+      window.electronAPI.listActiveAgentSessions(),
+      window.electronAPI.countArchivedAgentSessions(),
+    ])
+    const sessions = includeArchived
+      ? [...activeSessions, ...(await window.electronAPI.listArchivedAgentSessions())]
+      : activeSessions
+    setAgentSessions(sessions)
+    setArchivedAgentSessionCount(archivedCount)
+  }, [setAgentSessions])
+
   const handleOpenSettings = React.useCallback((): void => {
     setSettingsOpen(true)
   }, [setSettingsOpen])
+
+  /** 归档视图按需加载归档列表，离开后恢复轻量 active 列表。 */
+  React.useEffect(() => {
+    if (mode !== 'agent') return
+    refreshAgentSidebarSessions(viewMode === 'archived').catch(console.error)
+  }, [mode, refreshAgentSidebarSessions, viewMode])
 
   const handleUpdateButtonClick = React.useCallback((): void => {
     setSettingsTab('about')
@@ -1021,13 +1041,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     [conversations]
   )
 
-  /** 已归档 Agent 会话数量（跨项目） */
-  const archivedAgentSessionCount = React.useMemo(
-    () => agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id)).length,
-    [agentSessions, draftSessionIds]
-  )
+  /** 已归档 Agent 会话数量由主进程轻量统计返回，active 视图不扫描归档元数据。 */
 
-  // 初始加载对话列表 + 用户档案 + Agent 会话
+  // 初始加载对话列表 + 用户档案
   React.useEffect(() => {
     window.electronAPI
       .listConversations()
@@ -1039,22 +1055,20 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       .getUserProfile()
       .then(setUserProfile)
       .catch(console.error)
-    window.electronAPI
-      .listAgentSessions()
-      .then(setAgentSessions)
-      .catch(console.error)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setConversations, setUserProfile, setAgentSessions])
+  }, [setConversations, setUserProfile])
 
   // 窗口聚焦时重新同步列表，修复长时间后前后端不一致
   React.useEffect(() => {
     const handleFocus = (): void => {
       window.electronAPI.listConversations().then(setConversations).catch(console.error)
-      window.electronAPI.listAgentSessions().then(setAgentSessions).catch(console.error)
+      if (mode === 'agent') {
+        refreshAgentSidebarSessions(viewMode === 'archived').catch(console.error)
+      }
     }
     window.addEventListener('focus', handleFocus)
     return () => window.removeEventListener('focus', handleFocus)
-  }, [setConversations, setAgentSessions])
+  }, [mode, refreshAgentSidebarSessions, setConversations, viewMode])
 
   /** 打开/关闭自动任务列表 */
   const handleOpenAutomations = React.useCallback((): void => {
@@ -1237,9 +1251,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           }
         }
         await window.electronAPI.deleteAgentSession(pendingDeleteId)
-        // 全量刷新确保与后端同步
-        const sessions = await window.electronAPI.listAgentSessions()
-        setAgentSessions(sessions)
+        // 按当前视图刷新：active 不重新加载归档元数据。
+        await refreshAgentSidebarSessions(viewMode === 'archived')
       } catch (error) {
         console.error('[侧边栏] 删除 Agent 会话失败:', error)
         // 即使后端报错，也从本地列表移除（可能是会话已不存在）
@@ -1421,13 +1434,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       setActiveTabId(nextActiveTabId)
       syncActiveTabSideEffects(nextActiveTabId ? nextTabs.find((tab) => tab.id === nextActiveTabId) ?? null : null)
 
-      const [remainingWorkspaces, sessions] = await Promise.all([
-        window.electronAPI.listAgentWorkspaces(),
-        window.electronAPI.listAgentSessions(),
-      ])
+      const remainingWorkspaces = await window.electronAPI.listAgentWorkspaces()
 
       setWorkspaces(remainingWorkspaces)
-      setAgentSessions(sessions)
+      await refreshAgentSidebarSessions(viewMode === 'archived')
 
       setExpandedExtraCountMap((prev) => {
         if (!prev.has(workspaceId)) return prev
@@ -1480,6 +1490,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     syncActiveTabSideEffects,
     setWorkspaces,
     setAgentSessions,
+    refreshAgentSidebarSessions,
+    viewMode,
     currentWorkspaceId,
     setCurrentWorkspaceId,
   ])
@@ -2011,14 +2023,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           await window.electronAPI.togglePinAgentSession(child.id)
         }
       }
-      const refreshedSessions = delegatedChildren.length > 0
-        ? await window.electronAPI.listAgentSessions()
-        : null
-      if (refreshedSessions) {
-        setAgentSessions(refreshedSessions)
-      } else {
-        setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
-      }
+      await refreshAgentSidebarSessions(viewMode === 'archived')
       if (updated.pinned) {
         if (original?.archived && !updated.archived) {
           toast.success('已置顶', { description: '已自动取消归档' })
@@ -2041,13 +2046,13 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       // 重新拉取磁盘真实状态，避免侧边栏与磁盘不一致直到下次重载。
       if (delegatedChildren.length > 0) {
         try {
-          setAgentSessions(await window.electronAPI.listAgentSessions())
+          await refreshAgentSidebarSessions(viewMode === 'archived')
         } catch (refreshError) {
           console.error('[侧边栏] 置顶失败后刷新会话列表失败:', refreshError)
         }
       }
     }
-  }, [draftSessionIds, store, setAgentSessions])
+  }, [draftSessionIds, refreshAgentSidebarSessions, setAgentSessions, store, viewMode])
 
   /** 切换 Agent 会话星标状态 */
   const handleToggleStarAgent = React.useCallback(async (id: string): Promise<void> => {
@@ -2086,14 +2091,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           }
         }
       }
-      const refreshedSessions = delegatedChildren.length > 0
-        ? await window.electronAPI.listAgentSessions()
-        : null
-      if (refreshedSessions) {
-        setAgentSessions(refreshedSessions)
-      } else {
-        setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
-      }
+      await refreshAgentSidebarSessions(viewMode === 'archived')
       // 归档时自动关闭该会话的标签页，并同步新激活标签的副作用，
       // 否则 RightSidePanel（依赖 currentAgentSessionIdAtom）会因为
       // 指针被错误置 null 而消失。
@@ -2118,13 +2116,13 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           closeArchivedAgentTabs(changedChildIds)
         }
         try {
-          setAgentSessions(await window.electronAPI.listAgentSessions())
+          await refreshAgentSidebarSessions(viewMode === 'archived')
         } catch (refreshError) {
           console.error('[侧边栏] 归档失败后刷新会话列表失败:', refreshError)
         }
       }
     }
-  }, [closeArchivedAgentTabs, draftSessionIds, store, setAgentSessions])
+  }, [closeArchivedAgentTabs, draftSessionIds, refreshAgentSidebarSessions, setAgentSessions, store, viewMode])
 
   /** 请求迁移会话到其他项目（弹出迁移对话框） */
   const handleRequestMove = React.useCallback((id: string): void => {
@@ -2138,8 +2136,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const handleSessionMoved = async (updatedSession: AgentSessionMeta, targetWorkspaceName: string): Promise<void> => {
     const movedSessionIds = collectDelegatedSessionTreeIds(store.get(agentSessionsAtom), updatedSession.id)
     try {
-      const sessions = await window.electronAPI.listAgentSessions()
-      setAgentSessions(sessions)
+      await refreshAgentSidebarSessions(viewMode === 'archived')
     } catch (error) {
       console.error('[侧边栏] 迁移后刷新 Agent 会话列表失败:', error)
       setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updatedSession))
@@ -2222,8 +2219,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     [agentProjectGroups, automationGroup, automationGroupOrder],
   )
 
-  /** Agent 归档会话按日期分组（跨项目），含委派树 */
+  /** Agent 归档会话按日期分组（跨项目），仅在归档视图已加载时构建。 */
   const archivedAgentSessionTrees = React.useMemo(() => {
+    if (viewMode !== 'archived') return []
     const archived = sortAgentSessionsByUpdatedAtDesc(
       agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id))
     )
@@ -2231,7 +2229,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     // groupByDate 要求 T extends { updatedAt: number }，AgentSessionTreeItem 不直接满足
     const wrapped = trees.map((tree) => ({ updatedAt: tree.session.updatedAt, tree }))
     return groupByDate(wrapped).map((g) => ({ label: g.label, items: g.items.map((w) => w.tree) }))
-  }, [agentSessions, draftSessionIds])
+  }, [agentSessions, draftSessionIds, viewMode])
 
   const handleRailModeSwitch = React.useCallback((targetMode: AppMode) => {
     setViewMode('active')
@@ -2692,6 +2690,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   }, [activeSessionId, agentIndicatorMap, archivedAgentSessionTrees, collapsedDelegationParentIds, expandedDelegationParentIds, handleAgentRename, handleRequestDelete, handleRequestMove, handleSelectAgentSession, handleToggleArchiveAgent, handleToggleDelegationParent, handleTogglePinAgent, handleToggleStarAgent, relativeTimeNow, sessionHoverPreviewEnabled, workspaceNameMap])
 
   const agentActiveVirtualRows = React.useMemo<VirtualSidebarRow[]>(() => {
+    if (viewMode !== 'active') return []
     const rows: VirtualSidebarRow[] = []
 
     const pushSessionTreeRows = (
@@ -3011,21 +3010,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setPendingRestoreProjectRootId,
     workspaceNameMap,
     currentWorkspaceId,
+    viewMode,
   ])
-
-  const activeAgentRowId = React.useMemo(() => {
-    if (!activeSessionId) return null
-    const directRow = agentActiveVirtualRows.find((row) => (
-      row.id === `agent-${activeSessionId}` || row.id === `agent-child-${activeSessionId}`
-    ))
-    if (directRow) return directRow.id
-
-    const parentItem = [
-      ...pinnedAgentSessionTrees,
-      ...displayProjectGroups.flatMap((group) => buildAgentSessionTrees(group.sessions)),
-    ].find((item) => treeContainsSessionId(item, activeSessionId))
-    return parentItem ? `agent-${parentItem.session.id}` : null
-  }, [activeSessionId, agentActiveVirtualRows, displayProjectGroups, pinnedAgentSessionTrees])
 
   // ===== 折叠状态：精简图标视图 =====
   if (sidebarCollapsed) {
@@ -3379,12 +3365,11 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           activeRowId={activeSessionId ? `chat-${activeSessionId}` : null}
         />
       ) : mode === 'agent' && viewMode === 'active' ? (
-        <VirtualSidebarList
-          key="agent-active-list"
-          className="flex-1 px-2 pb-3"
-          rows={agentActiveVirtualRows}
-          activeRowId={activeAgentRowId}
-        />
+        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin titlebar-no-drag px-2 pb-3">
+          {agentActiveVirtualRows.map((row) => (
+            <React.Fragment key={row.id}>{row.content}</React.Fragment>
+          ))}
+        </div>
       ) : (
         <>
           {/* 归档视图标题栏 */}

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -523,7 +523,7 @@ export function AutomationFormView({ standalone = false }: { standalone?: boolea
       if (!automationId) throw new Error('任务尚未创建')
       await window.electronAPI.runAutomationNow(automationId)
       await refreshAutomations()
-      const sessions = await window.electronAPI.listAgentSessions()
+      const sessions = await window.electronAPI.listActiveAgentSessions()
       setAgentSessions(sessions)
     } catch (err) {
       console.error('[定时任务] 立即运行失败:', err)

--- a/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
+++ b/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
@@ -73,7 +73,7 @@ export function AgentRecommendBanner(): React.ReactElement | null {
       await window.electronAPI.migrateChatToAgent(conversationId, session.id)
 
       // 3. 刷新会话列表
-      const sessions = await window.electronAPI.listAgentSessions()
+      const sessions = await window.electronAPI.listActiveAgentSessions()
       store.set(agentSessionsAtom, sessions)
 
       // 4. 切换到默认工作区（确保 AgentView 能正确显示新会话）

--- a/apps/electron/src/renderer/components/chat/MigrateToAgentButton.tsx
+++ b/apps/electron/src/renderer/components/chat/MigrateToAgentButton.tsx
@@ -60,7 +60,7 @@ export function MigrateToAgentButton({ conversationId }: MigrateToAgentButtonPro
       await window.electronAPI.migrateChatToAgent(conversationId, session.id)
 
       // 3. 刷新会话列表
-      const sessions = await window.electronAPI.listAgentSessions()
+      const sessions = await window.electronAPI.listActiveAgentSessions()
       store.set(agentSessionsAtom, sessions)
 
       // 4. 切换到默认工作区

--- a/apps/electron/src/renderer/components/ui/virtual-sidebar-list.tsx
+++ b/apps/electron/src/renderer/components/ui/virtual-sidebar-list.tsx
@@ -39,11 +39,21 @@ export function VirtualSidebarList({
     overscan,
   })
   const items = virtualizer.getVirtualItems()
+  const lastAutoScrolledRowIdRef = React.useRef<string | null>(null)
 
   React.useEffect(() => {
-    if (!activeRowId) return
+    if (!activeRowId) {
+      lastAutoScrolledRowIdRef.current = null
+      return
+    }
+    // 列表行会因状态更新或归档加载重建；这些变化不应打断用户手动滚动。
+    if (lastAutoScrolledRowIdRef.current === activeRowId) return
+
     const index = rows.findIndex((row) => row.id === activeRowId)
-    if (index >= 0) virtualizer.scrollToIndex(index, { align: 'auto', behavior: 'smooth' })
+    if (index < 0) return
+
+    lastAutoScrolledRowIdRef.current = activeRowId
+    virtualizer.scrollToIndex(index, { align: 'auto', behavior: 'auto' })
   }, [activeRowId, rows, virtualizer])
 
   return (

--- a/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
@@ -104,7 +104,7 @@ export function WelcomeView(): React.ReactElement {
         currentCreateChat({ draft: true })
       }).catch(console.error)
     } else {
-      window.electronAPI.listAgentSessions().then((freshSessions) => {
+      window.electronAPI.listActiveAgentSessions().then((freshSessions) => {
         // 如果 mode 已切换，丢弃过期回调
         if (initRef.current !== currentMode) return
         const {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -701,7 +701,7 @@ export function useGlobalAgentListeners(): void {
         return
       }
 
-      window.electronAPI.listAgentSessions()
+      window.electronAPI.listActiveAgentSessions()
         .then((sessions) => {
           unstable_batchedUpdates(() => applyActivation(sessions))
         })
@@ -898,7 +898,7 @@ export function useGlobalAgentListeners(): void {
     })
 
     // ===== 0. 初始化：从持久化 meta 恢复 stoppedByUser 状态 =====
-    window.electronAPI.listAgentSessions().then((sessions) => {
+    window.electronAPI.listActiveAgentSessions().then((sessions) => {
       const stoppedIds = new Set<string>(
         sessions.filter((s) => s.stoppedByUser).map((s) => s.id)
       )

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -528,7 +528,7 @@ function AutomationInitializer(): null {
   useEffect(() => {
     const load = (): void => {
       window.electronAPI.listAutomations().then(setAutomations).catch(console.error)
-      window.electronAPI.listAgentSessions().then(setAgentSessions).catch(console.error)
+      window.electronAPI.listActiveAgentSessions().then(setAgentSessions).catch(console.error)
     }
     load()
     const unsub = window.electronAPI.onAutomationChanged(load)
@@ -835,16 +835,24 @@ function TabStatePersistenceInitializer(): null {
 
   // 启动恢复：读取 settings.tabState + 校验会话有效性
   useEffect(() => {
-    Promise.all([
-      window.electronAPI.getSettings(),
-      window.electronAPI.listConversations(),
-      window.electronAPI.listAgentSessions(),
-    ]).then(([settings, conversations, agentSessions]) => {
+    const restore = async (): Promise<void> => {
+      const [settings, conversations, activeAgentSessions] = await Promise.all([
+        window.electronAPI.getSettings(),
+        window.electronAPI.listConversations(),
+        window.electronAPI.listActiveAgentSessions(),
+      ])
       const tabState = settings.tabState
-      if (!tabState?.tabs?.length) {
-        restoredRef.current = true
-        return
-      }
+      if (!tabState?.tabs?.length) return
+
+      // 已归档会话仅在上次打开的标签引用它时才读取，以兼容恢复该标签。
+      const activeAgentSessionIds = new Set(activeAgentSessions.map((session) => session.id))
+      const hasArchivedAgentTab = tabState.tabs.some(
+        (tab) => tab.type === 'agent' && !activeAgentSessionIds.has(tab.sessionId),
+      )
+      const archivedAgentSessions = hasArchivedAgentTab
+        ? await window.electronAPI.listArchivedAgentSessions()
+        : []
+      const agentSessions = [...activeAgentSessions, ...archivedAgentSessions]
 
       // 构建有效 sessionId 集合
       const validSessionIds = new Set([
@@ -864,10 +872,7 @@ function TabStatePersistenceInitializer(): null {
           (t.type === 'chat' || t.type === 'agent') &&
           validSessionIds.has(t.sessionId),
       )
-      if (validTabs.length === 0) {
-        restoredRef.current = true
-        return
-      }
+      if (validTabs.length === 0) return
 
       const validTabIds = new Set(validTabs.map((t) => t.id))
 
@@ -901,7 +906,9 @@ function TabStatePersistenceInitializer(): null {
       }
 
       console.log(`[TabRestore] 已恢复当前会话入口，历史标签 ${validTabs.length} 个已收敛到左侧列表`)
-    }).catch((err) => console.error('[TabRestore] 恢复标签页失败:', err))
+    }
+
+    restore().catch((err) => console.error('[TabRestore] 恢复标签页失败:', err))
       .finally(() => { restoredRef.current = true })
   }, [store])
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1651,6 +1651,12 @@ export const AGENT_IPC_CHANNELS = {
   // 会话管理
   /** 获取会话列表 */
   LIST_SESSIONS: 'agent:list-sessions',
+  /** 获取未归档会话列表，供左侧 active 视图使用 */
+  LIST_ACTIVE_SESSIONS: 'agent:list-active-sessions',
+  /** 获取归档会话列表，进入归档视图时按需调用 */
+  LIST_ARCHIVED_SESSIONS: 'agent:list-archived-sessions',
+  /** 获取归档会话数量，不返回归档元数据 */
+  COUNT_ARCHIVED_SESSIONS: 'agent:count-archived-sessions',
   /** 创建会话 */
   CREATE_SESSION: 'agent:create-session',
   /** 获取会话 SDKMessage（Phase 4 新格式） */


### PR DESCRIPTION
## Summary

- active Agent 侧栏默认只加载未归档会话，并通过主进程获取归档数量
- 进入归档视图时按需加载归档会话，保留归档列表虚拟化
- 移除 active Agent 列表虚拟化，保留分组、置顶、委派树和选中定位行为
- 修复侧栏会话状态刷新触发自动滚动、抢夺用户滚动位置的问题
- 补充 active/archive IPC、preload 与启动恢复路径的边界处理

## Verification

- `bun run typecheck`
- `bun run --filter='@proma/electron' build:main`
- `bun run --filter='@proma/electron' build:preload`
- `bun run --filter='@proma/electron' build:renderer`
- `bun test apps/electron/src/main/lib/agent-session-manager.test.ts apps/electron/src/renderer/lib/agent-session-list.test.ts` (30 pass, 0 fail)
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)