### PR TITLE
fix(watcher): 修复会话文件变更归属与高噪声过滤【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.42",
+  "version": "0.17.43",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/workspace-watcher-utils.ts
+++ b/apps/electron/src/main/lib/workspace-watcher-utils.ts
@@ -1,7 +1,10 @@
-// 高频变动目录：跳过其中的变更事件，防止 node_modules / .next 等产生 IPC 事件风暴。
+// 高频变动目录：跳过依赖、缓存和构建中间物，防止产生 IPC 事件风暴。
 const HIGH_NOISE_SEGMENTS = new Set([
   'node_modules', '.next', '.nuxt', '.git', 'dist', 'build',
   '.cache', '__pycache__', '.turbo', '.parcel-cache', '.svelte-kit',
+  '.venv', 'venv', '.tox', '.nox', '__pypackages__',
+  '.pytest_cache', '.mypy_cache', '.ruff_cache', '.hypothesis',
+  '.gradle',
 ])
 
 const GIT_DIFF_STATE_FILES = new Set([

--- a/apps/electron/src/main/lib/workspace-watcher.test.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.test.ts
@@ -11,6 +11,30 @@ describe('shouldNotifyForWatchFilename', () => {
     expect(shouldNotifyForWatchFilename('src\\components\\Button.tsx')).toBe(true)
   })
 
+  it('ignores Python, test and build cache directories', () => {
+    const noisyPaths = [
+      '.venv/lib/python3.12/site-packages/pkg.py',
+      'venv/Lib/site-packages/pkg.py',
+      '.tox/py312/lib/pkg.py',
+      '.nox/tests/lib/pkg.py',
+      '__pypackages__/3.12/lib/pkg.py',
+      '.pytest_cache/v/cache/lastfailed',
+      '.mypy_cache/3.12/pkg.meta.json',
+      '.ruff_cache/0.8.0/cache',
+      '.hypothesis/examples/example.db',
+      '.gradle/caches/modules-2/metadata.bin',
+    ]
+
+    for (const path of noisyPaths) {
+      expect(shouldNotifyForWatchFilename(path)).toBe(false)
+    }
+  })
+
+  it('keeps generic coverage and target directories observable', () => {
+    expect(shouldNotifyForWatchFilename('coverage/lcov.info')).toBe(true)
+    expect(shouldNotifyForWatchFilename('target/debug/generated.rs')).toBe(true)
+  })
+
   it('normalizes Buffer filenames before filtering', () => {
     expect(shouldNotifyForWatchFilename(Buffer.from('.git/index'))).toBe(true)
     expect(shouldNotifyForWatchFilename(Buffer.from('src/file.ts'))).toBe(true)

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -80,7 +80,7 @@ import {
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
 import { detectIsWindows } from '@/lib/platform'
-import { getSessionFileChangeKind, arePathsEqual, isPathWithinRoot, upsertSessionFileChange } from '@/lib/session-file-changes'
+import { getSessionFileChangeKind, getOwnedSessionWatcherPaths, upsertSessionFileChange } from '@/lib/session-file-changes'
 import { removeQueuedMessage, createQueuedAgentStreamState } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
 
@@ -842,24 +842,16 @@ export function useGlobalAgentListeners(): void {
           const sessionPath = sessionPaths.get(sessionId)
           const workspaceFilesPath = await getWorkspaceFilesPathForSession(sessionId)
           const workspaceAttachments = await getWorkspaceAttachmentsForSession(sessionId)
-          if (!session || !workspaceAttachments.complete) {
-            // 缺少运行会话的权威附件配置时，任何路径都不能安全归属给其他会话。
-            return { sessionId, matchingPaths: [...filePaths] }
-          }
-          const directoryRoots = uniqueTruthyPaths([
+          const matchingPaths = getOwnedSessionWatcherPaths(filePaths, {
+            sessionExists: Boolean(session),
             sessionPath,
+            sessionAttachedDirectories: session?.attachedDirectories ?? [],
+            sessionAttachedFiles: session?.attachedFiles ?? [],
+            workspaceAttachmentsComplete: workspaceAttachments.complete,
             workspaceFilesPath,
-            ...(session.attachedDirectories ?? []),
-            ...workspaceAttachments.directories,
-          ])
-          const attachedFiles = uniqueTruthyPaths([
-            ...(session.attachedFiles ?? []),
-            ...workspaceAttachments.files,
-          ])
-          const matchingPaths = filePaths.filter((changedPath) => (
-            directoryRoots.some((rootPath) => isPathWithinRoot(rootPath, changedPath, isWindows))
-            || attachedFiles.some((filePath) => arePathsEqual(filePath, changedPath, isWindows))
-          ))
+            workspaceAttachedDirectories: workspaceAttachments.directories,
+            workspaceAttachedFiles: workspaceAttachments.files,
+          }, isWindows)
           return { sessionId, matchingPaths }
         }))
 

--- a/apps/electron/src/renderer/lib/session-file-changes.test.ts
+++ b/apps/electron/src/renderer/lib/session-file-changes.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+import { getOwnedSessionWatcherPaths } from './session-file-changes'
+
+describe('getOwnedSessionWatcherPaths', () => {
+  test('does not attribute paths for a missing session', () => {
+    expect(getOwnedSessionWatcherPaths(
+      ['/workspaces/current-session/generated/file.txt'],
+      {
+        sessionExists: false,
+        sessionPath: '/workspaces/current-session',
+        sessionAttachedDirectories: [],
+        sessionAttachedFiles: [],
+        workspaceAttachmentsComplete: true,
+        workspaceFilesPath: '/workspaces/workspace-files',
+        workspaceAttachedDirectories: [],
+        workspaceAttachedFiles: [],
+      },
+    )).toEqual([])
+  })
+
+  test('retains session-local paths when workspace attachments are unavailable', () => {
+    expect(getOwnedSessionWatcherPaths(
+      [
+        '/workspaces/current-session/generated/file.txt',
+        '/external/session-directory/file.txt',
+        '/external/session-file.md',
+        '/workspaces/workspace-files/shared.md',
+        '/external/workspace-directory/file.txt',
+        '/external/workspace-file.md',
+      ],
+      {
+        sessionExists: true,
+        sessionPath: '/workspaces/current-session',
+        sessionAttachedDirectories: ['/external/session-directory'],
+        sessionAttachedFiles: ['/external/session-file.md'],
+        workspaceAttachmentsComplete: false,
+        workspaceFilesPath: '/workspaces/workspace-files',
+        workspaceAttachedDirectories: ['/external/workspace-directory'],
+        workspaceAttachedFiles: ['/external/workspace-file.md'],
+      },
+    )).toEqual([
+      '/workspaces/current-session/generated/file.txt',
+      '/external/session-directory/file.txt',
+      '/external/session-file.md',
+    ])
+  })
+
+  test('includes complete workspace scope without crossing root boundaries', () => {
+    expect(getOwnedSessionWatcherPaths(
+      [
+        '/workspaces/current-session/generated/file.txt',
+        '/workspaces/current-session-copy/file.txt',
+        '/workspaces/workspace-files/shared.md',
+        '/external/workspace-directory/file.txt',
+        '/external/workspace-file.md',
+        '/external/unattached.md',
+      ],
+      {
+        sessionExists: true,
+        sessionPath: '/workspaces/current-session',
+        sessionAttachedDirectories: [],
+        sessionAttachedFiles: [],
+        workspaceAttachmentsComplete: true,
+        workspaceFilesPath: '/workspaces/workspace-files',
+        workspaceAttachedDirectories: ['/external/workspace-directory'],
+        workspaceAttachedFiles: ['/external/workspace-file.md'],
+      },
+    )).toEqual([
+      '/workspaces/current-session/generated/file.txt',
+      '/workspaces/workspace-files/shared.md',
+      '/external/workspace-directory/file.txt',
+      '/external/workspace-file.md',
+    ])
+  })
+})

--- a/apps/electron/src/renderer/lib/session-file-changes.ts
+++ b/apps/electron/src/renderer/lib/session-file-changes.ts
@@ -13,6 +13,49 @@ export function isPathWithinRoot(rootPath: string, targetPath: string, caseInsen
   return target === root || target.startsWith(`${root}/`)
 }
 
+export interface SessionWatcherOwnershipScope {
+  sessionExists: boolean
+  sessionPath?: string
+  sessionAttachedDirectories: readonly string[]
+  sessionAttachedFiles: readonly string[]
+  workspaceAttachmentsComplete: boolean
+  workspaceFilesPath?: string | null
+  workspaceAttachedDirectories: readonly string[]
+  workspaceAttachedFiles: readonly string[]
+}
+
+/** Returns watcher paths that can be attributed from the available session scope. */
+export function getOwnedSessionWatcherPaths(
+  changedPaths: readonly string[],
+  scope: SessionWatcherOwnershipScope,
+  caseInsensitive = false,
+): string[] {
+  if (!scope.sessionExists) return []
+
+  const directoryRoots = [
+    scope.sessionPath,
+    ...scope.sessionAttachedDirectories,
+  ]
+  const attachedFiles = [...scope.sessionAttachedFiles]
+
+  if (scope.workspaceAttachmentsComplete) {
+    directoryRoots.push(
+      scope.workspaceFilesPath ?? undefined,
+      ...scope.workspaceAttachedDirectories,
+    )
+    attachedFiles.push(...scope.workspaceAttachedFiles)
+  }
+
+  return changedPaths.filter((changedPath) => (
+    directoryRoots.some((rootPath) => (
+      typeof rootPath === 'string'
+      && rootPath.length > 0
+      && isPathWithinRoot(rootPath, changedPath, caseInsensitive)
+    ))
+    || attachedFiles.some((filePath) => arePathsEqual(filePath, changedPath, caseInsensitive))
+  ))
+}
+
 export type SessionFileChangeKind = "created" | "edited";
 
 export interface SessionFileChange {


### PR DESCRIPTION
## 概述
修复“本会话文件变更”的 watcher 路径归属：workspace 附件 IPC 失败时不再把全局路径错误归属给某个运行中会话，同时仍保留当前会话自身工作目录和会话级附件内的真实文件变化。补充 Python/uv 与测试缓存目录过滤，减少依赖产物填满右侧文件改动面板。

## 改动
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` — 将 watcher 归属改为显式 scope，区分 session-local 与 workspace 级路径。
- `apps/electron/src/renderer/lib/session-file-changes.ts` — 新增可测试的 session watcher scope 归属逻辑；附件 IPC 不完整时仅匹配安全的 session-local 路径。
- `apps/electron/src/renderer/lib/session-file-changes.test.ts` — 覆盖缺失 session、workspace scope 不完整及完整 scope 的路径边界。
- `apps/electron/src/main/lib/workspace-watcher-utils.ts` — 忽略 `.venv`、`venv`、Python 测试缓存、`__pypackages__`、`.gradle` 等高噪声目录。
- `apps/electron/src/main/lib/workspace-watcher.test.ts` — 覆盖新增过滤目录，并确认通用 `coverage/` 与 `target/` 目录继续可观察。
- `apps/electron/package.json` — Electron patch 版本升级至 `0.17.43`。

## 测试方法
1. 运行 `bun test apps/electron/src/main/lib/workspace-watcher.test.ts apps/electron/src/renderer/lib/session-file-changes.test.ts`。
2. 结果：8 个用例、24 个断言通过。
3. 运行 `git diff --check`，通过。
4. 运行时 A/B：正式版在 `.venv` 测试目录生成 500+ 文件后出现于右侧；本分支 dev 版未出现，确认 watcher 过滤生效。

## 备注
- `target/` 与 `coverage/` 不做全局忽略，避免隐藏项目业务产物；其内部若包含既有 `build/` 等高噪声段，仍遵循已有规则。
- 完整 `typecheck` 未运行：该临时 worktree 未安装依赖，环境中没有 `tsc`。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)