### PR TITLE
fix(agent): 保留中止时已生成的部分输出【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.62",
+  "version": "0.17.63",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -77,6 +77,7 @@ import { generateCodexTitle } from './adapters/pi-codex-title-generator'
 import { createFallbackTitle, sanitizeGeneratedTitle, TITLE_PROMPT } from './title-generation'
 import { claimWorkspaceMemoryRefreshOpportunity } from './agent-memory-refresh-service'
 import { browserController } from './browser-controller'
+import { AgentPartialMessageStore } from './agent-partial-message'
 
 // ===== 类型定义 =====
 
@@ -913,6 +914,21 @@ export class AgentOrchestrator {
 
     // 5. 状态初始化
     const accumulatedMessages: SDKMessage[] = []
+    // Delta 只用于实时渲染，正常情况下由完整 assistant 消息收束。
+    // provider 卡住并被强制中止时可能永远没有 message_end，因此保留最后一份
+    // 可持久化快照，避免 utility runtime 超时后实时气泡被刷新流程清掉。
+    const partialAssistantMessages = new AgentPartialMessageStore({
+      sessionId,
+      createdAt: streamStartedAt,
+      modelId,
+      provider: channel.provider,
+    })
+    const persistPartialAssistantMessages = (durationMs?: number): void => {
+      const partials = partialAssistantMessages.drainDurable()
+      if (partials.length > 0) {
+        this.persistSDKMessages(sessionId, partials, durationMs)
+      }
+    }
     let pendingSkillActivations: SkillActivation[] = []
     const recordSkillActivation = (
       activations: SkillActivation[],
@@ -1545,6 +1561,7 @@ export class AgentOrchestrator {
         // adapter query exists yet to cancel. Never start that later query.
         if (this.activeSessions.get(sessionId) !== runGeneration) {
           const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
+          persistPartialAssistantMessages(Date.now() - queryStartedAt)
           this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
           try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
           completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
@@ -1607,6 +1624,7 @@ export class AgentOrchestrator {
             pendingNext = null
             let msg = iterResult.value
             if (isAssistantDeltaSDKMessage(msg)) {
+              partialAssistantMessages.applyDelta(msg.uuid, msg.delta)
               this.eventBus.emit(sessionId, {
                 kind: 'sdk_delta',
                 delta: {
@@ -1620,6 +1638,10 @@ export class AgentOrchestrator {
               continue
             }
             const isPartialMessage = isPartialSDKMessage(msg)
+            if (msg.type === 'assistant' && !isPartialMessage) {
+              const uuid = (msg as SDKAssistantMessage).uuid
+              if (uuid) partialAssistantMessages.markComplete(uuid)
+            }
             if (msg.type === 'result') {
               const skillActivations = mergeSkillActivations(
                 pendingSkillActivations,
@@ -1740,6 +1762,7 @@ export class AgentOrchestrator {
                   // Reuse the Pi UUID to replace the latest partial frame with normal markdown output.
                   this.eventBus.emit(sessionId, { kind: 'sdk_message', message: partialOutput })
                 }
+                persistPartialAssistantMessages(Date.now() - queryStartedAt)
                 this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
                 accumulatedMessages.length = 0
                 if (typedError.code === 'prompt_too_long') {
@@ -1828,6 +1851,7 @@ export class AgentOrchestrator {
               capturedResultErrors = Array.isArray(rawResultErrors)
                 ? rawResultErrors.filter((e): e is string => typeof e === 'string' && e.trim().length > 0)
                 : undefined
+              persistPartialAssistantMessages(Date.now() - queryStartedAt)
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               accumulatedMessages.length = 0
               console.log(
@@ -1902,6 +1926,8 @@ export class AgentOrchestrator {
 
           const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
 
+          // 完整 assistant 未到达时，用已收到的 Delta 快照保留中止前的输出。
+          persistPartialAssistantMessages(Date.now() - queryStartedAt)
           // 15. 持久化 assistant 消息
           this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
 
@@ -1936,6 +1962,7 @@ export class AgentOrchestrator {
           // 本代际不再拥有 active slot，就只能收束自己，不能向新 run 泄漏终态。
           if (this.activeSessions.get(sessionId) !== runGeneration) {
             const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
+            persistPartialAssistantMessages(Date.now() - queryStartedAt)
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
             completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
@@ -1997,6 +2024,7 @@ export class AgentOrchestrator {
           console.error(`[Agent 编排] 执行失败:`, error)
 
           // 保存已累积的部分内容
+          persistPartialAssistantMessages(Date.now() - queryStartedAt)
           if (accumulatedMessages.length > 0) {
             try {
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)

--- a/apps/electron/src/main/lib/agent-partial-message.ts
+++ b/apps/electron/src/main/lib/agent-partial-message.ts
@@ -1,0 +1,141 @@
+import type {
+  AgentAssistantDelta,
+  SDKAssistantMessage,
+  SDKContentBlock,
+} from '@proma/shared'
+
+/**
+ * Build a durable assistant snapshot from the deltas already received from Pi.
+ * The snapshot is only used when the provider never emits message_end.
+ */
+export function applyAgentAssistantDelta(
+  message: SDKAssistantMessage,
+  delta: AgentAssistantDelta,
+): SDKAssistantMessage {
+  const content = [...message.message.content] as SDKContentBlock[]
+  const index = 'contentIndex' in delta ? delta.contentIndex : undefined
+  const ensureBlock = (fallback: SDKContentBlock): number => {
+    if (index == null) {
+      content.push(fallback)
+      return content.length - 1
+    }
+    while (content.length <= index) content.push({ type: 'text', text: '' })
+    return index
+  }
+  const existing = index != null ? content[index] : undefined
+
+  switch (delta.type) {
+    case 'text_start':
+      content[ensureBlock({ type: 'text', text: '' })] = { type: 'text', text: '' }
+      break
+    case 'text_delta': {
+      const blockIndex = ensureBlock({ type: 'text', text: '' })
+      const text = existing?.type === 'text' && 'text' in existing && typeof existing.text === 'string'
+        ? existing.text
+        : ''
+      content[blockIndex] = { type: 'text', text: text + delta.delta }
+      break
+    }
+    case 'text_end':
+      content[ensureBlock({ type: 'text', text: '' })] = { type: 'text', text: delta.content }
+      break
+    case 'thinking_start':
+      content[ensureBlock({ type: 'thinking', thinking: '' })] = { type: 'thinking', thinking: '' }
+      break
+    case 'thinking_delta': {
+      const blockIndex = ensureBlock({ type: 'thinking', thinking: '' })
+      const thinking = existing?.type === 'thinking'
+        && 'thinking' in existing
+        && typeof existing.thinking === 'string'
+        ? existing.thinking
+        : ''
+      content[blockIndex] = { type: 'thinking', thinking: thinking + delta.delta }
+      break
+    }
+    case 'thinking_end':
+      content[ensureBlock({ type: 'thinking', thinking: '' })] = { type: 'thinking', thinking: delta.content }
+      break
+    case 'toolcall_start':
+    case 'toolcall_delta':
+    case 'toolcall_end': {
+      const toolCall = delta.toolCall
+      if (!toolCall) break
+      const blockIndex = ensureBlock({ type: 'tool_use', id: toolCall.id, name: toolCall.name, input: {} })
+      const previous = content[blockIndex]
+      content[blockIndex] = {
+        type: 'tool_use',
+        id: toolCall.id,
+        name: toolCall.name,
+        input: toolCall.arguments
+          ?? (previous?.type === 'tool_use' && 'input' in previous ? previous.input : {}),
+      }
+      break
+    }
+    case 'start':
+      break
+  }
+
+  return { ...message, message: { ...message.message, content }, _partial: true } as SDKAssistantMessage
+}
+
+export function createPartialAssistantMessage(options: {
+  uuid: string
+  sessionId: string
+  createdAt: number
+  modelId?: string
+  provider?: SDKAssistantMessage['_channelProvider']
+}): SDKAssistantMessage {
+  return {
+    type: 'assistant',
+    message: { content: [] },
+    parent_tool_use_id: null,
+    session_id: options.sessionId,
+    uuid: options.uuid,
+    _partial: true,
+    _createdAt: options.createdAt,
+    ...(options.modelId ? { _channelModelId: options.modelId } : {}),
+    ...(options.provider ? { _channelProvider: options.provider } : {}),
+  } as SDKAssistantMessage
+}
+
+/** Remove the live-only marker before writing the snapshot to JSONL. */
+export function finalizePartialAssistantMessage(
+  message: SDKAssistantMessage,
+): SDKAssistantMessage | null {
+  if (message.message.content.length === 0) return null
+  const { _partial: _ignored, ...durableMessage } = message as SDKAssistantMessage & { _partial?: boolean }
+  return durableMessage
+}
+
+/**
+ * Stores one run's live assistant messages until a complete SDK message arrives.
+ * Draining the store is the fallback for abort/timeout paths without message_end.
+ */
+export class AgentPartialMessageStore {
+  private readonly messages = new Map<string, SDKAssistantMessage>()
+
+  constructor(private readonly options: {
+    sessionId: string
+    createdAt: number
+    modelId?: string
+    provider?: SDKAssistantMessage['_channelProvider']
+  }) {}
+
+  applyDelta(uuid: string, delta: AgentAssistantDelta): void {
+    const current = this.messages.get(uuid)
+      ?? createPartialAssistantMessage({ uuid, ...this.options })
+    this.messages.set(uuid, applyAgentAssistantDelta(current, delta))
+  }
+
+  markComplete(uuid: string): void {
+    this.messages.delete(uuid)
+  }
+
+  drainDurable(): SDKAssistantMessage[] {
+    const durableMessages = Array.from(this.messages.values())
+      .map(finalizePartialAssistantMessage)
+      .filter((message): message is SDKAssistantMessage => message !== null)
+    this.messages.clear()
+    return durableMessages
+  }
+}


### PR DESCRIPTION
## 概述
修复 Agent 流式输出在运行时卡住、用户点击停止或查询异常结束时，之前已经显示的 assistant 内容可能消失的问题。流式 Delta 原本只用于 renderer 实时显示；如果 provider 没有发出完整的 `message_end`，异常收尾时就没有完整 assistant 消息可持久化。本 PR 在主进程编排层保留并持久化已收到的部分输出。

## 改动
- `apps/electron/src/main/lib/agent-orchestrator.ts` — 在每次 Agent run 内聚合 assistant text、thinking 和 tool-call Delta；完整 assistant 消息到达时清理对应快照；在 result、用户中止、超时和不可重试异常路径中持久化尚未收束的部分消息。
- `apps/electron/src/main/lib/agent-partial-message.ts` — 新增部分 assistant 消息快照状态机，负责 Delta 聚合、完整消息清理和可持久化消息生成，避免重复写入。
- `apps/electron/package.json` — 将 `@proma/electron` patch 版本从 `0.17.62` 更新为 `0.17.63`。

## 测试方法
1. 在最新 upstream/main 基线上执行 `bun run typecheck`，通过。
2. 本地曾执行部分 assistant 快照回归测试，覆盖文本 Delta 聚合、abort/timeout 且缺少 `message_end`、完整 assistant 去重、thinking/tool block 保留和空快照忽略，测试通过。
3. 按需求，测试用的 `agent-partial-message.test.ts` 未随本 PR 提交；当前 PR 保留生产修复代码。
4. 真实 Electron UI 中的“流式卡住 -> 点击停止 -> renderer 刷新后历史仍可见”尚未完成端到端自动化验证。

## 备注
- upstream 没有直接 push 权限，本分支推送到 `Andreaseszhang/Proma`，PR base 为 `ErlichLiu/Proma:main`。
- 本修复只在缺少完整 assistant 终态时写入部分快照；正常完整 assistant 消息到达时不会重复持久化。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
