### PR TITLE
feat(browser): fall back to Bing after Google timeout

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.47",
+  "version": "0.17.48",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, WebContentsView, session as electronSession, type D
 import path from 'node:path'
 import type { BrowserExecutionSource, BrowserOperationStatus, BrowserSessionClosed, BrowserTraceAction, BrowserTraceItem, BrowserViewLayout, BrowserViewState, BrowserTabState } from '@proma/shared'
 import { AGENT_IPC_CHANNELS } from '@proma/shared'
-import { assertSafeBrowserDestination, assertSafeBrowserDownloadUrl, assertSafeBrowserUrl, isSupportedBrowserPopupUrl, isTransientBrowserPopupUrl, USER_NEW_TAB_URL } from './browser-policy'
+import { assertSafeBrowserDestination, assertSafeBrowserDestinationWithFallback, assertSafeBrowserDownloadUrl, assertSafeBrowserUrl, isSupportedBrowserPopupUrl, isTransientBrowserPopupUrl, USER_NEW_TAB_URL } from './browser-policy'
 import { createAuthorizedPreviewUrl, isAuthorizedPreviewProtocol } from './browser-preview-service'
 import { handlePromaFileRequest } from './local-file-protocol'
 import { BrowserCdpTimeoutError, BrowserOperationAbortedError, BROWSER_OBSERVE_TIMEOUT_MS, resolveBrowserObserveAxDepth, throwIfBrowserOperationAborted, withBrowserCdpTimeout } from './browser-cdp'
@@ -23,6 +23,8 @@ const MAX_BACKGROUND_BROWSER_SESSIONS = 8
 const MAX_SCREENSHOT_BYTES = 3 * 1024 * 1024
 const ACTION_HIGHLIGHT_DURATION_MS = 900
 const MAX_BROWSER_SCRIPT_RESULT_CHARS = 64_000
+/** 国内网络下默认 Google 新标签页/搜索等待此时长后转向 Bing。 */
+const GOOGLE_DEFAULT_LOAD_TIMEOUT_MS = 3_000
 
 /** 下载文件名脱敏：去掉控制字符与路径穿越，替换 Windows 非法字符，兜底默认名，避免写入 Downloads 之外的路径。 */
 function sanitizeDownloadFilename(raw: string): string {
@@ -1081,9 +1083,23 @@ export class BrowserController {
     }
   }
 
