### PR TITLE
feat(pi): enable DeepSeek V4 Flash vision

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.54",
+  "version": "0.17.55",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -1164,7 +1164,7 @@ export async function buildPiBuiltinTools(
     console.error('[Pi 桥接] 注入受管浏览器工具失败:', error)
   }
 
-  // 视觉助手仅在明确不支持视觉的 DeepSeek V4 用户会话中按需出现。
+  // 视觉助手仅在仍不支持原生视觉的 DeepSeek V4 Pro 用户会话中按需出现。
   try {
     tools.push(...buildVisionRelayTools(sdk, ctx))
   } catch (error) {

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -257,6 +257,26 @@ function createXaiRuntimeCredentialStore(
   }
 }
 
+/**
+ * Pi 0.84.2 的内置 catalog 尚未声明以下 DeepSeek V4 Flash 变体的原生视觉。
+ * 在上游目录同步前，本地覆盖只扩展 input，不改变实际模型 ID、协议或推理参数。
+ */
+const DEEPSEEK_V4_FLASH_VISION_MODEL_IDS = new Set([
+  'deepseek-v4-flash',
+  'deepseek-v4-flash-vision-exp',
+])
+
+/** 判断模型是否已确认支持原生图片输入。 */
+export function supportsPiNativeImageInput(modelId: string | undefined): boolean {
+  const normalized = stripLegacyAgentSdkContextSuffix(modelId)?.trim().toLowerCase()
+  return normalized !== undefined && DEEPSEEK_V4_FLASH_VISION_MODEL_IDS.has(normalized)
+}
+
+function applyPiModelCapabilityOverrides(model: PiCatalogModel | undefined): PiCatalogModel | undefined {
+  if (!model || !supportsPiNativeImageInput(model.id) || model.input.includes('image')) return model
+  return { ...model, input: [...model.input, 'image'] }
+}
+
 const CODEX_MODEL_PATCHES: PiCatalogModelPatch[] = [
   {
     id: 'gpt-5.4',
@@ -385,8 +405,10 @@ function candidatePiProviders(provider: ProviderType): KnownProvider[] {
 function findCatalogModelById(models: readonly PiCatalogModel[], modelId: string): PiCatalogModel | undefined {
   const normalized = modelId.toLowerCase()
   // ID 是渠道实际发送到上游的稳定标识；同名展示名称只能在没有 ID 命中时兜底。
-  return models.find((model) => model.id.toLowerCase() === normalized)
-    ?? models.find((model) => model.name.toLowerCase() === normalized)
+  return applyPiModelCapabilityOverrides(
+    models.find((model) => model.id.toLowerCase() === normalized)
+      ?? models.find((model) => model.name.toLowerCase() === normalized),
+  )
 }
 
 /**
@@ -478,6 +500,8 @@ export async function resolvePiImageInputCapability(
 ): Promise<'supported' | 'unsupported' | 'unknown'> {
   const resolvedModelId = stripLegacyAgentSdkContextSuffix(modelId)
   if (!resolvedModelId) return 'unknown'
+  // 实验变体尚未进入 Pi catalog，不能因目录缺失退回 unknown。
+  if (supportsPiNativeImageInput(resolvedModelId)) return 'supported'
   const catalogModel = await findPiCatalogModel(provider, resolvedModelId)
   if (!catalogModel) return 'unknown'
   return catalogModel.input.includes('image') ? 'supported' : 'unsupported'

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -67,6 +67,7 @@ const ARK_CODING_PLAN_TEST_MODEL = 'doubao-seed-2.0-code'
 const DEEPSEEK_PRESET_MODELS: ChannelModel[] = [
   { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
   { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
+  { id: 'deepseek-v4-flash-vision-exp', name: 'DeepSeek V4 Flash Vision Exp', enabled: true },
 ]
 const KIMI_PRESET_MODELS: ChannelModel[] = [
   { id: 'kimi-k3', name: 'Kimi K3', enabled: true },
@@ -100,13 +101,16 @@ const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
 /**
  * 一次性预设更新 ID。独立于配置 schema 版本，保证高版本配置也能收到新增候选模型。
  */
-const GLM_53_PRESET_MODEL_UPDATE_ID = 'glm-5.3-candidates-v1'
+const PRESET_MODEL_CANDIDATE_UPDATE_ID = 'model-candidates-v2'
 
 /**
  * 本次预设更新向存量渠道追加的候选模型，默认禁用。
  * 不在每次启动时按完整预设列表补齐，以尊重用户主动删除过的模型。
  */
-const GLM_53_PRESET_MODEL_CANDIDATES: Partial<Record<ProviderType, readonly ChannelModel[]>> = {
+const PRESET_MODEL_CANDIDATES: Partial<Record<ProviderType, readonly ChannelModel[]>> = {
+  deepseek: [
+    { id: 'deepseek-v4-flash-vision-exp', name: 'DeepSeek V4 Flash Vision Exp', enabled: false },
+  ],
   'ark-coding-plan': [
     { id: 'glm-5.3', name: 'GLM-5.3', enabled: false },
   ],
@@ -274,12 +278,12 @@ function migrateConfig(config: ChannelsConfig): { config: ChannelsConfig; change
  */
 function applyPresetModelCandidateUpdates(config: ChannelsConfig): { config: ChannelsConfig; changed: boolean } {
   const appliedUpdates = new Set(config.appliedPresetModelUpdates ?? [])
-  if (appliedUpdates.has(GLM_53_PRESET_MODEL_UPDATE_ID)) {
+  if (appliedUpdates.has(PRESET_MODEL_CANDIDATE_UPDATE_ID)) {
     return { config, changed: false }
   }
 
   const channels = config.channels.map((channel) => {
-    const candidates = GLM_53_PRESET_MODEL_CANDIDATES[channel.provider]
+    const candidates = PRESET_MODEL_CANDIDATES[channel.provider]
     if (!candidates) return channel
 
     const existingModelIds = new Set(channel.models.map((model) => model.id))
@@ -287,7 +291,7 @@ function applyPresetModelCandidateUpdates(config: ChannelsConfig): { config: Cha
     if (missingCandidates.length === 0) return channel
 
     console.log(
-      `[渠道管理] 预设更新 ${GLM_53_PRESET_MODEL_UPDATE_ID} 为渠道 ${channel.name} (${channel.provider}) 添加 ${missingCandidates.length} 个候选模型`,
+      `[渠道管理] 预设更新 ${PRESET_MODEL_CANDIDATE_UPDATE_ID} 为渠道 ${channel.name} (${channel.provider}) 添加 ${missingCandidates.length} 个候选模型`,
     )
     return {
       ...channel,
@@ -295,7 +299,7 @@ function applyPresetModelCandidateUpdates(config: ChannelsConfig): { config: Cha
     }
   })
 
-  appliedUpdates.add(GLM_53_PRESET_MODEL_UPDATE_ID)
+  appliedUpdates.add(PRESET_MODEL_CANDIDATE_UPDATE_ID)
   return {
     config: {
       ...config,

--- a/apps/electron/src/main/lib/vision-relay-service.ts
+++ b/apps/electron/src/main/lib/vision-relay-service.ts
@@ -157,7 +157,8 @@ function parseVisionResult(content: string, filename: string): VisionRelayResult
 }
 
 export function isVisionRelayEligibleForModel(modelId: string | undefined): boolean {
-  return /^deepseek-v4-(?:pro|flash)$/i.test(modelId?.trim() ?? '')
+  // Flash 与 Flash Vision Exp 已支持原生视觉；仅 Pro 仍需经独立视觉模型转发。
+  return /^deepseek-v4-pro$/i.test(modelId?.trim() ?? '')
 }
 
 export function isVisionRelayConfigured(): boolean {

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -85,7 +85,7 @@ const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', '
 
 /** 需要用 messages 端点测试的供应商预设模型 */
 const PROVIDER_TEST_MODEL_PRESETS: Partial<Record<ProviderType, string[]>> = {
-  deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+  deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-v4-flash-vision-exp'],
   'kimi-api': ['kimi-k3', 'kimi-k2.6'],
   'opencode-go-openai': ['grok-4.5', 'kimi-k3'],
   xiaomi: ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
@@ -406,6 +406,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         setModels([
           { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
           { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
+          { id: 'deepseek-v4-flash-vision-exp', name: 'DeepSeek V4 Flash Vision Exp', enabled: true },
         ])
       } else if (p === 'kimi-api') {
         setModels([

--- a/apps/electron/src/renderer/components/settings/VisionRelaySettings.tsx
+++ b/apps/electron/src/renderer/components/settings/VisionRelaySettings.tsx
@@ -41,7 +41,7 @@ export function VisionRelaySettings(): React.ReactElement {
     <div className="space-y-8">
       <SettingsSection
         title="视觉助手"
-        description="为不支持原生视觉的 Agent（当前为 DeepSeek V4）接入独立视觉模型。图片不会发送给当前 DeepSeek 渠道。"
+        description="为不支持原生视觉的 Agent（当前为 DeepSeek V4 Pro）接入独立视觉模型。图片不会发送给当前 DeepSeek 渠道。"
       >
         <SettingsCard>
           <SettingsRow


### PR DESCRIPTION
## Summary

- Mark `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` as native image-input models in Pi.
- Add the experimental model to DeepSeek channel presets and existing-channel candidates.
- Skip Vision Relay for Flash variants; DeepSeek V4 Pro remains eligible.

## Validation

- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:main`
- `bun run --filter='@proma/electron' build:agent-runtime`

## Performance

No material runtime impact: this changes static model capability metadata and avoids adding the relay tool for native-vision Flash sessions.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)