### PR TITLE
fix(browser): 修复原生浏览器浮层遮挡【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
@@ -78,6 +78,7 @@ export function WorkspaceMemoryChangeShelf({ changes, memoryFiles, onOpen, onOpe
   const detail = hovered && anchorRect && typeof document !== 'undefined'
     ? createPortal(
         <div
+          data-app-local-overlay=""
           role="dialog"
           aria-label={change ? '记忆更新详情' : '工作区记忆文件'}
           onMouseEnter={keepOpen}

--- a/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
+++ b/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
@@ -468,6 +468,7 @@ export function SearchDialog(): React.ReactElement {
         <DialogPortal>
           <div
             aria-hidden
+            data-app-modal-overlay=""
             className="fixed inset-0 z-[99] bg-black/40 pointer-events-none animate-in fade-in-0 duration-150"
           />
         </DialogPortal>

--- a/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
 import { nextBrowserLayoutRevision } from './browser-layout-revision'
+import { browserLayoutSnapshotsEqual, toBrowserLayoutSnapshot, type BrowserLayoutSnapshot } from './browser-layout-publish'
+import { overlayBlocksBrowser, type BrowserOverlayRect } from './browser-overlay'
+import { observeAppOverlayLifecycle } from './browser-overlay-observer'
 
 // 每次 publish（包括卸载隐藏）分配全局单调 revision。旧 slot 的 IPC 即使晚到，
 // 主进程也不会覆盖随后已挂载 tab 的可见性和边界。
@@ -9,89 +12,29 @@ import { nextBrowserLayoutRevision } from './browser-layout-revision'
  * 应用级 Dialog / Select / Popover / Dropdown 与 Sonner 通知出现时，临时隐藏原生视图，
  * 让 portal 内容获得正确的层级；浮层关闭后立即恢复浏览器。
  */
-const APP_OVERLAY_LIFECYCLE_SELECTOR = [
-  '[role="dialog"]',
-  '[role="alertdialog"]',
-  '[data-sonner-toast]',
-  '[data-sonner-toaster]',
-  '[data-radix-popper-content-wrapper]',
-].join(', ')
+function getElementRect(element: Element): BrowserOverlayRect {
+  const rect = element.getBoundingClientRect()
+  return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }
+}
 
-function hasBlockingAppOverlay(): boolean {
-  if (document.querySelector('[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]')) return true
-  if (document.querySelector('[data-sonner-toast][data-mounted="true"], [data-sonner-toast][data-visible="true"]')) return true
+function hasBlockingAppOverlay(browserRect: BrowserOverlayRect): boolean {
+  const modalOverlays = document.querySelectorAll<HTMLElement>('[data-app-modal-overlay]')
+  if (Array.from(modalOverlays).some((overlay) => overlayBlocksBrowser({ kind: 'modal', rect: getElementRect(overlay) }, browserRect))) return true
+
+  const visibleToasts = document.querySelectorAll<HTMLElement>('[data-sonner-toast][data-mounted="true"], [data-sonner-toast][data-visible="true"]')
+  if (Array.from(visibleToasts).some((toast) => overlayBlocksBrowser({ kind: 'local', rect: getElementRect(toast) }, browserRect))) return true
+
+  const localOverlays = document.querySelectorAll<HTMLElement>('[data-app-local-overlay]')
+  if (Array.from(localOverlays).some((overlay) => overlayBlocksBrowser({ kind: 'local', rect: getElementRect(overlay) }, browserRect))) return true
 
   return Array.from(document.querySelectorAll<HTMLElement>('[data-radix-popper-content-wrapper]'))
     .some((wrapper) => {
-      const openContent = wrapper.querySelector<HTMLElement>('[data-state="open"]')
-      // 浏览器自身的 Tooltip 不需要遮住网页；菜单、选择器与 Popover 则必须优先显示。
-      return !!openContent && openContent.getAttribute('role') !== 'tooltip'
+      const contents = wrapper.querySelectorAll<HTMLElement>('[data-state="open"], [data-state="closed"]')
+      // Browser Tooltip does not block interaction; other connected local overlays
+      // keep the native view hidden through their close animation until unmount.
+      return Array.from(contents).some((content) => content.getAttribute('role') !== 'tooltip'
+        && overlayBlocksBrowser({ kind: 'local', rect: getElementRect(content) }, browserRect))
     })
-}
-
-function isAppOverlayElement(element: Element): boolean {
-  return element.matches(APP_OVERLAY_LIFECYCLE_SELECTOR)
-}
-
-function findAppOverlayElements(node: Node): Element[] {
-  if (!(node instanceof Element)) return []
-  const elements = isAppOverlayElement(node) ? [node] : []
-  return elements.concat(Array.from(node.querySelectorAll(APP_OVERLAY_LIFECYCLE_SELECTOR)))
-}
-
-/**
- * 只跟踪 portal/toast 生命周期，避免 Agent 流式渲染触发无意义的 layout IPC。
- *
- * body 只监听直接子节点：Radix/Toast portal 都挂在这里，普通消息 DOM 的深层
- * 更新不会进入 observer。识别出浮层根节点后，再把 attributes/subtree 监听限制
- * 在该浮层内部，以便捕获 data-state 等开关变化。
- */
-function observeAppOverlayLifecycle(onChange: () => void): () => void {
-  const overlayRoots = new Set<Element>()
-  const overlayObserver = new MutationObserver((mutations) => {
-    if (mutations.length > 0) onChange()
-  })
-  const bodyObserver = new MutationObserver((mutations) => {
-    let changed = false
-    for (const mutation of mutations) {
-      for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
-        const overlayElements = findAppOverlayElements(node)
-        if (overlayElements.length > 0) changed = true
-        for (const element of overlayElements) overlayRoots.add(element)
-      }
-    }
-    syncOverlayRoots()
-    if (changed) onChange()
-  })
-
-  function syncOverlayRoots(): void {
-    for (const root of overlayRoots) {
-      if (!root.isConnected) overlayRoots.delete(root)
-    }
-
-    for (const root of Array.from(document.body.children)) {
-      for (const element of findAppOverlayElements(root)) overlayRoots.add(element)
-    }
-
-    overlayObserver.disconnect()
-    for (const root of overlayRoots) {
-      overlayObserver.observe(root, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['data-mounted', 'data-state', 'data-visible', 'role'],
-      })
-    }
-  }
-
-  syncOverlayRoots()
-  bodyObserver.observe(document.body, { childList: true })
-
-  return () => {
-    bodyObserver.disconnect()
-    overlayObserver.disconnect()
-    overlayRoots.clear()
-  }
 }
 
 export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: string }): React.ReactElement {
@@ -101,39 +44,47 @@ export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: st
     const element = ref.current
     const setLayout = (window.electronAPI as Partial<typeof window.electronAPI>).setAgentBrowserLayout
     if (!element || typeof setLayout !== 'function') return
-    let frame = 0
-    const publish = (visible: boolean, preserveSessionOnHide = false) => {
-      if (frame) cancelAnimationFrame(frame)
+    let frame: number | null = null
+    let lastPublished: BrowserLayoutSnapshot | null = null
+    let lastPreserveSessionOnHide: boolean | null = null
+    const requestLayout = () => {
+      if (frame !== null) return
       frame = requestAnimationFrame(() => {
+        frame = null
         const rect = element.getBoundingClientRect()
+        const browserRect: BrowserOverlayRect = {
+          left: rect.left,
+          top: rect.top,
+          right: rect.right,
+          bottom: rect.bottom,
+        }
+        const overlayOpen = hasBlockingAppOverlay(browserRect)
+        const snapshot = toBrowserLayoutSnapshot(rect, overlayOpen)
+        const preserveSessionOnHide = overlayOpen
+        if (browserLayoutSnapshotsEqual(lastPublished, snapshot)
+          && lastPreserveSessionOnHide === preserveSessionOnHide) return
+        lastPublished = snapshot
+        lastPreserveSessionOnHide = preserveSessionOnHide
         void setLayout({
           sessionId,
           tabId,
           revision: nextBrowserLayoutRevision(),
-          visible: visible && rect.width > 4 && rect.height > 4,
+          visible: snapshot.visible,
           preserveSessionOnHide,
-          bounds: {
-            x: Math.round(rect.x), y: Math.round(rect.y),
-            width: Math.round(rect.width), height: Math.round(rect.height),
-          },
+          bounds: snapshot.bounds,
         })
       })
     }
-    const publishCurrentVisibility = () => {
-      const overlayOpen = hasBlockingAppOverlay()
-      publish(!overlayOpen, overlayOpen)
-    }
-    const observer = new ResizeObserver(publishCurrentVisibility)
-    const disconnectOverlayObserver = observeAppOverlayLifecycle(publishCurrentVisibility)
-    const publishBounded = () => publishCurrentVisibility()
+    const observer = new ResizeObserver(requestLayout)
+    const disconnectOverlayObserver = observeAppOverlayLifecycle(requestLayout)
     observer.observe(element)
-    window.addEventListener('resize', publishBounded)
-    publishCurrentVisibility()
+    window.addEventListener('resize', requestLayout)
+    requestLayout()
     return () => {
       observer.disconnect()
       disconnectOverlayObserver()
-      window.removeEventListener('resize', publishBounded)
-      if (frame) cancelAnimationFrame(frame)
+      window.removeEventListener('resize', requestLayout)
+      if (frame !== null) cancelAnimationFrame(frame)
       void setLayout({ sessionId, tabId, revision: nextBrowserLayoutRevision(), visible: false, preserveSessionOnHide: false, bounds: { x: 0, y: 0, width: 0, height: 0 } })
     }
   }, [sessionId, tabId])

