### PR TITLE
fix(agent): preserve adaptive Claude thinking

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -125,6 +125,20 @@ function compilePiReasoningCapabilities(
   }
 }
 
+/**
+ * Proma re-registers every non-OAuth channel as an ephemeral Pi provider. Preserve
+ * only this protocol-safe catalog flag: current Claude models require adaptive
+ * thinking, while copying the complete catalog compat object could leak unrelated
+ * tool/sampling behaviour across provider protocols.
+ */
+export function shouldForcePiAdaptiveThinking(
+  api: Api,
+  catalogModel: { api: Api, compat?: unknown } | undefined,
+): boolean {
+  if (api !== 'anthropic-messages' || catalogModel?.api !== 'anthropic-messages') return false
+  return (catalogModel.compat as { forceAdaptiveThinking?: unknown } | undefined)?.forceAdaptiveThinking === true
+}
+
 const CODEX_56_THINKING_LEVEL_MAP = compilePiReasoningCapabilities('openai-responses', 'gpt-5.6')?.thinkingLevelMap
 
 type CodexRuntimeCredential = CodexOAuthCredentials & {
@@ -545,11 +559,14 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const isCatalogMissingGlm53 = !catalogModel && glmModelId === 'glm-5.3'
   const catalogContextWindow = catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
   const inferredContextWindow = inferContextWindow(input.model) ?? DEFAULT_CONTEXT_WINDOW
+  const shouldForceAdaptiveThinking = shouldForcePiAdaptiveThinking(api, catalogModel)
   return {
     reasoning: catalogModel?.reasoning ?? true,
     thinkingLevelMap: providerSpecificCapabilities?.thinkingLevelMap
       ?? catalogModel?.thinkingLevelMap,
-    compat: providerSpecificCapabilities?.compat,
+    compat: shouldForceAdaptiveThinking
+      ? { ...providerSpecificCapabilities?.compat, forceAdaptiveThinking: true }
+      : providerSpecificCapabilities?.compat,
     input: catalogModel ? [...catalogModel.input] : ['text', 'image'],
     cost: catalogModel ? { ...catalogModel.cost } : { ...ZERO_MODEL_COST },
     // Codex 对齐策略优先；其他模型仍保留 catalog 与 shared inference 中更大的已验证能力。


### PR DESCRIPTION
## Summary

- Preserve Pi catalog's `forceAdaptiveThinking` only when the configured request and catalog entry both use Anthropic Messages.
- Send current Claude models through adaptive thinking without leaking unrelated compatibility flags across protocols.

## Test plan

- [x] `bun run --filter @proma/electron typecheck`
- [x] `bun test apps/electron/src/main/lib/adapters/pi-*.test.ts`

## Performance impact

- No renderer, IPC, listener, or streaming-loop changes. The added compatibility check runs once while resolving a model for a new Agent session; no measurable runtime pressure is expected.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
