### PR TITLE
perf(agent): 修复长时间运行后的累积性卡顿

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.37",
+  "version": "0.17.42",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -206,10 +206,42 @@ function migrateRetiredClaudeRuntime(index: AgentSessionsIndex): boolean {
 }
 
 /**
+ * 会话索引的内存缓存。
+ *
+ * 重度使用后索引可达数 MB（实测 3600 个会话约 6.4MB），单次 JSON.parse 约 11ms。
+ * 一轮 Agent 会多次读写索引，累计上百毫秒全部同步阻塞主进程，而键盘事件需要经主进程
+ * IPC 转发到 renderer，因此表现为“renderer 内无长任务但输入延迟尖尖”。
+ * 用 mtime+size 校验缓存：既避免重复解析，也允许测试与外部直接改写索引文件后被正确感知。
+ */
+let indexCache: { data: AgentSessionsIndex; mtimeMs: number; size: number } | null = null
+
+/** 按当前索引文件状态记录缓存；stat 失败时丢弃缓存而不是保留可疑数据。 */
+function cacheIndex(data: AgentSessionsIndex): void {
+  try {
+    const stat = statSync(getAgentSessionsIndexPath())
+    indexCache = { data, mtimeMs: stat.mtimeMs, size: stat.size }
+  } catch {
+    indexCache = null
+  }
+}
+
+/**
  * 读取会话索引文件
  */
 function readIndex(): AgentSessionsIndex {
   const indexPath = getAgentSessionsIndexPath()
+
+  if (indexCache) {
+    try {
+      const stat = statSync(indexPath)
+      if (indexCache.mtimeMs === stat.mtimeMs && indexCache.size === stat.size) {
+        return indexCache.data
+      }
+    } catch {
+      indexCache = null
+    }
+  }
+
   const data = readJsonFileSafe<AgentSessionsIndex>(indexPath)
   if (data) {
     const permissionModeMigrated = migrateLegacyPermissionMode(data)
@@ -217,6 +249,7 @@ function readIndex(): AgentSessionsIndex {
     const retiredClaudeRuntimeMigrated = migrateRetiredClaudeRuntime(data)
     if (permissionModeMigrated || thinkingDefaultMigrated || retiredClaudeRuntimeMigrated || data.version < INDEX_VERSION) {
       data.version = INDEX_VERSION
+      // writeIndex 会按写入后的文件状态刷新缓存。
       writeIndex(data)
       if (permissionModeMigrated) {
         console.log('[Agent 会话] 已迁移历史权限模式 auto → bypassPermissions')
@@ -227,6 +260,8 @@ function readIndex(): AgentSessionsIndex {
       if (retiredClaudeRuntimeMigrated) {
         console.log('[Agent 会话] 已将历史 Claude 会话迁移为 Pi transcript-only 会话')
       }
+    } else {
+      cacheIndex(data)
     }
     return data
   }
@@ -245,6 +280,7 @@ function writeIndex(index: AgentSessionsIndex): void {
 
   try {
     writeJsonFileAtomic(indexPath, index)
+    cacheIndex(index)
   } catch (error) {
     console.error('[Agent 会话] 写入索引文件失败:', error)
     throw new Error('写入 Agent 会话索引失败')
@@ -460,9 +496,14 @@ export function appendSDKMessages(id: string, messages: SDKMessage[]): void {
   const filePath = getAgentSessionMessagesPath(id)
 
   try {
+    // 整批只做一次同步追写：逐条 appendFileSync 会为每条消息各做一次 open/write/close，
+    // 一轮输出常见几十条消息，在多 Agent 并发下会持续阶段性阻塞主进程，
+    // 进而延迟键盘事件的 IPC 转发（表现为 renderer 内无长任务但输入延迟高）。
+    let payload = ''
     for (const message of messages) {
-      appendFileSync(filePath, serializeSDKMessageForStorage(message) + '\n', 'utf-8')
+      payload += serializeSDKMessageForStorage(message) + '\n'
     }
+    appendFileSync(filePath, payload, 'utf-8')
   } catch (error) {
     console.error(`[Agent 会话] 追加 SDKMessage 失败 (${id}):`, error)
     throw new Error('追加 SDKMessage 失败')

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -575,7 +575,7 @@ interface AgentTranscriptHistoryProps {
   taskNotificationSignature: string
   sessionPath?: string | null
   sessionModelId?: string
-  groupHistoryTurns: Map<MessageGroup, number>
+  groupHistoryTurns: Map<string, number>
   streaming: boolean
   stoppedByUser?: boolean
   onFork?: (upToMessageUuid: string) => void
@@ -591,6 +591,25 @@ interface AgentTranscriptHistoryProps {
 
 const EMPTY_LIVE_GROUP_SET: ReadonlySet<MessageGroup> = new Set()
 const EMPTY_MESSAGE_GROUPS: MessageGroup[] = []
+
+/**
+ * 比较两批 group 的“结构身份”是否一致。
+ *
+ * 流式期间只有活跃 turn 的 group 是新引用，历史前缀由 stabilizeMessageGroups 保持原引用。
+ * 因此这里以引用比较为主路径，只对确实变化的位置回退到 type/id 比较，避免每帧构造签名字符串。
+ */
+function haveSameGroupIdentities(previous: MessageGroup[], next: MessageGroup[]): boolean {
+  if (previous.length !== next.length) return false
+  for (let index = 0; index < previous.length; index++) {
+    const previousGroup = previous[index]
+    const nextGroup = next[index]
+    if (previousGroup === nextGroup) continue
+    if (!previousGroup || !nextGroup) return false
+    if (previousGroup.type !== nextGroup.type) return false
+    if (getGroupId(previousGroup) !== getGroupId(nextGroup)) return false
+  }
+  return true
+}
 
 function areTranscriptRowsEqual(
   previous: AgentTranscriptHistoryProps,
@@ -654,9 +673,10 @@ const AgentTranscriptRows = React.memo(function AgentTranscriptRows({
         const isLastAssistantTurn = !streaming && stoppedByUser
           && group.type === 'assistant-turn'
           && index === lastAssistantTurnIndex
+        const groupId = getGroupId(group)
 
         return (
-          <div key={getGroupId(group)} className="w-full pb-1">
+          <div key={groupId} className="w-full pb-1">
             <MessageGroupRenderer
               group={group}
               allMessages={group.type === 'assistant-turn' ? allMessages : EMPTY_SDK_MESSAGES}
@@ -671,7 +691,7 @@ const AgentTranscriptRows = React.memo(function AgentTranscriptRows({
               onRelinkProjectRoot={shouldDisableActions ? undefined : onRelinkProjectRoot}
               onRestoreProjectRoot={shouldDisableActions ? undefined : onRestoreProjectRoot}
               onCompact={shouldDisableActions ? undefined : onCompact}
-              historyTurn={groupHistoryTurns.get(group)}
+              historyTurn={groupHistoryTurns.get(groupId)}
               isStreaming={isLive || undefined}
               stoppedByUser={isLastAssistantTurn || undefined}
               sessionModelId={sessionModelId}
@@ -946,7 +966,10 @@ export const AgentMessages = React.memo(function AgentMessages({
     const live = liveMessages ?? []
     const stampStableKey = (message: SDKMessage): SDKMessage => {
       const key = getSDKMessageStableKey(message)
-      ;(message as Record<string, unknown>)._promaStableKey = key
+      const record = message as Record<string, unknown>
+      // 已标记且未变化时不重写：对老世代消息对象的属性写入会触发 GC 写屏障，
+      // 在数百条历史 × 高频 partial 下形成持续开销。
+      if (record._promaStableKey !== key) record._promaStableKey = key
       return message
     }
     const hasUuid = (message: SDKMessage): boolean => {
@@ -1021,6 +1044,23 @@ export const AgentMessages = React.memo(function AgentMessages({
   )
   visibleGroupsRef.current = visibleGroups
 
+  // 结构派生（迷你地图、用户锚点、turn 编号、sticky 布局）只关心 group 身份，不关心流式 token。
+  // 流式期间活跃 group 每帧都是新引用；若直接依赖 visibleGroups，getGroupPreview 与
+  // parseAttachedFiles 的正则会按 partial 帧率重跑整段历史。此处在身份未变时保持旧数组引用，
+  // 让这些派生只在真正新增/删除消息时重算。
+  const structuralGroupsRef = React.useRef<MessageGroup[]>(visibleGroups)
+  const structuralStreamingRef = React.useRef(streaming)
+  // 流式开始/结束时必须刷新一次：活跃 group 的 id 不变但正文从空到完整，
+  // 否则本轮迷你地图 preview 会永久停留在空值。
+  if (
+    structuralStreamingRef.current !== streaming
+    || !haveSameGroupIdentities(structuralGroupsRef.current, visibleGroups)
+  ) {
+    structuralStreamingRef.current = streaming
+    structuralGroupsRef.current = visibleGroups
+  }
+  const structuralGroups = structuralGroupsRef.current
+
   // 标记哪些 group 属于实时流式消息（用于 isStreaming / onFork 差异化渲染）
   const liveGroupSet = React.useMemo(() => {
     return buildLiveGroupSet({
@@ -1031,9 +1071,9 @@ export const AgentMessages = React.memo(function AgentMessages({
     })
   }, [allGroups, liveMessages, streaming, streamState?.startedAt])
 
-  // 迷你地图数据 — 直接使用统一的 allGroups（无需去重）
+  // 迷你地图数据 — 只依赖结构快照，流式 token 不触发 getGroupPreview 正则
   const minimapItems: MinimapItem[] = React.useMemo(
-    () => visibleGroups.map((group) => ({
+    () => structuralGroups.map((group) => ({
       id: getGroupId(group),
       role: group.type === 'user' ? 'user' as const
         : group.type === 'system' ? 'status' as const
@@ -1042,23 +1082,24 @@ export const AgentMessages = React.memo(function AgentMessages({
       avatar: group.type === 'user' ? userProfile.avatar : undefined,
       model: group.type === 'assistant-turn' ? group.model : undefined,
     })),
-    [visibleGroups, userProfile.avatar]
+    [structuralGroups, userProfile.avatar]
   )
 
-  // 同步 minimap 缓存到 Tab 级别（供 Tab hover 预览使用）
+  // 同步 minimap 缓存到 Tab 级别（供 Tab hover 预览使用）。
+  // 流式期间不写：本轮结束后统一同步一次，避免高频写入全局 atom 唤醒其他订阅者。
   React.useEffect(() => {
-    if (minimapItems.length > 0) {
-      setMinimapCache((prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, minimapItems)
-        return next
-      })
-    }
-  }, [sessionId, minimapItems, setMinimapCache])
+    if (streaming || minimapItems.length === 0) return
+    setMinimapCache((prev) => {
+      const next = new Map(prev)
+      next.set(sessionId, minimapItems)
+      return next
+    })
+  }, [sessionId, minimapItems, streaming, setMinimapCache])
 
-  // 所有用户消息的数据 — 供 StickyUserMessage 使用
+  // 所有用户消息的数据 — 供 StickyUserMessage 使用；只依赖结构快照，
+  // 避免流式期间重复解析已存在用户消息的附件标记。
   const allUserMessagesData = React.useMemo(() => {
-    return visibleGroups
+    return structuralGroups
       .filter((g): g is MessageGroup & { type: 'user' } => g.type === 'user')
       .map((g) => {
         const rawText = extractUserText(g.message) ?? ''
@@ -1069,7 +1110,7 @@ export const AgentMessages = React.memo(function AgentMessages({
           attachments: files.map((f) => ({ filename: f.filename, isImage: sdkIsImageFile(f.filename) })),
         }
       })
-  }, [visibleGroups])
+  }, [structuralGroups])
 
   // 实时消息中是否已有可渲染的助手内容
   // 流式中：通过 liveGroupSet 精确判断（只有 streaming 时 liveGroupSet 才非空）
@@ -1087,18 +1128,18 @@ export const AgentMessages = React.memo(function AgentMessages({
   // turn 在消息渲染时一次性标注到 DOM；历史划选只需读取锚点属性，绝不回扫全部消息。
   const groupHistoryTurns = React.useMemo(() => {
     let turn = 0
-    const turns = new Map<MessageGroup, number>()
-    for (const group of visibleGroups) {
+    const turns = new Map<string, number>()
+    for (const group of structuralGroups) {
       if (group.type === 'user') turn += 1
-      turns.set(group, Math.max(turn, 1))
+      turns.set(getGroupId(group), Math.max(turn, 1))
     }
     return turns
-  }, [visibleGroups])
+  }, [structuralGroups])
 
   const stickyLayoutSignature = React.useMemo(() => {
-    const firstGroup = visibleGroups[0]
-    return `${visibleGroups.length}:${firstGroup ? getGroupId(firstGroup) : ''}`
-  }, [visibleGroups])
+    const firstGroup = structuralGroups[0]
+    return `${structuralGroups.length}:${firstGroup ? getGroupId(firstGroup) : ''}`
+  }, [structuralGroups])
 
   return (
     <BasePathsProvider basePaths={messageBasePaths}>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -12,6 +12,7 @@ import { unstable_batchedUpdates } from 'react-dom'
 import { useStore } from 'jotai'
 import {
   agentStreamingStatesAtom,
+  agentSessionStreamingStateAtomFamily,
   agentStreamErrorsAtom,
   agentSessionMessageQueueAtom,
   agentSessionsAtom,
@@ -146,63 +147,69 @@ function deltaToLegacyControlEvents(delta: AgentAssistantDelta): AgentEvent[] {
   }]
 }
 
-function applyAssistantDeltaToPreview(
+function applyAssistantDeltasToPreview(
   message: SDKAssistantMessage,
-  delta: AgentAssistantDelta,
+  deltas: readonly AgentAssistantDelta[],
 ): SDKAssistantMessage {
+  if (deltas.length === 0) return message
+  // 整批 delta 共用一份 content 并只产出一个消息对象。
+  // batcher 会把同一帧内的几十个 delta 合并，逐个复制会在一帧内产生几十份
+  // content 数组与消息对象，在多 Agent 并发下形成持续的 GC 压力。
   const content = [...message.message.content] as SDKContentBlock[]
-  const index = 'contentIndex' in delta ? delta.contentIndex : undefined
-  const ensureBlock = (fallback: SDKContentBlock): number => {
-    if (index == null) {
-      content.push(fallback)
-      return content.length - 1
-    }
-    while (content.length <= index) content.push({ type: 'text', text: '' })
-    return index
-  }
-  const existing = index != null ? content[index] : undefined
-  switch (delta.type) {
-    case 'text_start':
-      content[ensureBlock({ type: 'text', text: '' })] = { type: 'text', text: '' }
-      break
-    case 'text_delta': {
-      const blockIndex = ensureBlock({ type: 'text', text: '' })
-      const text = existing?.type === 'text' && 'text' in existing && typeof existing.text === 'string' ? existing.text : ''
-      content[blockIndex] = { type: 'text', text: text + delta.delta }
-      break
-    }
-    case 'text_end':
-      content[ensureBlock({ type: 'text', text: '' })] = { type: 'text', text: delta.content }
-      break
-    case 'thinking_start':
-      content[ensureBlock({ type: 'thinking', thinking: '' })] = { type: 'thinking', thinking: '' }
-      break
-    case 'thinking_delta': {
-      const blockIndex = ensureBlock({ type: 'thinking', thinking: '' })
-      const thinking = existing?.type === 'thinking' && 'thinking' in existing && typeof existing.thinking === 'string' ? existing.thinking : ''
-      content[blockIndex] = { type: 'thinking', thinking: thinking + delta.delta }
-      break
-    }
-    case 'thinking_end':
-      content[ensureBlock({ type: 'thinking', thinking: '' })] = { type: 'thinking', thinking: delta.content }
-      break
-    case 'toolcall_start':
-    case 'toolcall_delta':
-    case 'toolcall_end': {
-      const toolCall = delta.toolCall
-      if (!toolCall) break
-      const blockIndex = ensureBlock({ type: 'tool_use', id: toolCall.id, name: toolCall.name, input: {} })
-      const previous = content[blockIndex]
-      content[blockIndex] = {
-        type: 'tool_use',
-        id: toolCall.id,
-        name: toolCall.name,
-        input: toolCall.arguments ?? (previous?.type === 'tool_use' && 'input' in previous ? previous.input : {}),
+  for (const delta of deltas) {
+    const index = 'contentIndex' in delta ? delta.contentIndex : undefined
+    const ensureBlock = (fallback: SDKContentBlock): number => {
+      if (index == null) {
+        content.push(fallback)
+        return content.length - 1
       }
-      break
+      while (content.length <= index) content.push({ type: 'text', text: '' })
+      return index
     }
-    case 'start':
-      break
+    const existing = index != null ? content[index] : undefined
+    switch (delta.type) {
+      case 'text_start':
+        content[ensureBlock({ type: 'text', text: '' })] = { type: 'text', text: '' }
+        break
+      case 'text_delta': {
+        const blockIndex = ensureBlock({ type: 'text', text: '' })
+        const text = existing?.type === 'text' && 'text' in existing && typeof existing.text === 'string' ? existing.text : ''
+        content[blockIndex] = { type: 'text', text: text + delta.delta }
+        break
+      }
+      case 'text_end':
+        content[ensureBlock({ type: 'text', text: '' })] = { type: 'text', text: delta.content }
+        break
+      case 'thinking_start':
+        content[ensureBlock({ type: 'thinking', thinking: '' })] = { type: 'thinking', thinking: '' }
+        break
+      case 'thinking_delta': {
+        const blockIndex = ensureBlock({ type: 'thinking', thinking: '' })
+        const thinking = existing?.type === 'thinking' && 'thinking' in existing && typeof existing.thinking === 'string' ? existing.thinking : ''
+        content[blockIndex] = { type: 'thinking', thinking: thinking + delta.delta }
+        break
+      }
+      case 'thinking_end':
+        content[ensureBlock({ type: 'thinking', thinking: '' })] = { type: 'thinking', thinking: delta.content }
+        break
+      case 'toolcall_start':
+      case 'toolcall_delta':
+      case 'toolcall_end': {
+        const toolCall = delta.toolCall
+        if (!toolCall) break
+        const blockIndex = ensureBlock({ type: 'tool_use', id: toolCall.id, name: toolCall.name, input: {} })
+        const previous = content[blockIndex]
+        content[blockIndex] = {
+          type: 'tool_use',
+          id: toolCall.id,
+          name: toolCall.name,
+          input: toolCall.arguments ?? (previous?.type === 'tool_use' && 'input' in previous ? previous.input : {}),
+        }
+        break
+      }
+      case 'start':
+        break
+    }
   }
   return { ...message, message: { ...message.message, content }, _partial: true } as SDKAssistantMessage
 }
@@ -908,21 +915,10 @@ export function useGlobalAgentListeners(): void {
     }).catch(console.error)
 
     // ===== 1. 流式事件 =====
-    // [FLASH-DEBUG] 事件频率计数器
-    let eventCount = 0
-    let lastLogTime = Date.now()
     const handleStreamEvent = (streamEvent: AgentStreamEvent): void => {
-        // [FLASH-DEBUG] 每 2 秒输出一次事件频率
-        eventCount++
-        const now = Date.now()
-        if (now - lastLogTime >= 2000) {
-          console.log(`[FLASH-DEBUG] GlobalListener: ${eventCount} events in ${((now - lastLogTime) / 1000).toFixed(1)}s (${(eventCount / ((now - lastLogTime) / 1000)).toFixed(1)} evt/s)`)
-          eventCount = 0
-          lastLogTime = now
-        }
+        const { sessionId, payload } = streamEvent
 
         unstable_batchedUpdates(() => {
-        const { sessionId, payload } = streamEvent
 
         if (payload.kind === 'proma_event' && payload.event.type === 'external_run_started') {
           activateExternalAgentRun(payload.event)
@@ -975,7 +971,7 @@ export function useGlobalAgentListeners(): void {
         // Phase 2: 直接累积 SDKMessage 到 liveMessagesMapAtom（跳过 replay 消息，避免与持久化消息重复）
         if (payload.kind === 'sdk_delta') {
           const deltaPayload = payload.delta
-          const currentRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+          const currentRunStartedAt = store.get(agentSessionStreamingStateAtomFamily(sessionId))?.startedAt
           // Delta 必须携带产生它的 run 标识。迟到的旧 run Delta 不能借用当前 run，
           // 否则会被 live-group-set 误判为新一轮消息；无标识的旧协议事件也不强行归类。
           if (currentRunStartedAt != null && deltaPayload.runStartedAt !== currentRunStartedAt) return
@@ -1002,7 +998,7 @@ export function useGlobalAgentListeners(): void {
                 ...(provider ? { _channelProvider: provider } : {}),
                 ...(deltaRunStartedAt != null ? { _promaLiveRunStartedAt: deltaRunStartedAt } : {}),
               })
-            const nextMessage = deltaPayload.deltas.reduce(applyAssistantDeltaToPreview, existing)
+            const nextMessage = applyAssistantDeltasToPreview(existing, deltaPayload.deltas)
             // live-group-set 依赖 run 标记区分当前队列轮次；Delta 预览也必须携带它，
             // 否则 transcript 已有 assistant，但会被误判为非 live 并额外渲染 smooth fallback。
             const markedMessage = deltaRunStartedAt != null
@@ -1023,15 +1019,12 @@ export function useGlobalAgentListeners(): void {
           // 不会触碰 AgentStreamState，从而避免重新引入逐 token 的第二次 Map 更新。
           const hasAssistantActivity = deltaPayload.deltas.some((delta) => delta.type !== 'start')
           if (hasAssistantActivity) {
-            store.set(agentStreamingStatesAtom, (prev) => {
-              const current = prev.get(sessionId)
+            store.set(agentSessionStreamingStateAtomFamily(sessionId), (current) => {
               const shouldResume = current?.retrying !== undefined
                 || current?.contextCompaction?.status === 'success'
                 || current?.contextCompaction?.status === 'noop'
-              if (!current || !shouldResume) return prev
-              const map = new Map(prev)
-              map.set(sessionId, resumeAgentStreamState(current))
-              return map
+              if (!current || !shouldResume) return current
+              return resumeAgentStreamState(current)
             })
           }
         }
@@ -1046,7 +1039,7 @@ export function useGlobalAgentListeners(): void {
             // thinking_tokens 是高频进度估算，只更新流式状态，不进入消息转录。
           } else if (!msgRecord.isReplay) {
             // 当前 run 的 assistant 消息沿用 run 起始时间，与首个 Delta 预览和乐观 header 保持一致。
-            const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+            const activeRunStartedAt = store.get(agentSessionStreamingStateAtomFamily(sessionId))?.startedAt
             // 为实时消息补充 _createdAt 时间戳（与持久化时的逻辑一致），
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
             if (typeof msgRecord._createdAt !== 'number') {
@@ -1115,7 +1108,7 @@ export function useGlobalAgentListeners(): void {
         for (const event of legacyEvents) {
           // 带 run 标识的 retry 事件必须在所有外围副作用前严格匹配当前流；
           // 否则旧 IPC 事件会复活已结束的 stream，或错误清掉新 run 的完成提醒。
-          const eventStreamState = store.get(agentStreamingStatesAtom).get(sessionId)
+          const eventStreamState = store.get(agentSessionStreamingStateAtomFamily(sessionId))
           if (isRunScopedRetryEvent(event) && event.runStartedAt != null && (
             !eventStreamState || !isRetryEventForCurrentStream(eventStreamState, event)
           )) {
@@ -1124,7 +1117,7 @@ export function useGlobalAgentListeners(): void {
 
           // 会话首次进入 running 时，清除旧的完成提醒状态
           if (event.type !== 'prompt_suggestion') {
-            const prevState = store.get(agentStreamingStatesAtom).get(sessionId)
+            const prevState = store.get(agentSessionStreamingStateAtomFamily(sessionId))
             if (!prevState || !prevState.running) {
               store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
                 if (!prev.has(sessionId)) return prev
@@ -1137,13 +1130,12 @@ export function useGlobalAgentListeners(): void {
 
           // 更新流式状态（prompt_suggestion 不影响流式状态，跳过以避免在 session 结束后用默认值 running:true 重新激活）
           if (event.type !== 'prompt_suggestion') {
-            store.set(agentStreamingStatesAtom, (prev) => {
-              const existing = prev.get(sessionId)
+            store.set(agentSessionStreamingStateAtomFamily(sessionId), (existing) => {
               // 再做一次 scope 校验，防止同一 batch 内其它回调更新流状态后旧事件落入。
               if (isRunScopedRetryEvent(event) && event.runStartedAt != null && (
                 !existing || !isRetryEventForCurrentStream(existing, event)
               )) {
-                return prev
+                return existing
               }
               const current: AgentStreamState = existing ?? {
                 running: true,
@@ -1151,14 +1143,11 @@ export function useGlobalAgentListeners(): void {
                 // 无 run 标识的历史事件才允许 fallback；带标识的 retry 必须已在上方匹配。
                 startedAt: undefined,
               }
-              const next = applyAgentEvent(current, event)
-              const map = new Map(prev)
-              map.set(sessionId, next)
-              return map
+              return applyAgentEvent(current, event)
             })
           }
 
-          const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+          const activeRunStartedAt = store.get(agentSessionStreamingStateAtomFamily(sessionId))?.startedAt
           if (activeRunStartedAt != null) {
             const activeRunId = String(activeRunStartedAt)
             store.set(agentFileChangesCurrentRunAtom, (prev) => {
@@ -1172,7 +1161,7 @@ export function useGlobalAgentListeners(): void {
           // Pi 原生重试成功后仍会沿用同一会话；仅在事件属于当前 stream run 时
           // 清掉过期错误，避免迟到的旧 retry_cleared 掩盖新一轮真实失败。
           if (event.type === 'retry_cleared') {
-            const current = store.get(agentStreamingStatesAtom).get(sessionId)
+            const current = store.get(agentSessionStreamingStateAtomFamily(sessionId))
             if (current && isRetryEventForCurrentStream(current, event)) {
               store.set(agentStreamErrorsAtom, (prev) => clearAgentStreamError(prev, sessionId))
             }
@@ -1188,7 +1177,7 @@ export function useGlobalAgentListeners(): void {
               ?? (input?.path as string | undefined)
               ?? (input?.notebook_path as string | undefined)
             const runId = store.get(agentFileChangesCurrentRunAtom).get(sessionId)
-              ?? String(store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt ?? event.turnId ?? Date.now())
+              ?? String(store.get(agentSessionStreamingStateAtomFamily(sessionId))?.startedAt ?? event.turnId ?? Date.now())
             const entry = {
               path: targetPath || '',
               sessionId,
@@ -1443,12 +1432,9 @@ export function useGlobalAgentListeners(): void {
             )
           } else if (event.type === 'run_resumed') {
             // 后台任务完成自动唤醒：从"空闲可输入"恢复到"运行中"。
-            store.set(agentStreamingStatesAtom, (prev) => {
-              const current = prev.get(sessionId)
-              if (!current || current.running) return prev
-              const map = new Map(prev)
-              map.set(sessionId, { ...current, running: true })
-              return map
+            store.set(agentSessionStreamingStateAtomFamily(sessionId), (current) => {
+              if (!current || current.running) return current
+              return { ...current, running: true }
             })
           }
         }
@@ -1465,7 +1451,6 @@ export function useGlobalAgentListeners(): void {
       (data: AgentStreamCompletePayload) => {
         // 无终态 assistant 的异常路径也不能让等待中的 partial 在完成后倒灌。
         streamEventBatcher.clear(data.sessionId)
-        console.log(`[FLASH-DEBUG] STREAM_COMPLETE for session=${data.sessionId.slice(0, 8)}, stoppedByUser=${data.stoppedByUser}, resultSubtype=${data.resultSubtype}`)
         unstable_batchedUpdates(() => {
         // 后台任务等待态：turn 主体结束但仍有后台任务在飞行，UI 进入"空闲可输入"。
         // 不发"任务已完成"通知（任务并未真正完成）、不清后台任务列表、不重载消息——
@@ -1619,6 +1604,41 @@ export function useGlobalAgentListeners(): void {
 
           // 清理后台任务
           store.set(backgroundTasksAtomFamily(data.sessionId), [])
+
+          // 后台会话没有挂载的 AgentView 来执行收尾清理（MainArea 只渲染活动 Tab）。
+          // 若不在此处回收，liveMessagesMap 与流式状态索引会随运行时长单调增长，
+          // 让每个 delta 的 Map 复制与聚合读取越来越慢（表现为“同样 1 个 Agent 越跑越卡”）。
+          // 可见会话仍由 AgentView 在消息加载完成后清理，以保留防闪烁语义。
+          if (store.get(activeSessionIdAtom) !== data.sessionId) {
+            store.set(liveMessagesMapAtom, (prev) => {
+              if (!prev.has(data.sessionId)) return prev
+              const map = new Map(prev)
+              map.delete(data.sessionId)
+              return map
+            })
+            store.set(agentSessionStreamingStateAtomFamily(data.sessionId), (state) => {
+              if (!state || state.running || state.backgroundWaiting) return state
+              // 上下文用量圆环需要 usage；其余运行态随本轮结束回收。
+              if (state.inputTokens !== undefined) {
+                return {
+                  running: false,
+                  inputTokens: state.inputTokens,
+                  outputTokens: state.outputTokens,
+                  cacheReadTokens: state.cacheReadTokens,
+                  cacheCreationTokens: state.cacheCreationTokens,
+                  contextWindow: state.contextWindow,
+                  contextUsageIsEstimated: state.contextUsageIsEstimated,
+                  model: state.model,
+                  contextCompaction: state.contextCompaction,
+                }
+              }
+              if (state.contextCompaction) {
+                return { running: false, contextCompaction: state.contextCompaction }
+              }
+              // 无需保留的会话彼底移出索引，避免聚合视图无限遍历。
+              return undefined
+            })
+          }
 
           // 清理该 session 关联的未完成写工具记录，防止内存泄漏
           for (const [toolId, entry] of pendingWriteTools) {


### PR DESCRIPTION
## 问题

长时间运行后输入、会话切换和 Agent 历史滚动持续变卡，且**与并发 Agent 数无关**。本地性能日志按时间分桶后，证据很明确：

| 运行时长 | 运行中 Agent | keydown 平均 | P95 |
| --- | --- | --- | --- |
| 启动初期 | 中位 1 | 19ms | 38ms |
| 20 分钟后 | 中位 1（max 1） | 35ms | **166ms** |
| 30 分钟后 | 中位 1 | 57ms | **185ms** |

并发数完全相同，延迟涨了近 5 倍——这是**累积性退化**，不是并发压力。

## 定位过程中排除的方向

- **不是历史 DOM 规模**：滚动帧间隔与历史高度无相关性（`<3k` 高度 176ms vs `15-40k` 高度 177ms）；修复后 32447px 的历史滚动中位仍为 19ms。
- **不是 renderer 长任务**：174 次高延迟 keydown 与 Long Task 记录**零重合**，React commit 全程低于 8ms。键盘事件需经主进程 IPC 转发，因此主进程的同步阻塞在 renderer 内完全观测不到。
- renderer 进程采样热点集中在 `cppgc::WriteBarrier` / `MoveTracedReference`，指向 GC 压力而非渲染。

## 修改内容

| 位置 | 问题 | 修改 |
| --- | --- | --- |
| `useGlobalAgentListeners.applyAssistantDeltasToPreview` | batcher 会合并一帧内的 delta（实测单帧最多 47 个），原先逐个 delta 都完整复制 `content` 数组与消息对象 | 整批只复制一次 |
| `agent-session-manager.readIndex/writeIndex` | 索引在 3600 会话时约 6.4MB，单次 `JSON.parse` 约 11ms；`updateAgentSessionMeta` 一轮被调用 5-10 次 | 增加 `mtime+size` 校验的内存缓存 |
| `useGlobalAgentListeners.finalize` | liveMessages 与 streaming state 的清理只由挂载中的 `AgentView` 执行，而 `MainArea` 只渲染活动 Tab，后台会话跑完后运行态永久驻留 | 非可见会话完成时回收，保留 usage 与 `backgroundWaiting` |
| `agent-session-manager.appendSDKMessages` | 一轮常有几十条消息，逐条 `appendFileSync` 各做一次 open/write/close | 整批拼接后一次追写 |
| `useGlobalAgentListeners.handleStreamEvent` | 10 处聚合 `agentStreamingStatesAtom` 读写，成本随累计会话数增长 | 改为 per-session family 直读，`O(事件 × 累计会话)` → `O(事件)` |
| `AgentMessages.stampStableKey` | 每帧对全部历史消息无条件写 `_promaStableKey`，触发 GC 写屏障 | 增加值相等守卫 |
| `AgentMessages` 结构派生 | 迷你地图、用户锚点、turn 编号每个 delta 都重跑 `getGroupPreview` / `parseAttachedFiles` 的正则 | 改为只依赖 group 身份快照；`groupHistoryTurns` 相应改为按 group id 索引 |

## 性能影响

**影响等级**：性能修复，无功能行为变更。

**压力来源**：Agent 流式输出（前台约 20fps partial）、多会话并发、长历史会话、随使用增长的会话索引。

**控制手段**：降低每帧分配、回收后台会话运行态、消除主进程重复全量解析、把热路径的聚合读改为按会话直读。

**实测结果**（Electron 真实运行，2-6 个并发 Agent，连续运行 50 分钟）：

| 指标 | 修复前 | 修复后稳定态 |
| --- | --- | --- |
| keydown 平均 / P95 | 42.6ms / 227.7ms | **16.3ms / 28.9ms** |
| keydown > 100ms | 228 / 2136 | **1 / 1811** |
| 真实渲染帧率 | 未测 | **中位 60fps**，957 个采样窗口仅 1 个低于 55fps |
| Agent 历史滚动中位帧间隔 | 33ms | **19ms**（历史高度 32447px） |
| 侧边栏滚动中位帧间隔 | 36ms | **23ms** |
| 累积退化 | 固定 1 Agent，20 分钟后 P95 38→185ms | **后期优于前期**，P95 稳定 28-32ms |

**语义保留验证**：
- 后台会话回收保留 usage 数据（上下文用量圆环）与 `backgroundWaiting`（软空闲判定，避免 `handleSend` 误走新建 run 路径）。
- 索引缓存用 `mtime+size` 校验而非常驻，测试与外部直接改写索引文件仍能被正确感知；`agent-session-manager` 21 个测试全部通过。
- 上索引缓存前逐个核对了全部 14 个 `readIndex` 调用点：5 个只读路径不修改对象，8 个修改对象的都会 `writeIndex`（`moveSessionToWorkspace` 的写盘在 743 行）。
- 结构派生在流式状态翻转时强制刷新一次快照，避免活跃 group id 不变但正文由空变完整时迷你地图预览停留在空值。

**剩余风险**：
- 索引写入侧仍是每次同步 `stringify` + 写盘（约 8.4ms + 磁盘）。写入合并（防抖）可再省约 80ms/轮，但需权衡崩溃丢失 metadata 并在退出前 flush，本 PR 未做。
- 早期观测到的少量 `>200ms` keydown 尖峰集中在启动后 6-22 分钟，与上述写入侧成本相关；稳定态后已消失（最近 16 分钟 1811 次采样中仅 1 次 >100ms）。

## 测试

- `bun run typecheck` 全部包通过
- `bun test apps/electron/src`：396 pass / 4 fail
- 那 4 个失败已用临时 worktree 检出干净 `origin/main` 对照，结果完全一致（同为 396 pass / 4 fail），是 `bun test` 无法加载 Electron 主进程 API 的既有环境问题（`Export named 'BrowserWindow' not found`），与本 PR 无关
- Electron main / preload / renderer 三段构建通过

诊断期间使用的性能日志代码（`performance-diagnostics-service.ts`、`renderer.frames` / `agent.stream.window` 采集、滚动与 resize 监测、`React.Profiler` 包裹）已全部从本 PR 移除，仅保留修复本身。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)