### PR TITLE
fix(browser): allow internal HTTPS certificates

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.46",
+  "version": "0.17.47",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -452,6 +452,11 @@ export class BrowserController {
     if (this.guardedSessions.has(browserSession)) return
     this.guardedSessions.add(browserSession)
     browserSession.setPermissionRequestHandler((_contents, _permission, callback) => callback(false))
+    browserSession.setCertificateVerifyProc((_request, callback) => {
+      // 受管浏览器面向用户明确打开的网页；内网自签名证书和企业 CA 由用户自行负责，
+      // 仅在该浏览器 Session 内放行，不影响 Proma 主窗口或其他 Electron Session。
+      callback(0)
+    })
     browserSession.webRequest.onBeforeRequest((details, callback) => {
       let protocol = ''
       try { protocol = new URL(details.url).protocol } catch { callback({ cancel: true }); return }

--- a/apps/electron/src/main/lib/browser-policy.ts
+++ b/apps/electron/src/main/lib/browser-policy.ts
@@ -36,13 +36,14 @@ export function normalizeBrowserUrl(input: string): string {
   // `localhost:3000` 和 `example.com:8080` 是没有协议的常见地址栏输入，不能被误判为 scheme。
   if (/^[^/?#:\s]+:\d+(?:[/?#]|$)/.test(value)) {
     const localCandidate = new URL(`http://${value}`)
-    // 本机和局域网开发服务通常未配置 TLS；其他地址仍默认 HTTPS。
+    if (localCandidate.port === '443') return `https://${value}`
     return isLocalNetworkAddress(localCandidate.hostname) ? `http://${value}` : `https://${value}`
   }
   if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value)) return value
   // `localhost` / `app.localhost` 没有端口时同样按 HTTP 打开。
   try {
     const localCandidate = new URL(`http://${value}`)
+    if (localCandidate.port === '443') return `https://${value}`
     if (isLocalNetworkAddress(localCandidate.hostname)) return `http://${value}`
   } catch { /* 交由后续 URL 校验输出统一错误 */ }
   return `https://${value}`


### PR DESCRIPTION
## Summary

- c5b20f7d fix(browser): allow internal HTTPS certificates

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)