--- a/apps/electron/src/renderer/components/browser/browser-layout-publish.test.ts
+++ b/apps/electron/src/renderer/components/browser/browser-layout-publish.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  browserLayoutSnapshotsEqual,
+  toBrowserLayoutSnapshot,
+  type BrowserLayoutSnapshot,
+} from './browser-layout-publish'
+
+const visible: BrowserLayoutSnapshot = {
+  visible: true,
+  bounds: { x: 600, y: 100, width: 500, height: 700 },
+}
+
+describe('受管浏览器布局发布快照', () => {
+  test('首次布局必须发布', () => {
+    expect(browserLayoutSnapshotsEqual(null, visible)).toBe(false)
+  })
+
+  test('亚像素变动归一化后不重复发布', () => {
+    const next = toBrowserLayoutSnapshot(
+      { x: 600.2, y: 100.4, width: 500.3, height: 699.8 },
+      false,
+    )
+    expect(browserLayoutSnapshotsEqual(visible, next)).toBe(true)
+  })
+
+  test('整数边界或可见性变化必须发布', () => {
+    expect(browserLayoutSnapshotsEqual(visible, {
+      visible: true,
+      bounds: { ...visible.bounds, x: 601 },
+    })).toBe(false)
+    expect(browserLayoutSnapshotsEqual(visible, {
+      ...visible,
+      visible: false,
+    })).toBe(false)
+  })
+
+  test('过小浏览器槽归一化为隐藏状态', () => {
+    expect(toBrowserLayoutSnapshot({ x: 0, y: 0, width: 4.4, height: 20 }, false).visible).toBe(false)
+    expect(toBrowserLayoutSnapshot({ x: 0, y: 0, width: 20, height: 20 }, true).visible).toBe(false)
+  })
+})

