### PR TITLE
fix(agent): cancel stale background stream frames

### DIFF
--- a/apps/electron/src/renderer/lib/agent-stream-event-batcher.ts
+++ b/apps/electron/src/renderer/lib/agent-stream-event-batcher.ts
@@ -46,12 +46,17 @@ export function createAgentStreamEventBatcher(options: AgentStreamEventBatcherOp
   let frame: number | null = null
   let fallback: number | null = null
 
-  const flush = (): void => {
+  /** rAF 与 timeout 是同一批 pending events 的竞速调度器；任一方获胜都必须撤销另一方。 */
+  const cancelScheduledFlush = (): void => {
+    if (frame !== null) cancelFrame(frame)
+    if (fallback !== null) cancelFallback(fallback)
     frame = null
-    if (fallback !== null) {
-      cancelFallback(fallback)
-      fallback = null
-    }
+    fallback = null
+  }
+
+  const flush = (): void => {
+    // 后台时 fallback 会先运行；若不撤销被冻结的 rAF，窗口恢复后会集中执行所有旧回调。
+    cancelScheduledFlush()
     const events = [...pending.values()]
     pending.clear()
     for (const event of events) options.dispatch(event)
@@ -88,12 +93,10 @@ export function createAgentStreamEventBatcher(options: AgentStreamEventBatcherOp
     },
     clear(sessionId: string): void {
       pending.delete(sessionId)
+      if (pending.size === 0) cancelScheduledFlush()
     },
     dispose(): void {
-      if (frame !== null) cancelFrame(frame)
-      if (fallback !== null) cancelFallback(fallback)
-      frame = null
-      fallback = null
+      cancelScheduledFlush()
       pending.clear()
     },
   }


### PR DESCRIPTION
## Summary

- Cancel the paused `requestAnimationFrame` when the fallback timer flushes a background Agent stream batch.
- Cancel both schedulers once the final pending session is cleared or the batcher is disposed.

## Performance impact

Background Agent partial events are forwarded at up to 4Hz. This keeps each batch to at most one outstanding rAF and fallback timer, preventing restored Windows windows from draining an unbounded rAF callback backlog. The change adds only O(1) cancellation work per flush and introduces no new IPC, subscriptions, or rendering updates.

## Validation

- `bun run --cwd apps/electron typecheck`
- `bun run --cwd apps/electron build:renderer`
- `git diff --check`

## Remaining validation

Run the Windows scenario: keep a streaming Agent minimized or backgrounded for 5–10 minutes, restore Proma, then verify responsive input and scrolling in a Performance recording.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