-  private async loadUrl(tab: BrowserTabRecord, url: string, signal?: AbortSignal): Promise<void> {
+  private async loadUrl(tab: BrowserTabRecord, url: string, signal?: AbortSignal, timeoutMs = BROWSER_OBSERVE_TIMEOUT_MS + 3_000): Promise<void> {
     throwIfBrowserOperationAborted(signal)
-    await withBrowserCdpTimeout(() => tab.view.webContents.loadURL(url), 'Page.navigate', BROWSER_OBSERVE_TIMEOUT_MS + 3_000, signal)
+    await withBrowserCdpTimeout(() => tab.view.webContents.loadURL(url), 'Page.navigate', timeoutMs, signal)
+  }
+
+  /** 默认 Google 页面在 3 秒内未完成加载时停止旧导航，并在同一标签页加载 Bing。 */
+  private async loadUrlWithFallback(tab: BrowserTabRecord, url: string, fallbackUrl: string | undefined, signal?: AbortSignal): Promise<{ loadedUrl: string; usedFallback: boolean }> {
+    try {
+      await this.loadUrl(tab, url, signal, fallbackUrl ? GOOGLE_DEFAULT_LOAD_TIMEOUT_MS : undefined)
+      return { loadedUrl: url, usedFallback: false }
+    } catch (error) {
+      if (!fallbackUrl || !(error instanceof BrowserCdpTimeoutError)) throw error
+      try { tab.view.webContents.stop() } catch { /* WebContents 已销毁时由后续加载统一报错 */ }
+      throwIfBrowserOperationAborted(signal)
+      await this.loadUrl(tab, fallbackUrl, signal)
+      return { loadedUrl: fallbackUrl, usedFallback: true }
+    }
   }
 
   async navigate(sessionId: string, url: string, tabId?: string, signal?: AbortSignal): Promise<BrowserViewState> {
@@ -1092,14 +1108,15 @@ export class BrowserController {
     try {
       this.assertRiskDisclaimerAcknowledged()
       const tab = this.getAgentTab(browserSession, tabId)
-      const safeUrl = await assertSafeBrowserDestination(url)
-      const host = new URL(safeUrl).host
+      const destination = await assertSafeBrowserDestinationWithFallback(url)
+      const host = new URL(destination.url).host
       return this.runTabOperation(browserSession, tab, signal ?? browserSession.agentAbortController.signal, async (operationSignal) => {
         tab.isLocalPreview = false
         this.trace(browserSession, tab, 'navigate', `正在打开 ${host}`, 'dispatched')
         try {
-          await this.loadUrl(tab, safeUrl, operationSignal)
-          this.trace(browserSession, tab, 'navigate', `已打开 ${host}`, 'verified')
+          const result = await this.loadUrlWithFallback(tab, destination.url, destination.fallbackUrl, operationSignal)
+          const loadedHost = new URL(result.loadedUrl).host
+          this.trace(browserSession, tab, 'navigate', result.usedFallback ? `Google 在 3 秒内未响应，已改用 ${loadedHost}` : `已打开 ${loadedHost}`, 'verified')
           this.updateNavigationState(browserSession, tab)
           return structuredClone(this.buildState(browserSession))
         } catch (error) {
@@ -1119,14 +1136,15 @@ export class BrowserController {
     this.assertRiskDisclaimerAcknowledged()
     this.markUserBrowserContext(browserSession)
     const tab = this.getDisplayTab(browserSession, tabId)
-    const safeUrl = await assertSafeBrowserDestination(url)
-    const host = new URL(safeUrl).host
+    const destination = await assertSafeBrowserDestinationWithFallback(url)
+    const host = new URL(destination.url).host
     return this.runTabOperation(browserSession, tab, undefined, async () => {
       tab.isLocalPreview = false
       this.trace(browserSession, tab, 'navigate', `正在打开 ${host}`, 'dispatched')
       try {
-        await this.loadUrl(tab, safeUrl)
-        this.trace(browserSession, tab, 'navigate', `已打开 ${host}`, 'verified')
+        const result = await this.loadUrlWithFallback(tab, destination.url, destination.fallbackUrl)
+        const loadedHost = new URL(result.loadedUrl).host
+        this.trace(browserSession, tab, 'navigate', result.usedFallback ? `Google 在 3 秒内未响应，已改用 ${loadedHost}` : `已打开 ${loadedHost}`, 'verified')
         this.updateNavigationState(browserSession, tab)
         return structuredClone(this.buildState(browserSession))
       } catch (error) {

--- a/apps/electron/src/main/lib/browser-policy.ts
+++ b/apps/electron/src/main/lib/browser-policy.ts
@@ -1,7 +1,15 @@
 /** 受管浏览器的 URL 规范化与合法性校验；保持无 Electron 依赖，便于在普通 Bun 测试中验证。 */
 
 const GOOGLE_SEARCH_URL = 'https://www.google.com/search'
+const BING_SEARCH_URL = 'https://www.bing.com/search'
 const USER_NEW_TAB_URL = 'https://www.google.com/'
+const USER_NEW_TAB_FALLBACK_URL = 'https://www.bing.com/'
+
+export interface BrowserDestination {
+  url: string
+  /** 仅默认 Google 新标签页和搜索词在 3 秒加载超时时回退。 */
+  fallbackUrl?: string
+}
 
 function isLoopbackAddress(hostname: string): boolean {
   const host = hostname.toLowerCase()
@@ -109,22 +117,43 @@ function isLikelyUrl(value: string): boolean {
  * 明确的 URL 和可识别的主机名保持直达，普通文本按搜索词处理。
  */
 export function resolveBrowserDestination(input: string): string {
+  return resolveBrowserDestinationWithFallback(input).url
+}
+
+/**
+ * 仅默认 Google 新标签页和由普通文本生成的 Google 搜索有 Bing 回退；用户输入的 URL 永远直达。
+ */
+export function resolveBrowserDestinationWithFallback(input: string): BrowserDestination {
   const value = input.trim()
   if (!value) throw new Error('浏览器地址或搜索内容不能为空。')
-  if (isLikelyUrl(value)) return normalizeBrowserUrl(value)
-  return `${GOOGLE_SEARCH_URL}?q=${encodeURIComponent(value)}`
+  if (value === USER_NEW_TAB_URL) return { url: USER_NEW_TAB_URL, fallbackUrl: USER_NEW_TAB_FALLBACK_URL }
+  if (isLikelyUrl(value)) return { url: normalizeBrowserUrl(value) }
+  const query = encodeURIComponent(value)
+  return {
+    url: `${GOOGLE_SEARCH_URL}?q=${query}`,
+    fallbackUrl: `${BING_SEARCH_URL}?q=${query}`,
+  }
 }
 
 /**
  * 仅拒绝空值或无法被 URL 标准解析的输入；搜索词会先被转换为 Google 搜索 URL。
  */
 export async function assertSafeBrowserDestination(input: string): Promise<string> {
-  const resolved = resolveBrowserDestination(input)
+  const destination = await assertSafeBrowserDestinationWithFallback(input)
+  return destination.url
+}
+
+/** 验证默认搜索及其回退地址，并保留是否允许回退的语义。 */
+export async function assertSafeBrowserDestinationWithFallback(input: string): Promise<BrowserDestination> {
+  const destination = resolveBrowserDestinationWithFallback(input)
   try {
-    return new URL(resolved).toString()
+    return {
+      url: new URL(destination.url).toString(),
+      ...(destination.fallbackUrl ? { fallbackUrl: new URL(destination.fallbackUrl).toString() } : {}),
+    }
   } catch {
     throw new Error('浏览器地址或搜索内容无效。')
   }
 }
 
-export { GOOGLE_SEARCH_URL, USER_NEW_TAB_URL }
+export { BING_SEARCH_URL, GOOGLE_SEARCH_URL, USER_NEW_TAB_FALLBACK_URL, USER_NEW_TAB_URL }


### PR DESCRIPTION
## Summary

- 默认新标签页及普通搜索词优先加载 Google，3 秒未完成时停止旧导航并回退至 Bing。
- 用户明确输入的 URL 不会被替换；Bing 搜索保留原始查询词。
- Electron 版本更新至 0.17.48。

## Validation

- [x] `bun run --filter='@proma/electron' typecheck`
- [x] `bun run --filter='@proma/electron' build:main`
- [ ] 未在受限网络环境下完成 Electron 手动超时回退验证。

## Performance impact

低风险：仅在默认 Google 导航上新增一次 3 秒超时；正常加载无额外渲染、IPC、订阅或定时器开销。超时时会先停止旧导航，再在同一标签加载 Bing。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)