### PR TITLE
fix(agent): 修复自动任务参数桥接【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.42",
+  "version": "0.17.43",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/automation-tool-schema.ts
+++ b/apps/electron/src/main/lib/adapters/automation-tool-schema.ts
@@ -1,0 +1,54 @@
+import { Type } from 'typebox'
+import type { CreateAutomationInput, UpdateAutomationInput } from '@proma/shared'
+
+export type AutomationScheduleType = CreateAutomationInput['scheduleType']
+
+/**
+ * A few model tool-call transports still materialize optional properties. At this
+ * bridge boundary, discard schedule fields that cannot affect the selected mode
+ * before applying the strict domain validation shared with direct IPC callers.
+ */
+export function discardInapplicableAutomationScheduleFields(
+  input: Partial<CreateAutomationInput | UpdateAutomationInput>,
+  scheduleType: AutomationScheduleType,
+): void {
+  if (scheduleType !== 'interval') {
+    input.activeWindowStart = undefined
+    input.activeWindowEnd = undefined
+    input.activeWeekdays = undefined
+  }
+  if (scheduleType !== 'daily' && scheduleType !== 'weekly' && scheduleType !== 'monthly') {
+    input.timeOfDay = undefined
+  }
+  if (scheduleType !== 'weekly') input.dayOfWeek = undefined
+  if (scheduleType !== 'monthly') input.dayOfMonth = undefined
+  if (scheduleType !== 'once') input.scheduledAt = undefined
+  // Some tool transports decode an omitted/null maxRuns as 0; both mean unlimited.
+  if (input.maxRuns === 0) input.maxRuns = null
+}
+
+export const automationCreateToolParameters = Type.Object({
+  name: Type.String({ description: '任务名，简短说明长期反复执行的目标' }),
+  prompt: Type.String({ description: '每次触发时发送给 Agent 的完整自然语言指令' }),
+  scheduleType: Type.Union([
+    Type.Literal('interval'),
+    Type.Literal('daily'),
+    Type.Literal('weekly'),
+    Type.Literal('monthly'),
+    Type.Literal('once'),
+  ], { description: '调度类型' }),
+  intervalMinutes: Type.Optional(Type.Number({ description: '固定间隔分钟数；scheduleType=interval 时必填' })),
+  activeWindowStart: Type.Optional(Type.String({ description: 'interval 的每日有效开始时刻，HH:MM；需与 activeWindowEnd 同时设置' })),
+  activeWindowEnd: Type.Optional(Type.String({ description: 'interval 的每日有效结束时刻（不包含），HH:MM；需与 activeWindowStart 同时设置' })),
+  activeWeekdays: Type.Optional(Type.Array(Type.Number({ description: '运行日：0=周日，1=周一 … 6=周六；空数组表示每天' }), { description: 'interval 的周内运行日集合，例如工作日传 [1,2,3,4,5]' })),
+  timeOfDay: Type.Optional(Type.String({ description: '每天/每周/每月触发时间，24 小时制 HH:MM' })),
+  dayOfWeek: Type.Optional(Type.Number({ description: '每周触发日，0=周日，...，6=周六' })),
+  dayOfMonth: Type.Optional(Type.Number({ description: '每月触发日，1-31' })),
+  scheduledAt: Type.Optional(Type.Number({ description: '一次性任务的绝对触发时间（毫秒时间戳）；scheduleType=once 时必填' })),
+  maxRuns: Type.Optional(Type.Union([
+    Type.Number({ description: '最大运行次数上限；达到后任务自动停用' }),
+    Type.Null({ description: '清除运行次数上限，长期运行' }),
+  ])),
+  active: Type.Optional(Type.Boolean({ description: '创建后是否启用，默认 true' })),
+  sessionMode: Type.Optional(Type.Union([Type.Literal('daily'), Type.Literal('reuse')], { description: '会话模式' })),
+})

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -73,6 +73,10 @@ import {
 } from '../web-search-service'
 import { browserController } from '../browser-controller'
 import { resolveBrowserProfileKey } from '../browser-profile-policy'
+import {
+  automationCreateToolParameters,
+  discardInapplicableAutomationScheduleFields,
+} from './automation-tool-schema'
 
 type PiSdk = typeof import('@earendil-works/pi-coding-agent')
 
@@ -341,31 +345,7 @@ function buildAutomationTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefin
       name: 'mcp__automation__create_automation',
       label: '创建定时任务',
       description: '创建 Proma 持久化定时任务。适合无人值守、有稳定价值的场景。纯提醒/闹钟、需要用户实时参与判断、或现在就该做完即终结的事不要创建。',
