### PR TITLE
fix(renderer): 修复 Markdown 粘贴与长文本附件流程【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -16,6 +16,7 @@
 import { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback, useImperativeHandle, forwardRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { useEditor, EditorContent } from '@tiptap/react'
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model'
 import { TextSelection } from '@tiptap/pm/state'
 import type { Transaction } from '@tiptap/pm/state'
 import StarterKit from '@tiptap/starter-kit'
@@ -28,7 +29,12 @@ import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { lowlight } from '@/lib/lowlight'
-import { htmlToMarkdown } from '@/lib/markdown-rich-text'
+import {
+  hasRichClipboardMarkup,
+  htmlToMarkdown,
+  looksLikeMarkdownText,
+  markdownToHtml,
+} from '@/lib/markdown-rich-text'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   buildAgentHistoryQuoteLabel,
@@ -775,6 +781,14 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
         ) {
           event.preventDefault()
           onPasteLongTextRef.current(text)
+          return true
+        }
+        if (looksLikeMarkdownText(plainText) && !hasRichClipboardMarkup(html)) {
+          const container = document.createElement('div')
+          container.innerHTML = markdownToHtml(plainText)
+          const slice = ProseMirrorDOMParser.fromSchema(view.state.schema).parseSlice(container)
+          event.preventDefault()
+          view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView().setMeta('uiEvent', 'paste'))
           return true
         }
         return false

--- a/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
+++ b/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
@@ -9,7 +10,12 @@ import { TextSelection } from '@tiptap/pm/state'
 import type { FileAccessOptions } from '@proma/shared'
 import type { MarkdownEditorSelection, MarkdownScrollPosition } from '@/lib/markdown-editor-state'
 import { cn } from '@/lib/utils'
