### PR TITLE
feat(usage): 新增用量统计面板（Token/费用统计、时间范围聚合与圆饼图）

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -10,7 +10,7 @@ import { existsSync, realpathSync, readFileSync, writeFileSync, mkdirSync, statS
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, USAGE_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
   VoiceDictationAudioChunkInput,
@@ -289,6 +289,7 @@ import { exitPlanService } from './lib/agent-exit-plan-service'
 import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getConfigDir, getWorkspaceSkillsDir, getScratchPadPath } from './lib/config-paths'
 import { getCachedDefaultAppInfo, saveCachedDefaultAppInfo } from './lib/default-app-cache'
 import { calculateStorageStats, cleanupStorage, cleanupTempFiles } from './lib/storage-service'
+import { getUsageStatsSnapshot, rescanAll } from './lib/usage-stats-service'
 import type { CleanupOptions } from './lib/storage-service'
 import {
   listAgentWorkspaces,
@@ -4708,6 +4709,16 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(STORAGE_IPC_CHANNELS.CLEANUP_TEMP, async () => {
     return cleanupTempFiles()
+  })
+
+  // ===== 用量统计 =====
+
+  ipcMain.handle(USAGE_IPC_CHANNELS.GET_SNAPSHOT, async () => {
+    return getUsageStatsSnapshot()
+  })
+
+  ipcMain.handle(USAGE_IPC_CHANNELS.RESCAN, async () => {
+    return rescanAll()
   })
 
   // 启动时自动清理临时文件

--- a/apps/electron/src/main/lib/usage-stats-service.test.ts
+++ b/apps/electron/src/main/lib/usage-stats-service.test.ts
@@ -1,0 +1,271 @@
+/**
+ * 用量统计服务单测
+ *
+ * 覆盖：消息解析、assistant/result 口径、result 兜底、日期分桶、
+ * 增量指纹（不变不重扫 / 变更重扫 / 删除 detach）、快照聚合。
+ * 全部使用临时目录，不触碰真实 ~/.proma。
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync, rmSync, existsSync, utimesSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  applyIncrementalScan,
+  buildSnapshot,
+  localDayKey,
+  parseUsageLine,
+  scanSessionFile,
+  type UsageStatsCacheFile,
+} from './usage-stats-service'
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'proma-usage-stats-'))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+function writeSession(id: string, lines: string[]): string {
+  const filePath = join(tempDir, `${id}.jsonl`)
+  writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8')
+  return filePath
+}
+
+function assistantLine(ts: number, provider: string, model: string, usage: Record<string, number> | null): string {
+  const msg: Record<string, unknown> = {
+    type: 'assistant',
+    _createdAt: ts,
+    _channelProvider: provider,
+    _channelModelId: model,
+    message: {},
+  }
+  if (usage) msg.message = { model, usage }
+  return JSON.stringify(msg)
+}
+
+function resultLine(ts: number, provider: string, model: string, usage: Record<string, number> | null, costUsd = 0): string {
+  const msg: Record<string, unknown> = {
+    type: 'result',
+    _createdAt: ts,
+    _channelProvider: provider,
+    _channelModelId: model,
+    subtype: 'success',
+    usage,
+    total_cost_usd: costUsd,
+  }
+  return JSON.stringify(msg)
+}
+
+function emptyCache(): UsageStatsCacheFile {
+  return { version: 1, lastScannedAt: 0, sessions: {}, days: {} }
+}
+
+describe('parseUsageLine', () => {
+  test('解析 assistant 消息的 token usage', () => {
+    const line = assistantLine(1_750_000_000_000, 'deepseek', 'deepseek-v3', {
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 5,
+    })
+    const parsed = parseUsageLine(line)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.isResult).toBe(false)
+    expect(parsed!.provider).toBe('deepseek')
+    expect(parsed!.model).toBe('deepseek-v3')
+    expect(parsed!.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 5,
+    })
+    expect(parsed!.costUsd).toBe(0)
+  })
+
+  test('解析 result 消息的聚合 usage 与 cost', () => {
+    const line = resultLine(
+      1_750_000_000_000,
+      'ark-coding-plan',
+      'glm-5.2',
+      { input_tokens: 1000, output_tokens: 200, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+      0.05,
+    )
+    const parsed = parseUsageLine(line)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.isResult).toBe(true)
+    expect(parsed!.costUsd).toBe(0.05)
+    expect(parsed!.usage!.inputTokens).toBe(1000)
+  })
+
+  test('usage 全零视为无 usage', () => {
+    const line = assistantLine(1_750_000_000_000, 'p', 'm', {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+    const parsed = parseUsageLine(line)
+    expect(parsed!.usage).toBeNull()
+  })
+
+  test('坏行返回 null，字段缺失兜底 unknown', () => {
+    expect(parseUsageLine('{bad json')).toBeNull()
+    expect(parseUsageLine('hello')).toBeNull()
+    const parsed = parseUsageLine(JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' }, _createdAt: 1000 }))
+    expect(parsed).toBeNull()
+  })
+})
+
+describe('scanSessionFile', () => {
+  const DAY = 1_750_000_000_000 // 落在某一天
+
+  test('assistant 为主口径：token 按 assistant，cost/runs 按 result', () => {
+    const filePath = writeSession('s1', [
+      assistantLine(DAY, 'deepseek', 'deepseek-v3', { input_tokens: 100, output_tokens: 10, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+      assistantLine(DAY, 'deepseek', 'deepseek-v3', { input_tokens: 50, output_tokens: 5, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+      resultLine(DAY - 86_400_000, 'deepseek', 'deepseek-v3', { input_tokens: 999, output_tokens: 999, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, 0.08),
+    ])
+    const days = scanSessionFile(filePath)
+    // result 的 token 不应被计入（assistant 有 usage 时）
+    const dayKey = localDayKey(DAY)
+    expect(days[dayKey]!.tokens.inputTokens).toBe(150)
+    expect(days[dayKey]!.tokens.outputTokens).toBe(15)
+    // assistant 不计 runs/cost；result 消息归到它自己的日期（前一天）
+    expect(days[dayKey]!.runs).toBe(0)
+    expect(days[dayKey]!.costUsd).toBe(0)
+    const prevKey = localDayKey(DAY - 86_400_000)
+    expect(days[prevKey]!.tokens.inputTokens).toBe(0)
+    expect(days[prevKey]!.runs).toBe(1)
+    expect(days[prevKey]!.costUsd).toBe(0.08)
+  })
+
+  test('整个会话无 assistant usage 时用 result 聚合兜底计 token', () => {
+    const filePath = writeSession('s2', [
+      resultLine(DAY, 'ark', 'glm-5.2', { input_tokens: 500, output_tokens: 50, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, 0.03),
+      resultLine(DAY, 'ark', 'glm-5.2', { input_tokens: 200, output_tokens: 20, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, 0.01),
+    ])
+    const days = scanSessionFile(filePath)
+    const dayKey = localDayKey(DAY)
+    expect(days[dayKey]!.tokens.inputTokens).toBe(700)
+    expect(days[dayKey]!.tokens.outputTokens).toBe(70)
+    expect(days[dayKey]!.runs).toBe(2)
+    expect(days[dayKey]!.costUsd).toBe(0.04)
+  })
+
+  test('多 provider/model 拆分聚合', () => {
+    const filePath = writeSession('s3', [
+      assistantLine(DAY, 'openai', 'gpt-4o', { input_tokens: 10, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+      assistantLine(DAY, 'deepseek', 'deepseek-v3', { input_tokens: 20, output_tokens: 2, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+    ])
+    const days = scanSessionFile(filePath)
+    const dayKey = localDayKey(DAY)
+    const providers = Object.keys(days[dayKey]!.providers).sort()
+    expect(providers).toEqual(['deepseek', 'openai'])
+    expect(days[dayKey]!.providers.openai!.models['gpt-4o']!.tokens.inputTokens).toBe(10)
+    expect(days[dayKey]!.providers.deepseek!.models['deepseek-v3']!.tokens.inputTokens).toBe(20)
+  })
+})
+
+describe('applyIncrementalScan', () => {
+  test('指纹不变不重扫；文件变更后重扫更新', () => {
+    const filePath = writeSession('s1', [
+      assistantLine(1_750_000_000_000, 'p', 'm', { input_tokens: 100, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+    ])
+    const cache = emptyCache()
+    expect(applyIncrementalScan(cache, tempDir)).toBe(1)
+    expect(buildSnapshot(cache).totals.tokens.inputTokens).toBe(100)
+
+    // 第二次不变 → 不重扫
+    expect(applyIncrementalScan(cache, tempDir)).toBe(0)
+    expect(buildSnapshot(cache).totals.tokens.inputTokens).toBe(100)
+
+    // 追加一行 → 重扫并更新
+    writeFileSync(filePath, filePath + '', 'utf-8') // 占位（下面会重写）
+    // 直接重写文件内容（size/mtime 都变化）
+    const fs = require('node:fs') as typeof import('node:fs')
+    fs.writeFileSync(
+      filePath,
+      [
+        assistantLine(1_750_000_000_000, 'p', 'm', { input_tokens: 100, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+        assistantLine(1_750_000_000_000, 'p', 'm', { input_tokens: 50, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+    expect(applyIncrementalScan(cache, tempDir)).toBe(1)
+    expect(buildSnapshot(cache).totals.tokens.inputTokens).toBe(150)
+  })
+
+  test('会话文件删除后从缓存 detach', () => {
+    const filePath = writeSession('s1', [
+      assistantLine(1_750_000_000_000, 'p', 'm', { input_tokens: 100, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+    ])
+    const cache = emptyCache()
+    applyIncrementalScan(cache, tempDir)
+    expect(buildSnapshot(cache).totals.tokens.inputTokens).toBe(100)
+
+    rmSync(filePath)
+    applyIncrementalScan(cache, tempDir)
+    expect(buildSnapshot(cache).totals.tokens.inputTokens).toBe(0)
+    expect(buildSnapshot(cache).totals.sessions).toBe(0)
+  })
+
+  test('多会话聚合到同一快照', () => {
+    writeSession('a', [assistantLine(1_750_000_000_000, 'p', 'm', { input_tokens: 30, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 })])
+    writeSession('b', [assistantLine(1_750_000_000_000, 'p', 'm', { input_tokens: 70, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 })])
+    const cache = emptyCache()
+    applyIncrementalScan(cache, tempDir)
+    const snap = buildSnapshot(cache)
+    expect(snap.totals.sessions).toBe(2)
+    expect(snap.totals.tokens.inputTokens).toBe(100)
+    expect(snap.daily).toHaveLength(1)
+    expect(snap.daily[0]!.tokens.inputTokens).toBe(100)
+  })
+
+  test('breakdownDaily 按天×渠道×模型展开，增量重扫后正确更新且不重复', () => {
+    const day1 = new Date(2026, 7, 19, 12, 0, 0).getTime()
+    const day2 = new Date(2026, 7, 20, 12, 0, 0).getTime()
+    writeSession('a', [
+      assistantLine(day1, 'openai', 'gpt-4o', { input_tokens: 30, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+      assistantLine(day2, 'deepseek', 'deepseek-v3', { input_tokens: 40, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+    ])
+    const fileB = writeSession('b', [
+      assistantLine(day1, 'openai', 'gpt-4o', { input_tokens: 70, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }),
+    ])
+    const cache = emptyCache()
+    applyIncrementalScan(cache, tempDir)
+    let snap = buildSnapshot(cache)
+    expect(snap.breakdownDaily).toHaveLength(2)
+    const rowOf = (day: string, provider: string, model: string) =>
+      snap.breakdownDaily.find((r) => r.day === day && r.provider === provider && r.model === model)
+    expect(rowOf('2026-08-19', 'openai', 'gpt-4o')!.tokens.inputTokens).toBe(100)
+    expect(rowOf('2026-08-20', 'deepseek', 'deepseek-v3')!.tokens.inputTokens).toBe(40)
+
+    // 会话 b 挪到第二天 → detach+attach 后明细同步、无重复残留
+    writeFileSync(
+      fileB,
+      [assistantLine(day2, 'openai', 'gpt-4o', { input_tokens: 70, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 })].join('\n') + '\n',
+      'utf-8',
+    )
+    applyIncrementalScan(cache, tempDir)
+    snap = buildSnapshot(cache)
+    expect(snap.breakdownDaily).toHaveLength(3)
+    expect(rowOf('2026-08-19', 'openai', 'gpt-4o')!.tokens.inputTokens).toBe(30)
+    expect(rowOf('2026-08-20', 'openai', 'gpt-4o')!.tokens.inputTokens).toBe(70)
+    // 明细合计与总量守恒
+    const detailInput = snap.breakdownDaily.reduce((sum, r) => sum + r.tokens.inputTokens, 0)
+    expect(detailInput).toBe(snap.totals.tokens.inputTokens)
+  })
+})
+
+describe('localDayKey', () => {
+  test('按本地日期生成 yyyy-mm-dd', () => {
+    const d = new Date(2026, 7, 19, 12, 0, 0) // 2026-08-19 12:00 本地时间
+    expect(localDayKey(d.getTime())).toBe('2026-08-19')
+    const edge = new Date(2026, 0, 5, 0, 0, 0)
+    expect(localDayKey(edge.getTime())).toBe('2026-01-05')
+  })
+})

--- a/apps/electron/src/main/lib/usage-stats-service.ts
+++ b/apps/electron/src/main/lib/usage-stats-service.ts
@@ -1,0 +1,539 @@
+/**
+ * 用量统计服务
+ *
+ * 从 ~/.proma/agent-sessions/*.jsonl 提取 LLM 调用用量并聚合持久化，
+ * 供"用量统计"面板展示 token 消耗与费用（USD）。
+ *
+ * 统计口径（防重复）：
+ * - Token：逐条 assistant 消息 message.usage（input / output / cache_read / cache_creation）
+ *   - 兜底：会话完全没有 assistant usage（如 GLM-5.2 等走 Anthropic 兼容端点的流式渠道），
+ *     退而用该会话所有 result 消息的聚合 usage 计 token。
+ * - 费用：sum(result.total_cost_usd)——SDK 实测成本；缺失渠道不自行估算（避免错误定价）。
+ * - 运行次数：result 消息条数（每轮 Agent run 结束一条）。
+ * - 时间：按消息顶层 _createdAt（毫秒）归入本地自然日 yyyy-mm-dd。
+ * - 拆分：provider × model 双维度。
+ *
+ * 增量策略：usage-stats.json 记录每个会话文件的 { size, mtimeMs } 指纹与其按日贡献；
+ * 只有新增/变更的文件才重扫（detach 旧贡献 → 扫描 → attach 新贡献），
+ * 避免每次打开面板都全量扫 63+ 份 JSONL 阻塞主进程。
+ * 运行时新消耗随消息落盘自然被下一轮增量补扫捕获（面板内 30s 轮询刷新即可）。
+ */
+
+import { existsSync, readFileSync, statSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import type { UsageBreakdownDailyRow, UsageBreakdownRow, UsageDayRow, UsageStatsSnapshot, UsageTokens } from '@proma/shared'
+import { getAgentSessionsDir, getConfigDir } from './config-paths'
+
+// 对外类型直接复用 @proma/shared，避免主/渲染进程类型漂移
+export type { UsageBreakdownDailyRow, UsageBreakdownRow, UsageDayRow, UsageStatsSnapshot, UsageTokens }
+
+// ─── 内部聚合结构 ───
+
+interface ModelBucket {
+  tokens: UsageTokens
+  costUsd: number
+  runs: number
+}
+
+interface ProviderBucket {
+  tokens: UsageTokens
+  costUsd: number
+  runs: number
+  models: Record<string, ModelBucket>
+}
+
+interface DayBucket {
+  tokens: UsageTokens
+  costUsd: number
+  runs: number
+  providers: Record<string, ProviderBucket>
+}
+
+interface SessionFingerprint {
+  size: number
+  mtimeMs: number
+  /** 该会话按日贡献（用于增量 detach） */
+  days: Record<string, DayBucket>
+}
+
+export interface UsageStatsCacheFile {
+  version: 1
+  lastScannedAt: number
+  sessions: Record<string, SessionFingerprint>
+  days: Record<string, DayBucket>
+}
+
+const CACHE_FILENAME = 'usage-stats.json'
+const CACHE_VERSION = 1
+
+const EMPTY_TOKENS: UsageTokens = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 }
+
+function emptyTokens(): UsageTokens {
+  return { ...EMPTY_TOKENS }
+}
+
+function addTokens(target: UsageTokens, src: UsageTokens): void {
+  target.inputTokens += src.inputTokens
+  target.outputTokens += src.outputTokens
+  target.cacheReadTokens += src.cacheReadTokens
+  target.cacheCreationTokens += src.cacheCreationTokens
+}
+
+function emptyModelBucket(): ModelBucket {
+  return { tokens: emptyTokens(), costUsd: 0, runs: 0 }
+}
+
+function emptyProviderBucket(): ProviderBucket {
+  return { tokens: emptyTokens(), costUsd: 0, runs: 0, models: {} }
+}
+
+function emptyDayBucket(): DayBucket {
+  return { tokens: emptyTokens(), costUsd: 0, runs: 0, providers: {} }
+}
+
+function addModelBucket(target: ModelBucket, value: { tokens?: UsageTokens; costUsd?: number; runs?: number }): void {
+  if (value.tokens) addTokens(target.tokens, value.tokens)
+  target.costUsd += value.costUsd ?? 0
+  target.runs += value.runs ?? 0
+}
+
+function addDayBucket(target: DayBucket, value: DayBucket): void {
+  addTokens(target.tokens, value.tokens)
+  target.costUsd += value.costUsd
+  target.runs += value.runs
+  for (const [provider, pBucket] of Object.entries(value.providers)) {
+    const targetProvider = (target.providers[provider] ??= emptyProviderBucket())
+    addTokens(targetProvider.tokens, pBucket.tokens)
+    targetProvider.costUsd += pBucket.costUsd
+    targetProvider.runs += pBucket.runs
+    for (const [model, mBucket] of Object.entries(pBucket.models)) {
+      const targetModel = (targetProvider.models[model] ??= emptyModelBucket())
+      addModelBucket(targetModel, mBucket)
+    }
+  }
+}
+
+function subtractDayBucket(target: DayBucket, value: DayBucket): void {
+  target.tokens.inputTokens -= value.tokens.inputTokens
+  target.tokens.outputTokens -= value.tokens.outputTokens
+  target.tokens.cacheReadTokens -= value.tokens.cacheReadTokens
+  target.tokens.cacheCreationTokens -= value.tokens.cacheCreationTokens
+  target.costUsd -= value.costUsd
+  target.runs -= value.runs
+  for (const [provider, pBucket] of Object.entries(value.providers)) {
+    const targetProvider = target.providers[provider]
+    if (!targetProvider) continue
+    targetProvider.tokens.inputTokens -= pBucket.tokens.inputTokens
+    targetProvider.tokens.outputTokens -= pBucket.tokens.outputTokens
+    targetProvider.tokens.cacheReadTokens -= pBucket.tokens.cacheReadTokens
+    targetProvider.tokens.cacheCreationTokens -= pBucket.tokens.cacheCreationTokens
+    targetProvider.costUsd -= pBucket.costUsd
+    targetProvider.runs -= pBucket.runs
+    for (const [model, mBucket] of Object.entries(pBucket.models)) {
+      const targetModel = targetProvider.models[model]
+      if (!targetModel) continue
+      targetModel.tokens.inputTokens -= mBucket.tokens.inputTokens
+      targetModel.tokens.outputTokens -= mBucket.tokens.outputTokens
+      targetModel.tokens.cacheReadTokens -= mBucket.tokens.cacheReadTokens
+      targetModel.tokens.cacheCreationTokens -= mBucket.tokens.cacheCreationTokens
+      targetModel.costUsd -= mBucket.costUsd
+      targetModel.runs -= mBucket.runs
+    }
+  }
+}
+
+// ─── 持久化 ───
+
+function getCachePath(): string {
+  return join(getConfigDir(), CACHE_FILENAME)
+}
+
+function loadCache(): UsageStatsCacheFile {
+  const path = getCachePath()
+  if (!existsSync(path)) {
+    return { version: CACHE_VERSION, lastScannedAt: 0, sessions: {}, days: {} }
+  }
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Partial<UsageStatsCacheFile>
+    if (raw.version !== CACHE_VERSION) {
+      return { version: CACHE_VERSION, lastScannedAt: 0, sessions: {}, days: {} }
+    }
+    return {
+      version: CACHE_VERSION,
+      lastScannedAt: raw.lastScannedAt ?? 0,
+      sessions: raw.sessions ?? {},
+      days: raw.days ?? {},
+    }
+  } catch {
+    return { version: CACHE_VERSION, lastScannedAt: 0, sessions: {}, days: {} }
+  }
+}
+
+function persistCache(cache: UsageStatsCacheFile): void {
+  try {
+    const configDir = getConfigDir()
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(getCachePath(), JSON.stringify(cache), 'utf-8')
+  } catch (err) {
+    console.warn('[用量统计] 缓存写入失败:', err)
+  }
+}
+
+// ─── 会话文件扫描 ───
+
+interface UsageLine {
+  ts: number
+  provider: string
+  model: string
+  usage: UsageTokens | null
+  costUsd: number
+  isResult: boolean
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** 毫秒时间戳 → 本地自然日 yyyy-mm-dd */
+export function localDayKey(tsMs: number): string {
+  const d = new Date(tsMs)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function safeParseUsage(raw: unknown): UsageTokens | null {
+  if (!raw || typeof raw !== 'object') return null
+  const u = raw as Record<string, unknown>
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+  const inputTokens = num(u.input_tokens)
+  const outputTokens = num(u.output_tokens)
+  const cacheReadTokens = num(u.cache_read_input_tokens)
+  const cacheCreationTokens = num(u.cache_creation_input_tokens)
+  if (inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens === 0) return null
+  return { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens }
+}
+
+function toProvider(provider: unknown): string {
+  return typeof provider === 'string' && provider.trim() ? provider.trim() : 'unknown'
+}
+
+function toModel(model: unknown): string {
+  return typeof model === 'string' && model.trim() ? model.trim() : 'unknown'
+}
+
+/**
+ * 解析一条 JSONL 消息为用量行。
+ *
+ * 只关心两类：
+ * - assistant：message.usage 是单次模型调用（含子 agent 调用），计 token
+ * - result（每轮 run 结束）：usage 为整轮聚合，计 cost 与 runs；token 仅在
+ *   会话完全没有 assistant usage 时兜底使用
+ */
+export function parseUsageLine(raw: string): UsageLine | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const msg = parsed as Record<string, unknown>
+
+  const tsRaw = msg._createdAt
+  const ts = typeof tsRaw === 'number' && Number.isFinite(tsRaw) ? tsRaw : Date.now()
+  const provider = toProvider(msg._channelProvider)
+  const model = toModel(msg._channelModelId)
+
+  if (msg.type === 'result') {
+    const costRaw = msg.total_cost_usd
+    const costUsd = typeof costRaw === 'number' && Number.isFinite(costRaw) ? costRaw : 0
+    return {
+      ts,
+      provider,
+      model,
+      usage: safeParseUsage(msg.usage),
+      costUsd,
+      isResult: true,
+    }
+  }
+
+  if (msg.type === 'assistant') {
+    const inner = (msg.message ?? {}) as Record<string, unknown>
+    const usage = safeParseUsage(inner.usage)
+    const fallbackModel = typeof inner.model === 'string' && inner.model.trim() ? inner.model.trim() : undefined
+    return {
+      ts,
+      provider,
+      model: model === 'unknown' && fallbackModel ? fallbackModel : model,
+      usage,
+      costUsd: 0,
+      isResult: false,
+    }
+  }
+
+  return null
+}
+
+/**
+ * 全量解析一个会话文件，返回按日贡献。
+ *
+ * token 主口径为 assistant 消息；整文件没有任何 assistant usage 时，
+ * 用 result 聚合 usage 兜底计 token。
+ */
+export function scanSessionFile(filePath: string): Record<string, DayBucket> {
+  let content: string
+  try {
+    content = readFileSync(filePath, 'utf-8')
+  } catch {
+    return {}
+  }
+
+  const assistantLines: UsageLine[] = []
+  const resultLines: UsageLine[] = []
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue
+    const usageLine = parseUsageLine(line)
+    if (!usageLine) continue
+    if (usageLine.isResult) resultLines.push(usageLine)
+    else assistantLines.push(usageLine)
+  }
+
+  const hasAssistantUsage = assistantLines.some((l) => l.usage !== null)
+  const tokenSource = hasAssistantUsage
+    ? assistantLines.filter((l) => l.usage !== null)
+    : resultLines.filter((l) => l.usage !== null)
+
+  const days: Record<string, DayBucket> = {}
+
+  const addLine = (line: UsageLine, countTokens: boolean, countRun: boolean, costUsd: number) => {
+    const dayKey = localDayKey(line.ts)
+    const day = (days[dayKey] ??= emptyDayBucket())
+    const providerBucket = (day.providers[line.provider] ??= emptyProviderBucket())
+    const modelBucket = (providerBucket.models[line.model] ??= emptyModelBucket())
+    if (countTokens && line.usage) {
+      addTokens(day.tokens, line.usage)
+      addTokens(providerBucket.tokens, line.usage)
+      addModelBucket(modelBucket, { tokens: line.usage })
+    }
+    if (countRun || costUsd > 0) {
+      const runs = countRun ? 1 : 0
+      day.runs += runs
+      providerBucket.runs += runs
+      addModelBucket(modelBucket, { runs })
+      if (costUsd > 0) {
+        day.costUsd += costUsd
+        providerBucket.costUsd += costUsd
+        addModelBucket(modelBucket, { costUsd })
+      }
+    }
+  }
+
+  if (hasAssistantUsage) {
+    for (const line of assistantLines) addLine(line, true, false, 0)
+    for (const line of resultLines) addLine(line, false, true, line.costUsd)
+  } else {
+    // 全部走 result：token 兜底 + runs + cost
+    for (const line of resultLines) addLine(line, true, true, line.costUsd)
+  }
+
+  return days
+}
+
+// ─── 增量扫描 ───
+
+function listSessionFiles(dir = getAgentSessionsDir()): { id: string; filePath: string; size: number; mtimeMs: number }[] {
+  if (!existsSync(dir)) return []
+  const result: { id: string; filePath: string; size: number; mtimeMs: number }[] = []
+  try {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.jsonl')) continue
+      const filePath = join(dir, file)
+      try {
+        const stat = statSync(filePath)
+        if (!stat.isFile()) continue
+        result.push({ id: file.slice(0, -6), filePath, size: stat.size, mtimeMs: stat.mtimeMs })
+      } catch {
+        // 跳过无法读取的文件
+      }
+    }
+  } catch {
+    // 目录不可读则返回空
+  }
+  return result
+}
+
+function detachSession(cache: UsageStatsCacheFile, id: string): void {
+  const fingerprint = cache.sessions[id]
+  if (!fingerprint) return
+  for (const [dayKey, dayBucket] of Object.entries(fingerprint.days)) {
+    const target = cache.days[dayKey]
+    if (!target) continue
+    subtractDayBucket(target, dayBucket)
+    // 清理归零的桶，避免脏数据膨胀
+    if (target.runs === 0 && target.costUsd === 0 && totalTokenCount(target.tokens) === 0) {
+      delete cache.days[dayKey]
+    }
+  }
+  delete cache.sessions[id]
+}
+
+function totalTokenCount(tokens: UsageTokens): number {
+  return tokens.inputTokens + tokens.outputTokens + tokens.cacheReadTokens + tokens.cacheCreationTokens
+}
+
+function attachSession(cache: UsageStatsCacheFile, id: string, fingerprint: SessionFingerprint): void {
+  cache.sessions[id] = fingerprint
+  for (const [dayKey, dayBucket] of Object.entries(fingerprint.days)) {
+    addDayBucket((cache.days[dayKey] ??= emptyDayBucket()), dayBucket)
+  }
+}
+
+function rescanSession(cache: UsageStatsCacheFile, id: string, filePath: string, size: number, mtimeMs: number): void {
+  detachSession(cache, id)
+  const days = scanSessionFile(filePath)
+  attachSession(cache, id, { size, mtimeMs, days })
+}
+
+/** 找到内容有变化的会话并重扫，返回重扫数量。 */
+export function applyIncrementalScan(cache: UsageStatsCacheFile, dir?: string): number {
+  const files = listSessionFiles(dir)
+  const seenIds = new Set<string>()
+  let rescanned = 0
+
+  for (const file of files) {
+    seenIds.add(file.id)
+    const fingerprint = cache.sessions[file.id]
+    if (fingerprint && fingerprint.size === file.size && fingerprint.mtimeMs === file.mtimeMs) continue
+    rescanSession(cache, file.id, file.filePath, file.size, file.mtimeMs)
+    rescanned++
+  }
+
+  // 清理已不存在的会话文件贡献（用户清理存储/归档删除时同步扣除）
+  for (const id of Object.keys(cache.sessions)) {
+    if (!seenIds.has(id)) detachSession(cache, id)
+  }
+
+  if (rescanned > 0) cache.lastScannedAt = Date.now()
+  else cache.lastScannedAt = cache.lastScannedAt || Date.now()
+  return rescanned
+}
+
+/** 忽略指纹全量重扫（面板"重新扫描"）。 */
+export function rescanAll(dir?: string): UsageStatsSnapshot {
+  const cache = loadCache()
+  const files = listSessionFiles(dir)
+  for (const file of files) {
+    rescanSession(cache, file.id, file.filePath, file.size, file.mtimeMs)
+  }
+  // 清理不存在的
+  const seenIds = new Set(files.map((f) => f.id))
+  for (const id of Object.keys(cache.sessions)) {
+    if (!seenIds.has(id)) detachSession(cache, id)
+  }
+  cache.lastScannedAt = Date.now()
+  persistCache(cache)
+  return buildSnapshot(cache)
+}
+
+// ─── 快照构建 ───
+
+function buildBreakdownRows(cache: UsageStatsCacheFile, byModel: boolean): UsageBreakdownRow[] {
+  const rows: UsageBreakdownRow[] = []
+  for (const dayBucket of Object.values(cache.days)) {
+    for (const [provider, pBucket] of Object.entries(dayBucket.providers)) {
+      if (byModel) {
+        for (const [model, mBucket] of Object.entries(pBucket.models)) {
+          if (mBucket.runs === 0 && totalTokenCount(mBucket.tokens) === 0 && mBucket.costUsd === 0) continue
+          rows.push({
+            provider,
+            model,
+            tokens: { ...mBucket.tokens },
+            costUsd: mBucket.costUsd,
+            runs: mBucket.runs,
+          })
+        }
+      } else {
+        if (pBucket.runs === 0 && totalTokenCount(pBucket.tokens) === 0 && pBucket.costUsd === 0) continue
+        rows.push({
+          provider,
+          model: '*',
+          tokens: { ...pBucket.tokens },
+          costUsd: pBucket.costUsd,
+          runs: pBucket.runs,
+        })
+      }
+    }
+  }
+  // 排序：runs 降序，其次 token 降序，保证 UI 稳定
+  rows.sort((a, b) => b.runs - a.runs || totalTokenCount(b.tokens) - totalTokenCount(a.tokens))
+  return rows
+}
+
+/** 按自然日 × 渠道 × 模型展开缓存聚合，day 升序；供面板按时间范围过滤后重新聚合 */
+function buildBreakdownDaily(cache: UsageStatsCacheFile): UsageBreakdownDailyRow[] {
+  const rows: UsageBreakdownDailyRow[] = []
+  for (const [day, dayBucket] of Object.entries(cache.days).sort()) {
+    for (const [provider, pBucket] of Object.entries(dayBucket.providers)) {
+      for (const [model, mBucket] of Object.entries(pBucket.models)) {
+        if (mBucket.runs === 0 && totalTokenCount(mBucket.tokens) === 0 && mBucket.costUsd === 0) continue
+        rows.push({
+          day,
+          provider,
+          model,
+          tokens: { ...mBucket.tokens },
+          costUsd: mBucket.costUsd,
+          runs: mBucket.runs,
+        })
+      }
+    }
+  }
+  return rows
+}
+
+export function buildSnapshot(cache: UsageStatsCacheFile): UsageStatsSnapshot {
+  const totals = { tokens: emptyTokens(), costUsd: 0, runs: 0, sessions: Object.keys(cache.sessions).length }
+  const daily: UsageDayRow[] = []
+  for (const [dayKey, dayBucket] of Object.entries(cache.days).sort()) {
+    addTokens(totals.tokens, dayBucket.tokens)
+    totals.costUsd += dayBucket.costUsd
+    totals.runs += dayBucket.runs
+    daily.push({
+      day: dayKey,
+      tokens: { ...dayBucket.tokens },
+      costUsd: dayBucket.costUsd,
+      runs: dayBucket.runs,
+    })
+  }
+  // 去掉 token 全零但 sessions 存在的空壳（避免 totals 为 0 的会话数误导）
+  return {
+    version: CACHE_VERSION,
+    lastScannedAt: cache.lastScannedAt,
+    totals,
+    daily,
+    byProvider: buildBreakdownRows(cache, false),
+    byModel: buildBreakdownRows(cache, true),
+    breakdownDaily: buildBreakdownDaily(cache),
+  }
+}
+
+// ─── 对外入口 ───
+
+/**
+ * 获取用量统计快照。
+ *
+ * 先返回缓存，若发现变更会话则增量补扫并即时返回最新结果。
+ * 面板每次请求都会调用，成本约等于读取一份小 JSON + 变更文件重扫。
+ */
+export function getUsageStatsSnapshot(): UsageStatsSnapshot {
+  const cache = loadCache()
+  const rescanned = applyIncrementalScan(cache)
+  if (rescanned > 0) {
+    try {
+      persistCache(cache)
+    } catch {
+      // 写失败不阻断返回
+    }
+  }
+  return buildSnapshot(cache)
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -7,7 +7,7 @@
 
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, AGENT_ISLAND_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, USAGE_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -1200,6 +1200,13 @@ export interface ElectronAPI {
   cleanupStorage: (options: unknown) => Promise<unknown>
   /** 清理临时文件（快速） */
   cleanupTempStorage: () => Promise<unknown>
+
+  // ===== 用量统计 =====
+
+  /** 获取用量统计快照（含增量补扫） */
+  getUsageStats: () => Promise<unknown>
+  /** 忽略增量缓存全量重扫 */
+  rescanUsageStats: () => Promise<unknown>
 
   // ===== 定时任务（Automation）=====
   /** 获取全部定时任务 */
@@ -2787,6 +2794,16 @@ const electronAPI: ElectronAPI = {
 
   cleanupTempStorage: () => {
     return ipcRenderer.invoke(STORAGE_IPC_CHANNELS.CLEANUP_TEMP)
+  },
+
+  // ===== 用量统计 =====
+
+  getUsageStats: () => {
+    return ipcRenderer.invoke(USAGE_IPC_CHANNELS.GET_SNAPSHOT)
+  },
+
+  rescanUsageStats: () => {
+    return ipcRenderer.invoke(USAGE_IPC_CHANNELS.RESCAN)
   },
 
   // ===== 定时任务（Automation）=====

--- a/apps/electron/src/renderer/atoms/active-view.ts
+++ b/apps/electron/src/renderer/atoms/active-view.ts
@@ -9,7 +9,7 @@
 
 import { atom } from 'jotai'
 
-export type ActiveView = 'conversations' | 'planning' | 'agent-skills'
+export type ActiveView = 'conversations' | 'planning' | 'agent-skills' | 'usage'
 export type AgentSkillsCapabilityTab = 'skills' | 'mcp' | 'memory'
 
 /** 当前活跃视图（不持久化，每次启动默认显示对话） */

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -59,7 +59,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
   const isClassic = interfaceVariant === 'classic'
   // 定时任务表单打开时隐藏右侧文件面板，让中间区域扩展到全宽（表单内含自己的右栏配置）
   const activeView = useAtomValue(activeViewAtom)
-  const showRightPanel = appMode === 'agent' && !!currentSessionId && !automationForm.open && activeView !== 'planning' && activeView !== 'agent-skills'
+  const showRightPanel = appMode === 'agent' && !!currentSessionId && !automationForm.open && activeView !== 'planning' && activeView !== 'agent-skills' && activeView !== 'usage'
   const isWindows = React.useMemo(() => detectIsWindows(), [])
 
   // 左侧边栏可拖拽宽度

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, ChevronDown, ChevronUp, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
+import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, ChevronDown, ChevronUp, Blocks, GitBranch, Download, Loader2, RotateCw, BarChart3 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -303,6 +303,34 @@ function SkillsSidebarEntry({ count, updateCount, active, onClick }: SkillsSideb
         )}
       >
         {formatAutomationCount(count)}
+      </span>
+    </button>
+  )
+}
+
+interface UsageSidebarEntryProps {
+  active: boolean
+  onClick: () => void
+}
+
+function UsageSidebarEntry({ active, onClick }: UsageSidebarEntryProps): React.ReactElement {
+  return (
+    <button
+      type="button"
+      aria-label="用量统计"
+      onClick={onClick}
+      className={cn(
+        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
+        active
+          ? 'bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
+      )}
+    >
+      <span className="flex items-center gap-3 min-w-0">
+        <span className={cn('flex-shrink-0 w-[18px] h-[18px]', active ? 'text-accent-foreground' : 'text-foreground/45')}>
+          <BarChart3 size={16} className="block" />
+        </span>
+        <span className="truncate">用量统计</span>
       </span>
     </button>
   )
@@ -1102,6 +1130,15 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       return
     }
     setActiveView('agent-skills')
