### PR TITLE
fix(browser): open agent links directly

### DIFF
--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -991,8 +991,10 @@ export class BrowserController {
 
   /** Agent 新建工作 tab，并立即切到该标签让用户能看到接下来的操作。 */
   async createNewTab(sessionId: string, url?: string): Promise<BrowserViewState> {
-    const browserSession = this.getOrCreateSession(sessionId)
+    // 新会话由本方法直接创建 Agent 标签，不能经 getOrCreateSession 预建空白标签，
+    // 否则携带 URL 时会留下一个无用的初始标签。
     this.assertRiskDisclaimerAcknowledged()
+    const browserSession = this.sessions.get(sessionId) ?? this.createSession(sessionId)
     const tab = this.createTab(browserSession, false, true)
     browserSession.agentTabId = tab.tabId
     this.activateDisplayTab(browserSession, tab)

--- a/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
+++ b/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
@@ -72,14 +72,15 @@ export function AgentBrowserLinkProvider({
             next.delete(sessionId)
             return next
           })
-          const [settings, state] = await Promise.all([
+          const [settings, existingState] = await Promise.all([
             window.electronAPI.getSettings(),
-            openBrowser(sessionId),
+            window.electronAPI.getAgentBrowserState(sessionId),
           ])
-          publishBrowserState(state)
-
           const riskAcknowledged = (settings.browserRiskDisclaimerVersion ?? 0) >= BROWSER_RISK_DISCLAIMER_VERSION
+
           if (!riskAcknowledged) {
+            // 风险告知尚未确认时，先打开空白浏览器展示确认弹窗，确认后再导航。
+            publishBrowserState(existingState ?? await openBrowser(sessionId))
             setPendingNavigationMap((previous) => {
               const next = new Map(previous)
               next.set(sessionId, url)
@@ -88,7 +89,9 @@ export function AgentBrowserLinkProvider({
             return
           }
 
-          const nextState = shouldReuseInitialBrowserTab(state)
+          // 带目标 URL 的首次打开直接创建并导航 Agent 标签，避免 openAgentBrowser
+          // 先将初始空白标签加载为 Google 后再额外创建一个目标标签。
+          const nextState = existingState && shouldReuseInitialBrowserTab(existingState)
             ? await window.electronAPI.navigateAgentBrowser({ sessionId, url })
             : await window.electronAPI.createAgentBrowserTab({ sessionId, url })
           publishBrowserState(nextState)


### PR DESCRIPTION
## Summary

- 让 Agent 历史消息中的链接在首次打开时直接导航至目标网址，不再先加载 Google。
- 创建首个 Agent 浏览器标签时不再遗留空白初始标签。

## Testing

- [x] `bun run typecheck`
- [x] `git diff --check`
- [ ] `bun test`：471 passed；4 项既有 Electron/Bun 环境测试失败（Electron 导出、OAuth proxy、Planning 数据库），与本次浏览器标签逻辑无关。

## Performance

低风险：仅在链接点击时并行读取配置与现有浏览器状态；未增加 React 订阅、计时器、持续 IPC 或额外渲染。未进行 Electron 交互实测，仍建议在桌面端点击一条带 URL 的 Agent 历史消息复核。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
