### PR TITLE
feat(changes): show memory updates in diff panel

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.56",
+  "version": "0.17.57",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -13,6 +13,7 @@ import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
 import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom, agentSessionsAtom, workspaceGitDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
 import { WorktreeSelector } from './WorktreeSelector'
+import { WorkspaceMemoryChangeDock } from '@/components/agent-skills/WorkspaceMemoryChangeDock'
 import { groupSessionFileChanges } from '@/lib/session-file-changes'
 import type { SessionFileChange } from '@/lib/session-file-changes'
 
@@ -267,7 +268,8 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   const shouldShowWorktreeSelector = isGitRepo && Boolean(workspaceSlug || (worktreeRepoPaths?.length ?? 0) > 0)
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto">
       {/* Worktree 分支选择器仅作用于 Git 改动。 */}
       {shouldShowWorktreeSelector && (
         <WorktreeSelector
@@ -387,6 +389,8 @@ export const DiffChangesList = React.memo(function DiffChangesList({
           })}
         </>
       )}
+      </div>
+      {workspaceSlug && <WorkspaceMemoryChangeDock workspaceSlug={workspaceSlug} />}
     </div>
   )
 })


### PR DESCRIPTION
## Summary
- 在“文件改动”面板底部复用项目记忆更新栏。
- 让改动列表独立滚动，记忆更新栏固定在底部。
- Electron 版本升级至 0.17.57。

## Validation
- `bun run typecheck`
- `bun run electron:build`
- `bun test`（471 通过；4 个既有 Electron/环境相关失败，详见本地测试输出）

## Performance
低风险：仅在已打开的“文件改动”面板挂载既有的记忆更新组件；不新增 IPC 订阅或高频状态更新。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)