### PR TITLE
Fix queued Agent message state

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -237,6 +237,8 @@ export class AgentOrchestrator {
 
   /** 被用户手动中止的运行代际（在 stop 中标记，在对应运行的终态路径消费）。 */
   private stoppedBySessions = new Map<string, number>()
+  /** 队列启动投影已显示、但运行槽尚未占用时的停止请求。 */
+  private stoppedBeforeRunSessions = new Set<string>()
 
   /** 运行中会话的当前权限模式（支持运行时动态切换） */
   private sessionPermissionModes = new Map<string, PromaPermissionMode>()
@@ -547,11 +549,16 @@ export class AgentOrchestrator {
     appendSDKMessages(sessionId, withTimestamps)
   }
 
-  private persistUserMessage(sessionId: string, userMessage: string, createdAt = Date.now()): string {
-    const uuid = randomUUID()
+  private persistUserMessage(
+    sessionId: string,
+    userMessage: string,
+    createdAt = Date.now(),
+    uuid?: string,
+  ): string {
+    const persistedUuid = uuid ?? randomUUID()
     const userSDKMsg: SDKMessage = {
       type: 'user',
-      uuid,
+      uuid: persistedUuid,
       message: {
         content: [{ type: 'text', text: userMessage }],
       },
@@ -559,7 +566,7 @@ export class AgentOrchestrator {
       _createdAt: createdAt,
     } as unknown as SDKMessage
     appendSDKMessages(sessionId, [userSDKMsg])
-    return uuid
+    return persistedUuid
   }
 
   private recordUserSkillActivations(
@@ -650,7 +657,7 @@ export class AgentOrchestrator {
     callbacks: SessionCallbacks,
     extensions: { piCustomTools?: ToolDefinition[] } = {},
   ): Promise<void> {
-    const { sessionId, userMessage, rawUserMessage, channelId, modelId, workspaceId: requestedWorkspaceId, additionalDirectories, permissionModeOverride, mentionedSkills, mentionedMcpServers, mentionedSessionIds, mentionedTodoIds, mentionedCalendarEventIds, automationContext, retryOfErrorUuid } = input
+    const { sessionId, userMessage, rawUserMessage, userMessageUuid, channelId, modelId, workspaceId: requestedWorkspaceId, additionalDirectories, permissionModeOverride, mentionedSkills, mentionedMcpServers, mentionedSessionIds, mentionedTodoIds, mentionedCalendarEventIds, automationContext, retryOfErrorUuid } = input
     const streamStartedAt = input.startedAt ?? Date.now()
     let userMessagePersisted = false
     let initialUserMessageUuid: string | undefined
@@ -660,7 +667,12 @@ export class AgentOrchestrator {
       if (userMessagePersisted) return
       // rawUserMessage 保留展示/持久化用的原始文本（@file 编码原文，remarkMentions 解码显示）；
       // userMessage 是传给 Agent 的 SDK 文本（@file 路径已解码为真实路径）。
-      initialUserMessageUuid = this.persistUserMessage(sessionId, rawUserMessage ?? userMessage)
+      initialUserMessageUuid = this.persistUserMessage(
+        sessionId,
+        rawUserMessage ?? userMessage,
+        Date.now(),
+        userMessageUuid,
+      )
       userMessagePersisted = true
     }
 
@@ -850,6 +862,10 @@ export class AgentOrchestrator {
     // 2.1 立即抢占会话槽位（在所有同步检查通过后、第一个 await 之前）
     // 防止 buildSdkEnv 等 await 期间并发调用绕过上方的检查，导致多条重复消息写入 JSONL
     // finally 块会通过 generation 匹配来安全清理，不影响正常流程
+    if (this.stoppedBeforeRunSessions.delete(sessionId)) {
+      callbacks.onComplete([], { stoppedByUser: true, startedAt: streamStartedAt })
+      return
+    }
     const runGeneration = ++this.nextRunGeneration
     this.activeSessions.set(sessionId, runGeneration)
     callbacks.onRunStarted?.({ startedAt: streamStartedAt })
@@ -2081,12 +2097,18 @@ export class AgentOrchestrator {
    * 先从 activeSessions 移除（供 sendMessage catch 块检测用户中止），
    * 再调用 adapter.abort() 中止底层 SDK 进程。
    */
-  stop(sessionId: string): void {
+  stop(sessionId: string, stopBeforeRun = false): void {
     const runGeneration = this.activeSessions.get(sessionId)
     this.activeSessions.delete(sessionId)
     this.sessionPermissionModes.delete(sessionId)
     browserController.cancelSession(sessionId)
-    if (runGeneration != null) this.stoppedBySessions.set(sessionId, runGeneration)
+    if (runGeneration != null) {
+      this.stoppedBySessions.set(sessionId, runGeneration)
+    } else if (stopBeforeRun) {
+      // 队列启动状态已投影给 renderer 后，run 仍可能卡在预检阶段。
+      // 记录这次停止，防止预检完成后错误地创建一个无法终止的新 query。
+      this.stoppedBeforeRunSessions.add(sessionId)
+    }
     this.queuedMessageUuids.delete(sessionId)
     this.adapter.abort(sessionId)
     console.log(`[Agent 编排] 已中止会话: ${sessionId}`)
@@ -2189,6 +2211,7 @@ export class AgentOrchestrator {
     this.adapter.dispose()
     this.activeSessions.clear()
     this.sessionPermissionModes.clear()
+    this.stoppedBeforeRunSessions.clear()
     this.queuedMessageUuids.clear()
     this.pendingUserSkillActivations.clear()
   }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -663,6 +663,18 @@ export class AgentOrchestrator {
     let initialUserMessageUuid: string | undefined
     let sessionMeta = getAgentSessionMeta(sessionId)
 
+    const completeBeforeRun = (options: {
+      stoppedByUser?: boolean
+      startedAt?: number
+    } = {}): void => {
+      const stoppedByUser = this.stoppedBeforeRunSessions.delete(sessionId)
+      callbacks.onComplete([], {
+        ...options,
+        startedAt: options.startedAt ?? streamStartedAt,
+        stoppedByUser: options.stoppedByUser === true || stoppedByUser,
+      })
+    }
+
     const persistInitialUserMessage = (): void => {
       if (userMessagePersisted) return
       // rawUserMessage 保留展示/持久化用的原始文本（@file 编码原文，remarkMentions 解码显示）；
@@ -706,7 +718,7 @@ export class AgentOrchestrator {
         const message = error instanceof Error ? error.message : String(error)
         console.error('[Agent 编排] 持久化用户消息失败:', error)
         callbacks.onError(`消息保存失败：${message}`)
-        callbacks.onComplete([], { startedAt: streamStartedAt })
+        completeBeforeRun()
         return
       }
     }
@@ -738,7 +750,7 @@ export class AgentOrchestrator {
         console.error('[Agent 编排] 持久化 preflight error 失败:', e)
       }
       callbacks.onError(errorContent)
-      callbacks.onComplete([], { startedAt: streamStartedAt })
+      completeBeforeRun()
     }
 
     // 会话元数据是运行项目的权威来源。渲染端的当前项目只是导航状态，不能
@@ -862,8 +874,8 @@ export class AgentOrchestrator {
     // 2.1 立即抢占会话槽位（在所有同步检查通过后、第一个 await 之前）
     // 防止 buildSdkEnv 等 await 期间并发调用绕过上方的检查，导致多条重复消息写入 JSONL
     // finally 块会通过 generation 匹配来安全清理，不影响正常流程
-    if (this.stoppedBeforeRunSessions.delete(sessionId)) {
-      callbacks.onComplete([], { stoppedByUser: true, startedAt: streamStartedAt })
+    if (this.stoppedBeforeRunSessions.has(sessionId)) {
+      completeBeforeRun({ stoppedByUser: true })
       return
     }
     const runGeneration = ++this.nextRunGeneration

--- a/apps/electron/src/main/lib/agent-queue-coordinator.ts
+++ b/apps/electron/src/main/lib/agent-queue-coordinator.ts
@@ -73,6 +73,10 @@ export class AgentQueueCoordinator {
     this.tryDispatch(sessionId)
   }
 
+  isDispatching(sessionId: string): boolean {
+    return this.dispatching.has(sessionId)
+  }
+
   clear(sessionId: string): void {
     this.queues.delete(sessionId)
     this.dispatching.delete(sessionId)
@@ -103,7 +107,7 @@ export class AgentQueueCoordinator {
         rawUserMessage: entry.input.rawUserMessage,
         startedAt,
     })
-    void this.options.startRun({ ...entry.input, startedAt }, webContents)
+    void this.options.startRun({ ...entry.input, startedAt, userMessageUuid: messageId }, webContents)
       .finally(() => {
         if (this.dispatching.get(sessionId) === messageId) this.dispatching.delete(sessionId)
       })

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -429,7 +429,7 @@ export async function generateAgentTitle(input: AgentGenerateTitleInput): Promis
  * 中止指定会话的 Agent 执行
  */
 export function stopAgent(sessionId: string): void {
-  orchestrator.stop(sessionId)
+  orchestrator.stop(sessionId, agentQueueCoordinator.isDispatching(sessionId))
 }
 
 setHeadlessAgentRunner(runAgentHeadless)

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -582,7 +582,7 @@ export function useGlobalAgentListeners(): void {
         })
         store.set(liveMessagesMapAtom, (prev) => {
           const current = prev.get(status.sessionId) ?? []
-          const uuid = `queued-${status.messageId}`
+          const uuid = status.messageId
           if (current.some((message) => (message as unknown as { uuid?: string }).uuid === uuid)) return prev
           const optimisticMessage: SDKMessage = {
             type: "user",
@@ -926,6 +926,33 @@ export function useGlobalAgentListeners(): void {
 
         if (payload.kind === 'proma_event' && payload.event.type === 'external_run_started') {
           activateExternalAgentRun(payload.event)
+        }
+
+        const runStartedEvent = payload.kind === 'proma_event' && payload.event.type === 'run_started'
+          ? payload.event
+          : null
+        if (runStartedEvent) {
+          // 队列 run 会先通过独立 IPC 发送 started 投影，但该投影可能在窗口
+          // 重载或跨 renderer 路由时丢失。run_started 是同一轮的第二个权威启动信号，
+          // 必须在首个 SDK/tool 事件之前恢复 running、startedAt 和正常的 live UI。
+          store.set(agentStreamingStatesAtom, (prev) => {
+            const current = prev.get(sessionId)
+            // 迟到的旧 run_started 不能重新激活当前更新的一轮运行；同一 run
+            // 已处于 running 时保留已有模型和上下文数据，避免重复初始化。
+            if (current?.startedAt != null && (
+              current.startedAt > runStartedEvent.startedAt
+              || (current.startedAt === runStartedEvent.startedAt && current.running)
+            )) return prev
+            const map = new Map(prev)
+            map.set(sessionId, createQueuedAgentStreamState(current, runStartedEvent.startedAt))
+            return map
+          })
+          store.set(unviewedCompletedSessionIdsAtom, (prev) => {
+            if (!prev.has(sessionId)) return prev
+            const next = new Set(prev)
+            next.delete(sessionId)
+            return next
+          })
         }
 
         // 自动任务会话被用户接管（毕业）：向用户提示，后续定时运行将新建独立会话

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1154,6 +1154,8 @@ export interface AgentSendInput {
   userMessage: string
   /** 仅用于持久化/展示的原始用户输入（保留 @file 编码原文，省略时回退到 userMessage） */
   rawUserMessage?: string
+  /** 预分配的用户消息 UUID，用于将主进程持久化消息与渲染端乐观消息去重。 */
+  userMessageUuid?: string
   /** 渠道 ID（用于获取 API Key） */
   channelId: string
   /** 模型 ID */


### PR DESCRIPTION
## Summary

- 修复排队 Agent 消息自动发送时的用户消息重复显示。
- 让队列消息复用同一个 UUID，统一渲染端乐观消息与主进程持久化消息。
- 修复队列启动预检阶段点击停止后仍继续启动 Agent 的竞态。
- 统一消费预检失败和启动前停止的 deferred stop 标记，避免误派发下一条消息或吞掉后续普通消息。
- 保留队列 run 的启动状态恢复，确保 Logo、计时、停止按钮和展开态及时显示。

## Test plan

- `bun run typecheck`
- `bun test ./apps/electron/src/renderer/lib/agent-message-queue.test.ts`
- 已按需求移除本次新增测试文件，保留仓库原有测试。

## Performance

低风险：改动集中在队列启动、停止和消息身份同步路径，不增加 token 流式热路径的更新频率。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)