+  }, [activeView, setActiveView])
+
+  /** 打开/关闭用量统计视图 */
+  const handleOpenUsage = React.useCallback((): void => {
+    if (activeView === 'usage') {
+      setActiveView('conversations')
+      return
+    }
+    setActiveView('usage')
   }, [activeView, setActiveView])
 
   /** 打开当前工作区的 MCP 管理页 */
@@ -3202,6 +3239,26 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               <TooltipContent side="right">Agent 技能</TooltipContent>
             </Tooltip>
           )}
+
+          {/* 用量统计入口 */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="用量统计"
+                onClick={handleOpenUsage}
+                className={cn(
+                  'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
+                  activeView === 'usage'
+                    ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
+                    : 'border-border/45 bg-foreground/[0.025] text-foreground/45 hover:border-border/70 hover:bg-foreground/[0.045] hover:text-primary',
+                )}
+              >
+                <BarChart3 size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">用量统计</TooltipContent>
+          </Tooltip>
         </div>
 
         <div className="my-3 h-px w-8 bg-border/70" />
@@ -3365,6 +3422,14 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           />
         </div>
       )}
+
+      {/* 用量统计入口：Token / 费用统计面板，与折叠态图标栏保持一致 */}
+      <div className="px-3 pb-0.5">
+        <UsageSidebarEntry
+          active={activeView === 'usage'}
+          onClick={handleOpenUsage}
+        />
+      </div>
 
       {/* Chat 模式 active 视图：置顶 + 对话历史，结构与 Agent active 视图保持一致 */}
       {mode === 'chat' && viewMode === 'active' ? (

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -28,6 +28,7 @@ import { TabContent } from './TabContent'
 import { AutomationFormView } from '@/components/automation/AutomationFormView'
 import { PlanningView } from '@/components/planning/PlanningView'
 import { AgentSkillsView } from '@/components/agent-skills/AgentSkillsView'
+import { UsageView } from '@/components/usage/UsageView'
 import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
@@ -279,6 +280,9 @@ export function MainArea(): React.ReactElement {
             ) : activeView === 'agent-skills' ? (
               // Agent 技能视图：全屏取代 TabBar + TabContent
               <AgentSkillsView />
+            ) : activeView === 'usage' ? (
+              // 用量统计视图：全屏取代 TabBar + TabContent
+              <UsageView />
             ) : (
               <>
                 <TabBar />

--- a/apps/electron/src/renderer/components/usage/UsageView.tsx
+++ b/apps/electron/src/renderer/components/usage/UsageView.tsx
@@ -1,0 +1,341 @@
+/**
+ * 用量统计面板
+ *
+ * 展示 Agent 会话产生的 LLM Token 消耗与费用（USD）：
+ * - 汇总卡片：总 Token / 总费用 / 运行次数 / 会话数
+ * - 时间段切换：今日 / 近7天 / 近30天 / 全部
+ * - 每日 token 堆叠柱状图 + 每日费用柱状图（SVG 自绘）
+ * - 按渠道、按模型拆分的消耗占比
+ * - 重新扫描按钮与最近扫描时间
+ *
+ * 数据来自主进程 usage-stats-service（agent-sessions JSONL 聚合），
+ * 打开面板时拉取快照，之后每 30s 轮询刷新（增量补扫在 IPC handler 内完成）。
+ */
+
+import * as React from 'react'
+import { BarChart3, RefreshCw, Sparkles } from 'lucide-react'
+import type { UsageBreakdownDailyRow, UsageStatsSnapshot, UsageTokens } from '@proma/shared'
+import { cn } from '@/lib/utils'
+import {
+  DailyCostChart,
+  DailyTokensChart,
+  StatCard,
+  TOKEN_SERIES,
+  UsageChartCard,
+  UsageDonutChart,
+  formatTokenCount,
+  formatUsd,
+} from './usage-charts'
+
+const REFRESH_INTERVAL_MS = 30_000
+
+type RangeKey = 'today' | '7d' | '30d' | 'all'
+
+const RANGES: Array<{ key: RangeKey; label: string }> = [
+  { key: 'today', label: '今日' },
+  { key: '7d', label: '近7天' },
+  { key: '30d', label: '近30天' },
+  { key: 'all', label: '全部' },
+]
+
+function sumTokens(tokens: UsageTokens): number {
+  return tokens.inputTokens + tokens.outputTokens + tokens.cacheReadTokens + tokens.cacheCreationTokens
+}
+
+function formatDateTime(ms: number): string {
+  if (!ms) return '—'
+  const d = new Date(ms)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+function addTokensInPlace(a: UsageTokens, b: UsageTokens): void {
+  a.inputTokens += b.inputTokens
+  a.outputTokens += b.outputTokens
+  a.cacheReadTokens += b.cacheReadTokens
+  a.cacheCreationTokens += b.cacheCreationTokens
+}
+
+interface BreakdownRowView {
+  name: string
+  sub: string | undefined
+  tokens: UsageTokens
+  costUsd: number
+  runs: number
+}
+
+function emptyViewTokens(): UsageTokens {
+  return { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 }
+}
+
+/** 把按天明细聚合到指定维度（provider 或 model）；model 维度按 provider+model 分组，避免同名模型跨渠道被合并 */
+function aggregateBreakdown(rows: UsageBreakdownDailyRow[], dimension: 'provider' | 'model'): BreakdownRowView[] {
+  const map = new Map<string, BreakdownRowView>()
+  for (const row of rows) {
+    const key = dimension === 'provider' ? row.provider : `${row.provider}/${row.model}`
+    const entry = map.get(key) ?? {
+      name: dimension === 'provider' ? row.provider : row.model,
+      sub: dimension === 'provider' ? undefined : row.provider,
+      tokens: emptyViewTokens(),
+      costUsd: 0,
+      runs: 0,
+    }
+    addTokensInPlace(entry.tokens, row.tokens)
+    entry.costUsd += row.costUsd
+    entry.runs += row.runs
+    map.set(key, entry)
+  }
+  return [...map.values()].sort((a, b) => sumTokens(b.tokens) - sumTokens(a.tokens))
+}
+
+export function UsageView(): React.ReactElement {
+  const [snapshot, setSnapshot] = React.useState<UsageStatsSnapshot | null>(null)
+  const [range, setRange] = React.useState<RangeKey>('7d')
+  const [loading, setLoading] = React.useState(true)
+  const [rescanned, setRescanned] = React.useState(false)
+
+  const load = React.useCallback(async (force = false) => {
+    try {
+      const api = (window as unknown as { electronAPI: { getUsageStats: () => Promise<unknown>; rescanUsageStats: () => Promise<unknown> } }).electronAPI
+      if (!api?.getUsageStats) return
+      const raw = force ? await api.rescanUsageStats() : await api.getUsageStats()
+      setSnapshot(raw as UsageStatsSnapshot)
+      if (force) setRescanned(true)
+    } catch (err) {
+      console.error('[用量统计] 加载失败:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    void load()
+  }, [load])
+
+  // 面板常驻时轮询刷新，让新消耗自动出现在图表里
+  React.useEffect(() => {
+    const timer = setInterval(() => void load(false), REFRESH_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [load])
+
+  const rangeCutoffMs = React.useMemo(() => {
+    const now = Date.now()
+    if (range === 'today') return new Date(now).setHours(0, 0, 0, 0)
+    if (range === '7d') return now - 7 * 24 * 60 * 60 * 1000
+    if (range === '30d') return now - 30 * 24 * 60 * 60 * 1000
+    return 0
+  }, [range])
+
+  const filteredDaily = React.useMemo(() => {
+    if (!snapshot) return []
+    return snapshot.daily.filter((d) => (range === 'all' ? true : new Date(`${d.day}T00:00:00`).getTime() >= rangeCutoffMs))
+  }, [snapshot, range, rangeCutoffMs])
+
+  const totalsInRange = React.useMemo(() => {
+    const tokens = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 }
+    let costUsd = 0
+    let runs = 0
+    for (const d of filteredDaily) {
+      addTokensInPlace(tokens, d.tokens)
+      costUsd += d.costUsd
+      runs += d.runs
+    }
+    return { tokens, costUsd, runs }
+  }, [filteredDaily])
+
+  // 渠道/模型占比：按所选时间范围内所有会话的按天明细重新聚合（与汇总卡同口径）
+  const filteredBreakdown = React.useMemo(() => {
+    if (!snapshot?.breakdownDaily) return []
+    return snapshot.breakdownDaily.filter(
+      (r) => range === 'all' || new Date(`${r.day}T00:00:00`).getTime() >= rangeCutoffMs,
+    )
+  }, [snapshot, range, rangeCutoffMs])
+
+  const byProvider = React.useMemo(() => aggregateBreakdown(filteredBreakdown, 'provider'), [filteredBreakdown])
+
+  const byModel = React.useMemo(() => aggregateBreakdown(filteredBreakdown, 'model'), [filteredBreakdown])
+
+  const totalTokens = snapshot ? sumTokens(snapshot.totals.tokens) : 0
+  const rangeTokens = sumTokens(totalsInRange.tokens)
+
+  return (
+    <div className="h-full overflow-y-auto">
+      {/* pt-14：避开 AppShell 顶部 50px 的全局窗口拖拽层，否则时间切换/重新扫描按钮的点击会被拖拽吞掉 */}
+      <div className="titlebar-no-drag mx-auto max-w-5xl px-6 pb-6 pt-14">
+        {/* 标题行 */}
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2.5">
+            <div className="flex size-9 items-center justify-center rounded-xl border border-primary/25 bg-primary/10 text-primary">
+              <BarChart3 size={18} />
+            </div>
+            <div>
+              <h1 className="text-lg font-semibold leading-tight">用量统计</h1>
+              <p className="text-xs text-foreground/45">Agent 会话 Token 消耗与费用（SDK 实测口径）</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1 rounded-lg border border-border/60 bg-card/40 p-1">
+              {RANGES.map((r) => (
+                <button
+                  key={r.key}
+                  type="button"
+                  onClick={() => setRange(r.key)}
+                  className={cn(
+                    'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                    range === r.key ? 'bg-primary text-primary-foreground' : 'text-foreground/55 hover:text-foreground',
+                  )}
+                >
+                  {r.label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => void load(true)}
+              disabled={loading}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border/60 bg-card/40 px-3 py-2 text-xs font-medium text-foreground/70 transition-colors hover:bg-foreground/5 disabled:opacity-50"
+              title="忽略增量缓存，全量重新扫描历史会话"
+            >
+              <RefreshCw size={14} className={cn(loading && 'animate-spin')} />
+              重新扫描
+            </button>
+          </div>
+        </div>
+
+        {rescanned && (
+          <div className="mb-4 rounded-lg border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-600 dark:text-emerald-400">
+            已全量重新扫描历史会话，数据已更新。
+          </div>
+        )}
+
+        {/* 汇总卡片 */}
+        <div className="mb-5 grid grid-cols-2 gap-3 md:grid-cols-4">
+          <StatCard
+            label={`Token 消耗${range === 'all' ? '' : '（本区间）'}`}
+            value={formatTokenCount(rangeTokens)}
+            sub={range === 'all' ? `累计 ${formatTokenCount(totalTokens)}` : `总计 ${formatTokenCount(totalTokens)}`}
+            accent
+          />
+          <StatCard
+            label="费用（USDT）"
+            value={formatUsd(totalsInRange.costUsd)}
+            sub={range === 'all' ? '' : `总计 ${formatUsd(snapshot?.totals.costUsd ?? 0)}`}
+          />
+          <StatCard
+            label="运行次数"
+            value={String(range === 'all' ? snapshot?.totals.runs ?? 0 : totalsInRange.runs)}
+            sub={range === 'all' ? '' : `总计 ${snapshot?.totals.runs ?? 0}`}
+          />
+          <StatCard
+            label="会话数"
+            value={String(snapshot?.totals.sessions ?? 0)}
+            sub="已纳入统计的 Agent 会话"
+          />
+        </div>
+
+        {/* 图表区 */}
+        <div className="mb-5 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <UsageChartCard title="每日 Token 消耗（按日堆叠）">
+            <div className="mb-2 flex flex-wrap gap-3 text-[11px] text-foreground/55">
+              {TOKEN_SERIES.map((s) => (
+                <span key={s.key} className="inline-flex items-center gap-1.5">
+                  <span className="inline-block size-2.5 rounded-sm" style={{ backgroundColor: s.color }} />
+                  {s.label}
+                </span>
+              ))}
+            </div>
+            {filteredDaily.length > 0 ? (
+              <DailyTokensChart days={filteredDaily} maxBars={range === 'all' ? 120 : 30} />
+            ) : (
+              <EmptyHint />
+            )}
+          </UsageChartCard>
+          <UsageChartCard title="每日费用（USD）">
+            {filteredDaily.length > 0 ? (
+              <DailyCostChart days={filteredDaily} maxBars={range === 'all' ? 120 : 30} />
+            ) : (
+              <EmptyHint />
+            )}
+          </UsageChartCard>
+        </div>
+
+        {/* 占比圆饼图 */}
+        <div className="mb-5 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <UsageChartCard title="渠道占比（Token）">
+            <UsageDonutChart
+              items={byProvider.map((r) => ({ name: r.name, value: sumTokens(r.tokens) }))}
+              formatValue={formatTokenCount}
+            />
+          </UsageChartCard>
+          <UsageChartCard title="模型占比（Token）">
+            <UsageDonutChart
+              items={byModel.map((r) => ({ name: r.name, sub: r.sub, value: sumTokens(r.tokens) }))}
+              formatValue={formatTokenCount}
+            />
+          </UsageChartCard>
+        </div>
+
+        {/* 明细表格 */}
+        <UsageChartCard title="模型明细">
+          {byModel.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-xs">
+                <thead>
+                  <tr className="border-b border-border/60 text-foreground/40">
+                    <th className="py-2 pr-3 font-normal">模型</th>
+                    <th className="py-2 pr-3 font-normal">渠道</th>
+                    <th className="py-2 pr-3 text-right font-normal">输入</th>
+                    <th className="py-2 pr-3 text-right font-normal">输出</th>
+                    <th className="py-2 pr-3 text-right font-normal">缓存</th>
+                    <th className="py-2 pr-3 text-right font-normal">Token 合计</th>
+                    <th className="py-2 pr-3 text-right font-normal">费用</th>
+                    <th className="py-2 text-right font-normal">运行</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {byModel.map((row) => (
+                    <tr key={`${row.sub ?? ''}-${row.name}`} className="border-b border-border/40 last:border-0">
+                      <td className="py-2 pr-3 font-medium text-foreground/80">{row.name}</td>
+                      <td className="py-2 pr-3 text-foreground/50">{row.sub ?? '—'}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums text-foreground/60">{formatTokenCount(row.tokens.inputTokens)}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums text-foreground/60">{formatTokenCount(row.tokens.outputTokens)}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums text-foreground/60">
+                        {formatTokenCount(row.tokens.cacheReadTokens + row.tokens.cacheCreationTokens)}
+                      </td>
+                      <td className="py-2 pr-3 text-right font-medium tabular-nums">{formatTokenCount(sumTokens(row.tokens))}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums text-emerald-600 dark:text-emerald-400">{formatUsd(row.costUsd)}</td>
+                      <td className="py-2 text-right tabular-nums text-foreground/60">{row.runs}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyHint />
+          )}
+        </UsageChartCard>
+
+        {/* Proma Cloud 余额占位 + 页脚 */}
+        <div className="mt-5 flex flex-col gap-3">
+          <div className="flex items-start gap-2.5 rounded-xl border border-dashed border-border/70 bg-card/30 p-4 text-xs text-foreground/55">
+            <Sparkles size={16} className="mt-0.5 shrink-0 text-primary/70" />
+            <div>
+              <div className="mb-1 font-medium text-foreground/75">Proma Cloud 积分</div>
+              <div>
+                本地渠道消耗（含 proma-cloud 渠道）已纳入上方统计；账户余额需前往 Proma Cloud 控制台查看。
+                接入余额查询接口后，此处将展示实时积分余额与预估可用额度。
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center justify-between text-[11px] text-foreground/35">
+            <span>统计口径：Token 按 assistant 消息逐条累加；费用取 SDK 返回的 total_cost_usd 实测值；缺失渠道不估算。</span>
+            <span>最近扫描：{formatDateTime(snapshot?.lastScannedAt ?? 0)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EmptyHint(): React.ReactElement {
+  return <div className="flex h-32 items-center justify-center text-sm text-foreground/35">暂无数据</div>
+}

--- a/apps/electron/src/renderer/components/usage/usage-charts.tsx
+++ b/apps/electron/src/renderer/components/usage/usage-charts.tsx
@@ -1,0 +1,311 @@
+/**
+ * 用量统计面板的轻量 SVG 图表
+ *
+ * 项目未引入图表库（recharts/echarts 均无），这里用纯 SVG 自绘：
+ * - DailyTokensChart：按日 token 堆叠柱状图（input / output / cache_read / cache_creation）
+ * - DailyCostChart：按日费用柱状图（USD）
+ * - UsageDonutChart：渠道/模型占比圆环饼图（按所选时间范围聚合后的数据）
+ *
+ * 全部数值在组件内格式化，不依赖外部工具库。
+ */
+
+import * as React from 'react'
+import type { UsageDayRow } from '@proma/shared'
+import { cn } from '@/lib/utils'
+
+const TOKEN_COLORS = {
+  input: 'hsl(222 85% 62%)',
+  output: 'hsl(262 82% 68%)',
+  cacheRead: 'hsl(158 70% 54%)',
+  cacheCreation: 'hsl(35 85% 58%)',
+}
+
+export const TOKEN_SERIES = [
+  { key: 'inputTokens', label: '输入', color: TOKEN_COLORS.input },
+  { key: 'outputTokens', label: '输出', color: TOKEN_COLORS.output },
+  { key: 'cacheReadTokens', label: '缓存读', color: TOKEN_COLORS.cacheRead },
+  { key: 'cacheCreationTokens', label: '缓存写', color: TOKEN_COLORS.cacheCreation },
+] as const
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 100_000 ? 0 : 1)}K`
+  return String(n)
+}
+
+function formatUsd(n: number): string {
+  if (n === 0) return '$0'
+  if (n < 0.01) return `$${n.toFixed(4)}`
+  return `$${n.toFixed(2)}`
+}
+
+function sumDayTokens(day: UsageDayRow): number {
+  return day.tokens.inputTokens + day.tokens.outputTokens + day.tokens.cacheReadTokens + day.tokens.cacheCreationTokens
+}
+
+/** 短日期标签：MM-DD */
+function shortDay(day: string): string {
+  const [, m, d] = day.split('-')
+  return `${m}-${d}`
+}
+
+interface BarChartProps {
+  width?: number
+  height?: number
+  children?: React.ReactNode
+}
+
+/** 统一图表外壳：带背景与圆角，防止暗色主题下图表突兀 */
+export function UsageChartCard({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/40 p-4">
+      <h3 className="mb-3 text-sm font-medium text-foreground/70">{title}</h3>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * 按日 token 堆叠柱状图
+ *
+ * @param days 按日升序的行
+ * @param maxBars 最多展示多少根柱子（保留最近 N 天）
+ */
+export function DailyTokensChart({ days, maxBars = 60, height = 220 }: { days: UsageDayRow[]; maxBars?: number; height?: number }): React.ReactElement {
+  const chartDays = days.slice(-maxBars)
+  const totals = chartDays.map(sumDayTokens)
+  const max = Math.max(1, ...totals)
+
+  const W = Math.max(320, chartDays.length * 36 + 24)
+  const H = height
+  const padTop = 16
+  const padBottom = 26
+  const padLeft = 8
+  const padRight = 8
+  const innerH = H - padTop - padBottom
+  const barW = Math.max(6, Math.min(22, (W - padLeft - padRight) / chartDays.length - 6))
+
+  const yScale = (v: number): number => padTop + innerH - (v / max) * innerH
+
+  return (
+    <div className="overflow-x-auto">
+      <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} role="img" aria-label="按日 token 消耗柱状图">
+        {/* 网格线 0 / 50% / 100% */}
+        {[0, 0.5, 1].map((ratio) => {
+          const y = padTop + innerH - ratio * innerH
+          return (
+            <g key={ratio}>
+              <line x1={padLeft} x2={W - padRight} y1={y} y2={y} stroke="currentColor" strokeOpacity={0.08} />
+              <text x={W - padRight} y={y - 3} textAnchor="end" fontSize={9} fill="currentColor" fillOpacity={0.4}>
+                {ratio === 0 ? '' : ratio === 1 ? formatTokenCount(max) : formatTokenCount(max / 2)}
+              </text>
+            </g>
+          )
+        })}
+
+        {chartDays.map((day, i) => {
+          const x = padLeft + i * ((W - padLeft - padRight) / chartDays.length) + (barW > 6 ? 3 : 0)
+          // 堆叠：从底部（padTop + innerH）向上逐段累加
+          let cursor = padTop + innerH
+          const rects: React.ReactElement[] = []
+          for (const series of TOKEN_SERIES) {
+            const v = day.tokens[series.key]
+            if (v <= 0) continue
+            const h = Math.max(1, (v / max) * innerH)
+            cursor -= h
+            rects.push(
+              <rect
+                key={series.key}
+                x={x}
+                y={cursor}
+                width={barW}
+                height={h}
+                fill={series.color}
+                rx={1}
+                opacity={0.9}
+              >
+                <title>{`${day.day} ${series.label}: ${v.toLocaleString()} tokens`}</title>
+              </rect>,
+            )
+          }
+          // 全零日期画一条底部基线
+          const showAxis = i % Math.ceil(chartDays.length / 12) === 0 || chartDays.length <= 15
+          return (
+            <g key={day.day}>
+              {rects}
+              {showAxis && (
+                <text x={x + barW / 2} y={H - 8} textAnchor="middle" fontSize={9} fill="currentColor" fillOpacity={0.45}>
+                  {shortDay(day.day)}
+                </text>
+              )}
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+/** 按日费用柱状图（USD） */
+export function DailyCostChart({ days, maxBars = 60, height = 160 }: { days: UsageDayRow[]; maxBars?: number; height?: number }): React.ReactElement {
+  const chartDays = days.slice(-maxBars)
+  const max = Math.max(0.0001, ...chartDays.map((d) => d.costUsd))
+  const W = Math.max(320, chartDays.length * 36 + 24)
+  const H = height
+  const padTop = 16
+  const padBottom = 26
+  const padLeft = 8
+  const padRight = 8
+  const innerH = H - padTop - padBottom
+  const barW = Math.max(6, Math.min(22, (W - padLeft - padRight) / chartDays.length - 6))
+
+  return (
+    <div className="overflow-x-auto">
+      <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} role="img" aria-label="按日费用柱状图">
+        {chartDays.map((day, i) => {
+          const v = day.costUsd
+          const h = (v / max) * innerH
+          const x = padLeft + i * ((W - padLeft - padRight) / chartDays.length) + (barW > 6 ? 3 : 0)
+          const y = padTop + innerH - h
+          const showAxis = i % Math.ceil(chartDays.length / 12) === 0 || chartDays.length <= 15
+          return (
+            <g key={day.day}>
+              <rect
+                x={x}
+                y={y}
+                width={barW}
+                height={Math.max(1, h)}
+                fill="hsl(142 71% 45%)"
+                rx={1}
+                opacity={v > 0 ? 0.85 : 0.15}
+              >
+                <title>{`${day.day}: ${formatUsd(v)}`}</title>
+              </rect>
+              {showAxis && (
+                <text x={x + barW / 2} y={H - 8} textAnchor="middle" fontSize={9} fill="currentColor" fillOpacity={0.45}>
+                  {shortDay(day.day)}
+                </text>
+              )}
+            </g>
+          )
+        })}
+        {max > 0.0001 && (
+          <text x={W - padRight} y={padTop - 4} textAnchor="end" fontSize={9} fill="currentColor" fillOpacity={0.4}>
+            {formatUsd(max)}
+          </text>
+        )}
+      </svg>
+    </div>
+  )
+}
+
+/** 占比圆饼图配色盘（按切片顺序循环取色） */
+const PIE_COLORS = [
+  'hsl(222 85% 62%)',
+  'hsl(262 82% 68%)',
+  'hsl(158 70% 54%)',
+  'hsl(35 85% 58%)',
+  'hsl(0 78% 62%)',
+  'hsl(190 80% 55%)',
+  'hsl(300 70% 62%)',
+  'hsl(84 65% 55%)',
+]
+
+/** 渠道/模型占比圆环饼图：超出 topN 的项合并为「其他」，中心展示合计，右侧图例带百分比与数值 */
+export function UsageDonutChart({
+  items,
+  formatValue,
+  topN = 8,
+}: {
+  items: Array<{ name: string; sub?: string; value: number }>
+  formatValue: (v: number) => string
+  topN?: number
+}): React.ReactElement {
+  const sorted = items.filter((item) => item.value > 0).sort((a, b) => b.value - a.value)
+  const top = sorted.slice(0, topN)
+  const rest = sorted.slice(topN)
+  const slices = rest.length > 0
+    ? [...top, { name: '其他', sub: undefined as string | undefined, value: rest.reduce((sum, item) => sum + item.value, 0) }]
+    : top
+  const total = slices.reduce((sum, slice) => sum + slice.value, 0)
+
+  if (total <= 0 || slices.length === 0) {
+    return <div className="flex h-32 items-center justify-center text-sm text-foreground/35">暂无数据</div>
+  }
+
+  // 用 stroke-dasharray 在同一半径上依次画扇区，间隙 1.5px 保证切片边界可辨
+  const size = 136
+  const radius = 52
+  const strokeWidth = 22
+  const circumference = 2 * Math.PI * radius
+  let drawn = 0
+
+  return (
+    <div className="flex flex-wrap items-center gap-5">
+      <div className="shrink-0 text-foreground">
+        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label="占比圆饼图">
+          <g transform={`rotate(-90 ${size / 2} ${size / 2})`}>
+            {slices.map((slice, index) => {
+              const length = (slice.value / total) * circumference
+              const gap = slices.length > 1 ? Math.min(1.5, length * 0.15) : 0
+              const dash = Math.max(length - gap, 0.5)
+              const dashOffset = -drawn - gap / 2
+              drawn += length
+              return (
+                <circle
+                  key={`${slice.name}-${index}`}
+                  cx={size / 2}
+                  cy={size / 2}
+                  r={radius}
+                  fill="none"
+                  stroke={PIE_COLORS[index % PIE_COLORS.length]!}
+                  strokeWidth={strokeWidth}
+                  strokeDasharray={`${dash} ${circumference - dash}`}
+                  strokeDashoffset={dashOffset}
+                />
+              )
+            })}
+          </g>
+          <text x="50%" y="48%" textAnchor="middle" className="text-[13px] font-semibold tabular-nums" fill="currentColor">
+            {formatValue(total)}
+          </text>
+          <text x="50%" y="61%" textAnchor="middle" className="text-[10px]" fill="currentColor" opacity="0.4">
+            合计
+          </text>
+        </svg>
+      </div>
+      <div className="min-w-0 flex-1 space-y-1.5">
+        {slices.map((slice, index) => (
+          <div key={`${slice.name}-${index}`} className="flex items-center gap-2 text-xs">
+            <span
+              className="inline-block size-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: PIE_COLORS[index % PIE_COLORS.length] }}
+            />
+            <span
+              className="min-w-0 flex-1 truncate text-foreground/70"
+              title={slice.sub ? `${slice.name}（${slice.sub}）` : slice.name}
+            >
+              {slice.name}
+              {slice.sub ? <span className="ml-1 text-[10px] text-foreground/40">{slice.sub}</span> : null}
+            </span>
+            <span className="shrink-0 tabular-nums text-foreground/45">{Math.round((slice.value / total) * 100)}%</span>
+            <span className="w-14 shrink-0 text-right tabular-nums text-foreground/60">{formatValue(slice.value)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** 汇总数字卡片 */
+export function StatCard({ label, value, sub, accent }: { label: string; value: string; sub?: string; accent?: boolean }): React.ReactElement {
+  return (
+    <div className={cn('rounded-xl border p-4', accent ? 'border-primary/25 bg-primary/5' : 'border-border/60 bg-card/40')}>
+      <div className="text-xs text-foreground/50">{label}</div>
+      <div className={cn('mt-1 text-2xl font-semibold tabular-nums', accent ? 'text-primary' : 'text-foreground')}>{value}</div>
+      {sub ? <div className="mt-0.5 text-[11px] text-foreground/40">{sub}</div> : null}
+    </div>
+  )
+}
+
+export { formatTokenCount, formatUsd, sumDayTokens }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -573,3 +573,11 @@ export const STORAGE_IPC_CHANNELS = {
   /** 仅清理临时文件（启动时/快速清理） */
   CLEANUP_TEMP: 'storage:cleanup-temp',
 } as const
+
+/** 用量统计 IPC 通道 */
+export const USAGE_IPC_CHANNELS = {
+  /** 获取用量统计快照（含增量补扫） */
+  GET_SNAPSHOT: 'usage:get-snapshot',
+  /** 忽略增量缓存全量重扫 */
+  RESCAN: 'usage:rescan',
+} as const

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -61,3 +61,6 @@ export * from './planning'
 
 // Agent 灵动岛相关类型
 export * from './agent-island'
+
+// 用量统计（Usage Stats）相关类型
+export * from './usage-stats'

--- a/packages/shared/src/types/usage-stats.ts
+++ b/packages/shared/src/types/usage-stats.ts
@@ -1,0 +1,65 @@
+/**
+ * 用量统计（Usage Stats）共享类型
+ *
+ * 主进程 usage-stats-service 聚合 Agent 会话的 LLM 消耗后，
+ * 通过 IPC 把该快照传给渲染层用量统计面板。
+ */
+
+/** Token 消耗拆分（与 SDK usage 字段一一对应） */
+export interface UsageTokens {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+}
+
+/** 按渠道（provider）或模型拆分的行（model='*' 表示 provider 汇总） */
+export interface UsageBreakdownRow {
+  provider: string
+  model: string
+  tokens: UsageTokens
+  costUsd: number
+  runs: number
+}
+
+/** 按自然日 × 渠道 × 模型的明细行（供面板按所选时间范围重新聚合） */
+export interface UsageBreakdownDailyRow {
+  /** yyyy-mm-dd（本地时区） */
+  day: string
+  provider: string
+  model: string
+  tokens: UsageTokens
+  costUsd: number
+  runs: number
+}
+
+/** 按自然日聚合一格 */
+export interface UsageDayRow {
+  /** yyyy-mm-dd（本地时区） */
+  day: string
+  tokens: UsageTokens
+  costUsd: number
+  runs: number
+}
+
+/** 用量统计面板一次性拿到的快照 */
+export interface UsageStatsSnapshot {
+  version: 1
+  /** 最近一次完整/增量扫描时间（ms） */
+  lastScannedAt: number
+  totals: {
+    tokens: UsageTokens
+    costUsd: number
+    runs: number
+    /** 纳入统计的 Agent 会话文件数 */
+    sessions: number
+  }
+  /** 按自然日升序 */
+  daily: UsageDayRow[]
+  /** 按渠道（provider）汇总，runs 降序 */
+  byProvider: UsageBreakdownRow[]
+  /** 按渠道×模型汇总，runs 降序 */
+  byModel: UsageBreakdownRow[]
+  /** 按自然日 × 渠道 × 模型明细，day 升序；面板按时间范围过滤后自行聚合 */
+  breakdownDaily: UsageBreakdownDailyRow[]
+}


### PR DESCRIPTION
- 主进程 usage-stats-service：扫描 agent-sessions JSONL 聚合 LLM 用量， 增量缓存（usage-stats.json）只重扫变更会话；assistant 消息计 token、 result 计费用/运行次数，口径防重复
- 快照新增 breakdownDaily（天×渠道×模型明细），面板按所选时间范围 对所有会话重新聚合渠道/模型占比，替换原全时段常量口径
- 渠道/模型占比改为 SVG 圆环饼图（超 topN 合并为「其他」）
- 展开态侧边栏补「用量统计」入口（原先仅折叠态图标栏有）
- 面板顶部避开 AppShell 全局窗口拖拽层，修复时间切换/重新扫描按钮点击失效
- 统计页与技能页一致：进入时隐藏右侧文件面板

Made-with: Proma