### PR TITLE
Fix agent stream output following

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -37,8 +37,9 @@ import { buildLiveGroupSet } from './live-group-set'
 import { AgentBrowserLinkProvider } from '@/components/browser/AgentBrowserLinkProvider'
 import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
+import { TASK_TOOL_NAMES } from './task-progress'
 import { createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
-import type { AgentEventUsage, RetryAttempt, SDKAssistantMessage, SDKMessage, SDKSystemMessage } from '@proma/shared'
+import type { AgentEventUsage, RetryAttempt, SDKAssistantMessage, SDKMessage, SDKSystemMessage, SDKTextBlock, SDKThinkingBlock, SDKToolUseBlock } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
 import { agentLiveMessagesAtomFamily, agentSessionStreamingStateAtomFamily, type AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
@@ -97,7 +98,14 @@ export function isCompactionControlHistoryGroup(group: MessageGroup): boolean {
 }
 
 function hasRenderableAssistantMessage(message: SDKAssistantMessage): boolean {
-  return message.error != null || message.message.content.length > 0
+  if (message.error != null) return true
+
+  return message.message.content.some((block) => {
+    if (block.type === 'text') return Boolean((block as SDKTextBlock).text)
+    if (block.type === 'thinking') return Boolean((block as SDKThinkingBlock).thinking)
+    if (block.type === 'tool_use') return !TASK_TOOL_NAMES.has((block as SDKToolUseBlock).name)
+    return false
+  })
 }
 
 export function hasRenderableAssistantTurnContent(group: MessageGroup): boolean {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -38,7 +38,7 @@ import { AgentBrowserLinkProvider } from '@/components/browser/AgentBrowserLinkP
 import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
 import { createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
-import type { AgentEventUsage, RetryAttempt, SDKMessage, SDKSystemMessage } from '@proma/shared'
+import type { AgentEventUsage, RetryAttempt, SDKAssistantMessage, SDKMessage, SDKSystemMessage } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
 import { agentLiveMessagesAtomFamily, agentSessionStreamingStateAtomFamily, type AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
@@ -94,6 +94,14 @@ function getSDKMessageStableKey(message: SDKMessage): string {
 export function isCompactionControlHistoryGroup(group: MessageGroup): boolean {
   if (group.type === 'system') return getSDKCompactStatus(group.message) != null
   return group.type === 'user' && (extractUserText(group.message) ?? '').trim() === '/compact'
+}
+
+function hasRenderableAssistantMessage(message: SDKAssistantMessage): boolean {
+  return message.error != null || message.message.content.length > 0
+}
+
+export function hasRenderableAssistantTurnContent(group: MessageGroup): boolean {
+  return group.type === 'assistant-turn' && group.assistantMessages.some(hasRenderableAssistantMessage)
 }
 
 export function getContextCompactionProgress(
@@ -1112,13 +1120,14 @@ export const AgentMessages = React.memo(function AgentMessages({
       })
   }, [structuralGroups])
 
-  // 实时消息中是否已有可渲染的助手内容
-  // 流式中：通过 liveGroupSet 精确判断（只有 streaming 时 liveGroupSet 才非空）
-  // 流式结束后：直接检查 liveMessages 中是否有助手消息，
-  // 防止 streaming→false 到 liveMessages 被清除之间的过渡帧中 fallback 气泡重复渲染
+  // 只有 assistant turn 产生实际内容后，才把计时器从乐观消息壳迁移到历史区。
+  // Pi 会先推送空 assistant snapshot；若立即迁移，空消息头会把计时器下推，
+  // 直到首个过程/文本块到达才填补空白。
   const hasLiveAssistantContent = streaming
-    ? allGroups.some((g) => g.type === 'assistant-turn' && liveGroupSet.has(g))
-    : (liveMessages != null && liveMessages.some((m) => (m as { type: string }).type === 'assistant'))
+    ? allGroups.some((group) => liveGroupSet.has(group) && hasRenderableAssistantTurnContent(group))
+    : (liveMessages != null && liveMessages.some((message) => (
+      message.type === 'assistant' && hasRenderableAssistantMessage(message as SDKAssistantMessage)
+    )))
 
   const messageBasePaths = React.useMemo(
     () => [sessionPath, ...(attachedDirs ?? [])].filter((path): path is string => Boolean(path)),

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -37,9 +37,8 @@ import { buildLiveGroupSet } from './live-group-set'
 import { AgentBrowserLinkProvider } from '@/components/browser/AgentBrowserLinkProvider'
 import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
-import { TASK_TOOL_NAMES } from './task-progress'
 import { createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
-import type { AgentEventUsage, RetryAttempt, SDKAssistantMessage, SDKMessage, SDKSystemMessage, SDKTextBlock, SDKThinkingBlock, SDKToolUseBlock } from '@proma/shared'
+import type { AgentEventUsage, RetryAttempt, SDKAssistantMessage, SDKMessage, SDKSystemMessage, SDKTextBlock, SDKThinkingBlock } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
 import { agentLiveMessagesAtomFamily, agentSessionStreamingStateAtomFamily, type AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
@@ -103,8 +102,7 @@ function hasRenderableAssistantMessage(message: SDKAssistantMessage): boolean {
   return message.message.content.some((block) => {
     if (block.type === 'text') return Boolean((block as SDKTextBlock).text)
     if (block.type === 'thinking') return Boolean((block as SDKThinkingBlock).thinking)
-    if (block.type === 'tool_use') return !TASK_TOOL_NAMES.has((block as SDKToolUseBlock).name)
-    return false
+    return true
   })
 }
 

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -110,6 +110,10 @@ export function hasRenderableAssistantTurnContent(group: MessageGroup): boolean 
   return group.type === 'assistant-turn' && group.assistantMessages.some(hasRenderableAssistantMessage)
 }
 
+export function shouldRenderLiveAssistantTurn(group: MessageGroup, isLive: boolean): boolean {
+  return !isLive || group.type !== 'assistant-turn' || hasRenderableAssistantTurnContent(group)
+}
+
 export function getContextCompactionProgress(
   messages: SDKMessage[],
   isCompacting: boolean | undefined,
@@ -1051,10 +1055,26 @@ export const AgentMessages = React.memo(function AgentMessages({
     messageGroupCacheRef.current = result.cache
     return result.groups
   }, [allSDKMessages, sessionModelId, streaming])
+  // 标记哪些 group 属于实时流式消息（用于 isStreaming / onFork 差异化渲染）。
+  // 该集合必须先于 visibleGroups 计算，让空 assistant snapshot 能在真正渲染前被过滤。
+  const liveGroupSet = React.useMemo(() => {
+    return buildLiveGroupSet({
+      allGroups,
+      liveMessages,
+      streaming,
+      activeRunStartedAt: streamState?.startedAt,
+    })
+  }, [allGroups, liveMessages, streaming, streamState?.startedAt])
+
   // 压缩过程由底部 Progress Overlay 独立承载，不占用对话历史、迷你地图或用户锚点。
+  // Pi 的 text_start/thinking_start 会产生没有可见 DOM 的空内容块；过滤掉对应的 live turn，
+  // 直到有实际内容时再交给 transcript 渲染，避免与乐观计时器壳重复显示 assistant header。
   const visibleGroups = React.useMemo(
-    () => allGroups.filter((group) => !isCompactionControlHistoryGroup(group)),
-    [allGroups],
+    () => allGroups.filter((group) => (
+      !isCompactionControlHistoryGroup(group)
+      && shouldRenderLiveAssistantTurn(group, liveGroupSet.has(group))
+    )),
+    [allGroups, liveGroupSet],
   )
   visibleGroupsRef.current = visibleGroups
 
@@ -1074,16 +1094,6 @@ export const AgentMessages = React.memo(function AgentMessages({
     structuralGroupsRef.current = visibleGroups
   }
   const structuralGroups = structuralGroupsRef.current
-
-  // 标记哪些 group 属于实时流式消息（用于 isStreaming / onFork 差异化渲染）
-  const liveGroupSet = React.useMemo(() => {
-    return buildLiveGroupSet({
-      allGroups,
-      liveMessages,
-      streaming,
-      activeRunStartedAt: streamState?.startedAt,
-    })
-  }, [allGroups, liveMessages, streaming, streamState?.startedAt])
 
   // 迷你地图数据 — 只依赖结构快照，流式 token 不触发 getGroupPreview 正则
   const minimapItems: MinimapItem[] = React.useMemo(

--- a/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
+++ b/apps/electron/src/renderer/components/agent/ProcessBlockGroup.tsx
@@ -28,6 +28,7 @@ const PROCESS_GROUP_LIVE_CHILD_WINDOW = 4
 const PROCESS_GROUP_COLLAPSE_DURATION_MS = 500
 const PROCESS_GROUP_AUTO_COLLAPSE_SOUND_DELAY_MS = 900
 const PROCESS_GROUP_AUTO_COLLAPSE_COUNTDOWN_SECONDS = 3
+const PROCESS_GROUP_FOLLOW_BOTTOM_THRESHOLD = 24
 const PROGRESS_SCROLL_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '])
 
 interface IndexedContentBlock {
@@ -177,6 +178,14 @@ export function buildProcessGroupToolNames(blocks: SDKContentBlock[]): string[] 
 }
 
 type ProcessGroupDisplayMode = 'collapsed' | 'expanded'
+
+export function isProgressViewportAtBottom({
+  clientHeight,
+  scrollHeight,
+  scrollTop,
+}: Pick<HTMLElement, 'clientHeight' | 'scrollHeight' | 'scrollTop'>): boolean {
+  return scrollHeight - scrollTop - clientHeight <= PROCESS_GROUP_FOLLOW_BOTTOM_THRESHOLD
+}
 
 function getProcessChildKey(child: React.ReactNode, index: number): string {
   if (React.isValidElement(child) && child.key != null) return String(child.key)
@@ -347,12 +356,10 @@ export function ProcessBlockGroup({ blocks, isStreaming, renderChildren, isMessa
   }, [blocks, isStreaming, keepProgressViewport, scrollToLatest])
 
   const handleProgressScroll = React.useCallback((event: React.UIEvent<HTMLDivElement>): void => {
-    if (scrollFrameRef.current !== null) return
-    const { clientHeight, scrollHeight, scrollTop } = event.currentTarget
-    if (scrollHeight - scrollTop - clientHeight <= 24) {
-      followLatestRef.current = true
-    }
-  }, [])
+    if (!isProgressViewportAtBottom(event.currentTarget)) return
+    followLatestRef.current = true
+    scrollToLatest()
+  }, [scrollToLatest])
 
   const handleProgressScrollIntent = React.useCallback((): void => {
     smoothScrollTargetRef.current = null

--- a/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
+++ b/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { SDKMessage } from '@proma/shared'
-import { getContextCompactionProgress, isCompactionControlHistoryGroup } from './AgentMessages'
+import { getContextCompactionProgress, hasRenderableAssistantTurnContent, isCompactionControlHistoryGroup } from './AgentMessages'
 import { shouldClearRetainedCompactionForResumedStream, shouldRestoreCompactionProgress } from './TaskProgressOverlay'
 
 function systemMessage(fields: Record<string, unknown>): SDKMessage {
@@ -12,6 +12,29 @@ function assistantMessage(): SDKMessage {
 }
 
 describe('context compaction progress overlay state', () => {
+  test('keeps the optimistic timer shell until a live assistant turn has visible content', () => {
+    const emptyTurn = {
+      type: 'assistant-turn',
+      assistantMessages: [{
+        type: 'assistant',
+        message: { content: [] },
+        parent_tool_use_id: null,
+      }],
+      turnMessages: [],
+    } as Parameters<typeof hasRenderableAssistantTurnContent>[0]
+    const contentTurn = {
+      ...emptyTurn,
+      assistantMessages: [{
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: '开始执行' }] },
+        parent_tool_use_id: null,
+      }],
+    } as Parameters<typeof hasRenderableAssistantTurnContent>[0]
+
+    expect(hasRenderableAssistantTurnContent(emptyTurn)).toBe(false)
+    expect(hasRenderableAssistantTurnContent(contentTurn)).toBe(true)
+  })
+
   test('hides /compact control messages from conversation history', () => {
     expect(isCompactionControlHistoryGroup({
       type: 'user',

--- a/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
+++ b/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
@@ -13,26 +13,24 @@ function assistantMessage(): SDKMessage {
 
 describe('context compaction progress overlay state', () => {
   test('keeps the optimistic timer shell until a live assistant turn has visible content', () => {
-    const emptyTurn = {
+    const assistantTurn = (content: unknown[], error?: { message: string }) => ({
       type: 'assistant-turn',
       assistantMessages: [{
         type: 'assistant',
-        message: { content: [] },
+        message: { content },
         parent_tool_use_id: null,
+        error,
       }],
       turnMessages: [],
-    } as Parameters<typeof hasRenderableAssistantTurnContent>[0]
-    const contentTurn = {
-      ...emptyTurn,
-      assistantMessages: [{
-        type: 'assistant',
-        message: { content: [{ type: 'text', text: '开始执行' }] },
-        parent_tool_use_id: null,
-      }],
-    } as Parameters<typeof hasRenderableAssistantTurnContent>[0]
+    } as Parameters<typeof hasRenderableAssistantTurnContent>[0])
 
-    expect(hasRenderableAssistantTurnContent(emptyTurn)).toBe(false)
-    expect(hasRenderableAssistantTurnContent(contentTurn)).toBe(true)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([]))).toBe(false)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'text', text: '' }]))).toBe(false)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'thinking', thinking: '' }]))).toBe(false)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'tool_use', name: 'TaskUpdate' }]))).toBe(false)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'text', text: '开始执行' }]))).toBe(true)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'tool_use', name: 'Bash' }]))).toBe(true)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([], { message: '请求失败' }))).toBe(true)
   })
 
   test('hides /compact control messages from conversation history', () => {

--- a/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
+++ b/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { SDKMessage } from '@proma/shared'
-import { getContextCompactionProgress, hasRenderableAssistantTurnContent, isCompactionControlHistoryGroup } from './AgentMessages'
+import { getContextCompactionProgress, hasRenderableAssistantTurnContent, isCompactionControlHistoryGroup, shouldRenderLiveAssistantTurn } from './AgentMessages'
 import { shouldClearRetainedCompactionForResumedStream, shouldRestoreCompactionProgress } from './TaskProgressOverlay'
 
 function systemMessage(fields: Record<string, unknown>): SDKMessage {
@@ -24,14 +24,21 @@ describe('context compaction progress overlay state', () => {
       turnMessages: [],
     } as Parameters<typeof hasRenderableAssistantTurnContent>[0])
 
+    const emptyTextTurn = assistantTurn([{ type: 'text', text: '' }])
+    const contentTurn = assistantTurn([{ type: 'text', text: '开始执行' }])
+
     expect(hasRenderableAssistantTurnContent(assistantTurn([]))).toBe(false)
-    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'text', text: '' }]))).toBe(false)
+    expect(hasRenderableAssistantTurnContent(emptyTextTurn)).toBe(false)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'thinking', thinking: '' }]))).toBe(false)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'tool_use', name: 'TaskUpdate' }]))).toBe(true)
-    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'text', text: '开始执行' }]))).toBe(true)
+    expect(hasRenderableAssistantTurnContent(contentTurn)).toBe(true)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'tool_use', name: 'Bash' }]))).toBe(true)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'custom_block' }]))).toBe(true)
     expect(hasRenderableAssistantTurnContent(assistantTurn([], { message: '请求失败' }))).toBe(true)