-      parameters: Type.Object({
-        name: Type.String({ description: '任务名，简短说明长期反复执行的目标' }),
-        prompt: Type.String({ description: '每次触发时发送给 Agent 的完整自然语言指令' }),
-        scheduleType: Type.Union([
-          Type.Literal('interval'),
-          Type.Literal('daily'),
-          Type.Literal('weekly'),
-          Type.Literal('monthly'),
-          Type.Literal('once'),
-        ], { description: '调度类型' }),
-        intervalMinutes: Type.Optional(Type.Number({ description: '固定间隔分钟数；scheduleType=interval 时必填' })),
-        activeWindowStart: Type.Optional(Type.String({ description: 'interval 的每日有效开始时刻，HH:MM；需与 activeWindowEnd 同时设置' })),
-        activeWindowEnd: Type.Optional(Type.String({ description: 'interval 的每日有效结束时刻（不包含），HH:MM；需与 activeWindowStart 同时设置' })),
-        activeWeekdays: Type.Optional(Type.Array(Type.Number({ description: '运行日：0=周日，1=周一 … 6=周六；空数组表示每天' }), { description: 'interval 的周内运行日集合，例如工作日传 [1,2,3,4,5]' })),
-        timeOfDay: Type.Optional(Type.String({ description: '每天/每周/每月触发时间，24 小时制 HH:MM' })),
-        dayOfWeek: Type.Optional(Type.Number({ description: '每周触发日，0=周日，...，6=周六' })),
-        dayOfMonth: Type.Optional(Type.Number({ description: '每月触发日，1-31' })),
-        scheduledAt: Type.Optional(Type.Number({ description: '一次性任务的绝对触发时间（毫秒时间戳）；scheduleType=once 时必填' })),
-        maxRuns: Type.Optional(Type.Union([
-          Type.Number({ description: '最大运行次数上限；达到后任务自动停用' }),
-          Type.Null({ description: '清除运行次数上限，长期运行' }),
-        ])),
-        active: Type.Optional(Type.Boolean({ description: '创建后是否启用，默认 true' })),
-        sessionMode: Type.Optional(Type.Union([Type.Literal('daily'), Type.Literal('reuse')], { description: '会话模式' })),
-      }),
+      parameters: automationCreateToolParameters,
       async execute(_toolCallId: string, params: unknown) {
         const args = params as Record<string, unknown>
         if (ctx.triggeredBy === 'automation' || getCurrentAutomationId(ctx)) {
@@ -391,6 +371,7 @@ function buildAutomationTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefin
           sourceSessionId: ctx.sessionId,
           active: (args.active as boolean) ?? true,
         }
+        discardInapplicableAutomationScheduleFields(input, input.scheduleType)
         validateScheduleFields(input)
         validateExplicitAutomationScheduleFields(input, input.scheduleType)
         if (input.scheduleType === 'interval' && args.intervalMinutes === undefined) {
@@ -477,10 +458,11 @@ function buildAutomationTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefin
         }
         if (input.name !== undefined) assertNonBlank(input.name, 'name')
         if (input.prompt !== undefined) assertNonBlank(input.prompt, 'prompt')
-        validateScheduleFields(input)
         const existing = getAutomation(id)
         if (!existing) throw new Error(`定时任务不存在: ${id}`)
         const scheduleType = input.scheduleType ?? existing.scheduleType
+        discardInapplicableAutomationScheduleFields(input, scheduleType)
+        validateScheduleFields(input)
         validateExplicitAutomationScheduleFields(input, scheduleType)
         const effective = getEffectiveAutomationScheduleFields(input, existing)
         if (effective.scheduleType === 'interval' && (!isFiniteInt(effective.intervalMinutes) || effective.intervalMinutes < 1)) {


### PR DESCRIPTION
## 概述
修复 Agent 创建和更新 Proma 自动任务时，工具传输层补齐无关调度字段导致后端拒绝请求的问题。同时兼容部分运行时把省略的 `maxRuns` 解码为 `0` 的情况，确保其仍按“不限次数”处理。

## 改动
- `apps/electron/src/main/lib/adapters/automation-tool-schema.ts` — 集中维护自动任务创建 schema，并按调度类型清理不适用字段。
- `apps/electron/src/main/lib/adapters/pi-builtin-tools.ts` — 在 Agent 创建/更新任务进入严格校验前应用字段规范化，兼容 `maxRuns: 0`。
- `apps/electron/package.json` — 将 Electron patch 版本从 `0.17.42` 升至 `0.17.43`。

## 测试方法
1. `bun run --filter="@proma/electron" typecheck`
2. `bun run --filter="@proma/electron" build:main`
3. 使用临时 Bun 表达式验证 `maxRuns: 0` 会规范为 `null`。

## 备注
- 直接 IPC 的严格参数校验保持不变，仅 Agent 工具桥接入口增加兼容处理。
- 按需求删除了本轮新增的自动任务测试文件；后续可在 upstream 测试策略确定后补充端到端覆盖。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)