### PR TITLE
fix(input): preserve editor state across Markdown toggle

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -13,7 +13,7 @@
  * - 自动扩高
  */
 
-import { useState, useEffect, useRef, useMemo, useCallback, useImperativeHandle, forwardRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback, useImperativeHandle, forwardRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { useEditor, EditorContent } from '@tiptap/react'
 import { TextSelection } from '@tiptap/pm/state'
@@ -471,6 +471,30 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
     [],
   )
 
+  // useEditor 只会在 richTextEnabled 变化时重建；键盘处理器由旧实例创建，必须在事件时读取当前 editor。
+  const editorRef = useRef<NonNullable<ReturnType<typeof useEditor>> | null>(null)
+  // TipTap 在 richTextEnabled 变化时会于被动 effect 中销毁旧 editor。
+  // 先在 layout cleanup 中 flush，避免延迟草稿 timer 继续引用已销毁实例。
+  useLayoutEffect(() => {
+    return () => {
+      if (lineCheckTimerRef.current !== null) {
+        clearTimeout(lineCheckTimerRef.current)
+        lineCheckTimerRef.current = null
+      }
+
+      const currentEditor = editorRef.current
+      const hasPendingDraft = draftSyncTimerRef.current !== null
+        || draftSyncFrameRef.current !== null
+        || pendingDraftEditorRef.current === currentEditor
+      if (!currentEditor || currentEditor.isDestroyed || !hasPendingDraft) return
+
+      flushPendingDraftSync(currentEditor)
+      if (lineCheckTimerRef.current !== null) {
+        clearTimeout(lineCheckTimerRef.current)
+        lineCheckTimerRef.current = null
+      }
+    }
+  }, [flushPendingDraftSync, richTextEnabled])
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -764,12 +788,12 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
             const key = event.key.toLowerCase()
             if (key === 'b') {
               event.preventDefault()
-              editor?.chain().focus().toggleBold().run()
+              editorRef.current?.chain().focus().toggleBold().run()
               return true
             }
             if (key === 's') {
               event.preventDefault()
-              editor?.chain().focus().toggleStrike().run()
+              editorRef.current?.chain().focus().toggleStrike().run()
               return true
             }
           }
@@ -811,7 +835,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
             event.preventDefault()
             // Enter 可能紧跟最后一次输入；先同步当前编辑器，再把最新 Markdown
             // 直接交给发送方，避免 rAF 批处理导致发送旧草稿。
-            onSubmitRef.current(editor ? flushPendingDraftSync(editor) : undefined, true)
+            onSubmitRef.current(editorRef.current ? flushPendingDraftSync(editorRef.current) : undefined, true)
             return true
           }
 
@@ -827,21 +851,21 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
               break
             }
           }
-          if (isInList && editor) {
+          if (isInList && editorRef.current) {
             // 空列表项再次按 Enter：退出列表，回到普通输入
             if (listItemNode && listItemNode.textContent === '') {
-              editor.chain().focus().liftListItem('listItem').run()
+              editorRef.current.chain().focus().liftListItem('listItem').run()
             } else {
               // 发送模式下 Enter 会提交消息，因此 Shift+Enter 也应作为列表续项键。
-              editor.chain().focus().splitListItem('listItem').run()
+              editorRef.current.chain().focus().splitListItem('listItem').run()
             }
-          } else if (editor) {
+          } else if (editorRef.current) {
             if (hasShift) {
               // Shift+Enter：同段落内硬换行
-              editor.chain().focus().setHardBreak().run()
+              editorRef.current.chain().focus().setHardBreak().run()
             } else {
               // 普通 Enter：拆分为新段落
-              editor.chain().focus().splitBlock().run()
+              editorRef.current.chain().focus().splitBlock().run()
             }
           }
           return true
@@ -860,9 +884,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
               break
             }
           }
-          if (isInList && listItemNode && listItemNode.textContent === '' && editor) {
+          if (isInList && listItemNode && listItemNode.textContent === '' && editorRef.current) {
             event.preventDefault()
-            editor.chain().focus().liftListItem('listItem').run()
+            editorRef.current.chain().focus().liftListItem('listItem').run()
             return true
           }
         }
@@ -875,6 +899,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
       scheduleDraftSync(ed)
     },
   }, [richTextEnabled])
+  editorRef.current = editor
 
   // 卸载时取消未触发的行数检查和草稿同步；同步最后一笔输入，避免快速切换会话丢草稿。
   useEffect(() => {


### PR DESCRIPTION
## Summary

- 修复 `切换输入框 Markdown` 渲染后 Enter / Shift+Enter 无法换行的问题。
- 键盘命令和发送路径改为读取当前 TipTap editor，避免使用已销毁的旧实例。
- 在 editor 重建前 flush 延迟草稿并清理旧 timer，避免 Agent 输入丢失或立即发送旧草稿。

## Verification

- `bun run typecheck`
- `bun run --filter=@proma/electron build:renderer`
- `git diff --check`
- 浏览器手动验证切换 Markdown 后空内容和已有内容的 Enter / Shift+Enter 换行。
- `bun test`：465 pass；4 个既有 Electron mock、OAuth 代理和 planning 原生进程环境失败。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)