### PR TITLE
Fix atomic queued message submission

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.56",
+  "version": "0.17.57",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -282,7 +282,7 @@ import {
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, isAgentSessionBusy, reserveAgentSessionStart, queueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, isAgentSessionBusy, reserveAgentSessionStart, queueAgentMessage, submitOrEnqueueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -2888,7 +2888,15 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 将等待当前 run 结束的消息交给主进程调度器
+  // 主进程原子决定立即注入活跃 Agent 或进入 deferred queue。
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SUBMIT_OR_ENQUEUE_MESSAGE,
+    async (event, input: import('@proma/shared').AgentSubmitOrEnqueueInput): Promise<import('@proma/shared').AgentSubmitOrEnqueueResult> => {
+      return submitOrEnqueueAgentMessage(input, event.sender)
+    },
+  )
+
+  // 兼容旧调用：将消息交给主进程 deferred queue。
   ipcMain.handle(
     AGENT_IPC_CHANNELS.ENQUEUE_QUEUED_MESSAGE,
     async (event, input: import('@proma/shared').AgentDeferredQueueMessageInput): Promise<void> => {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -44,6 +44,7 @@ import { friendlyErrorMessage, isPromptTooLongError, isThinkingSignatureError, m
 import { getActiveRunRejectionMessage, shouldPersistInitialUserMessage } from './agent-send-message-policy'
 import { isSessionNotFoundError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
+import { isStaleActiveQueueError } from './agent-queue-routing'
 import { decryptApiKey, getChannelById, listChannels, persistCodexOAuthCredentials, persistXaiOAuthCredentials, resolveChannelRuntimeApiKey, resolveCodexOAuthCredentials, resolveXaiOAuthCredentials } from './channel-manager'
 import { getAdapter, fetchTitle } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
@@ -111,7 +112,7 @@ function errorMessageOf(error: unknown): string {
 }
 
 function isMissingActiveQueueChannelError(error: unknown): boolean {
-  return errorMessageOf(error).includes('无活跃消息通道可注入队列消息')
+  return isStaleActiveQueueError(error)
 }
 
 function isPartialSDKMessage(message: SDKMessage): boolean {

--- a/apps/electron/src/main/lib/agent-queue-routing.ts
+++ b/apps/electron/src/main/lib/agent-queue-routing.ts
@@ -1,0 +1,21 @@
+/**
+ * Pi runtime 完成 query 与 renderer 收到终态事件之间，可能拒绝对旧通道的消息注入。
+ * 这些错误表示消息尚未被接受，应转交 deferred queue，而不是暴露为用户发送失败。
+ */
+export function isStaleActiveQueueError(error: unknown): boolean {
+  const record = error !== null && typeof error === 'object'
+    ? error as Record<string, unknown>
+    : undefined
+  const code = typeof record?.code === 'string' ? record.code : ''
+  const message = error instanceof Error
+    ? error.message
+    : typeof record?.message === 'string'
+      ? record.message
+      : String(error)
+
+  return code === 'agent.query.not_active' ||
+    message.includes('会话未运行，无法追加消息') ||
+    message.includes('无活跃消息通道可注入队列消息') ||
+    message.includes('当前会话没有正在运行的 Agent') ||
+    message.includes('Agent session is not active')
+}

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -26,6 +26,8 @@ import type {
   AgentStreamPayload,
   AgentQueueMessageInput,
   AgentDeferredQueueMessageInput,
+  AgentSubmitOrEnqueueInput,
+  AgentSubmitOrEnqueueResult,
   AgentQueuedMessageControlInput,
   AgentMoveQueuedMessageInput,
   PromaPermissionMode,
@@ -44,6 +46,7 @@ import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
 import { AgentStreamForwarder } from './agent-stream-forwarder'
 import { AgentQueueCoordinator } from './agent-queue-coordinator'
+import { isStaleActiveQueueError } from './agent-queue-routing'
 import { shouldStopBeforeAgentRun } from './agent-stop-policy'
 
 // ===== 实例创建 =====
@@ -528,6 +531,44 @@ export async function queueAgentMessage(
   )
 }
 
+/**
+ * 单一消息提交入口：主进程依据实时运行状态决定注入当前 Agent 或交给 deferred queue。
+ * renderer 的 streaming 状态仅用于展示，不能作为发送路由依据。
+ */
+export async function submitOrEnqueueAgentMessage(
+  input: AgentSubmitOrEnqueueInput,
+  webContents: WebContents,
+): Promise<AgentSubmitOrEnqueueResult> {
+  registerWebContents(input.sessionId, webContents)
+
+  if (input.dispatch === 'now' && orchestrator.isActive(input.sessionId)) {
+    try {
+      await queueAgentMessage({
+        sessionId: input.sessionId,
+        userMessage: input.userMessage,
+        rawUserMessage: input.rawUserMessage,
+        uuid: input.queueMessageId,
+        interrupt: input.interrupt,
+        mentionedSkills: input.mentionedSkills,
+        mentionedMcpServers: input.mentionedMcpServers,
+        mentionedSessionIds: input.mentionedSessionIds,
+        mentionedTodoIds: input.mentionedTodoIds,
+        mentionedCalendarEventIds: input.mentionedCalendarEventIds,
+      }, webContents)
+      return { disposition: 'injected' }
+    } catch (error) {
+      // Pi Utility 在 query 结束、renderer 尚未收到 STREAM_COMPLETE 的窗口会拒绝注入。
+      // 该消息尚未被 SDK 接受，安全地降级到主进程队列，而非向用户暴露瞬态错误。
+      if (!isStaleActiveQueueError(error)) throw error
+      console.warn(`[Agent 服务] 活跃通道已结束，转入 deferred queue: sessionId=${input.sessionId}`)
+    }
+  }
+
+  agentQueueCoordinator.enqueue(input)
+  return { disposition: 'queued' }
+}
+
+/** 兼容旧调用：仅将消息追加到主进程 deferred queue。 */
 export function enqueueAgentQueuedMessage(input: AgentDeferredQueueMessageInput, webContents: WebContents): void {
   registerWebContents(input.sessionId, webContents)
   agentQueueCoordinator.enqueue(input)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -111,6 +111,8 @@ import type {
   WeChatBridgeState,
   AgentQueueMessageInput,
   AgentDeferredQueueMessageInput,
+  AgentSubmitOrEnqueueInput,
+  AgentSubmitOrEnqueueResult,
   AgentQueuedMessageControlInput,
   AgentMoveQueuedMessageInput,
   AgentQueuedMessageStatus,
@@ -590,7 +592,9 @@ export interface ElectronAPI {
 
   /** 流式追加发送 Agent 消息（Agent 运行中） */
   queueAgentMessage: (input: AgentQueueMessageInput) => Promise<string>
-  /** 将等待当前 run 结束的消息交给主进程 */
+  /** 主进程原子决定立即注入或等待当前 run 结束后发送。 */
+  submitOrEnqueueAgentMessage: (input: AgentSubmitOrEnqueueInput) => Promise<AgentSubmitOrEnqueueResult>
+  /** 将等待当前 run 结束的消息交给主进程（兼容旧调用）。 */
   enqueueAgentQueuedMessage: (input: AgentDeferredQueueMessageInput) => Promise<void>
   cancelAgentQueuedMessage: (input: AgentQueuedMessageControlInput) => Promise<boolean>
   moveAgentQueuedMessage: (input: AgentMoveQueuedMessageInput) => Promise<boolean>
@@ -1820,6 +1824,9 @@ const electronAPI: ElectronAPI = {
   // Agent 队列消息
   queueAgentMessage: (input: AgentQueueMessageInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.QUEUE_MESSAGE, input)
+  },
+  submitOrEnqueueAgentMessage: (input: AgentSubmitOrEnqueueInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SUBMIT_OR_ENQUEUE_MESSAGE, input)
   },
   enqueueAgentQueuedMessage: (input: AgentDeferredQueueMessageInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ENQUEUE_QUEUED_MESSAGE, input)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -279,12 +279,6 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function isStaleAgentQueueError(error: unknown): boolean {
-  const message = getErrorMessage(error)
-  return message.includes('会话未运行，无法追加消息') ||
-    message.includes('无活跃消息通道可注入队列消息')
-}
-
 // ===== 思考模式 Hover Popover =====
 
 const OPENAI_THINKING_LEVELS = ['off', 'low', 'medium', 'high', 'xhigh', 'max'] as const satisfies readonly AgentThinkingLevel[]
@@ -966,17 +960,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [sessionId, store])
 
-  const removeLiveUserMessage = React.useCallback((messageId: string) => {
-    store.set(liveMessagesMapAtom, (prev) => {
-      const map = new Map(prev)
-      const current = (map.get(sessionId) ?? []).filter(
-        (item) => (item as Record<string, unknown>).uuid !== messageId,
-      )
-      map.set(sessionId, current)
-      return map
-    })
-  }, [sessionId, store])
-
   const clearStoppedByUser = React.useCallback(() => {
     store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
       if (!prev.has(sessionId)) return prev
@@ -985,105 +968,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return next
     })
   }, [sessionId, store])
-
-  const queueMessageIntoActiveAgent = React.useCallback(async (
-    message: AgentQueuedMessage,
-    rawText: string,
-    sdkText: string,
-    mentions: ReturnType<typeof parseQueuedMessageMentions>,
-    interruptCurrentTurn: boolean,
-  ): Promise<void> => {
-    // 气泡显示用原文 text（保留 /skill:、#mcp:、&session:、&todo: 和 &calendar_event: 语法），
-    // 让 message.tsx 的 remarkMentions 立即渲染出引用芯片；
-    // 剥离后的 sdkText 仅用于传给 SDK，不作为展示文本。
-    appendLiveUserMessage(createUserSDKMessage(rawText, message.id, Date.now()))
-
-    try {
-      await window.electronAPI.queueAgentMessage({
-        sessionId,
-        userMessage: sdkText,
-        rawUserMessage: rawText,
-        uuid: message.id,
-        interrupt: interruptCurrentTurn,
-        ...(mentions.mentionedSkills.length > 0 && { mentionedSkills: mentions.mentionedSkills }),
-        ...(mentions.mentionedMcpServers.length > 0 && { mentionedMcpServers: mentions.mentionedMcpServers }),
-        ...(mentions.mentionedSessionIds.length > 0 && { mentionedSessionIds: mentions.mentionedSessionIds }),
-        ...(mentions.mentionedTodoIds.length > 0 && { mentionedTodoIds: mentions.mentionedTodoIds }),
-        ...(mentions.mentionedCalendarEventIds.length > 0 && { mentionedCalendarEventIds: mentions.mentionedCalendarEventIds }),
-      })
-    } catch (error) {
-      removeLiveUserMessage(message.id)
-      throw error
-    }
-  }, [appendLiveUserMessage, removeLiveUserMessage, sessionId])
-
-  const startQueuedMessageRun = React.useCallback(async (
-    displayText: string,
-    sdkText: string,
-    mentions: ReturnType<typeof parseQueuedMessageMentions>,
-    channelId: string,
-    queuedAdditionalDirectories: string[] = [],
-  ): Promise<void> => {
-    const streamStartedAt = Date.now()
-    const additionalDirectoriesForRun = createBaseAdditionalDirectories()
-    for (const dir of queuedAdditionalDirectories) {
-      additionalDirectoriesForRun.add(dir)
-    }
-    setStreamingStates((prev) => {
-      const map = new Map(prev)
-      const existing = prev.get(sessionId)
-      map.set(sessionId, {
-        running: true,
-        model: agentModelId || undefined,
-        startedAt: streamStartedAt,
-        inputTokens: existing?.inputTokens,
-        contextWindow: existing?.contextWindow,
-      })
-      return map
-    })
-
-    appendOptimisticPersistedMessage(createUserSDKMessage(displayText, undefined, streamStartedAt))
-
-    try {
-      await window.electronAPI.sendAgentMessage({
-        sessionId,
-        // Agent 侧使用解码后的 SDK 文本（@file 路径还原为真实路径），
-        // 展示/持久化使用 displayText（编码原文，remarkMentions 解码显示）。
-        userMessage: sdkText,
-        rawUserMessage: displayText,
-        channelId,
-        modelId: agentModelId || undefined,
-        workspaceId: currentWorkspaceId || undefined,
-        startedAt: streamStartedAt,
-        permissionModeOverride: permissionMode,
-        ...(additionalDirectoriesForRun.size > 0 && {
-          additionalDirectories: Array.from(additionalDirectoriesForRun),
-        }),
-        ...(mentions.mentionedSkills.length > 0 && { mentionedSkills: mentions.mentionedSkills }),
-        ...(mentions.mentionedMcpServers.length > 0 && { mentionedMcpServers: mentions.mentionedMcpServers }),
-        ...(mentions.mentionedSessionIds.length > 0 && { mentionedSessionIds: mentions.mentionedSessionIds }),
-        ...(mentions.mentionedTodoIds.length > 0 && { mentionedTodoIds: mentions.mentionedTodoIds }),
-        ...(mentions.mentionedCalendarEventIds.length > 0 && { mentionedCalendarEventIds: mentions.mentionedCalendarEventIds }),
-      })
-    } catch (error) {
-      setStreamingStates((prev) => {
-        const current = prev.get(sessionId)
-        if (!current) return prev
-        const map = new Map(prev)
-        map.set(sessionId, { ...current, running: false })
-        return map
-      })
-      throw error
-    }
-  }, [
-    agentModelId,
-    appendOptimisticPersistedMessage,
-    createBaseAdditionalDirectories,
-    currentWorkspaceId,
-    permissionMode,
-    sessionId,
-    setStreamingStates,
-  ])
 
   const sendPlainTextAgentMessage = React.useCallback(async (
     message: AgentQueuedMessage,
@@ -1095,9 +979,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (!payload.rawText || !agentChannelId || !hasAvailableModel) return
 
     clearStoppedByUser()
-
-    // 发起新一轮（含队列消息自动发送、后台续轮注入等非用户显式路径）时，
-    // 清除上一轮遗留的流式错误，避免正常输出后底部仍残留旧报错。
     setAgentStreamErrors((prev) => {
       if (!prev.has(sessionId)) return prev
       const map = new Map(prev)
@@ -1105,34 +986,45 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return map
     })
 
-    // interrupt 由本函数读到的实时 streaming 决定，而非调用方传入的快照：
-    // - streaming（本轮真正进行中）：注入前需软中断当前 turn
-    // - backgroundWaiting（软空闲，无活跃 turn）：直接注入，无需中断
-    // 避免"外层判定 streaming、内层已结束"两个快照不一致导致的竞态。
-    if (streaming || backgroundWaiting) {
-      try {
-        await queueMessageIntoActiveAgent(message, payload.rawText, payload.sdkText, payload.mentions, streaming)
-      } catch (error) {
-        if (isStaleAgentQueueError(error)) {
-          console.warn('[AgentView] 检测到陈旧的 Agent 追加通道，改为启动新一轮运行:', error)
-          await startQueuedMessageRun(payload.rawText, payload.sdkText, payload.mentions, agentChannelId, message.additionalDirectories)
-          return
-        }
-        throw error
-      }
+    // “立即发送”与后台续轮都由主进程用实时状态路由：活跃通道可用则注入，
+    // 否则保留到 deferred queue。这里的 streaming 只表达用户是否要求打断，不决定路由。
+    const result = await window.electronAPI.submitOrEnqueueAgentMessage({
+      queueMessageId: message.id,
+      sessionId,
+      userMessage: payload.sdkText,
+      rawUserMessage: payload.rawText,
+      channelId: agentChannelId,
+      modelId: agentModelId || undefined,
+      workspaceId: currentWorkspaceId || undefined,
+      additionalDirectories: message.additionalDirectories,
+      permissionModeOverride: permissionMode,
+      dispatch: 'now',
+      interrupt: streaming,
+      mentionedSkills: payload.mentions.mentionedSkills,
+      mentionedMcpServers: payload.mentions.mentionedMcpServers,
+      mentionedSessionIds: payload.mentions.mentionedSessionIds,
+      mentionedTodoIds: payload.mentions.mentionedTodoIds,
+      mentionedCalendarEventIds: payload.mentions.mentionedCalendarEventIds,
+    })
+    if (result.disposition === 'injected') {
+      appendLiveUserMessage(createUserSDKMessage(payload.rawText, message.id, Date.now()))
+      setQueuedMessages((prev) => removeQueuedMessage(prev, message.id))
       return
     }
 
-    await startQueuedMessageRun(payload.rawText, payload.sdkText, payload.mentions, agentChannelId, message.additionalDirectories)
+    // 活跃通道已结束或不存在时，主进程已接管消息；恢复/保留队列投影，等待 started 事件消费。
+    setQueuedMessages((prev) => prev.some((item) => item.id === message.id) ? prev : [...prev, message])
   }, [
     agentChannelId,
-    backgroundWaiting,
+    agentModelId,
+    appendLiveUserMessage,
     clearStoppedByUser,
+    currentWorkspaceId,
     hasAvailableModel,
-    queueMessageIntoActiveAgent,
+    permissionMode,
     sessionId,
     setAgentStreamErrors,
-    startQueuedMessageRun,
+    setQueuedMessages,
     streaming,
   ])
 
@@ -2136,7 +2028,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         ? buildQuotedSelectionBlock(quotedSelection)
         : ''
       const payload = buildQueuedMessageSendPayload(message, quotedSelectionBlock)
-      const queuedInput: AgentDeferredQueueMessageInput = {
+      const queuedInput: AgentDeferredQueueMessageInput & { dispatch: 'after_current' } = {
         queueMessageId: message.id,
         sessionId,
         userMessage: payload.sdkText,
@@ -2146,6 +2038,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         workspaceId: currentWorkspaceId || undefined,
         additionalDirectories: message.additionalDirectories,
         permissionModeOverride: permissionMode,
+        dispatch: 'after_current',
         mentionedSkills: payload.mentions.mentionedSkills,
         mentionedMcpServers: payload.mentions.mentionedMcpServers,
         mentionedSessionIds: payload.mentions.mentionedSessionIds,
@@ -2153,8 +2046,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         mentionedCalendarEventIds: payload.mentions.mentionedCalendarEventIds,
       }
       setQueuedMessages((prev) => [...prev, message])
-      void window.electronAPI.enqueueAgentQueuedMessage(queuedInput).catch((error) => {
-        console.error('[AgentView] 主进程队列入队失败:', error)
+      void window.electronAPI.submitOrEnqueueAgentMessage(queuedInput).catch((error) => {
+        console.error('[AgentView] 主进程消息提交失败:', error)
         setQueuedMessages((prev) => removeQueuedMessage(prev, message.id))
         restoreQueuedAttachmentsToPending(message.attachments)
         if (quotedSelection) {
@@ -2730,7 +2623,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     sendingQueuedMessageIdsRef.current.add(messageId)
     void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId })
       .then((cancelled) => {
-        if (!cancelled) return
+        if (!cancelled) {
+          toast.info('消息已开始发送，无法再立即发送')
+          return
+        }
         setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
         return sendPlainTextAgentMessage(message).catch((error) => {
           console.error('[AgentView] 队列消息发送失败:', error)
@@ -2754,7 +2650,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
     void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId })
       .then((cancelled) => {
-        if (!cancelled) return
+        if (!cancelled) {
+          toast.info('消息已开始发送，无法撤回')
+          return
+        }
         setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
         const recalledQuotedSelection = message.quotedSelection
         if (recalledQuotedSelection) {
@@ -2791,10 +2690,18 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [queuedMessages, restoreQueuedAttachmentsToPending, sessionId, setInputContent, setInputHtmlContent, setQueuedMessages, setQuotedSelectionMap, store])
 
   const handleRemoveQueuedMessage = React.useCallback((messageId: string): void => {
-    void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId }).catch((error) => {
-      console.warn('[AgentView] 取消主进程队列失败:', error)
-    })
-    setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+    void window.electronAPI.cancelAgentQueuedMessage({ sessionId, messageId })
+      .then((cancelled) => {
+        if (cancelled) {
+          setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+          return
+        }
+        toast.info('消息已开始发送，无法删除')
+      })
+      .catch((error) => {
+        console.warn('[AgentView] 取消主进程队列失败:', error)
+        toast.error('删除队列消息失败', { description: String(error) })
+      })
   }, [sessionId, setQueuedMessages])
 
   const handleMoveQueuedMessage = React.useCallback((

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1195,6 +1195,22 @@ export interface AgentDeferredQueueMessageInput extends AgentSendInput {
   queueMessageId: string
 }
 
+/**
+ * 消息提交意图。由主进程基于实时运行状态原子决定注入活跃 Agent 或保留到 deferred queue，
+ * 不能依赖 renderer 的 streaming 快照。
+ */
+export interface AgentSubmitOrEnqueueInput extends AgentDeferredQueueMessageInput {
+  /** after_current：本轮结束后发送；now：尽量立即注入，通道已结束时自动降级为 deferred queue。 */
+  dispatch: 'after_current' | 'now'
+  /** dispatch=now 时，是否软中断当前 turn。 */
+  interrupt?: boolean
+}
+
+export interface AgentSubmitOrEnqueueResult {
+  /** injected：已注入当前活跃 Agent；queued：已由主进程接管，等待或启动下一轮。 */
+  disposition: 'injected' | 'queued'
+}
+
 /** 流式追加消息的输入参数（Agent 流式中发送新消息） */
 export interface AgentQueueMessageInput {
   /** 会话 ID */
@@ -1934,7 +1950,9 @@ export const AGENT_IPC_CHANNELS = {
   // 队列消息（Agent 运行中排队发送）
   /** 流式追加发送消息 */
   QUEUE_MESSAGE: 'agent:queue-message',
-  /** 排队发送消息（主进程 deferred queue） */
+  /** 原子提交消息：注入当前运行或交由主进程 deferred queue。 */
+  SUBMIT_OR_ENQUEUE_MESSAGE: 'agent:submit-or-enqueue-message',
+  /** 排队发送消息（兼容旧调用；主进程 deferred queue） */
   ENQUEUE_QUEUED_MESSAGE: 'agent:enqueue-queued-message',
   /** 取消队列消息 */
   CANCEL_QUEUED_MESSAGE: 'agent:cancel-queued-message',


### PR DESCRIPTION
## Summary
- Route queued follow-ups, immediate sends, and background continuations through an atomic main-process submit-or-enqueue entry.
- Fall back to the deferred queue when Pi Utility has ended its active query during the renderer completion window.
- Keep queued-message UI actions consistent with main-process cancellation results.

## Validation
- `bun test apps/electron/src/renderer/lib/agent-message-queue.test.ts`
- `bun run typecheck`
- `bun run electron:build`
- Manual Electron verification of queue, ending-window, immediate-send, recall, and delete flows.

## Performance impact
No recurring render, IPC listener, timer, or data-copy work was added. Routing remains one IPC per user action and moves the race decision to the main process; queue state changes are interaction-level only.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
