### PR TITLE
feat(reasoning): expose GLM-5.3 thinking effort levels

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -122,18 +122,6 @@ function compilePiReasoningCapabilities(
         },
         thinkingLevelMap,
       }
-    case 'zai-toggle':
-      return {
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          thinkingFormat: 'zai',
-          zaiToolStream: true,
-        },
-        thinkingLevelMap,
-      }
-    case 'anthropic-manual':
-      return { thinkingLevelMap }
   }
 }
 

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -40,8 +40,6 @@ export type ReasoningEncodingKind =
   | 'deepseek-output-effort'
   | 'openai-reasoning-effort'
   | 'zai-thinking-effort'
-  | 'zai-toggle'
-  | 'anthropic-manual'
 
 /** 每个产品等级映射为目标协议可接受的 effort 值。 */
 export type ReasoningEffortMap = Partial<Record<AgentThinkingLevel, string | null>>
@@ -89,14 +87,33 @@ export interface ResolveReasoningProfileInput {
 const DEEPSEEK_V4_LEVELS = ['off', 'low', 'high', 'xhigh', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const K3_LEVELS = ['off', 'low', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const GLM_52_LEVELS = ['off', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
-const GLM_53_LEVELS = ['off', 'high'] as const satisfies readonly AgentThinkingLevel[]
-/** GLM-5.3 官方端点只支持思考开关，不接受 reasoning_effort；其余档位必须从 UI 隐藏。 */
-const GLM_53_THINKING_LEVEL_MAP: ReasoningEffortMap = {
+const GLM_53_LEVELS = ['off', 'low', 'medium', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
+// Verified against open.bigmodel.cn 2026-08-17: /api/anthropic accepts adaptive
+// effort low/medium/high/max; /api/v1 (OpenAI Responses) accepts all five natively;
+// /api/paas/v4 only accepts low/high/max, so medium degrades to high there.
+const GLM_53_ANTHROPIC_EFFORT_MAP: ReasoningEffortMap = {
   minimal: null,
-  low: null,
-  medium: null,
-  xhigh: null,
-  max: null,
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'max',
+  max: 'max',
+}
+const GLM_53_OPENAI_EFFORT_MAP: ReasoningEffortMap = {
+  minimal: null,
+  low: 'low',
+  medium: 'high',
+  high: 'high',
+  xhigh: 'max',
+  max: 'max',
+}
+const GLM_53_RESPONSES_EFFORT_MAP: ReasoningEffortMap = {
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'max',
+  max: 'max',
 }
 const OPENAI_STANDARD_LEVELS = ['off', 'low', 'medium', 'high', 'xhigh'] as const satisfies readonly AgentThinkingLevel[]
 const OPENAI_MAX_LEVELS = [...OPENAI_STANDARD_LEVELS, 'max'] as const satisfies readonly AgentThinkingLevel[]
@@ -203,7 +220,10 @@ function normalizeGlm52Level(level: AgentThinkingLevel | undefined): AgentThinki
 }
 
 function normalizeGlm53Level(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
-  return level === 'off' ? 'off' : 'high'
+  if (level === 'off') return 'off'
+  if (level === 'xhigh' || level === 'max') return 'max'
+  if (level === 'minimal') return 'low'
+  return level ?? 'high'
 }
 
 function normalizeOpenAIStandardLevel(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
@@ -255,8 +275,9 @@ const GLM_53_PROFILE: ReasoningProfile = {
   defaultLevel: 'high',
   normalize: normalizeGlm53Level,
   encodings: {
-    'anthropic-messages': { kind: 'anthropic-manual', effortMap: GLM_53_THINKING_LEVEL_MAP },
-    'openai-completions': { kind: 'zai-toggle', effortMap: GLM_53_THINKING_LEVEL_MAP },
+    'anthropic-messages': { kind: 'adaptive-effort', effortMap: GLM_53_ANTHROPIC_EFFORT_MAP },
+    'openai-completions': { kind: 'zai-thinking-effort', effortMap: GLM_53_OPENAI_EFFORT_MAP },
+    'openai-responses': { kind: 'openai-reasoning-effort', effortMap: GLM_53_RESPONSES_EFFORT_MAP },
   },
 }
 


### PR DESCRIPTION
## Summary

GLM-5.3 currently exposes only an off/high toggle (`zai-toggle` / `anthropic-manual`), based on the conclusion in #1708 that official endpoints only accept a thinking switch. That conclusion is now outdated — Zhipu endpoints have since added effort support.

Verified against `open.bigmodel.cn` with real keys on 2026-08-17:

| Endpoint | Thinking levels | Evidence |
|---|---|---|
| `/api/anthropic` | `thinking:{type:'adaptive',effort}` — low/medium/high/max all 200 with thinking blocks | adaptive+high already in production use |
| `/api/paas/v4` | `reasoning_effort` accepts low/high/max only | invalid `medium` returns 400: "请使用 low、high 或 max" |
| `/api/v1` (OpenAI Responses) | `reasoning.effort` — minimal/low/medium/high/max all natively supported | output length grows monotonically with effort |

## Changes

Follows the existing GLM-5.2 profile template — no new mechanisms, no UI changes:

- `GLM_53_LEVELS`: `['off','high']` → `['off','low','medium','high','max']`
- Encodings now reuse the three existing generic kinds:
  - `anthropic-messages`: `adaptive-effort` (native mapping)
  - `openai-completions`: `zai-thinking-effort` (`medium` degrades to `high`, same pattern GLM-5.2 uses for level compression)
  - `openai-responses`: `openai-reasoning-effort` (native mapping, fixes the profile not matching at all for Responses-mode channels)
- `normalizeGlm53Level` widened; existing sessions (off/high) migrate losslessly
- Dropped the now-unused `zai-toggle` / `anthropic-manual` encoding kinds and their compile branches

## Notes

- All three zai channel types are covered automatically: API (`zhipu`) uses openai-completions; Plan (`zhipu-coding`) and Team (`zhipu-coding-team`) share the anthropic-messages path (their default base URL is `/api/anthropic`, see `channel.ts`)
- No new channel provider options; `/api/v1` users can use the existing generic `openai-responses` channel type

## Verification

- `bun run typecheck` clean; 489 tests pass (1 pre-existing planning-db failure also on main)
- Runtime check of all three transports: level → normalize → effort mapping matches the table above; glm-5.2 / gpt-5.6 profiles unaffected
- E2E on dev via Plan channel (`/api/anthropic`): slider "low" produced `thinking:{type:'adaptive',effort:'low'}` in the request body (captured through a local pass-through proxy); responses normal