### PR TITLE
feat(channel): simplify Kimi API label and use kimi-k3 preset model id

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -68,7 +68,7 @@ const DEEPSEEK_PRESET_MODELS: ChannelModel[] = [
   { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
 ]
 const KIMI_PRESET_MODELS: ChannelModel[] = [
-  { id: 'k3', name: 'Kimi K3', enabled: true },
+  { id: 'kimi-k3', name: 'Kimi K3', enabled: true },
   { id: 'kimi-k2.6', name: 'Kimi K2.6', enabled: true },
 ]
 const XIAOMI_PRESET_MODELS: ChannelModel[] = [

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -85,7 +85,7 @@ const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', '
 /** 需要用 messages 端点测试的供应商预设模型 */
 const PROVIDER_TEST_MODEL_PRESETS: Partial<Record<ProviderType, string[]>> = {
   deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash'],
-  'kimi-api': ['k3', 'kimi-k2.6'],
+  'kimi-api': ['kimi-k3', 'kimi-k2.6'],
   'opencode-go-openai': ['grok-4.5', 'glm-5.2', 'kimi-k3'],
   xiaomi: ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
   'xiaomi-token-plan': ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
@@ -408,7 +408,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         ])
       } else if (p === 'kimi-api') {
         setModels([
-          { id: 'k3', name: 'Kimi K3', enabled: true },
+          { id: 'kimi-k3', name: 'Kimi K3', enabled: true },
           { id: 'kimi-k2.6', name: 'Kimi K2.6', enabled: true },
         ])
       } else if (p === 'kimi-coding') {

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -80,7 +80,7 @@ export const PROVIDER_LABELS: Record<ProviderType, string> = {
   'openai-responses': 'OpenAI Responses 格式',
   deepseek: 'DeepSeek',
   google: 'Google',
-  'kimi-api': 'Kimi API (Anthropic 协议)',
+  'kimi-api': 'Kimi API',
   'kimi-coding': 'Kimi Coding Plan',
   'opencode-go-openai': 'OpenCode Go (OpenAI 协议)',
   zhipu: '智谱 AI',


### PR DESCRIPTION
## 改动

- 供应商显示名 `Kimi API (Anthropic 协议)` → `Kimi API`（设置页下拉与渠道列表统一走 `PROVIDER_LABELS`）
- kimi-api 渠道预设/测试模型 ID `k3` → `kimi-k3`，涉及 3 处：
  - `channel-manager.ts` `KIMI_PRESET_MODELS`（连接测试兜底）
  - `ChannelForm.tsx` `PROVIDER_TEST_MODEL_PRESETS['kimi-api']`（创建时测试模型）
  - `ChannelForm.tsx` 新建 kimi-api 渠道默认模型列表

## 有意未改

- `kimi-coding`（Coding Plan）渠道预设仍用 `k3`：Coding Plan 端点真实模型 ID 即 `k3`
- `ark-coding-plan` 中的 `k3`：火山方舟平台模型 ID，与 Kimi API 无关

## 性能影响

无明显性能影响：纯常量字符串变更，不涉及渲染、IPC、订阅或数据流。

## 验证

- `bun run typecheck` 6 个包全部通过

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)