--- a/apps/electron/src/renderer/components/browser/browser-layout-publish.ts
+++ b/apps/electron/src/renderer/components/browser/browser-layout-publish.ts
@@ -1,0 +1,48 @@
+export interface BrowserLayoutBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface BrowserLayoutSnapshot {
+  visible: boolean
+  bounds: BrowserLayoutBounds
+}
+
+export interface BrowserLayoutRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** Convert a DOM measurement into the exact layout payload sent over IPC. */
+export function toBrowserLayoutSnapshot(
+  rect: BrowserLayoutRect,
+  overlayBlocksBrowser: boolean,
+): BrowserLayoutSnapshot {
+  const bounds = {
+    x: Math.round(rect.x),
+    y: Math.round(rect.y),
+    width: Math.round(rect.width),
+    height: Math.round(rect.height),
+  }
+  return {
+    visible: !overlayBlocksBrowser && bounds.width > 4 && bounds.height > 4,
+    bounds,
+  }
+}
+
+/** Layout revisions are only needed when the normalized IPC payload changes. */
+export function browserLayoutSnapshotsEqual(
+  first: BrowserLayoutSnapshot | null,
+  second: BrowserLayoutSnapshot,
+): boolean {
+  return !!first
+    && first.visible === second.visible
+    && first.bounds.x === second.bounds.x
+    && first.bounds.y === second.bounds.y
+    && first.bounds.width === second.bounds.width
+    && first.bounds.height === second.bounds.height
+}

