### PR TITLE
fix(agent): 修复上下文压缩后运行时间不显示【已审核 PR】

### DIFF
--- a/packages/session-core/src/group.ts
+++ b/packages/session-core/src/group.ts
@@ -97,12 +97,16 @@ export type MessageGroup =
  * 1. user（真正用户输入）→ 单独的 user group
  * 2. assistant + user(tool_result) + assistant... → 合并为一个 assistant-turn
  * 3. system（压缩状态 / permission_denied）→ 独立渲染，其他归入当前 turn
- * 4. 其他类型（result, tool_progress 等）→ 归入当前 assistant-turn
+ * 4. 其他类型（result, tool_progress 等）→ 归入当前 assistant-turn；被 system 状态分隔的 terminal result 回挂到刚关闭的 turn
  * 5. 后处理：合并相邻同模型的 assistant-turn（处理子代理切换模型导致的碎片化）
  */
 export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string): MessageGroup[] {
   const groups: MessageGroup[] = []
   let currentTurn: AssistantTurn | null = null
+  // 自动压缩会在最终 assistant 消息与 terminal result 之间插入可持久化的 system 状态。
+  // system 状态会关闭当前 turn；保留该引用，才能把随后到达的 result（包含耗时/usage）
+  // 仍归属到刚完成的回答，而不是让 renderer 丢失 DurationBadge 的数据来源。
+  const trailingResultTarget: { turn: AssistantTurn | null } = { turn: null }
   let pendingInputMessage: SDKUserMessage | undefined
   // 收到后台任务完成通知（task_notification）后，若没有用户输入就直接出现新的 assistant 输出，
   // 说明这是自动唤醒的新一轮，应另起独立消息块，而不是续接上一轮。
@@ -112,6 +116,7 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
   const flushTurn = (): void => {
     if (currentTurn && currentTurn.assistantMessages.length > 0) {
       groups.push(currentTurn)
+      trailingResultTarget.turn = currentTurn
     }
     currentTurn = null
   }
@@ -125,6 +130,7 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
         groups.push({ type: 'user', message: userMsg })
         pendingInputMessage = userMsg
         pendingWakeBoundary = false
+        trailingResultTarget.turn = null
       } else {
         // tool_result 消息 → 归入当前 turn
         if (currentTurn) {
@@ -201,7 +207,10 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
       }
       if (currentTurn) {
         currentTurn.turnMessages.push(msg)
+      } else if (msg.type === 'result' && trailingResultTarget.turn) {
+        trailingResultTarget.turn.turnMessages.push(msg)
       }
+      if (msg.type === 'result') trailingResultTarget.turn = null
     }
   }
 

--- a/packages/session-core/src/session-core.test.ts
+++ b/packages/session-core/src/session-core.test.ts
@@ -125,6 +125,26 @@ describe('SDK 压缩状态分组', () => {
     })
   })
 
+  test('Given 自动压缩发生在最终回答和 result 之间 When 分组 Then result 仍归属最终回答', () => {
+    const raw = jsonl([
+      { type: 'user', message: { content: [{ type: 'text', text: '完成任务' }] }, parent_tool_use_id: null },
+      { type: 'assistant', message: { id: 'a1', content: [{ type: 'text', text: '任务已完成' }] }, parent_tool_use_id: null },
+      { type: 'system', subtype: 'compacting' },
+      { type: 'system', subtype: 'compact_boundary' },
+      { type: 'result', subtype: 'success', _durationMs: 2_413_169 },
+    ])
+
+    const groups = groupIntoTurns(readSessionMessagesFromString(raw))
+    const assistantTurn = groups.find((group) => group.type === 'assistant-turn')
+
+    expect(groups.map((group) => group.type)).toEqual(['user', 'assistant-turn', 'system'])
+    expect(assistantTurn).toBeDefined()
+    expect(assistantTurn).toMatchObject({
+      type: 'assistant-turn',
+      turnMessages: [{ type: 'assistant' }, { type: 'result', _durationMs: 2_413_169 }],
+    })
+  })
+
   test('Given 上一次压缩已结束且下一次立即开始 When 分组 Then 保留两个压缩周期', () => {
     const raw = jsonl([
       { type: 'system', subtype: 'compacting' },


### PR DESCRIPTION
## 概述

修复 Agent 在自动上下文压缩发生于最终回答与 terminal result 之间时，运行时间徽章偶发不显示的问题。

根因是 session-core 的 turn 分组器在收到 `compacting` / `compact_boundary` system 消息时关闭了当前 assistant turn，而后续携带 `_durationMs` 的 result 没有重新归属任何 turn。运行时间实际已经持久化，但 renderer 无法从最终回答的 turn 中读取它。

## 改动

- `packages/session-core/src/group.ts` — 保留刚被 system 状态关闭的 assistant turn；若随后收到 terminal result，则将 result 回挂到该 turn。收到新的真实用户输入时清除候选引用，避免跨轮误归属。
- `packages/session-core/src/session-core.test.ts` — 新增“最终回答 -> 自动压缩 -> terminal result”时序的回归测试，验证 `_durationMs` 仍归属最终回答。

## 测试方法

1. `bun test packages/session-core/src/session-core.test.ts` — 17/17 通过。
2. `bun run typecheck` — `@proma/shared`、`@proma/session-core`、`@proma/core`、`@proma/cli`、`@proma/ui`、`@proma/electron` 全部通过。
3. `git diff --check` — 通过。

## 备注

本次修改不涉及 renderer 组件、CSS、滚动容器、动画、IPC 或 GPU/compositor 层，只修复会话消息分组的数据归属。已完成本地 GPU/compositor 审核，未发现新增渲染性能风险。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)