### PR TITLE
Fix scheduled-task editor back navigation

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -19,6 +19,7 @@ import { SearchDialog } from './SearchDialog'
 import { UserAvatar } from '@/components/chat/UserAvatar'
 import { activeViewAtom, agentSkillsTabAtom } from '@/atoms/active-view'
 import { automationFormAtom, automationsAtom } from '@/atoms/automation-atoms'
+import { planningTabAtom } from '@/atoms/planning-atoms'
 import { appModeAtom, type AppMode } from '@/atoms/app-mode'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import {
@@ -724,6 +725,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const [activeView, setActiveView] = useAtom(activeViewAtom)
   const setAgentSkillsTab = useSetAtom(agentSkillsTabAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
+  const setPlanningTab = useSetAtom(planningTabAtom)
   const automations = useAtomValue(automationsAtom)
   const setAutomations = useSetAtom(automationsAtom)
   const automationCount = automations.length
@@ -1092,8 +1094,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       return
     }
     setAutomationForm({ open: false, draft: null })
+    // 从侧栏进入规划中心仍以 Todo 为默认页；表单返回不会触发这条导航，因此可保留定时任务标签。
+    setPlanningTab('todos')
     setActiveView('planning')
-  }, [activeView, setAutomationForm, setActiveView, store])
+  }, [activeView, setAutomationForm, setActiveView, setPlanningTab, store])
 
   /** 打开/关闭 Agent 技能视图 */
   const handleOpenSkills = React.useCallback((): void => {

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -609,7 +609,7 @@ export function AutomationFormView({ standalone = false }: { standalone?: boolea
             aria-label="返回任务列表"
           >
             <ArrowLeft className="size-3.5" />
-            <span>自动任务</span>
+            <span>定时任务</span>
           </button>
           <Clock className="size-4 text-primary flex-shrink-0" />
           {editingName ? (

--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -47,12 +47,9 @@ function CreateShortcutHint(): React.ReactElement | null {
 }
 
 export function PlanningView({ standalone = false }: { standalone?: boolean } = {}): React.ReactElement {
+  // planningTabAtom 的初始值为 Todo；保留当前标签可让定时任务编辑页返回到任务列表。
   const [tab, setTab] = useAtom(planningTabAtom)
   const isWindows = React.useMemo(() => detectIsWindows(), [])
-  React.useEffect(() => {
-    // Todo 是规划中心的默认落点；用户仍可在当前窗口切换到其他规划视图。
-    setTab('todos')
-  }, [setTab])
   const automations = useAtomValue(automationsAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
   const requestTodoCreate = useSetAtom(planningTodoCreateRequestAtom)


### PR DESCRIPTION
## Summary

- 379634b6 fix(planning): restore automation list on editor back

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)