--- a/apps/electron/src/renderer/components/browser/browser-overlay-observer.test.ts
+++ b/apps/electron/src/renderer/components/browser/browser-overlay-observer.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  APP_OVERLAY_LIFECYCLE_SELECTOR,
+  classifyOverlayMutation,
+  observeAppOverlayLifecycle,
+  type OverlayMutationDescriptor,
+} from './browser-overlay-observer'
+
+function classify(mutation: OverlayMutationDescriptor): boolean {
+  return classifyOverlayMutation(mutation)
+}
+
+class TestElement {
+  parentNode: TestElement | null = null
+  private readonly childNodes: TestElement[] = []
+
+  get children(): TestElement[] {
+    return this.childNodes
+  }
+
+  constructor(private readonly selectors: readonly string[] = []) {}
+
+  append(child: TestElement): void {
+    child.parentNode = this
+    this.childNodes.push(child)
+  }
+
+  remove(child: TestElement): void {
+    const index = this.childNodes.indexOf(child)
+    if (index >= 0) this.childNodes.splice(index, 1)
+    child.parentNode = null
+  }
+
+  contains(node: TestElement): boolean {
+    if (node === this) return true
+    return this.childNodes.some((child) => child.contains(node))
+  }
+
+  matches(selector: string): boolean {
+    return selector.split(', ').some((part) => this.selectors.includes(part))
+  }
+
+  querySelectorAll(selector: string): TestElement[] {
+    return this.childNodes.flatMap((child) => [
+      ...(child.matches(selector) ? [child] : []),
+      ...child.querySelectorAll(selector),
+    ])
+  }
+}
+
+class TestMutationObserver {
+  static readonly instances = new Set<TestMutationObserver>()
+  private target: TestElement | null = null
+  private options: MutationObserverInit = {}
+  disconnected = false
+
+  constructor(private readonly callback: MutationCallback) {
+    TestMutationObserver.instances.add(this)
+  }
+
+  observe(target: Node, options: MutationObserverInit = {}): void {
+    this.target = target as unknown as TestElement
+    this.options = options
+  }
+
+  disconnect(): void {
+    this.disconnected = true
+  }
+
+  private observesTarget(target: Node): boolean {
+    const element = target as unknown as TestElement
+    if (element === this.target) return true
+    if (!this.options.subtree) return false
+    let current = element.parentNode
+    while (current) {
+      if (current === this.target) return true
+      current = current.parentNode
+    }
+    return false
+  }
+
+  private acceptsMutation(type: 'attributes' | 'childList'): boolean {
+    return this.options[type] === true
+  }
+
+  static emit(target: Node, addedNodes: Node[] = [], removedNodes: Node[] = []): void {
+    const mutation = { type: 'childList', target, addedNodes, removedNodes } as unknown as MutationRecord
+    for (const observer of TestMutationObserver.instances) {
+      if (!observer.disconnected && observer.acceptsMutation('childList') && observer.observesTarget(target)) {
+        observer.callback([mutation], observer as unknown as MutationObserver)
+      }
+    }
+  }
+
+  static emitAttribute(target: Node, attributeName: string): void {
+    const mutation = { type: 'attributes', target, attributeName } as unknown as MutationRecord
+    for (const observer of TestMutationObserver.instances) {
+      if (!observer.disconnected && observer.acceptsMutation('attributes') && observer.observesTarget(target)) {
+        observer.callback([mutation], observer as unknown as MutationObserver)
+      }
+    }
+  }
+}
+
+describe('应用浮层 mutation 过滤', () => {
+  test('普通 Agent 流式消息更新不会触发 selector 扫描或布局回调', () => {
+    expect(classify({
+      type: 'childList',
+      target: 'other',
+      addedNodes: ['other'],
+    })).toBe(false)
+
+    expect(classify({
+      type: 'attributes',
+      target: 'other',
+      attributeName: 'data-state',
+    })).toBe(false)
+  })
+
+  test('body 只挂载普通 Portal 容器时不触发，后续 Dialog 进入 Portal 路径时触发', () => {
+    expect(classify({
+      type: 'childList',
+      target: 'body',
+      addedNodes: ['other'],
+    })).toBe(false)
+
+    expect(classify({
+      type: 'childList',
+      target: 'portal-path',
+      addedNodes: ['overlay-root'],
+    })).toBe(true)
+  })
+
+  test('Radix/Sonner 浮层根直接挂载、卸载都会触发', () => {
+    expect(classify({
+      type: 'childList',
+      target: 'body',
+      addedNodes: ['overlay-root'],
+    })).toBe(true)
+
+    expect(classify({
+      type: 'childList',
+      target: 'portal-path',
+      removedNodes: ['overlay-root'],
+    })).toBe(true)
+  })
+
+  test('只处理浮层生命周期属性，忽略普通属性变化', () => {
+    expect(classify({
+      type: 'attributes',
+      target: 'overlay-root',
+      attributeName: 'data-state',
+    })).toBe(true)
+    expect(classify({
+      type: 'attributes',
+      target: 'inside-overlay',
+      attributeName: 'role',
+    })).toBe(true)
+    expect(classify({
+      type: 'attributes',
+      target: 'overlay-root',
+      attributeName: 'class',
+    })).toBe(false)
+  })
+
+  test('导出的 selector 覆盖 Radix Dialog、Popover 与 Sonner 根', () => {
+    expect(APP_OVERLAY_LIFECYCLE_SELECTOR).not.toContain('[role="dialog"]')
+    expect(APP_OVERLAY_LIFECYCLE_SELECTOR).not.toContain('[role="alertdialog"]')
+    expect(APP_OVERLAY_LIFECYCLE_SELECTOR).toContain('[data-app-local-overlay]')
+    expect(APP_OVERLAY_LIFECYCLE_SELECTOR).toContain('[data-radix-popper-content-wrapper]')
+    expect(APP_OVERLAY_LIFECYCLE_SELECTOR).toContain('[data-sonner-toast]')
+    expect(APP_OVERLAY_LIFECYCLE_SELECTOR).toContain('[data-app-modal-overlay]')
+  })
+
+  test('观察器启动前已存在的 Portal 根仍监听浮层状态变化', () => {
+    const originalElement = globalThis.Element
+    Object.defineProperty(globalThis, 'Element', { configurable: true, value: TestElement })
+    TestMutationObserver.instances.clear()
+
+    try {
+      const body = new TestElement()
+      const portal = new TestElement()
+      const dialog = new TestElement(['[data-app-local-overlay]'])
+      portal.append(dialog)
+      body.append(portal)
+
+      let changes = 0
+      const disconnect = observeAppOverlayLifecycle(() => { changes += 1 }, {
+        body: body as unknown as HTMLElement,
+        mutationObserver: TestMutationObserver as unknown as typeof MutationObserver,
+      })
+
+      // The portal and dialog were mounted before BrowserSlot created its observer.
+      // Closing the existing dialog must still trigger a layout recomputation.
+      TestMutationObserver.emitAttribute(dialog as unknown as Node, 'data-state')
+      expect(changes).toBe(1)
+
+      disconnect()
+    } finally {
+      Object.defineProperty(globalThis, 'Element', { configurable: true, value: originalElement })
+      TestMutationObserver.instances.clear()
+    }
+  })
+
+  test('观察器启动前已存在的 Portal 根中新增浮层仍触发生命周期回调', () => {
+    const originalElement = globalThis.Element
+    Object.defineProperty(globalThis, 'Element', { configurable: true, value: TestElement })
+    TestMutationObserver.instances.clear()
+
+    try {
+      const body = new TestElement()
+      const portal = new TestElement(['[data-sonner-toaster]'])
+      body.append(portal)
+
+      let changes = 0
+      const disconnect = observeAppOverlayLifecycle(() => { changes += 1 }, {
+        body: body as unknown as HTMLElement,
+        mutationObserver: TestMutationObserver as unknown as typeof MutationObserver,
+      })
+
+      const toast = new TestElement(['[data-sonner-toast]'])
+      portal.append(toast)
+      TestMutationObserver.emit(portal as unknown as Node, [toast as unknown as Node])
+      expect(changes).toBe(1)
+
+      disconnect()
+    } finally {
+      Object.defineProperty(globalThis, 'Element', { configurable: true, value: originalElement })
+      TestMutationObserver.instances.clear()
+    }
+  })
+
+  test('完整 Portal 子树从 body 卸载时清理浮层根、断开局部 observer 并回调', () => {
+    const originalElement = globalThis.Element
+    Object.defineProperty(globalThis, 'Element', { configurable: true, value: TestElement })
+    TestMutationObserver.instances.clear()
+
+    try {
+      const body = new TestElement()
+      const portal = new TestElement()
+      const dialog = new TestElement(['[data-app-local-overlay]'])
+      const popover = new TestElement(['[data-radix-popper-content-wrapper]'])
+      portal.append(dialog)
+      dialog.append(popover)
+      body.append(portal)
+
+      let changes = 0
+      const disconnect = observeAppOverlayLifecycle(() => { changes += 1 }, {
+        body: body as unknown as HTMLElement,
+        mutationObserver: TestMutationObserver as unknown as typeof MutationObserver,
+      })
+
+      // Portal and all descendant overlays existed before BrowserSlot created its observers.
+      TestMutationObserver.emitAttribute(dialog as unknown as Node, 'data-state')
+      expect(changes).toBe(1)
+
+      body.remove(portal)
+      TestMutationObserver.emit(body as unknown as Node, [], [portal as unknown as Node])
+      expect(changes).toBe(2)
+
+      // Removing the whole Portal must disconnect observers rooted at the Portal and its descendants.
+      TestMutationObserver.emitAttribute(dialog as unknown as Node, 'data-state')
+      TestMutationObserver.emit(dialog as unknown as Node, [popover as unknown as Node])
+      expect(changes).toBe(2)
+
+      disconnect()
+    } finally {
+      Object.defineProperty(globalThis, 'Element', { configurable: true, value: originalElement })
+      TestMutationObserver.instances.clear()
+    }
+  })
+})

