### PR TITLE
feat(changes): hide dotfile directory changes

### DIFF
--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -29,6 +29,15 @@ function normalizeLineEndings(content: string): string {
   return content.replace(/\r\n/g, '\n')
 }
 
+/**
+ * 改动面板默认不展示隐藏目录内的文件，避免 .github/.vscode 等元数据淹没业务改动。
+ * 根目录的 dotfile（如 .gitignore、.env.example）仍然展示；只判断父目录。
+ */
+function shouldDisplayChangedFile(filePath: string): boolean {
+  const pathParts = filePath.split(/[\\/]/)
+  return pathParts.slice(0, -1).every((part) => !part.startsWith('.'))
+}
+
 function normalizeComparablePath(filePath: string): string {
   return normalizePathForCompare(resolve(filePath))
 }
@@ -548,6 +557,7 @@ async function scanGitRoot(gitRoot: string): Promise<CachedRepoScan | null> {
         continue
       }
 
+      if (!shouldDisplayChangedFile(filePath)) continue
       const stats = numStatMap.get(filePath) ?? { additions: 0, deletions: 0 }
       files.push({ filePath, status, additions: stats.additions, deletions: stats.deletions, gitRoot })
     }
@@ -555,7 +565,7 @@ async function scanGitRoot(gitRoot: string): Promise<CachedRepoScan | null> {
 
   const untrackedFiles = await buildUntrackedFileEntries(
     gitRoot,
-    untrackedOutput ? untrackedOutput.split('\n').filter(Boolean) : [],
+    untrackedOutput ? untrackedOutput.split('\n').filter(Boolean).filter(shouldDisplayChangedFile) : [],
   )
 
   return { files, untrackedFiles }
@@ -973,6 +983,7 @@ export async function getWorktreeChanges(
         continue
       }
 
+      if (!shouldDisplayChangedFile(filePath)) continue
       const stats = committedStats.get(filePath) ?? { additions: 0, deletions: 0 }
       const entry: import('@proma/shared').ChangedFileEntry = {
         filePath,
@@ -1010,6 +1021,7 @@ export async function getWorktreeChanges(
         continue
       }
 
+      if (!shouldDisplayChangedFile(filePath)) continue
       const stats = uncommittedStats.get(filePath) ?? { additions: 0, deletions: 0 }
       const existing = fileMap.get(filePath)
       if (existing) {
@@ -1034,7 +1046,9 @@ export async function getWorktreeChanges(
   const untrackedOutput = await runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot)
   const untrackedFiles = await buildUntrackedFileEntries(
     gitRoot,
-    untrackedOutput ? untrackedOutput.split('\n').filter((filePath) => !fileMap.has(filePath)) : [],
+    untrackedOutput
+      ? untrackedOutput.split('\n').filter((filePath) => !fileMap.has(filePath) && shouldDisplayChangedFile(filePath))
+      : [],
   )
 
   return {


### PR DESCRIPTION
## Summary

- Hide changes beneath dot-directories such as `.github/` and `.vscode/` in Agent change panels.
- Preserve root dotfiles such as `.gitignore` and `.env.example`.
- Apply the same filtering to normal session and worktree change scans.

## Validation

- [x] `bun run typecheck`
- [x] `git diff --check`

## Performance impact

- Low risk: filtering runs after existing Git scans and reduces the IPC payload and rendered file rows; it adds no watchers, IPC calls, or background work.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)