### PR TITLE
fix(window): recover off-screen window bounds

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -107,7 +107,13 @@ import { startPlanningNativeSyncCoordinator, stopPlanningNativeSyncCoordinator }
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { getFeishuMultiBotConfig } from './lib/feishu-config'
 import { stopFeishuSyncSleepBlocker, syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
-import { getPersistableMainWindowState, hideMacMainWindowAfterClose } from './lib/main-window-lifecycle'
+import {
+  ensureWindowBoundsVisible,
+  getPersistableMainWindowState,
+  hideMacMainWindowAfterClose,
+  normalizeWindowBoundsToVisibleArea,
+  type WindowBounds,
+} from './lib/main-window-lifecycle'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
 import { getDingTalkMultiBotConfig } from './lib/dingtalk-config'
 import { wechatBridge } from './lib/wechat-bridge'
@@ -246,6 +252,35 @@ async function recoverEnabledDingTalkBots(): Promise<void> {
 let mainWindow: BrowserWindow | null = null
 let startupSplashWindow: BrowserWindow | null = null
 
+const DEFAULT_MAIN_WINDOW_WIDTH = 1400
+const DEFAULT_MAIN_WINDOW_HEIGHT = 900
+const MIN_MAIN_WINDOW_WIDTH = 800
+const MIN_MAIN_WINDOW_HEIGHT = 600
+
+function getVisibleMainWindowBounds(bounds: WindowBounds): WindowBounds {
+  return normalizeWindowBoundsToVisibleArea(
+    bounds,
+    screen.getAllDisplays(),
+    screen.getPrimaryDisplay(),
+    {
+      minWidth: MIN_MAIN_WINDOW_WIDTH,
+      minHeight: MIN_MAIN_WINDOW_HEIGHT,
+      fallbackWidth: DEFAULT_MAIN_WINDOW_WIDTH,
+      fallbackHeight: DEFAULT_MAIN_WINDOW_HEIGHT,
+    },
+  )
+}
+
+function getInitialMainWindowBounds(
+  savedState: ReturnType<typeof getSettings>['mainWindowState'],
+): Partial<WindowBounds> {
+  if (!savedState) {
+    return { width: DEFAULT_MAIN_WINDOW_WIDTH, height: DEFAULT_MAIN_WINDOW_HEIGHT }
+  }
+
+  return getVisibleMainWindowBounds(savedState)
+}
+
 /**
  * 原生启动页不依赖 Renderer bundle 或运行时检测，避免冷启动期间出现空白窗口。
  * dev 由 build:resources 复制到 dist/resources；打包版由 electron-builder extraResources 提供。
@@ -266,9 +301,7 @@ function createStartupSplashWindow(): void {
   if (startupSplashWindow && !startupSplashWindow.isDestroyed()) return
 
   const savedState = getSettings().mainWindowState
-  const initialBounds = savedState
-    ? { width: savedState.width, height: savedState.height, x: savedState.x, y: savedState.y }
-    : { width: 1400, height: 900 }
+  const initialBounds = getInitialMainWindowBounds(savedState)
 
   startupSplashWindow = new BrowserWindow({
     ...initialBounds,
@@ -327,27 +360,18 @@ function installWindowsZoomInFallback(win: BrowserWindow): void {
  * 处理外接显示器断开后窗口位于不可见区域的情况
  */
 function ensureWindowOnScreen(win: BrowserWindow): void {
-  const bounds = win.getBounds()
-  const displays = screen.getAllDisplays()
-  // 检查窗口中心点是否在任一显示器范围内
-  const centerX = bounds.x + bounds.width / 2
-  const centerY = bounds.y + bounds.height / 2
-  const isOnScreen = displays.some((display) => {
-    const { x, y, width, height } = display.workArea
-    return centerX >= x && centerX <= x + width && centerY >= y && centerY <= y + height
-  })
-  if (!isOnScreen) {
-    // 窗口不在任何屏幕内，移动到主显示器居中位置
-    const primary = screen.getPrimaryDisplay()
-    const { x, y, width, height } = primary.workArea
-    win.setBounds({
-      x: x + Math.round((width - bounds.width) / 2),
-      y: y + Math.round((height - bounds.height) / 2),
-      width: bounds.width,
-      height: bounds.height,
-    })
-    console.log('[窗口] 窗口已重新定位到主显示器')
-  }
+  const repositioned = ensureWindowBoundsVisible(
+    win,
+    screen.getAllDisplays(),
+    screen.getPrimaryDisplay(),
+    {
+      minWidth: MIN_MAIN_WINDOW_WIDTH,
+      minHeight: MIN_MAIN_WINDOW_HEIGHT,
+      fallbackWidth: DEFAULT_MAIN_WINDOW_WIDTH,
+      fallbackHeight: DEFAULT_MAIN_WINDOW_HEIGHT,
+    },
+  )
+  if (repositioned) console.log('[窗口] 窗口已重新定位到主显示器可见区域')
 }
 
 /** 显示并聚焦主窗口，确保窗口在可见区域；若窗口已销毁则重新创建 */
@@ -425,14 +449,12 @@ function createWindow(): void {
       : {}
 
   const savedState = getSettings().mainWindowState
-  const initialBounds = savedState
-    ? { width: savedState.width, height: savedState.height, x: savedState.x, y: savedState.y }
-    : { width: 1400, height: 900 }
+  const initialBounds = getInitialMainWindowBounds(savedState)
 
   mainWindow = new BrowserWindow({
     ...initialBounds,
-    minWidth: 800,
-    minHeight: 600,
+    minWidth: MIN_MAIN_WINDOW_WIDTH,
+    minHeight: MIN_MAIN_WINDOW_HEIGHT,
     icon: iconExists ? iconPath : undefined,
     show: false,
     webPreferences: {

--- a/apps/electron/src/main/lib/main-window-lifecycle.ts
+++ b/apps/electron/src/main/lib/main-window-lifecycle.ts
@@ -1,10 +1,35 @@
 import type { MainWindowState } from '../../types'
 
-interface WindowBounds {
+export interface WindowBounds {
   width: number
   height: number
   x: number
   y: number
+}
+
+export interface WindowWorkArea {
+  width: number
+  height: number
+  x: number
+  y: number
+}
+
+export interface WindowDisplayLike {
+  workArea: WindowWorkArea
+}
+
+export interface NormalizeWindowBoundsOptions {
+  minWidth?: number
+  minHeight?: number
+  fallbackWidth?: number
+  fallbackHeight?: number
+}
+
+export interface WindowBoundsController {
+  isMaximized(): boolean
+  isFullScreen(): boolean
+  getBounds(): WindowBounds
+  setBounds(bounds: WindowBounds): void
 }
 
 export interface MainWindowStateReadable {
@@ -31,6 +56,98 @@ export type ScheduleFn = (callback: () => void, delayMs: number) => unknown
 
 const FULL_SCREEN_HIDE_DELAY_MS = 160
 const FULL_SCREEN_HIDE_FALLBACK_DELAY_MS = 1000
+
+function isFiniteNumber(value: number): boolean {
+  return Number.isFinite(value)
+}
+
+function isUsableArea(area: WindowWorkArea | undefined): area is WindowWorkArea {
+  return !!area
+    && isFiniteNumber(area.x)
+    && isFiniteNumber(area.y)
+    && isFiniteNumber(area.width)
+    && isFiniteNumber(area.height)
+    && area.width > 0
+    && area.height > 0
+}
+
+function sanitizeDimension(value: number, fallback: number): number {
+  if (!isFiniteNumber(value) || value <= 0) return Math.max(1, Math.round(fallback))
+  return Math.max(1, Math.round(value))
+}
+
+function intersectionArea(bounds: WindowBounds, area: WindowWorkArea): number {
+  const left = Math.max(bounds.x, area.x)
+  const right = Math.min(bounds.x + bounds.width, area.x + area.width)
+  const top = Math.max(bounds.y, area.y)
+  const bottom = Math.min(bounds.y + bounds.height, area.y + area.height)
+  return Math.max(0, right - left) * Math.max(0, bottom - top)
+}
+
+/**
+ * 规范化用于“创建窗口”的持久化 bounds。
+ *
+ * 仅在窗口与所有当前显示器完全没有交叠时恢复到主屏；仍有任意可见像素时
+ * 原样保留，以免破坏用户有意横跨多块屏幕摆放的普通窗口。
+ */
+export function normalizeWindowBoundsToVisibleArea(
+  bounds: WindowBounds,
+  displays: readonly WindowDisplayLike[],
+  primaryDisplay: WindowDisplayLike,
+  options: NormalizeWindowBoundsOptions = {},
+): WindowBounds {
+  const areas = displays.map((display) => display.workArea).filter(isUsableArea)
+  const fallbackArea = isUsableArea(primaryDisplay.workArea)
+    ? primaryDisplay.workArea
+    : areas[0] ?? { x: 0, y: 0, width: options.fallbackWidth ?? 1400, height: options.fallbackHeight ?? 900 }
+  const safeBounds: WindowBounds = {
+    width: sanitizeDimension(bounds.width, options.fallbackWidth ?? fallbackArea.width),
+    height: sanitizeDimension(bounds.height, options.fallbackHeight ?? fallbackArea.height),
+    x: isFiniteNumber(bounds.x) ? Math.round(bounds.x) : fallbackArea.x,
+    y: isFiniteNumber(bounds.y) ? Math.round(bounds.y) : fallbackArea.y,
+  }
+
+  if (areas.some((area) => intersectionArea(safeBounds, area) > 0)) return safeBounds
+
+  const areaWidth = Math.max(1, Math.round(fallbackArea.width))
+  const areaHeight = Math.max(1, Math.round(fallbackArea.height))
+  const minWidth = Math.min(areaWidth, Math.max(1, Math.round(options.minWidth ?? 1)))
+  const minHeight = Math.min(areaHeight, Math.max(1, Math.round(options.minHeight ?? 1)))
+  const width = Math.min(areaWidth, Math.max(minWidth, safeBounds.width))
+  const height = Math.min(areaHeight, Math.max(minHeight, safeBounds.height))
+
+  return {
+    width,
+    height,
+    x: Math.round(fallbackArea.x + (areaWidth - width) / 2),
+    y: Math.round(fallbackArea.y + (areaHeight - height) / 2),
+  }
+}
+
+/**
+ * 确保已创建的普通窗口仍可见。最大化/全屏窗口的 bounds 是平台相关的系统值：
+ * Windows 会包含不可见边框，macOS 全屏会包含菜单栏，因此绝不主动覆盖。
+ */
+export function ensureWindowBoundsVisible(
+  win: WindowBoundsController,
+  displays: readonly WindowDisplayLike[],
+  primaryDisplay: WindowDisplayLike,
+  options: NormalizeWindowBoundsOptions = {},
+): boolean {
+  if (win.isMaximized() || win.isFullScreen()) return false
+
+  const currentBounds = win.getBounds()
+  const nextBounds = normalizeWindowBoundsToVisibleArea(currentBounds, displays, primaryDisplay, options)
+  if (
+    nextBounds.x === currentBounds.x
+    && nextBounds.y === currentBounds.y
+    && nextBounds.width === currentBounds.width
+    && nextBounds.height === currentBounds.height
+  ) return false
+
+  win.setBounds(nextBounds)
+  return true
+}
 
 /**
  * 全屏/最大化状态下只保存普通窗口 bounds，避免把全屏 Space 尺寸写入配置。

--- a/apps/electron/src/main/lib/planning-window.ts
+++ b/apps/electron/src/main/lib/planning-window.ts
@@ -2,7 +2,12 @@ import { app, BrowserWindow, screen, shell } from 'electron'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import type { MainWindowState } from '../../types'
-import { getPersistableMainWindowState } from './main-window-lifecycle'
+import {
+  ensureWindowBoundsVisible,
+  getPersistableMainWindowState,
+  normalizeWindowBoundsToVisibleArea,
+  type WindowBounds,
+} from './main-window-lifecycle'
 import { getSettings, updateSettings } from './settings-service'
 
 const DEFAULT_WIDTH = 1180
@@ -24,9 +29,27 @@ function getIconPath(): string | undefined {
   return existsSync(iconPath) ? iconPath : undefined
 }
 
+function normalizePlanningWindowBounds(
+  bounds: WindowBounds,
+  minWidth = MIN_WIDTH,
+  minHeight = MIN_HEIGHT,
+): WindowBounds {
+  return normalizeWindowBoundsToVisibleArea(
+    bounds,
+    screen.getAllDisplays(),
+    screen.getPrimaryDisplay(),
+    {
+      minWidth,
+      minHeight,
+      fallbackWidth: DEFAULT_WIDTH,
+      fallbackHeight: DEFAULT_HEIGHT,
+    },
+  )
+}
+
 function getInitialBounds(savedState?: MainWindowState): Electron.Rectangle {
   if (savedState) {
-    return { x: savedState.x, y: savedState.y, width: savedState.width, height: savedState.height }
+    return normalizePlanningWindowBounds(savedState)
   }
 
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
@@ -42,19 +65,17 @@ function getInitialBounds(savedState?: MainWindowState): Electron.Rectangle {
 }
 
 function ensureWindowOnScreen(win: BrowserWindow): void {
-  const bounds = win.getBounds()
-  const centerX = bounds.x + bounds.width / 2
-  const centerY = bounds.y + bounds.height / 2
-  const visible = screen.getAllDisplays().some((display) => {
-    const area = display.workArea
-    return centerX >= area.x && centerX <= area.x + area.width && centerY >= area.y && centerY <= area.y + area.height
-  })
-  if (visible) return
-
-  const area = screen.getPrimaryDisplay().workArea
-  win.setPosition(
-    area.x + Math.round((area.width - bounds.width) / 2),
-    area.y + Math.round((area.height - bounds.height) / 2),
+  const [minWidth, minHeight] = win.getMinimumSize()
+  ensureWindowBoundsVisible(
+    win,
+    screen.getAllDisplays(),
+    screen.getPrimaryDisplay(),
+    {
+      minWidth,
+      minHeight,
+      fallbackWidth: DEFAULT_WIDTH,
+      fallbackHeight: DEFAULT_HEIGHT,
+    },
   )
 }
 


### PR DESCRIPTION
## Summary

- 启动时校验主窗口与规划窗口的持久化 bounds，副屏断开后将完全离屏的窗口恢复到主屏。
- 保留仍与当前显示器交叠的跨屏普通窗口。
- 跳过 Windows 最大化与 macOS 全屏窗口的动态 bounds 校正，避免覆盖系统管理的窗口状态。

## Validation

- `apps/electron`: `npx tsc --noEmit -p tsconfig.json`
- `git diff --check`

Performance impact: only reads display geometry when a window is created or explicitly shown; no renderer, IPC, or high-frequency work.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)