### PR TITLE
feat(drafts): persist agent & chat composer drafts to disk

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -10,7 +10,8 @@ import { existsSync, realpathSync, readFileSync, writeFileSync, mkdirSync, statS
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, AGENT_DRAFT_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
+import type { AgentDraftsFileData } from '../types'
 import type {
   QuickTaskSubmitInput,
   VoiceDictationAudioChunkInput,
@@ -283,7 +284,8 @@ import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveF
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
-import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getConfigDir, getWorkspaceSkillsDir, getScratchPadPath } from './lib/config-paths'
+import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getConfigDir, getWorkspaceSkillsDir, getScratchPadPath, getAgentDraftsPath } from './lib/config-paths'
+import { readJsonFileSafe, writeJsonFileAtomic } from './lib/safe-file'
 import { getCachedDefaultAppInfo, saveCachedDefaultAppInfo } from './lib/default-app-cache'
 import { calculateStorageStats, cleanupStorage, cleanupTempFiles } from './lib/storage-service'
 import type { CleanupOptions } from './lib/storage-service'
@@ -1925,6 +1927,49 @@ export function registerIpcHandlers(): void {
       } catch (err) {
         console.error('[ScratchPad] 复制图片到剪贴板失败:', err)
         return { success: false, message: '复制失败' }
+      }
+    }
+  )
+
+  // ===== Agent/Chat 输入框草稿持久化 =====
+
+  // 从磁盘加载草稿快照
+  ipcMain.handle(
+    AGENT_DRAFT_IPC_CHANNELS.LOAD,
+    async (): Promise<AgentDraftsFileData | null> => {
+      try {
+        return readJsonFileSafe<AgentDraftsFileData>(getAgentDraftsPath())
+      } catch (err) {
+        console.error('[AgentDraft] 加载失败:', err)
+        return null
+      }
+    }
+  )
+
+  // 异步保存草稿快照
+  ipcMain.handle(
+    AGENT_DRAFT_IPC_CHANNELS.SAVE,
+    async (_, data: AgentDraftsFileData): Promise<boolean> => {
+      try {
+        writeJsonFileAtomic(getAgentDraftsPath(), data)
+        return true
+      } catch (err) {
+        console.error('[AgentDraft] 保存失败:', err)
+        return false
+      }
+    }
+  )
+
+  // 同步保存草稿快照（beforeunload 场景）
+  ipcMain.on(
+    AGENT_DRAFT_IPC_CHANNELS.SAVE_SYNC,
+    (event, data: AgentDraftsFileData) => {
+      try {
+        writeJsonFileAtomic(getAgentDraftsPath(), data)
+        event.returnValue = true
+      } catch (err) {
+        console.error('[AgentDraft] 同步保存失败:', err)
+        event.returnValue = false
       }
     }
   )

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -701,6 +701,15 @@ export function getScratchPadPath(): string {
 }
 
 /**
+ * 获取 Agent/Chat 输入框草稿快照文件路径
+ *
+ * @returns ~/.proma/agent-drafts.json
+ */
+export function getAgentDraftsPath(): string {
+  return join(getConfigDir(), 'agent-drafts.json')
+}
+
+/**
  * 获取定时任务（Automation）配置文件路径
  *
  * @returns ~/.proma/automations.json

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -7,7 +7,8 @@
 
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, AGENT_ISLAND_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, AGENT_DRAFT_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
+import type { AgentDraftsFileData } from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -442,6 +443,17 @@ export interface ElectronAPI {
 
   /** 将图片 data URL 写入系统剪贴板 */
   copyImageToClipboard: (dataUrl: string) => Promise<{ success: boolean; message?: string }>