+
+    expect(shouldRenderLiveAssistantTurn(emptyTextTurn, true)).toBe(false)
+    expect(shouldRenderLiveAssistantTurn(emptyTextTurn, false)).toBe(true)
+    expect(shouldRenderLiveAssistantTurn(contentTurn, true)).toBe(true)
   })
 
   test('hides /compact control messages from conversation history', () => {

--- a/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
+++ b/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
@@ -27,9 +27,10 @@ describe('context compaction progress overlay state', () => {
     expect(hasRenderableAssistantTurnContent(assistantTurn([]))).toBe(false)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'text', text: '' }]))).toBe(false)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'thinking', thinking: '' }]))).toBe(false)
-    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'tool_use', name: 'TaskUpdate' }]))).toBe(false)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'tool_use', name: 'TaskUpdate' }]))).toBe(true)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'text', text: '开始执行' }]))).toBe(true)
     expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'tool_use', name: 'Bash' }]))).toBe(true)
+    expect(hasRenderableAssistantTurnContent(assistantTurn([{ type: 'custom_block' }]))).toBe(true)
     expect(hasRenderableAssistantTurnContent(assistantTurn([], { message: '请求失败' }))).toBe(true)
   })
 


### PR DESCRIPTION
## Summary

- Restore streaming process-output following after the user returns to the bottom of the bounded viewport.
- Keep the running timer in its optimistic shell until a live assistant turn has visible content, avoiding the empty-message gap before the first progress block.

## Performance

- Low risk: the change reuses the existing scroll callback and smooth-scroll frame, and does not add state, observers, timers, IPC traffic, or cross-session updates.

## Test plan

- [x] `bun test ./apps/electron/src/renderer/components/agent/compaction-progress.test.ts`
- [x] `bun run --filter='@proma/electron' typecheck`
- [x] `bun run --filter='@proma/electron' build:renderer`
- [x] `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)