--- a/apps/electron/src/renderer/components/browser/browser-overlay-observer.ts
+++ b/apps/electron/src/renderer/components/browser/browser-overlay-observer.ts
@@ -1,0 +1,195 @@
+const OVERLAY_SELECTOR_PARTS = [
+  '[data-sonner-toast]',
+  '[data-sonner-toaster]',
+  '[data-app-modal-overlay]',
+  '[data-app-local-overlay]',
+  '[data-radix-popper-content-wrapper]',
+] as const
+
+/** Radix/Sonner 节点的生命周期选择器，供 BrowserSlot 复用。 */
+export const APP_OVERLAY_LIFECYCLE_SELECTOR = OVERLAY_SELECTOR_PARTS.join(', ')
+
+export type OverlayMutationTarget = 'body' | 'portal-path' | 'overlay-root' | 'inside-overlay' | 'other'
+export type OverlayMutationNode = 'overlay-root' | 'other'
+
+/**
+ * DOM 无关的 mutation 分类输入。它让过滤规则可以在 Bun 默认运行时测试，
+ * 不需要引入 jsdom，也避免测试依赖 Electron 的 renderer 环境。
+ */
+export interface OverlayMutationDescriptor {
+  type: 'attributes' | 'childList'
+  target: OverlayMutationTarget
+  addedNodes?: readonly OverlayMutationNode[]
+  removedNodes?: readonly OverlayMutationNode[]
+  attributeName?: string | null
+}
+
+const LIFECYCLE_ATTRIBUTES = new Set(['data-mounted', 'data-state', 'data-visible', 'role'])
+
+/** 仅把浮层生命周期相关的 mutation 交给布局回调。 */
+export function classifyOverlayMutation(mutation: OverlayMutationDescriptor): boolean {
+  if (mutation.type === 'attributes') {
+    return (mutation.target === 'overlay-root' || mutation.target === 'inside-overlay')
+      && (mutation.attributeName == null || LIFECYCLE_ATTRIBUTES.has(mutation.attributeName))
+  }
+
+  const addedOrRemovedOverlay = [...(mutation.addedNodes ?? []), ...(mutation.removedNodes ?? [])]
+    .some((node) => node === 'overlay-root')
+
+  if (addedOrRemovedOverlay) return true
+  return mutation.target === 'overlay-root'
+}
+
+type MutationObserverFactory = new (callback: MutationCallback) => MutationObserver
+
+export interface AppOverlayObserverOptions {
+  body?: HTMLElement
+  portalRoots?: readonly Element[]
+  mutationObserver?: MutationObserverFactory
+}
+
+/**
+ * 监听应用浮层生命周期。
+ *
+ * body 只监听直接 childList。新出现的 body 子节点被当作一个局部 Portal 路径，
+ * 只有该路径中的浮层根节点、浮层状态属性或已知浮层内部挂载才会触发回调。
+ * 因此普通 Agent 消息更新不会触发 body subtree selector 扫描。
+ */
+export function observeAppOverlayLifecycle(
+  onChange: () => void,
+  options: AppOverlayObserverOptions = {},
+): () => void {
+  const body = options.body ?? document.body
+  const Observer = options.mutationObserver ?? MutationObserver
+  const portalRoots = new Set<Element>(options.portalRoots ?? [])
+  const overlayRoots = new Set<Element>()
+  const pathObservers = new Map<Element, MutationObserver>()
+  let disconnected = false
+
+  const isOverlayRoot = (node: Node): node is Element =>
+    node instanceof Element && node.matches(APP_OVERLAY_LIFECYCLE_SELECTOR)
+
+  const isDescendantOfKnownOverlay = (node: Node): boolean => {
+    let current: Node | null = node
+    while (current instanceof Element) {
+      if (overlayRoots.has(current)) return true
+      current = current.parentNode
+    }
+    return false
+  }
+
+  const rememberOverlayRoot = (node: Node): boolean => {
+    if (!isOverlayRoot(node)) return false
+    overlayRoots.add(node)
+    return true
+  }
+
+  // A Portal can enter body with its complete subtree already attached. This is
+  // the only place we scan descendants; ordinary streamed message updates are
+  // never direct body children and therefore never take this path.
+  const rememberOverlayRootsInPortal = (node: Element): boolean => {
+    let found = rememberOverlayRoot(node)
+    for (const overlay of node.querySelectorAll(APP_OVERLAY_LIFECYCLE_SELECTOR)) {
+      overlayRoots.add(overlay)
+      found = true
+    }
+    return found
+  }
+
+  // body 只观察直接 childList；移除一个 Portal 容器时，已登记的浮层根和局部
+  // observer 可能都是它的后代。按 contains 清理整个 detached 子树，避免保留 DOM 引用。
+  const forgetDetachedSubtree = (node: Element): boolean => {
+    let found = false
+    for (const [root, observer] of pathObservers) {
+      if (root !== node && !node.contains(root)) continue
+      observer.disconnect()
+      pathObservers.delete(root)
+      portalRoots.delete(root)
+      found = true
+    }
+    for (const root of overlayRoots) {
+      if (root !== node && !node.contains(root)) continue
+      overlayRoots.delete(root)
+      found = true
+    }
+    return found
+  }
+
+  const handlePathMutations = (mutations: MutationRecord[]) => {
+    let changed = false
+    for (const mutation of mutations) {
+      if (mutation.type === 'attributes') {
+        const target = mutation.target
+        if (target instanceof Element
+          && (isDescendantOfKnownOverlay(target) || target.matches(APP_OVERLAY_LIFECYCLE_SELECTOR))) {
+          changed = true
+        }
+        continue
+      }
+
+      // 不查询 addedNode 的后代；Portal/Dialog 的两阶段挂载会在下一条 mutation
+      // 中把实际浮层根作为当前 addedNode 交给这里，普通消息节点则只做一次 matches。
+      for (const node of mutation.addedNodes) {
+        if (rememberOverlayRoot(node)) changed = true
+      }
+      for (const node of mutation.removedNodes) {
+        if (node instanceof Element && forgetDetachedSubtree(node)) changed = true
+      }
+    }
+    if (changed) onChange()
+  }
+
+  const observePortalPath = (root: Element) => {
+    if (pathObservers.has(root)) return
+    portalRoots.add(root)
+    const observer = new Observer(handlePathMutations)
+    pathObservers.set(root, observer)
+    observer.observe(root, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [...LIFECYCLE_ATTRIBUTES],
+    })
+  }
+
+  const initialPortalRoots = new Set<Element>(options.portalRoots ?? [])
+  for (const bodyChild of Array.from(body.children)) {
+    if (isOverlayRoot(bodyChild)) initialPortalRoots.add(bodyChild)
+    for (const overlay of bodyChild.querySelectorAll(APP_OVERLAY_LIFECYCLE_SELECTOR)) {
+      initialPortalRoots.add(overlay)
+    }
+  }
+
+  for (const root of initialPortalRoots) {
+    rememberOverlayRootsInPortal(root)
+    observePortalPath(root)
+  }
+
+  const bodyObserver = new Observer((mutations) => {
+    let changed = false
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (!(node instanceof Element)) continue
+        observePortalPath(node)
+        if (rememberOverlayRootsInPortal(node)) changed = true
+      }
+      for (const node of mutation.removedNodes) {
+        if (node instanceof Element) {
+          if (forgetDetachedSubtree(node)) changed = true
+        }
+      }
+    }
+    if (changed) onChange()
+  })
+  bodyObserver.observe(body, { childList: true })
+
+  return () => {
+    if (disconnected) return
+    disconnected = true
+    bodyObserver.disconnect()
+    for (const observer of pathObservers.values()) observer.disconnect()
+    pathObservers.clear()
+    portalRoots.clear()
+    overlayRoots.clear()
+  }
+}

