### PR TITLE
Fix Coding Plan model list

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -36,6 +36,7 @@ import {
   parseXaiCredentials,
   serializeXaiCredentials,
   isXaiCredentialExpired,
+  VOLCENGINE_CODING_PLAN_MODELS,
 } from '@proma/shared'
 import { refreshCodexOAuth } from './codex-oauth-service'
 import { refreshXaiOAuth } from './xai-oauth-service'
@@ -138,10 +139,14 @@ function cloneModels(models: ChannelModel[]): ChannelModel[] {
   return models.map((model) => ({ ...model }))
 }
 
-function createPresetModelsResult(providerName: string, models: ChannelModel[]): FetchModelsResult {
+function createPresetModelsResult(
+  providerName: string,
+  models: ChannelModel[],
+  reason = '未开放模型列表端点',
+): FetchModelsResult {
   return {
     success: true,
-    message: `${providerName} 未开放模型列表端点，已加载 ${models.length} 个预设模型`,
+    message: `${providerName} ${reason}，已加载 ${models.length} 个预设模型`,
     models: cloneModels(models),
   }
 }
@@ -1789,6 +1794,13 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
       case 'doubao-api':
       case 'qwen':
       case 'custom':
+        if (provider === 'doubao') {
+          return createPresetModelsResult(
+            '火山方舟 Coding Plan',
+            [...VOLCENGINE_CODING_PLAN_MODELS],
+            '使用套餐支持清单，不采用通用 /models 目录',
+          )
+        }
         return await fetchOpenAICompatibleModels(input.baseUrl, input.apiKey, proxyUrl, provider)
       case 'google':
         return await fetchGoogleModels(input.baseUrl, input.apiKey, proxyUrl)

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -32,6 +32,7 @@ import { Input } from '@/components/ui/input'
 import {
   PROVIDER_DEFAULT_URLS,
   PROVIDER_LABELS,
+  VOLCENGINE_CODING_PLAN_MODELS,
   parseZhipuTeamCredentials,
   parseCodexCredentials,
   parseXaiCredentials,
@@ -434,7 +435,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
           { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
           { id: 'glm-5.1', name: 'GLM-5.1', enabled: false },
         ])
-      } else if (p === 'ark-coding-plan' || p === 'doubao') {
+      } else if (p === 'ark-coding-plan') {
         setModels([
           { id: 'doubao-seed-2.1-pro', name: 'Doubao Seed 2.1 Pro', enabled: true },
           { id: 'doubao-seed-2.1-turbo', name: 'Doubao Seed 2.1 Turbo', enabled: true },
@@ -448,6 +449,8 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
           { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
           { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
         ])
+      } else if (p === 'doubao') {
+        setModels(VOLCENGINE_CODING_PLAN_MODELS.map((model) => ({ ...model })))
       } else if (p === 'minimax') {
         setModels([
           { id: 'MiniMax-M3', name: 'MiniMax-M3', enabled: true },

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -277,6 +277,22 @@ export interface ChannelModel {
 }
 
 /**
+ * 火山方舟 Coding Plan 当前支持的模型名。
+ *
+ * Coding Plan 的 `/models` 返回的是方舟通用模型目录，不等于订阅套餐的授权清单，
+ * 因此不能直接把该接口返回值作为渠道模型列表。
+ */
+export const VOLCENGINE_CODING_PLAN_MODELS: readonly ChannelModel[] = [
+  { id: 'doubao-seed-2.1-turbo', name: 'Doubao Seed 2.1 Turbo', enabled: true },
+  { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
+  { id: 'minimax-m3', name: 'MiniMax M3', enabled: true },
+  { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
+  { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
+  { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
+  { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },
+]
+
+/**
  * 渠道配置
  *
  * 存储在 ~/.proma/channels.json 中，apiKey 字段为加密后的 base64 字符串


### PR DESCRIPTION
## Summary

- Use the seven-model 火山方舟 Coding Plan allowlist instead of the generic `/models` catalog.
- Share the preset list between the main process and channel form.
- Keep the 火山引擎 API provider on its existing generic model-list behavior.

## Verification

- `bun run typecheck`

## Performance

- No runtime hot-path impact. Model retrieval is a user-initiated settings action and now avoids materializing the unrelated 130-item catalog.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)