### PR TITLE
fix(agent): stop all pending recovery runtimes

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-utility-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-utility-adapter.ts
@@ -100,8 +100,11 @@ export class PiUtilityAdapter {
   }
 
   abort(sessionId: string): void {
+    // A recovery iterator can be late to release its runtime. Abort every
+    // matching query rather than assuming the first map entry owns the session.
     for (const pending of this.pendingQueries.values()) {
       if (pending.sessionId !== sessionId) continue
+      this.abortCapabilitiesForQuery(pending.queryId)
       void pending.client.call<QueryAbortResponse>(
         AGENT_RUNTIME_METHODS.QUERY_ABORT,
         { queryId: pending.queryId, sessionId },
@@ -113,15 +116,23 @@ export class PiUtilityAdapter {
         console.warn(`[PiUtilityAdapter] abort failed: sessionId=${sessionId}`, error)
         this.failStoppedQuery(pending, error)
       })
-      return
     }
   }
 
   private failStoppedQuery(pending: PendingQuery, error: unknown): void {
     if (pending.ended || pending.runtimeFailed) return
     pending.runtimeFailed = true
+    this.abortCapabilitiesForQuery(pending.queryId)
     pending.queue.fail(error)
     void pending.client.stop()
+  }
+
+  private abortCapabilitiesForQuery(queryId: string): void {
+    for (const [requestId, capability] of this.capabilityAbortControllers) {
+      if (capability.queryId !== queryId) continue
+      capability.controller.abort()
+      this.capabilityAbortControllers.delete(requestId)
+    }
   }
 
   async sendQueuedMessage(

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1553,6 +1553,17 @@ export class AgentOrchestrator {
       const queryStartedAt = Date.now()
 
       for (let attempt = 1; attempt <= MAX_QUERY_ATTEMPTS; attempt++) {
+        // stop() releases the active slot before aborting the adapter. It can win
+        // the race against async preflight or a recoverable-error retry, when no
+        // adapter query exists yet to cancel. Never start that later query.
+        if (this.activeSessions.get(sessionId) !== runGeneration) {
+          const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
+          this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
+          try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
+          completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
+          return
+        }
+
         // A recovery query starts a fresh turn; activations from a failed attempt must not leak.
         pendingSkillActivations = []
         // 回退会清除 queryOptions.resumeSessionId；新建 Pi artifact 不应再触发 prompt replay。
@@ -1894,8 +1905,11 @@ export class AgentOrchestrator {
             }
           }
 
-          // 错误 break 触发了 → 继续循环
+          // 需要恢复时，前一次 adapter iterator 尚未自然结束。显式 return 才会
+          // 执行 PiUtilityAdapter 的 finally，释放旧 runtime 与 pending query；否则
+          // 同一 session 会残留多个运行时，后续 stop 只能取消其中一个。
           if (shouldRetryFromError) {
+            await queryIterator.return?.(undefined as never).catch(() => {})
             continue
           }
 
@@ -1931,7 +1945,9 @@ export class AgentOrchestrator {
           return
 
         } catch (error) {
-          if (!this.activeSessions.has(sessionId)) {
+          // 同一 session 的新 run 可能已在旧 run 的迟到错误之前开始；只要
+          // 本代际不再拥有 active slot，就只能收束自己，不能向新 run 泄漏终态。
+          if (this.activeSessions.get(sessionId) !== runGeneration) {
             const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -44,6 +44,7 @@ import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
 import { AgentStreamForwarder } from './agent-stream-forwarder'
 import { AgentQueueCoordinator } from './agent-queue-coordinator'
+import { shouldStopBeforeAgentRun } from './agent-stop-policy'
 
 // ===== 实例创建 =====
 
@@ -449,7 +450,16 @@ export async function generateAgentTitle(input: AgentGenerateTitleInput): Promis
  * 中止指定会话的 Agent 执行
  */
 export function stopAgent(sessionId: string): void {
-  orchestrator.stop(sessionId, agentQueueCoordinator.isDispatching(sessionId))
+  // SEND_MESSAGE reserves this slot before the async bridge setup reaches the
+  // orchestrator. Remember a stop in that window so the later run is never
+  // allowed to create an uncancellable adapter query.
+  orchestrator.stop(
+    sessionId,
+    shouldStopBeforeAgentRun(
+      startingAgentSessions.has(sessionId),
+      agentQueueCoordinator.isDispatching(sessionId),
+    ),
+  )
 }
 
 setHeadlessAgentRunner(runAgentHeadless)

--- a/apps/electron/src/main/lib/agent-stop-policy.ts
+++ b/apps/electron/src/main/lib/agent-stop-policy.ts
@@ -1,0 +1,11 @@
+/**
+ * Stop requests arriving while a run is reserved but has not reached the
+ * orchestrator must be remembered. Otherwise the later run starts with no
+ * active adapter query for `abort()` to cancel.
+ */
+export function shouldStopBeforeAgentRun(
+  isStarting: boolean,
+  isDispatchingQueuedRun: boolean,
+): boolean {
+  return isStarting || isDispatchingQueuedRun
+}


### PR DESCRIPTION
## Summary

- Remember stop requests that arrive while an Agent run is still reserved or queued.
- Close recovery iterators before retrying, and cancel every runtime/capability still associated with the session.
- Prevent late terminal events from an older run generation from affecting a newer run.

## Test plan

- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:main`

## Performance impact

Low risk: this only adds cancellation-state checks on run/retry transitions and releases pending runtimes/capabilities. It adds no new renderer updates, IPC listeners, timers, or steady-state work. Real Electron interaction testing remains recommended for rapid-stop and retry-stop flows.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)