### PR TITLE
Fix redundant Chat tool sync toast

### DIFF
--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -681,14 +681,12 @@ function ChatToolInitializer(): null {
       .catch((err: unknown) => console.error('[ChatToolInitializer] 加载工具列表失败:', err))
   }, [setChatTools])
 
-  // 订阅自定义工具配置变更
+  // 订阅自定义工具配置变更并静默刷新工具列表。
+  // 用户主动操作的反馈由各设置入口提供，避免文件监听产生重复 Toast。
   useEffect(() => {
     const cleanup = window.electronAPI.onCustomToolChanged(() => {
       window.electronAPI.getChatTools()
-        .then((tools) => {
-          setChatTools(tools)
-          toast.success('Chat 工具已更新')
-        })
+        .then(setChatTools)
         .catch((err: unknown) => console.error('[ChatToolInitializer] 刷新工具列表失败:', err))
     })
     return cleanup


### PR DESCRIPTION
## Summary

- 静默处理 chat-tools.json 文件变更后的工具列表同步，移除会对用户主动设置操作重复出现的全局 “Chat 工具已更新” Toast。
- 保留各设置入口自身的具体反馈，不改变工具配置刷新逻辑。

## Test plan

- [x] `git diff --check`
- [ ] `bun run typecheck`（worktree 未安装依赖，`tsc: command not found`）

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)