### PR TITLE
fix(agent): extend AskUserQuestion timeout

### DIFF
--- a/apps/electron/src/utility/agent-runtime-request-timeout.ts
+++ b/apps/electron/src/utility/agent-runtime-request-timeout.ts
@@ -1,0 +1,19 @@
+import { AGENT_RUNTIME_METHODS } from '@proma/shared'
+
+const DEFAULT_PARENT_REQUEST_TIMEOUT_MS = 120_000
+// AskUserQuestion 属于用户主导的自由文本交互；两分钟不足以完成输入。
+export const ASK_USER_QUESTION_TIMEOUT_MS = 15 * 60_000
+
+/**
+ * Utility Process 请求主进程的等待时间。
+ * 仅 AskUserQuestion 延长，避免放宽其他跨进程能力调用的故障检测。
+ */
+export function getParentRequestTimeoutMs(method: string, payload: unknown): number {
+  if (
+    method === AGENT_RUNTIME_METHODS.CAPABILITY_CAN_USE_TOOL
+    && (payload as { toolName?: unknown } | null)?.toolName === 'AskUserQuestion'
+  ) {
+    return ASK_USER_QUESTION_TIMEOUT_MS
+  }
+  return DEFAULT_PARENT_REQUEST_TIMEOUT_MS
+}

--- a/apps/electron/src/utility/agent-runtime.ts
+++ b/apps/electron/src/utility/agent-runtime.ts
@@ -12,6 +12,7 @@ import {
   type AgentRuntimeState,
 } from '@proma/shared'
 import { PiAgentAdapter, type PiAgentQueryOptions } from '../main/lib/adapters/pi-agent-adapter'
+import { getParentRequestTimeoutMs } from './agent-runtime-request-timeout'
 
 type MessagePortLike = {
   on(event: 'message', listener: (event: { data: unknown }) => void): void
@@ -318,6 +319,7 @@ function requestParent<Result = unknown>(
 ): Promise<Result> {
   const port = runtimePort
   if (!port) return Promise.reject(new Error('Agent runtime port is not connected'))
+  const timeoutMs = getParentRequestTimeoutMs(method, payload)
   const request = createAgentRuntimeRequest(method, payload, {
     sessionId: activeQuery?.sessionId,
     queryId: activeQuery?.queryId,
@@ -339,7 +341,7 @@ function requestParent<Result = unknown>(
         bootId,
       ))
       reject(new Error(`Main runtime request timed out: ${method}`))
-    }, 120_000)
+    }, timeoutMs)
     parentRequests.set(request.requestId, {
       resolve: (value) => resolve(value as Result),
       reject,


### PR DESCRIPTION
## Summary

- Extend the Utility Process wait for `AskUserQuestion` from 2 to 15 minutes, so custom text can be completed before expiry.
- Keep the existing 2-minute safety timeout for all other parent capability requests.

## Validation

- `bun run typecheck`

## Performance

No measurable rendering, IPC-volume, or main-thread impact: this only changes the timeout threshold for a pending user interaction.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)