### PR TITLE
fix(vision): route DeepSeek Flash Exp in VisionRelay

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -524,6 +524,11 @@ export async function resolvePiVisionRelayRoute(
 ): Promise<PiVisionRelayRoute | undefined> {
   const resolvedModelId = stripLegacyAgentSdkContextSuffix(modelId)
   if (!resolvedModelId) return undefined
+  // DeepSeek Flash 的实验视觉模型尚未进入 Pi catalog；其渠道协议无需 catalog 分流。
+  if (provider !== 'opencode-go-openai' && supportsPiNativeImageInput(resolvedModelId)) {
+    return { adapterProvider: provider }
+  }
+
   const catalogModel = await findPiCatalogModel(provider, resolvedModelId)
   if (!catalogModel?.input.includes('image')) return undefined
 


### PR DESCRIPTION
## Summary

- Route DeepSeek Flash Vision Exp directly when it is configured as the VisionRelay model.

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)