### PR TITLE
fix(agent): guide first-time users to model selector

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -108,7 +108,7 @@ import {
 } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
-import { channelsAtom } from '@/atoms/chat-atoms'
+import { channelsAtom, modelSelectorOpenAtom } from '@/atoms/chat-atoms'
 import { todoPlanningGroupsAtom } from '@/atoms/planning-atoms'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
@@ -480,6 +480,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const agentEffort = useAtomValue(agentEffortAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
+  const setModelSelectorOpen = useSetAtom(modelSelectorOpenAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
   const globalWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   // 从会话元数据派生 workspaceId：会话数据已加载时以自身为准，未加载时回退全局 atom
@@ -3069,17 +3070,17 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               </div>
             )}
 
-            {/* 无 Agent 渠道或无可用模型提示 */}
+            {/* 尚未选择模型或暂无可用模型时的引导 */}
             {(!agentChannelId || !hasAvailableModel) && (
               <div className="flex items-center gap-2 px-4 py-2 text-sm text-amber-600 dark:text-amber-400">
                 <Settings size={14} />
-                <span>{!agentChannelId ? '请在设置中选择 Agent 供应商' : '暂无可用模型，请在设置中启用 Agent 渠道并配置模型'}</span>
+                <span>{!hasAvailableModel ? '暂无可用模型，请在设置中添加或启用渠道和模型' : '请选择模型以开始 Agent 对话'}</span>
                 <button
                   type="button"
                   className="text-xs underline underline-offset-2 hover:text-foreground transition-colors"
-                  onClick={() => setSettingsOpen(true)}
+                  onClick={() => !hasAvailableModel ? setSettingsOpen(true) : setModelSelectorOpen(true)}
                 >
-                  前往设置
+                  {!hasAvailableModel ? '前往设置' : '选择模型'}
                 </button>
               </div>
             )}
@@ -3163,7 +3164,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                     ? '输入消息...（@ 引用文件，/ 调用 Skill，# 使用 MCP，& 引用会话，～ 引用待办/日程；⌘/Ctrl+Enter 发送）'
                     : '输入消息...（@ 引用文件，/ 调用 Skill，# 使用 MCP，& 引用会话，～ 引用待办/日程；Enter 发送）'
                   : !agentChannelId
-                    ? '请先在设置中选择 Agent 供应商'
+                    ? '请先选择模型'
                     : '暂无可用模型，请先在设置中启用渠道'
               }
               disabled={isLegacyTranscript || !agentChannelId || !hasAvailableModel}


### PR DESCRIPTION
## Summary

- Replace the stale Agent-provider setup route with the existing model selector for first-time Agent sessions.
- Keep Settings as the recovery route only when no enabled channel model is available.

## Validation

- `bun run --filter='*' typecheck`
- `bun run build:renderer` (apps/electron)

## Performance

No measurable runtime impact: the change reuses the existing shared model-selector atom and adds only a click-driven state update; it adds no IPC, listener, timer, or streaming-path render work.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)