### PR TITLE
fix(voice): reset lifecycle before restart

### DIFF
--- a/apps/electron/src/main/lib/voice-dictation-window.ts
+++ b/apps/electron/src/main/lib/voice-dictation-window.ts
@@ -21,7 +21,9 @@ const INDICATOR_WIDTH = 360
 const INDICATOR_HEIGHT = 110
 const INDICATOR_BOTTOM_MARGIN = 28
 
-let voiceDictationActive = false
+type VoiceDictationLifecycleState = 'idle' | 'active' | 'stopping'
+
+let voiceDictationState: VoiceDictationLifecycleState = 'idle'
 let usesExternalIndicator = false
 let indicatorState: 'preparing' | 'recording' | 'stopping' = 'preparing'
 let indicatorVolume = 0
@@ -53,7 +55,13 @@ export function toggleVoiceDictationWindow(options: VoiceDictationToggleOptions 
   if (!mainWindow || mainWindow.isDestroyed()) return
   installVoiceDictationMediaPermissions(mainWindow)
 
-  if (voiceDictationActive) {
+  if (voiceDictationState === 'stopping') {
+    // 停止/提交尚未完成时，忽略重复点击，避免旧会话与新会话交叉。
+    return
+  }
+
+  if (voiceDictationState === 'active') {
+    voiceDictationState = 'stopping'
     indicatorState = 'stopping'
     sendIndicatorState()
     mainWindow.webContents.send(VOICE_DICTATION_IPC_CHANNELS.TOGGLE_STOP)
@@ -66,7 +74,7 @@ export function toggleVoiceDictationWindow(options: VoiceDictationToggleOptions 
   const outputContextId = randomUUID()
   beginVoiceDictationOutputContext(outputContextId, { routeToPromaInput, outputMode })
   activeOutputContextId = outputContextId
-  voiceDictationActive = true
+  voiceDictationState = 'active'
   usesExternalIndicator = !targetIsProma
   indicatorState = 'preparing'
   indicatorVolume = 0
@@ -82,7 +90,7 @@ export function toggleVoiceDictationWindow(options: VoiceDictationToggleOptions 
 
 /** 听写完成、取消或失败后关闭所有可见状态。 */
 export function hideVoiceDictationWindow(): void {
-  voiceDictationActive = false
+  voiceDictationState = 'idle'
   usesExternalIndicator = false
   indicatorVolume = 0
   indicatorTranscript = ''

--- a/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
+++ b/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
@@ -187,21 +187,22 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
     const outputContextId = dictationOutputContextRef.current
     discardCurrentTranscript()
     if (!text) {
-      setStatus('idle')
       setMessage('没有识别到语音内容')
-      setDictationSource(null)
-      setDictationTarget(null)
-      setDictationOutputContext(null)
       cleanupAudio()
       if (asrSessionId) {
-        window.electronAPI.cancelVoiceDictation({
+        await window.electronAPI.cancelVoiceDictation({
           sessionId: asrSessionId,
           previewSessionId: dictationSessionId ?? undefined,
           targetInputId,
           outputContextId: outputContextId ?? undefined,
         }).catch(console.error)
       }
-      setTimeout(() => window.electronAPI.hideVoiceDictation().catch(console.error), 180)
+      // 主进程复位完成后再让按钮恢复 idle，避免下一次点击被旧会话吞掉。
+      await window.electronAPI.hideVoiceDictation().catch(console.error)
+      setStatus('idle')
+      setDictationSource(null)
+      setDictationTarget(null)
+      setDictationOutputContext(null)
       return
     }
 
@@ -214,6 +215,8 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
         targetInputId,
         outputContextId: outputContextId ?? undefined,
       })
+      // 先让主进程释放旧会话，再把按钮恢复为可开始状态。
+      await window.electronAPI.hideVoiceDictation().catch(console.error)
       setCommitResult(result)
       setStatus('completed')
       setMessage(result.message)
@@ -225,7 +228,6 @@ export function VoiceDictationApp({ embedded = false }: { embedded?: boolean }):
       setDictationTarget(null)
       setDictationOutputContext(null)
       cleanupAudio()
-      setTimeout(() => window.electronAPI.hideVoiceDictation().catch(console.error), 280)
     } catch (error) {
       commitInFlightRef.current = false
       const textMessage = error instanceof Error ? error.message : '未知错误'


### PR DESCRIPTION
## Summary
- make voice dictation lifecycle explicit across active and stopping phases
- release the main-process session before restoring the microphone button to idle

## Validation
- bun run typecheck
- bun test apps/electron/src/renderer/components/voice-dictation/voice-transcript-merge.test.ts apps/electron/src/renderer/lib/voice-dictation-preview.test.ts

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)