--- a/apps/electron/src/renderer/components/browser/browser-overlay.test.ts
+++ b/apps/electron/src/renderer/components/browser/browser-overlay.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  overlayBlocksBrowser,
+  rectanglesOverlap,
+  type BrowserOverlay,
+  type BrowserOverlayRect,
+} from './browser-overlay'
+
+const browser: BrowserOverlayRect = { left: 600, top: 100, right: 1200, bottom: 800 }
+
+const overlay = (kind: BrowserOverlay['kind'], rect: BrowserOverlayRect): BrowserOverlay => ({ kind, rect })
+
+describe('受管浏览器与应用浮层的矩形遮挡判定', () => {
+  test('左侧输入区的浮层不隐藏浏览器页面', () => {
+    expect(rectanglesOverlap({ left: 80, top: 600, right: 500, bottom: 760 }, browser)).toBe(false)
+  })
+
+  test('覆盖浏览器区域的浮层会隐藏原生页面以显示浮层', () => {
+    expect(rectanglesOverlap({ left: 560, top: 420, right: 760, bottom: 620 }, browser)).toBe(true)
+  })
+
+  test('仅边缘相切不算遮挡', () => {
+    expect(rectanglesOverlap({ left: 0, top: 100, right: 600, bottom: 800 }, browser)).toBe(false)
+  })
+})
+
+describe('应用浮层策略', () => {
+  const outsideBrowser = { left: 80, top: 600, right: 500, bottom: 760 }
+
+  test('Dialog 即使内容框在浏览器外也会阻塞原生页面', () => {
+    expect(overlayBlocksBrowser(overlay('modal', outsideBrowser), browser)).toBe(true)
+  })
+
+  test('AlertDialog 即使内容框在浏览器外也会阻塞原生页面', () => {
+    expect(overlayBlocksBrowser(overlay('modal', outsideBrowser), browser)).toBe(true)
+  })
+
+  test('局部覆盖物只有实际相交时才阻塞原生页面', () => {
+    expect(overlayBlocksBrowser(overlay('local', { left: 560, top: 420, right: 760, bottom: 620 }), browser)).toBe(true)
+    expect(overlayBlocksBrowser(overlay('local', outsideBrowser), browser)).toBe(false)
+  })
+
+  test('局部覆盖物与浏览器边缘相切时不阻塞原生页面', () => {
+    expect(overlayBlocksBrowser(overlay('local', { left: 0, top: 100, right: 600, bottom: 800 }), browser)).toBe(false)
+  })
+})