-import { MARKDOWN_RENDERER_VERSION, markdownToHtml } from '@/lib/markdown-rich-text'
+import {
+  hasRichClipboardMarkup,
+  looksLikeMarkdownText,
+  MARKDOWN_RENDERER_VERSION,
+  markdownToHtml,
+} from '@/lib/markdown-rich-text'
 import {
   MathBlock,
   MathInline,
@@ -155,6 +161,23 @@ export function MarkdownRichEditor({
           return true
         }
         return false
+      },
+      handlePaste: (view, event) => {
+        if (!isEditableRef.current) return false
+
+        const plainText = event.clipboardData?.getData('text/plain') ?? ''
+        const clipboardHtml = event.clipboardData?.getData('text/html') ?? ''
+        if (!plainText || !looksLikeMarkdownText(plainText)) return false
+        // 复制已有富文本时优先保留剪贴板中的语义 HTML；普通 <p>/<div> 包装的
+        // Markdown 文本则继续按 Markdown 解析，避免把 **粗体** 当成字面量插入。
+        if (hasRichClipboardMarkup(clipboardHtml)) return false
+
+        const container = document.createElement('div')
+        container.innerHTML = markdownToHtml(plainText)
+        const slice = ProseMirrorDOMParser.fromSchema(view.state.schema).parseSlice(container)
+        event.preventDefault()
+        view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView().setMeta('uiEvent', 'paste'))
+        return true
       },
       handleDoubleClick: (_view, pos) => {
         if (isEditableRef.current || disabledRef.current || !onRequestEditRef.current) return false

--- a/apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts
+++ b/apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { createClipboardPendingFile, createClipboardTextDraft } from './clipboard-text-attachment'
+import { createClipboardPendingFile, createClipboardTextDraft, shouldConvertClipboardTextToAttachment } from './clipboard-text-attachment'
+import { hasRichClipboardMarkup, looksLikeMarkdownText } from './markdown-rich-text'
 
 describe('长文本粘贴附件', () => {
   test('Given Markdown 长文本 When 转为草稿文件 Then 使用可编辑的 Markdown 文件元数据', () => {
@@ -33,5 +34,39 @@ describe('长文本粘贴附件', () => {
       sourcePath: '/tmp/proma-preview/clipboard-20260528-123456.txt',
       isClipboardDraft: true,
     })
+  })
+
+  test('Given 超过阈值的 Markdown 粘贴 When 附件转换开启 Then 优先转为 Markdown 附件', () => {
+    const markdown = `# 标题\n\n${'这是一段较长的内容。'.repeat(4)}`
+
+    expect(looksLikeMarkdownText(markdown)).toBe(true)
+    expect(shouldConvertClipboardTextToAttachment({
+      enabled: true,
+      plainText: markdown,
+      normalizedText: markdown,
+      threshold: 32,
+    })).toBe(true)
+  })
+
+  test('Given 未超过阈值的纯 Markdown When 附件转换开启 Then 保留富文本解析路径', () => {
+    const markdown = '# 标题\n\n**短文本**'
+
+    expect(looksLikeMarkdownText(markdown)).toBe(true)
+    expect(hasRichClipboardMarkup('')).toBe(false)
+    expect(shouldConvertClipboardTextToAttachment({
+      enabled: true,
+      plainText: markdown,
+      normalizedText: markdown,
+      threshold: 100,
+    })).toBe(false)
+  })
+
+  test('Given 普通文本或已带语义 HTML 的内容 When 粘贴 Then 不进入 Markdown 解析路径', () => {
+    const plainText = '这是一段没有 Markdown 标记的普通文本。'
+    const semanticMarkdown = '**粗体**'
+
+    expect(looksLikeMarkdownText(plainText)).toBe(false)
+    expect(looksLikeMarkdownText(semanticMarkdown)).toBe(true)
+    expect(hasRichClipboardMarkup('<p><strong>粗体</strong></p>')).toBe(true)
   })
 })

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import { DOMParser } from '@xmldom/xmldom'
-import { htmlToClipboardText, htmlToMarkdown, markdownToHtml } from './markdown-rich-text'
+import {
+  hasRichClipboardMarkup,
+  htmlToClipboardText,
+  htmlToMarkdown,
+  looksLikeMarkdownText,
+  markdownToHtml,
+} from './markdown-rich-text'
 
 function withHtmlDocument<T>(run: () => T): T {
   const originalDocument = globalThis.document
@@ -33,6 +39,18 @@ function withHtmlDocument<T>(run: () => T): T {
     Object.assign(globalThis, { document: originalDocument, Node: originalNode })
   }
 }
+
+describe('Markdown 剪贴板检测', () => {
+  test('识别常见 Markdown 文本并拒绝普通段落误判', () => {
+    expect(looksLikeMarkdownText('**粗体** 和 *斜体*\n\n---\n\n- 列表项')).toBe(true)
+    expect(looksLikeMarkdownText('这是一段没有格式标记的普通文本。')).toBe(false)
+  })
+
+  test('只把带语义标签的 HTML 当作已格式化剪贴板内容', () => {
+    expect(hasRichClipboardMarkup('<div><p>**粗体**</p></div>')).toBe(false)
+    expect(hasRichClipboardMarkup('<div><p><strong>粗体</strong></p></div>')).toBe(true)
+  })
+})
 
 describe('markdownToHtml rich preview blocks', () => {
   test('renders leading yaml frontmatter as a collapsible metadata block', () => {

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -329,6 +329,16 @@ function normalizeMarkdownLinePrefixes(markdown: string): string {
     .replace(/^\u00a0{1,3}(?=#{1,6}\s)/gm, (spaces) => ' '.repeat(spaces.length))
 }
 
+/** 判断剪贴板纯文本是否包含足够明确的 Markdown 语法。 */
+export function looksLikeMarkdownText(value: string): boolean {
+  return /(?:^|\n)\s{0,3}(?:#{1,6}\s|[-+*]\s|>\s|```|~~~|\d+[.)]\s|---\s*$)|(?:\*\*|__|~~|`[^`\n]+`|\[[^\]\n]+\]\([^)]+\)|\|[^|\n]+\|)|(?:^|\s)(?:\*[^*\n]+\*|_[^_\n]+_)/m.test(value)
+}
+
+/** 判断剪贴板 HTML 是否已经携带可直接交给 TipTap 的富文本语义。 */
+export function hasRichClipboardMarkup(value: string): boolean {
+  return /<(?:strong|b|em|i|u|s|del|h[1-6]|ul|ol|li|blockquote|pre|code|hr|table|thead|tbody|tr|th|td|a|img|video)\b/i.test(value)
+}
+
 function preprocessMarkdown(markdown: string): string {
   return splitMarkdownCodeRegions(wrapLeadingFrontmatterBlock(markdown))
     .map((chunk) => chunk.code


### PR DESCRIPTION
## 概述
修复 Markdown 内容粘贴到 Proma Agent 输入框和 Markdown 富文本编辑器后，粗体、斜体、分隔线等语法被当作普通文本并被二次转义的问题。同时修复 Markdown 长文本粘贴绕过“长文本粘贴转附件”策略的回归。

## 改动
- `apps/electron/src/renderer/lib/markdown-rich-text.ts` — 增加 Markdown 剪贴板文本识别和语义 HTML 判定。
- `apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx` — 将纯 Markdown 粘贴内容解析为 HTML/ProseMirror 内容后插入编辑器，同时保留已有富文本 HTML 粘贴行为。
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 修复 Agent 输入框的 Markdown 粘贴解析，并确保长文本附件判断优先于 Markdown 富文本插入。
- `apps/electron/src/renderer/lib/markdown-rich-text.test.ts` — 增加 Markdown 剪贴板识别和语义 HTML 判定测试。
- `apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts` — 增加长 Markdown、短 Markdown、普通文本和语义 HTML 的附件决策测试。

## 测试方法
1. 开启“输入框 Markdown 渲染”和“长文本粘贴转附件”。
2. 粘贴短 Markdown，确认粗体、斜体、列表和分隔线正常渲染且不出现 `\\*` 转义。
3. 粘贴超过 2000 字符的 Markdown，确认优先生成 Markdown 附件，不将全文直接插入输入框。
4. 粘贴已经带有 `<strong>`、`<em>` 等语义 HTML 的内容，确认保留原生富文本粘贴行为。
5. 运行 `bun test apps/electron/src/renderer/lib/markdown-rich-text.test.ts apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts`。
6. 运行 `cd apps/electron && bun run typecheck` 和 `bun run build:renderer`。

## 验证结果
- 相关测试：30 pass，0 fail。
- Electron typecheck：通过。
- Renderer build：通过，仅保留既有大 chunk 警告。
- `git diff --check`：通过。

## 备注
当前实现的自动化测试覆盖纯函数决策路径；真实 React/TipTap `handlePaste` 的完整运行时交互仍建议在开发版中手工验证。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)