### PR TITLE
fix(planning): align Todo header height

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.59",
+  "version": "0.17.60",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -84,7 +84,7 @@ export function PlanningView({ standalone = false }: { standalone?: boolean } = 
   }, [createAutomation, tab, triggerCalendarCreate, triggerTodoCreate]), true, { exclusive: true })
   return (
     <div className="flex h-full flex-col overflow-hidden bg-content-area">
-      <header className={cn('relative flex w-full items-center justify-between titlebar-no-drag', tab === 'todos' ? (standalone ? 'px-5 pb-3 pt-7' : 'px-6 pb-3 pt-6 sm:px-8 xl:px-10') : (standalone ? 'px-5 pb-4 pt-8' : 'px-6 pb-5 pt-8 sm:px-8 xl:px-10'))}>
+      <header className={cn('relative flex w-full items-center justify-between titlebar-no-drag', standalone ? 'px-5 pb-4 pt-8' : 'px-6 pb-5 pt-8 sm:px-8 xl:px-10')}>
         <div className={cn('absolute inset-y-0 left-0 z-0 titlebar-drag-region', isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0')} />
         <div className="relative z-[1]">
           <h1 className="text-2xl font-semibold tracking-tight text-wrap-balance">{tab === 'todos' ? 'Todo' : '任务/日程'}</h1>


### PR DESCRIPTION
## Summary

- Align the Todo title header spacing with the calendar and automation views.
- Bump the Electron app patch version to `0.17.60`.

## Verification

- `bun run typecheck`
- `bun test apps/electron/src/renderer/components/agent/planning-reference-state.test.ts`
- `bun run build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)