### PR TITLE
fix(startup): 精简启动加载状态文案

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.60",
+  "version": "0.17.61",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/resources/startup-splash/index.html
+++ b/apps/electron/resources/startup-splash/index.html
@@ -30,7 +30,6 @@
       .progress { width: 96px; height: 1px; margin-top: 28px; overflow: hidden; background: rgba(255,255,255,.35); }
       .progress::after { content: ""; display: block; width: 40%; height: 100%; background: rgba(255,255,255,.9); animation: pulse 1.6s ease-in-out infinite; }
       .title { margin: 16px 0 0; font-size: 14px; font-weight: 600; letter-spacing: .08em; }
-      .subtitle { margin: 8px 0 0; font-size: 12px; letter-spacing: .12em; color: rgba(255,255,255,.7); }
       .tagline { position: absolute; bottom: 32px; margin: 0; font-size: 11px; letter-spacing: .3em; color: rgba(255,255,255,.65); }
       @keyframes pulse { 50% { opacity: .45; } }
       @media (prefers-reduced-motion: reduce) { .progress::after { animation: none; } }
@@ -44,7 +43,6 @@
       <p class="slogan">让协作自然发生，让想法流动成形</p>
       <div class="progress"></div>
       <p class="title">正在启动 Proma</p>
-      <p class="subtitle">正在初始化你的工作空间</p>
       <p class="tagline">LOCAL-FIRST AI AGENT</p>
     </main>
   </body>

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -175,7 +175,6 @@ function StartupLoadingScreen(): React.ReactElement {
           <div className="h-full w-2/5 animate-pulse bg-white/90" />
         </div>
         <p className="mt-4 text-sm font-medium tracking-[0.08em] text-white/95">正在启动 Proma</p>
-        <p className="mt-2 text-xs tracking-[0.12em] text-white/70">正在初始化你的工作空间</p>
       </div>
 
       <p className="absolute bottom-8 px-6 text-center text-[11px] uppercase tracking-[0.3em] text-white/65">


### PR DESCRIPTION
## 概要

- 同步移除静态启动页与 React 兜底页的重复副标题
- 保留主启动状态、进度动画和本地优先标识，减少加载阶段的信息噪声
- 新增双页面 BDD 文案一致性测试，并将桌面端版本更新至 `0.17.61`

## 验证

- `bun test apps/electron/src/renderer/startup-loading-copy.test.ts`：2 项通过
- `git diff --check`：通过

## 依赖与合并顺序

- 依赖 #1795
- 这是本组拆分 PR 的第 2 个，请在 #1795 合并后处理；届时该 PR 的差异会收敛为本功能提交。

## 已知的仓库基线问题

完整 `bun test` 与 `bun run typecheck` 仍会被未改动的 Electron mock、OAuth proxy scope 及当前 Pi SDK 类型/导出不兼容问题阻断；本 PR 的定向测试均已通过。