### PR TITLE
Fix background Agent stream visibility

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.55",
+  "version": "0.17.56",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/lib/agent-stream-event-batcher.ts
+++ b/apps/electron/src/renderer/lib/agent-stream-event-batcher.ts
@@ -4,6 +4,10 @@ export interface AgentStreamEventBatcherOptions {
   dispatch: (event: AgentStreamEvent) => void
   requestFrame?: (callback: FrameRequestCallback) => number
   cancelFrame?: (handle: number) => void
+  /** 帧调度被后台节流时的交付兜底。 */
+  scheduleFallback?: (callback: () => void, delayMs: number) => number
+  cancelFallback?: (handle: number) => void
+  fallbackDelayMs?: number
 }
 
 function isPartialAssistantEvent(event: AgentStreamEvent): boolean {
@@ -36,10 +40,18 @@ export function createAgentStreamEventBatcher(options: AgentStreamEventBatcherOp
   const pending = new Map<string, AgentStreamEvent>()
   const requestFrame = options.requestFrame ?? window.requestAnimationFrame
   const cancelFrame = options.cancelFrame ?? window.cancelAnimationFrame
+  const scheduleFallback = options.scheduleFallback ?? ((callback, delayMs) => window.setTimeout(callback, delayMs))
+  const cancelFallback = options.cancelFallback ?? ((handle) => window.clearTimeout(handle))
+  const fallbackDelayMs = options.fallbackDelayMs ?? 100
   let frame: number | null = null
+  let fallback: number | null = null
 
   const flush = (): void => {
     frame = null
+    if (fallback !== null) {
+      cancelFallback(fallback)
+      fallback = null
+    }
     const events = [...pending.values()]
     pending.clear()
     for (const event of events) options.dispatch(event)
@@ -67,14 +79,21 @@ export function createAgentStreamEventBatcher(options: AgentStreamEventBatcherOp
         options.dispatch(existing)
       }
       pending.set(event.sessionId, existing ? mergePendingEvents(existing, event) : event)
-      if (frame === null) frame = requestFrame(flush)
+      if (frame === null) {
+        frame = requestFrame(flush)
+        // backgroundThrottling 可能暂停 requestAnimationFrame；定时器确保
+        // Agent 仍在运行时 renderer 至少能周期性收到可见增量。
+        fallback = scheduleFallback(flush, fallbackDelayMs)
+      }
     },
     clear(sessionId: string): void {
       pending.delete(sessionId)
     },
     dispose(): void {
       if (frame !== null) cancelFrame(frame)
+      if (fallback !== null) cancelFallback(fallback)
       frame = null
+      fallback = null
       pending.clear()
     },
   }


### PR DESCRIPTION
## Summary

- Add a 100ms timer watchdog to the renderer Agent stream batcher.
- Keep `requestAnimationFrame` as the normal foreground flush path and cancel the watchdog after a normal frame flush.
- Prevent background-throttled Electron renderers from silently withholding live Agent deltas while the main process continues running and persisting the session.
- Bump `@proma/electron` to `0.17.56`.

## Root cause

Electron has `backgroundThrottling` enabled. When the renderer is backgrounded, `requestAnimationFrame` may stop firing, while the main process continues forwarding and persisting the Agent stream. The session then appears to produce no output until the renderer is restarted and reloads the JSONL transcript.

## Test plan

- `bun test ./apps/electron/src/renderer/lib/agent-stream-event-batcher.test.ts ./apps/electron/src/renderer/atoms/agent-atoms.test.ts` passed before removing the requested test file.
- `bun run --filter='@proma/electron' typecheck` passed.
- `bun run --filter='@proma/electron' build:renderer` passed.
- Full `bun test`: 473 passed, with 4 existing environment-dependent failures in Electron mocks, OAuth proxy setup, and planning native execution.
- Runtime risk: low. Foreground rendering remains frame-driven; the watchdog only runs when a scheduled frame has not flushed within 100ms.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