--- a/apps/electron/src/renderer/components/browser/browser-overlay.ts
+++ b/apps/electron/src/renderer/components/browser/browser-overlay.ts
@@ -1,0 +1,29 @@
+export interface BrowserOverlayRect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+export type BrowserOverlayKind = 'modal' | 'local'
+
+export interface BrowserOverlay {
+  kind: BrowserOverlayKind
+  rect: BrowserOverlayRect
+}
+
+/** 判断两个屏幕矩形是否有实际面积的交集。边缘相切不算遮挡。 */
+export function rectanglesOverlap(first: BrowserOverlayRect, second: BrowserOverlayRect): boolean {
+  return first.left < second.right
+    && first.right > second.left
+    && first.top < second.bottom
+    && first.bottom > second.top
+}
+
+/**
+ * 判断应用浮层是否需要隐藏原生浏览器视图。
+ * 模态 Dialog 的 fixed 遮罩覆盖整个 renderer，即使内容矩形在浏览器外也必须阻塞。
+ */
+export function overlayBlocksBrowser(overlay: BrowserOverlay, browserRect: BrowserOverlayRect): boolean {
+  return overlay.kind === 'modal' || rectanglesOverlap(overlay.rect, browserRect)
+}

--- a/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
+++ b/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
@@ -426,6 +426,7 @@ function SessionMiniMapPopoverContent({
 
   return createPortal(
     <div
+      data-app-local-overlay=""
       className="fixed z-[9999] titlebar-no-drag transition-[top,height] duration-150 ease-out pointer-events-auto"
       style={{ top: position.top, left: position.left, width: PANEL_WIDTH, height: position.height }}
       onMouseEnter={onMouseEnter}

--- a/apps/electron/src/renderer/components/shortcuts/FaqDialog.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/FaqDialog.tsx
@@ -29,7 +29,7 @@ export function FaqDialog(): React.ReactElement {
   return (
     <DialogPrimitive.Root open={open} onOpenChange={(value) => setOpen(value)}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-[80] bg-black/40 backdrop-blur-sm" />
+        <DialogPrimitive.Overlay data-app-modal-overlay="" className="fixed inset-0 z-[80] bg-black/40 backdrop-blur-sm" />
         <DialogPrimitive.Content
           className={cn(
             'fixed left-1/2 top-1/2 z-[81] flex h-[80vh] w-[min(860px,90vw)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-2xl dark:border-neutral-800 dark:bg-neutral-900',

--- a/apps/electron/src/renderer/components/shortcuts/ShortcutGuideDialog.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/ShortcutGuideDialog.tsx
@@ -216,7 +216,10 @@ export function ShortcutGuideDialog(): React.ReactElement {
   return (
     <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-[100] bg-black/40 titlebar-no-drag transition-opacity duration-100 data-[state=open]:opacity-100 data-[state=closed]:opacity-0" />
+        <DialogPrimitive.Overlay
+          data-app-modal-overlay=""
+          className="fixed inset-0 z-[100] bg-black/40 titlebar-no-drag transition-opacity duration-100 data-[state=open]:opacity-100 data-[state=closed]:opacity-0"
+        />
         <DialogPrimitive.Content
           aria-describedby={undefined}
           className="fixed left-1/2 top-1/2 z-[100] flex h-[85vh] max-h-[752px] w-[85vw] max-w-[992px] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl bg-dialog text-dialog-foreground shadow-2xl titlebar-no-drag transition-all duration-100 data-[state=open]:opacity-100 data-[state=open]:scale-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-[0.98]"

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -266,6 +266,7 @@ function TabPreviewDropdown({
 
   return createPortal(
     <div
+      data-app-local-overlay=""
       className="fixed z-[9999] pt-1"
       style={{ top: pos.top, left: pos.left }}
       onMouseEnter={onMouseEnter}

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ReactElement, ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { useAtomValue, useSetAtom, useStore } from 'jotai'
 import type { AgentSessionMeta, ConversationMeta } from '@proma/shared'
 import { cn } from '@/lib/utils'
@@ -452,8 +453,8 @@ export function TabSwitcher(): ReactElement | null {
   const safeIndex = Math.min(selectedIndex, switcherModel.candidates.length - 1)
   let globalIndex = 0
 
-  return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
+  return createPortal(
+    <div data-app-modal-overlay="" className="fixed inset-0 z-[9999] flex items-center justify-center">
       <div className="absolute inset-0 bg-black/40" />
 
       <div className="relative bg-popover border border-border/50 rounded-xl shadow-2xl min-w-[420px] max-w-[540px] overflow-hidden">
@@ -510,7 +511,8 @@ export function TabSwitcher(): ReactElement | null {
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/apps/electron/src/renderer/components/ui/alert-dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/alert-dialog.tsx
@@ -17,6 +17,7 @@ const AlertDialogOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
+    data-app-modal-overlay=""
     className={cn(
       "fixed inset-0 z-[100] bg-black/40 titlebar-no-drag",
       "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",

--- a/apps/electron/src/renderer/components/ui/dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/dialog.tsx
@@ -20,6 +20,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
+    data-app-modal-overlay=""
     className={cn(
       "fixed inset-0 z-[100] bg-black/40 titlebar-no-drag",
       "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",

--- a/apps/electron/src/renderer/components/ui/image-lightbox.tsx
+++ b/apps/electron/src/renderer/components/ui/image-lightbox.tsx
@@ -130,6 +130,7 @@ export function ImageLightbox({
       <DialogPrimitive.Portal>
         {/* 遮罩层 — 与 DialogOverlay 完全一致 */}
         <DialogPrimitive.Overlay
+          data-app-modal-overlay=""
           className={cn(
             'fixed inset-0 z-[200] bg-black/40 titlebar-no-drag',
             'data-[state=open]:animate-in data-[state=closed]:animate-out',

--- a/apps/electron/src/renderer/components/ui/sheet.tsx
+++ b/apps/electron/src/renderer/components/ui/sheet.tsx
@@ -19,6 +19,7 @@ const SheetOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
+    data-app-modal-overlay=""
     className={cn(
       "fixed inset-0 z-[100] bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className


### PR DESCRIPTION
## 概述

修复 Electron 原生 `WebContentsView` 无法被 renderer CSS z-index 覆盖时，模型选择器、思考深度菜单、Dialog、Toast 与自定义 Portal 悬浮层被浏览器压住或关闭后未恢复的问题。通过按实际矩形判断遮挡、监听受控浮层生命周期并在临时隐藏期间保留浏览器 session，避免页面白屏和错误回收。

## 改动

- `apps/electron/src/renderer/components/browser/BrowserSlot.tsx` — 合并布局事件到单帧，基于整数 bounds 和可见性去重 IPC；支持上游 `preserveSessionOnHide`，并按局部/模态遮挡隐藏原生 view。
- `apps/electron/src/renderer/components/browser/browser-overlay-observer.ts` — 新增受限 MutationObserver，覆盖既有与新增的 Portal/Toast 浮层；完整 Portal 卸载时断开所有后代 observer，避免 detached DOM 引用和陈旧回调。
- `apps/electron/src/renderer/components/browser/browser-overlay*.ts` — 增加矩形遮挡、布局发布与 observer 生命周期单元测试。
- `apps/electron/src/renderer/components/ui/*`、`SearchDialog.tsx`、FAQ/快捷键 Dialog、`TabSwitcher.tsx` — 标记真正的全屏模态遮罩；TabSwitcher 改挂载到 body Portal。
- `SessionMiniMapPopover.tsx`、`TabBarItem.tsx`、`WorkspaceMemoryChangeShelf.tsx` — 标记局部自定义 Portal，仅在与浏览器区域相交时临时隐藏原生页面。

## 测试方法

1. 运行 `bun test apps/electron/src/renderer/components/browser/browser-overlay-observer.test.ts apps/electron/src/renderer/components/browser/browser-overlay.test.ts apps/electron/src/renderer/components/browser/browser-layout-publish.test.ts`，确认 19 项测试通过。
2. 运行 `bun run --filter @proma/electron typecheck`。
3. 运行 `bun run --filter @proma/electron build:renderer`。
4. 在受管浏览器打开时，分别测试模型选择、思考深度、Dialog、Toast、TabSwitcher 与局部 hover Portal 的打开/关闭，确认浮层可见且浏览器恢复。

## 备注

- 变更已 rebase 到最新 `main`，提交 `28eb5ee0`。
- renderer 构建通过；仍会输出项目既有的大 chunk warning。
- 尚未覆盖 macOS、Windows、Linux 的真实 Electron 人工冒烟验证。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)