+
+  // ===== Agent/Chat 输入框草稿 =====
+
+  /** 从磁盘加载输入框草稿快照 */
+  loadAgentDrafts: () => Promise<AgentDraftsFileData | null>
+
+  /** 异步保存输入框草稿快照 */
+  saveAgentDrafts: (data: AgentDraftsFileData) => Promise<boolean>
+
+  /** 同步保存输入框草稿快照（beforeunload 场景） */
+  saveAgentDraftsSync: (data: AgentDraftsFileData) => boolean
 
   // ===== 应用图标切换 =====
 
@@ -1623,6 +1635,19 @@ const electronAPI: ElectronAPI = {
 
   copyImageToClipboard: (dataUrl: string) => {
     return ipcRenderer.invoke(SCRATCH_PAD_IPC_CHANNELS.COPY_IMAGE, dataUrl)
+  },
+
+  // Agent/Chat 输入框草稿持久化
+  loadAgentDrafts: () => {
+    return ipcRenderer.invoke(AGENT_DRAFT_IPC_CHANNELS.LOAD)
+  },
+
+  saveAgentDrafts: (data: AgentDraftsFileData) => {
+    return ipcRenderer.invoke(AGENT_DRAFT_IPC_CHANNELS.SAVE, data)
+  },
+
+  saveAgentDraftsSync: (data: AgentDraftsFileData) => {
+    return ipcRenderer.sendSync(AGENT_DRAFT_IPC_CHANNELS.SAVE_SYNC, data)
   },
 
   // 应用图标切换

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -41,6 +41,9 @@ import {
   automationGroupOrderAtom,
   dockBadgeCountAtom,
   unviewedCompletedSessionIdsAtom,
+  agentSessionDraftsAtom,
+  agentSessionDraftHtmlAtom,
+  agentSessionDraftSyncVersionsAtom,
 } from './atoms/agent-atoms'
 import { updateStatusAtom, initializeUpdater } from './atoms/updater'
 import { automationsAtom } from './atoms/automation-atoms'
@@ -69,7 +72,8 @@ import type { TabItem } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
 import { feishuBotStatesAtom } from './atoms/feishu-atoms'
 import { dingtalkBotStatesAtom } from './atoms/dingtalk-atoms'
-import { currentConversationIdAtom, channelsAtom, channelsLoadedAtom, selectedModelAtom } from './atoms/chat-atoms'
+import { currentConversationIdAtom, channelsAtom, channelsLoadedAtom, selectedModelAtom, conversationDraftsAtom, conversationDraftSyncVersionsAtom } from './atoms/chat-atoms'
+import type { AgentDraftsFileData } from '../types'
 import { appModeAtom } from './atoms/app-mode'
 import type { FeishuBotBridgeState, FeishuBridgeState, DingTalkBotBridgeState, DingTalkBridgeState } from '@proma/shared'
 import { Toaster } from './components/ui/sonner'
@@ -963,6 +967,140 @@ function TabStatePersistenceInitializer(): null {
 }
 
 /**
+ * Agent/Chat 输入框草稿持久化组件
+ *
+ * 输入框草稿（agentSessionDraftsAtom / agentSessionDraftHtmlAtom / conversationDraftsAtom）
+ * 原本只存内存 jotai Map，应用重启即丢。此组件把三个 map 防抖持久化到
+ * ~/.proma/agent-drafts.json，启动时恢复，避免未发送的输入内容因退出丢失。
+ */
+function AgentDraftPersistence(): null {
+  const store = useStore()
+  const loadedRef = useRef(false)
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  // 启动：恢复上次退出时的草稿快照
+  useEffect(() => {
+    const init = async (): Promise<void> => {
+      try {
+        if (!window.electronAPI.loadAgentDrafts) return
+        const data = await window.electronAPI.loadAgentDrafts()
+        if (!data || typeof data !== 'object') return
+
+        // —— Agent 文本草稿 ——
+        const currentText = store.get(agentSessionDraftsAtom)
+        const nextText = new Map(currentText)
+        for (const [sessionId, draft] of Object.entries(data.agentDrafts ?? {})) {
+          const text = typeof draft?.text === 'string' ? draft.text : ''
+          if (text.trim() === '') continue
+          // 守卫：启动竞态下已有非空草稿的会话不覆盖
+          if ((currentText.get(sessionId) ?? '') !== '') continue
+          nextText.set(sessionId, text)
+        }
+
+        // —— Agent HTML 草稿（mention 等富文本；仅随被恢复的文本一起写入，
+        //    被竞态守卫跳过 text 恢复的会话不动 html，避免与编辑器实际内容脱节） ——
+        const nextHtml = new Map(store.get(agentSessionDraftHtmlAtom))
+        for (const [sessionId, draft] of Object.entries(data.agentDrafts ?? {})) {
+          if (nextText.get(sessionId) === currentText.get(sessionId)) continue
+          const html = draft?.html
+          if (typeof html === 'string' && html.trim() !== '' && html !== '<p></p>') {
+            nextHtml.set(sessionId, html)
+          }
+        }
+
+        // —— bump 外部同步版本：已挂载的 RichTextInput 才会接受外部值（echo 保护） ——
+        const versions = store.get(agentSessionDraftSyncVersionsAtom)
+        const nextVersions = new Map(versions)
+        for (const sessionId of nextText.keys()) {
+          if (nextText.get(sessionId) !== currentText.get(sessionId)) {
+            nextVersions.set(sessionId, (versions.get(sessionId) ?? 0) + 1)
+          }
+        }
+
+        store.set(agentSessionDraftsAtom, nextText)
+        store.set(agentSessionDraftHtmlAtom, nextHtml)
+        store.set(agentSessionDraftSyncVersionsAtom, nextVersions)
+
+        // —— Chat 对话草稿 ——
+        const currentChat = store.get(conversationDraftsAtom)
+        const nextChat = new Map(currentChat)
+        for (const [conversationId, text] of Object.entries(data.conversationDrafts ?? {})) {
+          if (typeof text !== 'string' || text.trim() === '') continue
+          if ((currentChat.get(conversationId) ?? '') !== '') continue
+          nextChat.set(conversationId, text)
+        }
+        const chatVersions = store.get(conversationDraftSyncVersionsAtom)
+        const nextChatVersions = new Map(chatVersions)
+        for (const [conversationId, text] of nextChat.entries()) {
+          if (text !== currentChat.get(conversationId)) {
+            nextChatVersions.set(conversationId, (chatVersions.get(conversationId) ?? 0) + 1)
+          }
+        }
+        store.set(conversationDraftsAtom, nextChat)
+        store.set(conversationDraftSyncVersionsAtom, nextChatVersions)
+
+        console.log('[AgentDraft] 草稿快照已恢复')
+      } catch (err) {
+        console.error('[AgentDraft] 初始化失败:', err)
+      } finally {
+        loadedRef.current = true
+      }
+    }
+
+    init()
+  }, [store])
+
+  // 自动保存：订阅三个草稿 map，500ms 防抖整体覆盖写盘（发送后清空的条目自然从文件消失）
+  useEffect(() => {
+    const buildPayload = (): AgentDraftsFileData => ({
+      version: 1,
+      agentDrafts: Object.fromEntries(
+        [...store.get(agentSessionDraftsAtom).entries()].map(([sessionId, text]) => [
+          sessionId,
+          { text, html: store.get(agentSessionDraftHtmlAtom).get(sessionId) },
+        ]),
+      ),
+      conversationDrafts: Object.fromEntries(store.get(conversationDraftsAtom).entries()),
+    })
+
+    const save = (): void => {
+      if (window.electronAPI.saveAgentDrafts) {
+        window.electronAPI.saveAgentDrafts(buildPayload()).catch(console.error)
+      }
+    }
+
+    const debouncedSave = (): void => {
+      if (!loadedRef.current) return
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      saveTimerRef.current = setTimeout(save, 500)
+    }
+
+    const unsubs = [
+      store.sub(agentSessionDraftsAtom, debouncedSave),
+      store.sub(agentSessionDraftHtmlAtom, debouncedSave),
+      store.sub(conversationDraftsAtom, debouncedSave),
+    ]
+
+    // beforeunload 时同步写入，确保关闭窗口前最后一刻的草稿不丢
+    const handleBeforeUnload = (): void => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      if (window.electronAPI.saveAgentDraftsSync) {
+        window.electronAPI.saveAgentDraftsSync(buildPayload())
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    return () => {
+      unsubs.forEach((unsub) => unsub())
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [store])
+
+  return null
+}
+
+/**
  * Scratch Pad 初始化和持久化组件
  *
  * 启动时注入 scratch tab 到 tabsAtom 首位，
@@ -1149,6 +1287,7 @@ if (isQuickTaskWindow) {
       <DingTalkInitializer />
       <TabStatePersistenceInitializer />
       <ScratchPadPersistence />
+      <AgentDraftPersistence />
       <VoiceDictationApp embedded />
       <GlobalShortcuts />
       <TabSwitcher />

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -425,6 +425,29 @@ export const SCRATCH_PAD_IPC_CHANNELS = {
   COPY_IMAGE: 'scratch-pad:copy-image',
 } as const
 
+/** Agent/Chat 输入框草稿 IPC 通道 */
+export const AGENT_DRAFT_IPC_CHANNELS = {
+  /** 从磁盘加载草稿快照 */
+  LOAD: 'agent-draft:load',
+  /** 异步保存草稿快照 */
+  SAVE: 'agent-draft:save',
+  /** 同步保存草稿快照（beforeunload 场景） */
+  SAVE_SYNC: 'agent-draft:save-sync',
+} as const
+
+/** 输入框草稿快照文件（~/.proma/agent-drafts.json）的数据结构。
+ *
+ * 背景：agentSessionDraftsAtom / agentSessionDraftHtmlAtom / conversationDraftsAtom
+ * 原本只存内存 jotai Map，重启即丢；此文件让未发送的输入框草稿跨重启恢复。
+ */
+export interface AgentDraftsFileData {
+  version: 1
+  /** Agent 会话输入框草稿：sessionId → 文本与可选 HTML（HTML 用于恢复 mention 等富文本） */
+  agentDrafts: Record<string, { text: string; html?: string }>
+  /** Chat 对话输入框草稿：conversationId → 文本 */
+  conversationDrafts: Record<string, string>
+}
+
 /** 应用图标 IPC 通道 */
 export const APP_ICON_IPC_CHANNELS = {
   /** 设置应用图标（variant ID） */


### PR DESCRIPTION
## Summary

- Agent 会话与 Chat 对话的输入框草稿原先只存在内存 jotai Map 中，应用重启即全部丢失；现在持久化到 `~/.proma/agent-drafts.json`。
- 新增 `AGENT_DRAFT_IPC_CHANNELS`（load / save / save-sync）与 `AgentDraftsFileData` 快照结构；读写全部走 safe-file 原子写入（write-to-temp → rename + `.bak` 容错）。
- 新增渲染层组件 `AgentDraftPersistence`：500ms 防抖自动保存三个草稿 map；启动时恢复并仅对实际发生恢复的会话 bump sync-version（echo 保护 + 非空守卫，绝不覆盖已挂载编辑器的实况内容）；`beforeunload` 时同步 flush 兜底。
- 发送后清空的草稿条目随整体覆盖写自然从文件中消失；未发送内容跨重启完整保留（含 mention 等富文本 HTML）。

## Verification

- `bun run typecheck`（6 packages 全部通过）+ `bun run build`
- Real-device test: typed drafts in multiple sessions → Cmd+Q full quit (beforeunload flush, file mtime change as evidence) → relaunch → all drafts restored into the composers.
- 发送消息后，对应会话的草稿条目从快照文件中正确清除。
- Three rounds of independent code review passed, including a post-rebase semantic-compat check against upstream #1787/#1789/#1790.
