### PR TITLE
fix(mcp): refresh test status after closing editor

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -460,9 +460,18 @@ export function AgentSkillsView(): React.ReactElement {
         open={mcpSheetOpen}
         server={editingMcp}
         workspaceSlug={data.workspaceSlug}
-        onOpenChange={(open) => { setMcpSheetOpen(open); if (!open) bumpCapabilities((v) => v + 1) }}
+        onOpenChange={(open) => {
+          setMcpSheetOpen(open)
+          if (!open) {
+            void data.refreshMcpConfig()
+            bumpCapabilities((v) => v + 1)
+          }
+        }}
         onSaved={() => setMcpSheetOpen(false)}
-        onChanged={() => bumpCapabilities((v) => v + 1)}
+        onChanged={() => {
+          void data.refreshMcpConfig()
+          bumpCapabilities((v) => v + 1)
+        }}
       />
 
       <BuiltinMcpDetailSheet

--- a/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
+++ b/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
@@ -33,6 +33,7 @@ export interface AgentSkillsData {
   toggleSkill: (slug: string, enabled: boolean) => Promise<void>
   deleteSkill: (slug: string, name: string) => Promise<boolean>
   updateSkill: (slug: string) => Promise<void>
+  refreshMcpConfig: () => Promise<void>
   toggleMcp: (name: string, enabled: boolean) => Promise<void>
   toggleBuiltinMcp: (id: string, enabled: boolean) => Promise<void>
   deleteMcp: (name: string) => Promise<void>
@@ -133,6 +134,16 @@ export function useAgentSkillsData(): AgentSkillsData {
     }
   }, [workspaceSlug, updatingSkill, bumpCapabilitiesVersion])
 
+  const refreshMcpConfig = React.useCallback(async () => {
+    if (!workspaceSlug) return
+    try {
+      const config = await window.electronAPI.getWorkspaceMcpConfig(workspaceSlug)
+      setMcpConfig(config)
+    } catch (error) {
+      console.error('[Agent 技能] 刷新 MCP 配置失败:', error)
+    }
+  }, [workspaceSlug])
+
   const toggleMcp = React.useCallback(async (name: string, enabled: boolean) => {
     try {
       const entry = mcpConfig.servers[name]
@@ -194,6 +205,7 @@ export function useAgentSkillsData(): AgentSkillsData {
     toggleSkill,
     deleteSkill,
     updateSkill,
+    refreshMcpConfig,
     toggleMcp,
     toggleBuiltinMcp,
     deleteMcp,

--- a/apps/electron/src/renderer/components/settings/McpServerForm.tsx
+++ b/apps/electron/src/renderer/components/settings/McpServerForm.tsx
@@ -154,7 +154,6 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onChanged, onCan
   const isFirstRenderRef = React.useRef(true)
   const mountedRef = React.useRef(true)
   const [saveStatus, setSaveStatus] = React.useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-  const lastSavedEnabledRef = React.useRef(server?.entry.enabled ?? false)
 
   // 保留最新表单值，供 unmount 时 flush 待保存变更
   const latestValuesRef = React.useRef({
@@ -216,10 +215,9 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onChanged, onCan
       }
       await window.electronAPI.saveWorkspaceMcpConfig(workspaceSlug, newConfig)
       if (generation === saveGenerationRef.current && mountedRef.current) {
-        if (entry.enabled !== lastSavedEnabledRef.current) {
-          lastSavedEnabledRef.current = entry.enabled
-          onChanged?.()
-        }
+        // 编辑抽屉外的 MCP 卡片使用独立快照；每次持久化后通知其局部重读，
+        // 让测试结果无需离开再进入页面即可同步显示。
+        onChanged?.()
         setSaveStatus('saved')
         setTimeout(() => {
           if (generation === saveGenerationRef.current && mountedRef.current) {


### PR DESCRIPTION
## Summary

- 测试连接结果持久化后，通知 MCP 列表局部重新读取配置。
- 关闭编辑抽屉时再次刷新，避免卡片保留旧的连接状态。

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`
- [x] `git diff --check`
- [x] `bun test`（471 通过；4 个 Electron/原生运行环境相关的既有失败）

## Performance

- 低风险：仅在 MCP 配置成功持久化或抽屉关闭时各触发一次配置读取；不新增持续订阅、计时器或高频 IPC。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)