### PR TITLE
fix(agent): wait for AskUserQuestion responses

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.36",
+  "version": "0.17.37",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -732,6 +732,13 @@ export function canRunCurrentSessionCompaction(toolNames: string[]): boolean {
   return toolNames.length === 1 && toolNames[0] === 'CompactContext'
 }
 
+/** AskUserQuestion 必须暂停整个工具批次，不能与后续动作混合执行。 */
+export function shouldBlockToolForAskUserQuestion(toolNames: string[], toolName: string): boolean {
+  return toolName !== 'AskUserQuestion'
+    && toolNames.includes('AskUserQuestion')
+    && toolNames.length > 1
+}
+
 /**
  * Pi emits `agent_end` before it decides whether an error needs overflow
  * compaction. Keep this one error class local until the matching compaction
@@ -769,11 +776,19 @@ function installCurrentSessionCompactionHooks(session: AgentSession): void {
   const previousBeforeToolCall = session.agent.beforeToolCall
   session.agent.beforeToolCall = async (context, signal) => {
     const previousResult = await previousBeforeToolCall?.(context, signal)
-    if (previousResult?.block || context.toolCall.name !== 'CompactContext') return previousResult
+    if (previousResult?.block) return previousResult
 
     const toolNames = context.assistantMessage.content
       .filter((block) => block.type === 'toolCall')
       .map((block) => block.name)
+    if (shouldBlockToolForAskUserQuestion(toolNames, context.toolCall.name)) {
+      return {
+        block: true,
+        reason: 'AskUserQuestion 会暂停 Agent，不能与其他工具在同一批次执行。请在收到用户回答后再调用后续工具。',
+      }
+    }
+
+    if (context.toolCall.name !== 'CompactContext') return previousResult
     if (canRunCurrentSessionCompaction(toolNames)) return previousResult
 
     // Pi only honors terminate when every tool in a batch is terminating. Rejecting

--- a/apps/electron/src/main/lib/agent-ask-user-service.ts
+++ b/apps/electron/src/main/lib/agent-ask-user-service.ts
@@ -62,8 +62,6 @@ export class AgentAskUserService {
       toolInput: input,
     }
 
-    sendToRenderer(request)
-
     return new Promise<PermissionResult>((resolve) => {
       this.pendingRequests.set(request.requestId, { resolve, request })
 
@@ -73,6 +71,9 @@ export class AgentAskUserService {
           resolve({ behavior: 'deny', message: '操作已中止' })
         }
       }, { once: true })
+
+      // 先登记再通知，避免事件监听方同步提交答案时找不到 pending request。
+      sendToRenderer(request)
     })
   }
 


### PR DESCRIPTION
## Summary
- Register AskUserQuestion requests before notifying the renderer.
- Block other tools when a batch contains AskUserQuestion so actions wait for a user response.
- Bump the Electron patch version to 0.17.37.

## Validation
- `bun run typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)