### PR TITLE
Fix GLM-5.3 reasoning depth and 1M context

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.42",
+  "version": "0.17.43",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -122,18 +122,6 @@ function compilePiReasoningCapabilities(
         },
         thinkingLevelMap,
       }
-    case 'zai-toggle':
-      return {
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          thinkingFormat: 'zai',
-          zaiToolStream: true,
-        },
-        thinkingLevelMap,
-      }
-    case 'anthropic-manual':
-      return { thinkingLevelMap }
   }
 }
 

--- a/apps/electron/src/main/lib/agent-thinking-level.test.ts
+++ b/apps/electron/src/main/lib/agent-thinking-level.test.ts
@@ -47,4 +47,22 @@ describe('Pi thinking level resolver', () => {
       'openai-responses',
     )).toBe('xhigh')
   })
+
+  test('Given GLM-5.3 and a disabled legacy setting When resolving Then keeps lightweight reasoning enabled', () => {
+    expect(resolvePiThinkingLevel(
+      { agentThinking: { type: 'disabled' }, agentEffort: 'high' },
+      { reasoningLevel: 'off' },
+      'zhipu',
+      'glm-5.3',
+    )).toBe('low')
+  })
+
+  test('Given GLM-5.3 and no override When resolving Then defaults to max reasoning', () => {
+    expect(resolvePiThinkingLevel(
+      { agentThinking: { type: 'adaptive' } },
+      undefined,
+      'zhipu-coding',
+      'glm-5.3',
+    )).toBe('max')
+  })
 })

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -331,7 +331,8 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
     codexConfig?.thinkingLevel,
     thinkingLevels,
   )
-  const isEnabled = isCodex ? normalizedLevel !== 'off' : agentThinking?.type === 'adaptive'
+  const supportsThinkingToggle = thinkingLevels.includes('off')
+  const isEnabled = isCodex ? !supportsThinkingToggle || normalizedLevel !== 'off' : agentThinking?.type === 'adaptive'
   const sliderPosition = thinkingLevels.indexOf(normalizedLevel)
 
   const handleMouseEnter = React.useCallback(() => {
@@ -351,6 +352,7 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
 
   const handleButtonClick = (): void => {
     if (codexConfig) {
+      if (!supportsThinkingToggle) return
       codexConfig.onThinkingLevelChange(isEnabled ? 'off' : 'high')
       return
     }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -41,8 +41,6 @@ export type ReasoningEncodingKind =
   | 'deepseek-output-effort'
   | 'openai-reasoning-effort'
   | 'zai-thinking-effort'
-  | 'zai-toggle'
-  | 'anthropic-manual'
 
 /** 每个产品等级映射为目标协议可接受的 effort 值。 */
 export type ReasoningEffortMap = Partial<Record<AgentThinkingLevel, string | null>>
@@ -90,14 +88,15 @@ export interface ResolveReasoningProfileInput {
 const DEEPSEEK_V4_LEVELS = ['off', 'low', 'high', 'xhigh', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const K3_LEVELS = ['off', 'low', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const GLM_52_LEVELS = ['off', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
-const GLM_53_LEVELS = ['off', 'high'] as const satisfies readonly AgentThinkingLevel[]
-/** GLM-5.3 官方端点只支持思考开关，不接受 reasoning_effort；其余档位必须从 UI 隐藏。 */
-const GLM_53_THINKING_LEVEL_MAP: ReasoningEffortMap = {
-  minimal: null,
-  low: null,
-  medium: null,
-  xhigh: null,
-  max: null,
+const GLM_53_LEVELS = ['low', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
+/**
+ * GLM-5.3 强制开启思考，深度由 reasoning_effort / output_config.effort 控制。
+ * Coding Plan 会把历史开关输入映射为 low，故不向运行时暴露 off。
+ */
+const GLM_53_EFFORT_MAP: ReasoningEffortMap = {
+  low: 'low',
+  high: 'high',
+  max: 'max',
 }
 const OPENAI_STANDARD_LEVELS = ['off', 'low', 'medium', 'high', 'xhigh'] as const satisfies readonly AgentThinkingLevel[]
 const OPENAI_MAX_LEVELS = [...OPENAI_STANDARD_LEVELS, 'max'] as const satisfies readonly AgentThinkingLevel[]
@@ -204,7 +203,20 @@ function normalizeGlm52Level(level: AgentThinkingLevel | undefined): AgentThinki
 }
 
 function normalizeGlm53Level(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
-  return level === 'off' ? 'off' : 'high'
+  switch (level) {
+    case 'minimal':
+    case 'low':
+    case 'off':
+      return 'low'
+    case 'medium':
+    case 'high':
+      return 'high'
+    case 'xhigh':
+    case 'max':
+      return 'max'
+    default:
+      return 'max'
+  }
 }
 
 function normalizeOpenAIStandardLevel(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
@@ -253,11 +265,11 @@ const K3_PROFILE: ReasoningProfile = {
 const GLM_53_PROFILE: ReasoningProfile = {
   id: 'glm-5.3',
   levels: GLM_53_LEVELS,
-  defaultLevel: 'high',
+  defaultLevel: 'max',
   normalize: normalizeGlm53Level,
   encodings: {
-    'anthropic-messages': { kind: 'anthropic-manual', effortMap: GLM_53_THINKING_LEVEL_MAP },
-    'openai-completions': { kind: 'zai-toggle', effortMap: GLM_53_THINKING_LEVEL_MAP },
+    'anthropic-messages': { kind: 'adaptive-effort', effortMap: GLM_53_EFFORT_MAP },
+    'openai-completions': { kind: 'zai-thinking-effort', effortMap: GLM_53_EFFORT_MAP },
   },
 }
 


### PR DESCRIPTION
## Summary
- align GLM-5.3 with Z.AI low/high/max effort semantics and always-on reasoning
- preserve the 1M context registration while using the API-compatible model ID
- prevent the thinking toolbar from sending an unsupported off state

## Validation
- `bun test ./apps/electron/src/main/lib/agent-thinking-level.test.ts ./apps/electron/src/main/lib/adapters/pi-codex-fast-mode.test.ts`
- `bun run typecheck`

Performance impact: no material runtime impact. The change only normalizes per-session reasoning levels and prevents an invalid toolbar action; it adds no render loop, IPC listener, timer, or streaming update path.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)