### PR TITLE
fix(planning): optimize todo completion rendering

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -5036,7 +5036,7 @@ export function registerIpcHandlers(): void {
         expectedUpdatedAt: existing.updatedAt,
       })
     if (!todo) throw new Error('Todo 不存在')
-    if (todo !== existing) broadcastPlanningChanged(['todos', 'reminders'])
+    if (todo !== existing) broadcastPlanningChanged(['todos', 'reminders'], { todo })
 
     const session = createAgentSession(
       `处理：${todo.title}`,
@@ -5078,7 +5078,7 @@ export function registerIpcHandlers(): void {
     if (input.dueAt !== undefined && input.dueAt !== null && !isPlanningTimestamp(input.dueAt)) throw new Error('Todo dueAt 非法')
     if (input.expectedUpdatedAt !== undefined && !isPlanningTimestamp(input.expectedUpdatedAt)) throw new Error('Todo expectedUpdatedAt 非法')
     const todo = updateTodo(input)
-    if (todo) broadcastPlanningChanged(['todos', 'reminders'])
+    if (todo) broadcastPlanningChanged(['todos', 'reminders'], { todo })
     return todo
   })
   ipcMain.handle(PLANNING_IPC_CHANNELS.DELETE_TODO, async (_, id: string): Promise<boolean> => {

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -591,7 +591,7 @@ function buildPlanningTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinit
         if (!updated) throw new Error('Todo 不存在')
         touchTodoSession(updated.id, ctx.sessionId)
         const todo = getTodo(updated.id)!
-        broadcastPlanningChanged(['todos', 'reminders'])
+        broadcastPlanningChanged(['todos', 'reminders'], { todo })
         broadcastPlanningAgentOperation({ sessionId: ctx.sessionId, target: 'todo', action: 'updated', title: todo.title })
         return jsonToolResult({ todo })
       },
@@ -607,7 +607,7 @@ function buildPlanningTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinit
         if (!updated) throw new Error('Todo 不存在')
         touchTodoSession(updated.id, ctx.sessionId)
         const todo = getTodo(updated.id)!
-        broadcastPlanningChanged(['todos', 'reminders'])
+        broadcastPlanningChanged(['todos', 'reminders'], { todo })
         broadcastPlanningAgentOperation({ sessionId: ctx.sessionId, target: 'todo', action: 'updated', title: todo.title })
         return jsonToolResult({ todo })
       },

--- a/apps/electron/src/main/lib/planning-events.ts
+++ b/apps/electron/src/main/lib/planning-events.ts
@@ -15,8 +15,11 @@ export function onPlanningChanged(listener: (change: PlanningChange) => void): (
 }
 
 /** 广播资源级失效通知，使各窗口和原生 Surface 只刷新受影响的规划数据。 */
-export function broadcastPlanningChanged(resources: PlanningChangeResource[] = ALL_PLANNING_CHANGE_RESOURCES): void {
-  const change: PlanningChange = { resources: [...new Set(resources)] }
+export function broadcastPlanningChanged(
+  resources: PlanningChangeResource[] = ALL_PLANNING_CHANGE_RESOURCES,
+  details: Omit<PlanningChange, 'resources'> = {},
+): void {
+  const change: PlanningChange = { resources: [...new Set(resources)], ...details }
   for (const listener of planningChangeListeners) listener(change)
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed()) win.webContents.send(PLANNING_IPC_CHANNELS.CHANGED, change)

--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -17,6 +17,7 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { useShortcut } from '@/hooks/useShortcut'
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
 import { getVisibleTodoNotesSaveState, type TodoNotesSaveState } from '@/lib/todo-notes-save-state'
+import { upsertTodo } from '@/lib/todo-state'
 import { selectVisibleTodos, type TodoListView } from '@/lib/todo-view'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -222,15 +223,6 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
   const [startingTodoId, setStartingTodoId] = React.useState<string | null>(null)
   const [assigningTodoId, setAssigningTodoId] = React.useState<string | null>(null)
   const [projectPickerOpen, setProjectPickerOpen] = React.useState(false)
-  const [recentlyCompletedIds, setRecentlyCompletedIds] = React.useState<Set<string>>(() => new Set())
-  const completionTimersRef = React.useRef(new Map<string, ReturnType<typeof setTimeout>>())
-
-  React.useEffect(() => {
-    return () => {
-      for (const timer of completionTimersRef.current.values()) clearTimeout(timer)
-      completionTimersRef.current.clear()
-    }
-  }, [])
 
   const applyTodoDetailDraft = React.useCallback((todo: Todo): void => {
     const title = todo.title
@@ -281,7 +273,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
     try {
       const updated = await window.electronAPI.updateTodo({ id, ...input })
       if (updated) {
-        setTodos((items) => items.map((item) => item.id === id ? updated : item))
+        setTodos((items) => upsertTodo(items, updated))
         if (selectedTodoIdRef.current === id) {
           todoBaseUpdatedAtRef.current = updated.updatedAt
           if (savedField === 'title') {
@@ -507,42 +499,22 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
     }
   }, [setGroups, setTodos])
 
-  const completeTodo = async (todo: Todo): Promise<void> => {
+  const viewRef = React.useRef(view)
+  viewRef.current = view
+  const completeTodo = React.useCallback(async (todo: Todo): Promise<void> => {
     const updated = await updateTodo(todo.id, { status: todo.status === 'completed' ? 'open' : 'completed', expectedUpdatedAt: todo.updatedAt })
     if (!updated) return
     if (updated.status === 'completed') {
-      setRecentlyCompletedIds((current) => new Set(current).add(todo.id))
-      const previousTimer = completionTimersRef.current.get(todo.id)
-      if (previousTimer) clearTimeout(previousTimer)
-      const timer = setTimeout(() => {
-        setRecentlyCompletedIds((current) => {
-          const next = new Set(current)
-          next.delete(todo.id)
-          return next
-        })
-        completionTimersRef.current.delete(todo.id)
-      }, 420)
-      completionTimersRef.current.set(todo.id, timer)
       toast.success('已完成', {
         description: todo.title,
         action: {
           label: '撤销',
-          onClick: () => {
-            const activeTimer = completionTimersRef.current.get(todo.id)
-            if (activeTimer) clearTimeout(activeTimer)
-            completionTimersRef.current.delete(todo.id)
-            setRecentlyCompletedIds((current) => {
-              const next = new Set(current)
-              next.delete(todo.id)
-              return next
-            })
-            void updateTodo(todo.id, { status: 'open', expectedUpdatedAt: updated.updatedAt })
-          },
+          onClick: () => { void updateTodo(todo.id, { status: 'open', expectedUpdatedAt: updated.updatedAt }) },
         },
       })
+      if (viewRef.current !== 'completed') setSelectedId((current) => current === todo.id ? null : current)
     }
-    if (updated.status === 'completed' && selectedId === todo.id && view !== 'completed') setSelectedId(null)
-  }
+  }, [setSelectedId, updateTodo])
 
   const deleteTodo = async (): Promise<void> => {
     const todo = todoPendingDeletion
@@ -572,7 +544,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
         expectedUpdatedAt: todo.updatedAt,
       })
       if (!updatedTodo) throw new Error('Todo 不存在')
-      setTodos((items) => items.map((item) => item.id === updatedTodo.id ? updatedTodo : item))
+      setTodos((items) => upsertTodo(items, updatedTodo))
       setProjectPickerOpen(false)
     } catch (error) {
       console.error('[Todo] 选择项目失败:', error)
@@ -606,7 +578,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
         channelId: agentChannelId,
         modelId: agentModelId ?? undefined,
       })
-      setTodos((items) => items.map((item) => item.id === updatedTodo.id ? updatedTodo : item))
+      setTodos((items) => upsertTodo(items, updatedTodo))
       setAgentSessions((items) => [session, ...items])
       if (!standalone) {
         setCurrentWorkspaceId(workspaceId)
@@ -631,7 +603,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
   }, [agentChannelId, agentModelId, agentWorkspaces, openSession, setAgentSessions, setCurrentWorkspaceId, setPendingPrompt, setTodos, standalone, startingTodoId])
 
   const dayVersion = useLocalDayVersion()
-  const openTodos = todos.filter((todo) => todo.status === 'open')
+  const openTodos = React.useMemo(() => todos.filter((todo) => todo.status === 'open'), [todos])
   const todoGroupUsageCounts = React.useMemo(() => {
     const counts = new Map<string, number>()
     for (const todo of todos) if (todo.status === 'open' && todo.groupId) counts.set(todo.groupId, (counts.get(todo.groupId) ?? 0) + 1)
@@ -640,8 +612,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
   const todoGroupHasAssociatedItems = React.useMemo(() => new Set(todos.flatMap((todo) => todo.groupId ? [todo.groupId] : [])), [todos])
   const todayEnd = React.useMemo(() => endOfToday(dayVersion), [dayVersion])
   const weekEnd = React.useMemo(() => endOfToday(addLocalDays(dayVersion, 7)), [dayVersion])
-  const isRecentlyCompleted = (todo: Todo): boolean => recentlyCompletedIds.has(todo.id)
-  const visibleTodos = selectVisibleTodos(todos, view, todayEnd, weekEnd, recentlyCompletedIds)
+  const visibleTodos = React.useMemo(() => selectVisibleTodos(todos, view, todayEnd, weekEnd), [todayEnd, todos, view, weekEnd])
   const viewTitle = view === 'all' ? '全部任务' : view === 'today' ? '今天' : view === 'upcoming' ? '未来 7 天' : view === 'completed' ? '已完成' : groups.find((group) => `group:${group.id}` === view)?.name ?? '分组'
   const count = (predicate: (todo: Todo) => boolean): number => openTodos.filter(predicate).length
 
@@ -652,6 +623,11 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
     { id: 'completed', label: '已完成', icon: <Check size={15} /> },
   ]
   const visibleNotesSaveState = getVisibleTodoNotesSaveState(notesSaveState, notesSaveStateTodoIdRef.current, selected?.id)
+  const selectTodo = React.useCallback((todo: Todo): void => setSelectedId(todo.id), [setSelectedId])
+  const requestTodoDeletion = React.useCallback((todo: Todo): void => setTodoPendingDeletion(todo), [])
+  const updateTodoDueAt = React.useCallback((todo: Todo, dueAt?: number): void => {
+    void updateTodo(todo.id, { dueAt: dueAt ?? null, expectedUpdatedAt: todo.updatedAt })
+  }, [updateTodo])
 
   return (
     <section className="relative h-full min-h-[500px] overflow-hidden rounded-none border border-foreground/20 bg-card">
@@ -668,12 +644,12 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
           <div className="border-b border-foreground/20 px-4 py-3">
             <div className="flex items-center justify-between gap-3"><h2 className="text-sm font-semibold">{viewTitle}</h2><div className="flex items-center gap-2"><PlanningNativeSyncControl entity="reminder" />{view !== 'completed' && <span className="text-xs tabular-nums text-muted-foreground">{visibleTodos.length} 项</span>}</div></div>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">{visibleTodos.length ? visibleTodos.map((todo) => <TodoListItem key={todo.id} todo={todo} selected={selectedId === todo.id} todayEnd={todayEnd} recentlyCompleted={isRecentlyCompleted(todo)} onSelect={() => setSelectedId(todo.id)} onToggle={() => void completeTodo(todo)} onDelete={() => setTodoPendingDeletion(todo)} onUpdateDueAt={(dueAt) => void updateTodo(todo.id, { dueAt: dueAt ?? null, expectedUpdatedAt: todo.updatedAt })} />) : <div className="flex h-full min-h-56 flex-col items-center justify-center gap-3 px-8 text-center text-sm text-muted-foreground"><span>{view === 'today' ? '今天还没有安排的任务。' : '这里还没有任务。'}</span>{view !== 'all' && view !== 'completed' && <button type="button" onClick={() => setView('all')} className="text-xs font-medium text-primary underline-offset-4 hover:underline">查看全部任务</button>}</div>}</div>
+          <div className="min-h-0 flex-1 overflow-y-auto">{visibleTodos.length ? visibleTodos.map((todo) => <TodoListItem key={todo.id} todo={todo} selected={selectedId === todo.id} todayEnd={todayEnd} onSelect={selectTodo} onToggle={completeTodo} onDelete={requestTodoDeletion} onUpdateDueAt={updateTodoDueAt} />) : <div className="flex h-full min-h-56 flex-col items-center justify-center gap-3 px-8 text-center text-sm text-muted-foreground"><span>{view === 'today' ? '今天还没有安排的任务。' : '这里还没有任务。'}</span>{view !== 'all' && view !== 'completed' && <button type="button" onClick={() => setView('all')} className="text-xs font-medium text-primary underline-offset-4 hover:underline">查看全部任务</button>}</div>}</div>
         </div>
 
         {selected && <PlanningFloatingInspector inline label="Todo 详情" onClose={() => { saveDetailNotes(); saveDetailTitle(); setSelectedId(null) }}><div className="space-y-4 p-4">
           {todoConflict && <div className="flex items-center justify-between gap-3 rounded-md border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-100"><span>此 Todo 已在其他窗口更新，请重新加载后再编辑。</span><Button type="button" variant="link" size="sm" className="h-auto shrink-0 px-0 text-xs" onClick={reloadTodoDetail}>重新加载</Button></div>}
-          <div className="pr-12"><label className="sr-only" htmlFor="todo-title">任务标题</label><Input id="todo-title" value={detailTitle} onChange={(event) => { detailTitleRef.current = event.target.value; setDetailTitle(event.target.value) }} onBlur={saveDetailTitle} disabled={todoConflict} className="h-auto border-0 bg-transparent px-0 text-base font-semibold shadow-none focus-visible:ring-0" /></div><div><label className="mb-1.5 flex items-center justify-between text-xs font-medium text-muted-foreground"><span>描述</span><span aria-live="polite" className={cn('text-[11px] font-normal text-muted-foreground transition-opacity duration-300', visibleNotesSaveState ? 'opacity-100' : 'opacity-0')}>{visibleNotesSaveState === 'saving' ? '保存中…' : visibleNotesSaveState === 'saved' ? '✓ 已保存' : ''}</span></label><Textarea value={detailNotes} onChange={(event) => { detailNotesRef.current = event.target.value; setDetailNotes(event.target.value); scheduleNotesAutoSave() }} onBlur={saveDetailNotes} placeholder="添加描述…" disabled={todoConflict} className="min-h-36 resize-y overflow-y-auto scrollbar-thin border-0 bg-muted/35 text-sm shadow-none focus-visible:ring-2" /></div><DetailSection title="时间"><DetailField label="计划完成时间"><TodoDatePicker value={selected.dueAt} onChange={(dueAt) => void updateTodo(selected.id, { dueAt: dueAt ?? null, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className="h-8 w-full justify-start bg-muted/45 text-xs text-foreground hover:bg-muted" /></DetailField></DetailSection><DetailSection title="组织"><DetailField label="优先级"><Select value={selected.priority} onValueChange={(value) => void updateTodo(selected.id, { priority: value as Todo['priority'], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="high">高优先级</SelectItem><SelectItem value="medium">中优先级</SelectItem><SelectItem value="low">低优先级</SelectItem></SelectContent></Select></DetailField><DetailField label="Todo 分组"><Select value={selected.groupId ?? '__none__'} onValueChange={(value) => void updateTodo(selected.id, { groupId: value === '__none__' ? null : value, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="__none__">不分组</SelectItem>{groups.map((group) => <SelectItem key={group.id} value={group.id}>{group.name}</SelectItem>)}</SelectContent></Select></DetailField><DetailField label="标签"><div className="flex flex-wrap gap-1">{tags.length ? tags.map((tag) => <button key={tag.id} type="button" onClick={() => void updateTodo(selected.id, { tagIds: selected.tags.some((item) => item.id === tag.id) ? selected.tags.filter((item) => item.id !== tag.id).map((item) => item.id) : [...selected.tags.map((item) => item.id), tag.id], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className={cn('rounded-md px-2 py-1 text-xs transition-colors', selected.tags.some((item) => item.id === tag.id) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted')}>#{tag.name}</button>) : <span className="text-xs text-muted-foreground">暂无标签</span>}</div></DetailField></DetailSection><DetailSection title="项目与 Agent"><DetailField label="执行项目"><Popover open={projectPickerOpen} onOpenChange={setProjectPickerOpen}><PopoverTrigger asChild><button type="button" disabled={startingTodoId === selected.id || assigningTodoId === selected.id || agentWorkspaces.length === 0} className="flex h-9 w-full items-center gap-2 rounded-md bg-muted/45 px-2 text-left text-xs transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60"><span className="min-w-0 flex-1 truncate">{selected.workspaceId ? agentWorkspaces.find((workspace) => workspace.id === selected.workspaceId)?.name ?? '关联项目已不可用' : agentWorkspaces.length ? '选择项目' : '暂无可用项目'}</span><ChevronRight size={14} className="shrink-0 text-muted-foreground" /></button></PopoverTrigger><PopoverContent align="start" className="w-72 overflow-hidden p-1"><p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">选择 Todo 的执行项目</p><div className="max-h-60 overflow-y-auto">{agentWorkspaces.map((workspace) => { const isCurrent = selected.workspaceId === workspace.id; const isAssigning = assigningTodoId === selected.id; return <button key={workspace.id} type="button" disabled={isAssigning} onClick={() => void assignTodoWorkspace(selected, workspace.id)} className={cn('flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60', isCurrent && 'bg-primary/10')}><span className="min-w-0 flex-1 truncate">{workspace.name}</span><span className={cn('shrink-0 text-xs', isCurrent ? 'text-primary' : 'text-muted-foreground')}>{isAssigning ? '选择中…' : isCurrent ? '当前项目' : '选择'}</span></button> })}</div></PopoverContent></Popover></DetailField><Button type="button" size="sm" className="w-full" disabled={!selected.workspaceId || startingTodoId === selected.id || assigningTodoId === selected.id} onClick={() => { if (selected.workspaceId) void startTodoInWorkspace(selected, selected.workspaceId) }}><Bot size={15} />{startingTodoId === selected.id ? '启动中…' : '开始运行 Agent'}</Button><DetailField label="关联会话">{selected.sessionLinks.length ? <div className="space-y-1">{selected.sessionLinks.map((link) => { const session = agentSessions.find((item) => item.id === link.sessionId); return <button key={link.sessionId} type="button" disabled={!session} title={!session ? '会话不可用' : undefined} onClick={() => { if (!session) return; if (standalone) void window.electronAPI.openAgentIslandSession(session.id, session.title); else openSession('agent', session.id, session.title) }} className={cn('flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors', session ? 'bg-muted/45 hover:bg-muted' : 'cursor-not-allowed bg-muted/25 text-muted-foreground/60')}><span className="min-w-0 flex-1 truncate">{session?.title ?? '会话不可用'}</span><time className="shrink-0 tabular-nums text-[11px] text-muted-foreground">{new Date(link.lastTouchedAt).toLocaleDateString('zh-CN', { month: 'numeric', day: 'numeric' })}</time></button> })}</div> : <span className="text-xs text-muted-foreground">尚未由 Agent Session 操作</span>}</DetailField></DetailSection><div className="flex items-center justify-between border-t border-foreground/20 pt-4"><Button size="sm" variant="ghost" onClick={() => void updateTodo(selected.id, { status: selected.status === 'completed' ? 'open' : 'completed', expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}>{selected.status === 'completed' ? '恢复任务' : '标记完成'}</Button><Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => setTodoPendingDeletion(selected)}><Trash2 size={14} />删除</Button></div></div></PlanningFloatingInspector>}
+          <div className="pr-12"><label className="sr-only" htmlFor="todo-title">任务标题</label><Input id="todo-title" value={detailTitle} onChange={(event) => { detailTitleRef.current = event.target.value; setDetailTitle(event.target.value) }} onBlur={saveDetailTitle} disabled={todoConflict} className="h-auto border-0 bg-transparent px-0 text-base font-semibold shadow-none focus-visible:ring-0" /></div><div><label className="mb-1.5 flex items-center justify-between text-xs font-medium text-muted-foreground"><span>描述</span><span aria-live="polite" className={cn('text-[11px] font-normal text-muted-foreground transition-opacity duration-300', visibleNotesSaveState ? 'opacity-100' : 'opacity-0')}>{visibleNotesSaveState === 'saving' ? '保存中…' : visibleNotesSaveState === 'saved' ? '✓ 已保存' : ''}</span></label><Textarea value={detailNotes} onChange={(event) => { detailNotesRef.current = event.target.value; setDetailNotes(event.target.value); scheduleNotesAutoSave() }} onBlur={saveDetailNotes} placeholder="添加描述…" disabled={todoConflict} className="min-h-36 resize-y overflow-y-auto scrollbar-thin border-0 bg-muted/35 text-sm shadow-none focus-visible:ring-2" /></div><DetailSection title="时间"><DetailField label="计划完成时间"><TodoDatePicker value={selected.dueAt} onChange={(dueAt) => void updateTodo(selected.id, { dueAt: dueAt ?? null, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className="h-8 w-full justify-start bg-muted/45 text-xs text-foreground hover:bg-muted" /></DetailField></DetailSection><DetailSection title="组织"><DetailField label="优先级"><Select value={selected.priority} onValueChange={(value) => void updateTodo(selected.id, { priority: value as Todo['priority'], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="high">高优先级</SelectItem><SelectItem value="medium">中优先级</SelectItem><SelectItem value="low">低优先级</SelectItem></SelectContent></Select></DetailField><DetailField label="Todo 分组"><Select value={selected.groupId ?? '__none__'} onValueChange={(value) => void updateTodo(selected.id, { groupId: value === '__none__' ? null : value, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="__none__">不分组</SelectItem>{groups.map((group) => <SelectItem key={group.id} value={group.id}>{group.name}</SelectItem>)}</SelectContent></Select></DetailField><DetailField label="标签"><div className="flex flex-wrap gap-1">{tags.length ? tags.map((tag) => <button key={tag.id} type="button" onClick={() => void updateTodo(selected.id, { tagIds: selected.tags.some((item) => item.id === tag.id) ? selected.tags.filter((item) => item.id !== tag.id).map((item) => item.id) : [...selected.tags.map((item) => item.id), tag.id], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className={cn('rounded-md px-2 py-1 text-xs transition-colors', selected.tags.some((item) => item.id === tag.id) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted')}>#{tag.name}</button>) : <span className="text-xs text-muted-foreground">暂无标签</span>}</div></DetailField></DetailSection><DetailSection title="项目与 Agent"><DetailField label="执行项目"><Popover open={projectPickerOpen} onOpenChange={setProjectPickerOpen}><PopoverTrigger asChild><button type="button" disabled={startingTodoId === selected.id || assigningTodoId === selected.id || agentWorkspaces.length === 0} className="flex h-9 w-full items-center gap-2 rounded-md bg-muted/45 px-2 text-left text-xs transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60"><span className="min-w-0 flex-1 truncate">{selected.workspaceId ? agentWorkspaces.find((workspace) => workspace.id === selected.workspaceId)?.name ?? '关联项目已不可用' : agentWorkspaces.length ? '选择项目' : '暂无可用项目'}</span><ChevronRight size={14} className="shrink-0 text-muted-foreground" /></button></PopoverTrigger><PopoverContent align="start" className="w-72 overflow-hidden p-1"><p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">选择 Todo 的执行项目</p><div className="max-h-60 overflow-y-auto">{agentWorkspaces.map((workspace) => { const isCurrent = selected.workspaceId === workspace.id; const isAssigning = assigningTodoId === selected.id; return <button key={workspace.id} type="button" disabled={isAssigning} onClick={() => void assignTodoWorkspace(selected, workspace.id)} className={cn('flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60', isCurrent && 'bg-primary/10')}><span className="min-w-0 flex-1 truncate">{workspace.name}</span><span className={cn('shrink-0 text-xs', isCurrent ? 'text-primary' : 'text-muted-foreground')}>{isAssigning ? '选择中…' : isCurrent ? '当前项目' : '选择'}</span></button> })}</div></PopoverContent></Popover></DetailField><Button type="button" size="sm" className="w-full" disabled={!selected.workspaceId || startingTodoId === selected.id || assigningTodoId === selected.id} onClick={() => { if (selected.workspaceId) void startTodoInWorkspace(selected, selected.workspaceId) }}><Bot size={15} />{startingTodoId === selected.id ? '启动中…' : '开始运行 Agent'}</Button><DetailField label="关联会话">{selected.sessionLinks.length ? <div className="space-y-1">{selected.sessionLinks.map((link) => { const session = agentSessions.find((item) => item.id === link.sessionId); return <button key={link.sessionId} type="button" disabled={!session} title={!session ? '会话不可用' : undefined} onClick={() => { if (!session) return; if (standalone) void window.electronAPI.openAgentIslandSession(session.id, session.title); else openSession('agent', session.id, session.title) }} className={cn('flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors', session ? 'bg-muted/45 hover:bg-muted' : 'cursor-not-allowed bg-muted/25 text-muted-foreground/60')}><span className="min-w-0 flex-1 truncate">{session?.title ?? '会话不可用'}</span><time className="shrink-0 tabular-nums text-[11px] text-muted-foreground">{new Date(link.lastTouchedAt).toLocaleDateString('zh-CN', { month: 'numeric', day: 'numeric' })}</time></button> })}</div> : <span className="text-xs text-muted-foreground">尚未由 Agent Session 操作</span>}</DetailField></DetailSection><div className="flex items-center justify-between border-t border-foreground/20 pt-4"><Button size="sm" variant="ghost" onClick={() => void completeTodo(selected)}>{selected.status === 'completed' ? '恢复任务' : '标记完成'}</Button><Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => setTodoPendingDeletion(selected)}><Trash2 size={14} />删除</Button></div></div></PlanningFloatingInspector>}
       </div>
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="top-[34%] max-w-xl gap-0 p-3" hideClose>
@@ -708,11 +684,10 @@ function DetailSection({ title, children }: { title: string; children: React.Rea
   return <section className="space-y-3"><h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>{children}</section>
 }
 
-function TodoListItem({
+const TodoListItem = React.memo(function TodoListItem({
   todo,
   selected,
   todayEnd,
-  recentlyCompleted,
   onSelect,
   onToggle,
   onDelete,
@@ -721,11 +696,10 @@ function TodoListItem({
   todo: Todo
   selected: boolean
   todayEnd: number
-  recentlyCompleted: boolean
-  onSelect: () => void
-  onToggle: () => void
-  onDelete: () => void
-  onUpdateDueAt: (dueAt?: number) => void
+  onSelect: (todo: Todo) => void
+  onToggle: (todo: Todo) => void
+  onDelete: (todo: Todo) => void
+  onUpdateDueAt: (todo: Todo, dueAt?: number) => void
 }): React.ReactElement {
   const priorityLabel = todo.priority === 'high' ? '高优先级' : todo.priority === 'low' ? '低优先级' : '中优先级'
   const isOverdue = todo.dueAt !== undefined && todo.dueAt < Date.now() && todo.status === 'open'
@@ -735,16 +709,16 @@ function TodoListItem({
     <div
       role="button"
       tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); onSelect() } }}
-      className={cn('group flex min-h-[56px] w-full items-center gap-3 border-b border-foreground/20 px-4 py-1.5 text-left transition-colors focus:outline-none motion-reduce:animate-none', selected ? 'bg-primary/8' : 'hover:bg-muted/45 focus-visible:bg-muted/45', recentlyCompleted && 'animate-[todo-complete_420ms_ease-out]')}
+      onClick={() => onSelect(todo)}
+      onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); onSelect(todo) } }}
+      className={cn('group flex min-h-[56px] w-full items-center gap-3 border-b border-foreground/20 px-4 py-1.5 text-left transition-colors focus:outline-none', selected ? 'bg-primary/8' : 'hover:bg-muted/45 focus-visible:bg-muted/45')}
     >
-      <button type="button" aria-label={`${todo.status === 'completed' ? '恢复' : '完成'} ${todo.title}`} onClick={(event) => { event.stopPropagation(); onToggle() }} className={cn('mt-0.5 flex size-5 shrink-0 self-start items-center justify-center rounded-sm border transition-colors', todo.status === 'completed' ? 'border-primary bg-primary text-primary-foreground' : 'border-border text-transparent hover:border-primary hover:bg-primary hover:text-primary-foreground')}><Check size={12} /></button>
+      <button type="button" aria-label={`${todo.status === 'completed' ? '恢复' : '完成'} ${todo.title}`} onClick={(event) => { event.stopPropagation(); onToggle(todo) }} className={cn('mt-0.5 flex size-5 shrink-0 self-start items-center justify-center rounded-sm border transition-colors', todo.status === 'completed' ? 'border-primary bg-primary text-primary-foreground' : 'border-border text-transparent hover:border-primary hover:bg-primary hover:text-primary-foreground')}><Check size={12} /></button>
       <span className="min-w-0 flex-1">
         <span className={cn('block min-w-0 truncate text-sm font-medium', todo.status === 'completed' && 'text-muted-foreground line-through')}>{todo.title}</span>
         <span className="mt-1.5 flex flex-wrap items-center gap-1">
           <span onClick={(event) => event.stopPropagation()}>
-            <TodoDatePicker value={todo.dueAt} onChange={onUpdateDueAt} label={`设置 ${todo.title} 的计划日期`} className={cn('h-6 max-w-40 rounded-md px-1.5 text-[11px] font-medium', dueTone)} />
+            <TodoDatePicker value={todo.dueAt} onChange={(dueAt) => onUpdateDueAt(todo, dueAt)} label={`设置 ${todo.title} 的计划日期`} className={cn('h-6 max-w-40 rounded-md px-1.5 text-[11px] font-medium', dueTone)} />
           </span>
           <TodoMetaBadge tone={todo.priority === 'high' ? 'high' : todo.priority === 'low' ? 'low' : 'medium'}>{priorityLabel}</TodoMetaBadge>
           {todo.group && <TodoMetaBadge>{todo.group.name}</TodoMetaBadge>}
@@ -752,10 +726,10 @@ function TodoListItem({
           {todo.tags.map((tag) => <TodoMetaBadge key={tag.id}>#{tag.name}</TodoMetaBadge>)}
         </span>
       </span>
-      <button type="button" aria-label={`删除 ${todo.title}`} onClick={(event) => { event.stopPropagation(); onDelete() }} onKeyDown={(event) => event.stopPropagation()} className="flex size-10 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"><Trash2 size={16} /></button>
+      <button type="button" aria-label={`删除 ${todo.title}`} onClick={(event) => { event.stopPropagation(); onDelete(todo) }} onKeyDown={(event) => event.stopPropagation()} className="flex size-10 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"><Trash2 size={16} /></button>
     </div>
   )
-}
+})
 
 function TodoMetaBadge({
   children,

--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -186,6 +186,22 @@ function useLocalDayVersion(): number {
   return dayStart
 }
 
+/** 只在下一个开放 Todo 到期时刷新，避免用高频时钟破坏行级渲染隔离。 */
+function useTodoDeadlineRefresh(todos: Todo[]): void {
+  const [deadlineVersion, setDeadlineVersion] = React.useState(0)
+  React.useEffect(() => {
+    const now = Date.now()
+    let nextDueAt: number | undefined
+    for (const todo of todos) {
+      if (todo.status !== 'open' || todo.dueAt === undefined || todo.dueAt <= now) continue
+      if (nextDueAt === undefined || todo.dueAt < nextDueAt) nextDueAt = todo.dueAt
+    }
+    if (nextDueAt === undefined) return
+    const timer = window.setTimeout(() => setDeadlineVersion((version) => version + 1), Math.max(1_000, nextDueAt - now + 50))
+    return () => window.clearTimeout(timer)
+  }, [deadlineVersion, todos])
+}
+
 function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): React.ReactElement {
   const todos = useAtomValue(todosAtom)
   const groups = useAtomValue(todoPlanningGroupsAtom)
@@ -603,6 +619,8 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
   }, [agentChannelId, agentModelId, agentWorkspaces, openSession, setAgentSessions, setCurrentWorkspaceId, setPendingPrompt, setTodos, standalone, startingTodoId])
 
   const dayVersion = useLocalDayVersion()
+  useTodoDeadlineRefresh(todos)
+  const now = Date.now()
   const openTodos = React.useMemo(() => todos.filter((todo) => todo.status === 'open'), [todos])
   const todoGroupUsageCounts = React.useMemo(() => {
     const counts = new Map<string, number>()
@@ -644,7 +662,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
           <div className="border-b border-foreground/20 px-4 py-3">
             <div className="flex items-center justify-between gap-3"><h2 className="text-sm font-semibold">{viewTitle}</h2><div className="flex items-center gap-2"><PlanningNativeSyncControl entity="reminder" />{view !== 'completed' && <span className="text-xs tabular-nums text-muted-foreground">{visibleTodos.length} 项</span>}</div></div>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">{visibleTodos.length ? visibleTodos.map((todo) => <TodoListItem key={todo.id} todo={todo} selected={selectedId === todo.id} todayEnd={todayEnd} onSelect={selectTodo} onToggle={completeTodo} onDelete={requestTodoDeletion} onUpdateDueAt={updateTodoDueAt} />) : <div className="flex h-full min-h-56 flex-col items-center justify-center gap-3 px-8 text-center text-sm text-muted-foreground"><span>{view === 'today' ? '今天还没有安排的任务。' : '这里还没有任务。'}</span>{view !== 'all' && view !== 'completed' && <button type="button" onClick={() => setView('all')} className="text-xs font-medium text-primary underline-offset-4 hover:underline">查看全部任务</button>}</div>}</div>
+          <div className="min-h-0 flex-1 overflow-y-auto">{visibleTodos.length ? visibleTodos.map((todo) => <TodoListItem key={todo.id} todo={todo} selected={selectedId === todo.id} todayEnd={todayEnd} isOverdue={todo.status === 'open' && todo.dueAt !== undefined && todo.dueAt < now} onSelect={selectTodo} onToggle={completeTodo} onDelete={requestTodoDeletion} onUpdateDueAt={updateTodoDueAt} />) : <div className="flex h-full min-h-56 flex-col items-center justify-center gap-3 px-8 text-center text-sm text-muted-foreground"><span>{view === 'today' ? '今天还没有安排的任务。' : '这里还没有任务。'}</span>{view !== 'all' && view !== 'completed' && <button type="button" onClick={() => setView('all')} className="text-xs font-medium text-primary underline-offset-4 hover:underline">查看全部任务</button>}</div>}</div>
         </div>
 
         {selected && <PlanningFloatingInspector inline label="Todo 详情" onClose={() => { saveDetailNotes(); saveDetailTitle(); setSelectedId(null) }}><div className="space-y-4 p-4">
@@ -688,6 +706,7 @@ const TodoListItem = React.memo(function TodoListItem({
   todo,
   selected,
   todayEnd,
+  isOverdue,
   onSelect,
   onToggle,
   onDelete,
@@ -696,13 +715,13 @@ const TodoListItem = React.memo(function TodoListItem({
   todo: Todo
   selected: boolean
   todayEnd: number
+  isOverdue: boolean
   onSelect: (todo: Todo) => void
   onToggle: (todo: Todo) => void
   onDelete: (todo: Todo) => void
   onUpdateDueAt: (todo: Todo, dueAt?: number) => void
 }): React.ReactElement {
   const priorityLabel = todo.priority === 'high' ? '高优先级' : todo.priority === 'low' ? '低优先级' : '中优先级'
-  const isOverdue = todo.dueAt !== undefined && todo.dueAt < Date.now() && todo.status === 'open'
   const dueTone = isOverdue ? 'text-rose-700 dark:text-rose-300' : todo.dueAt !== undefined && todo.dueAt <= todayEnd ? 'text-amber-800 dark:text-amber-200' : 'text-muted-foreground'
 
   return (

--- a/apps/electron/src/renderer/lib/todo-state.ts
+++ b/apps/electron/src/renderer/lib/todo-state.ts
@@ -6,6 +6,19 @@ function isSameTodo(current: Todo, incoming: Todo): boolean {
   return current.updatedAt === incoming.updatedAt && JSON.stringify(current) === JSON.stringify(incoming)
 }
 
+/** 与 planning-manager 的 listTodos 查询排序保持一致。 */
+function compareTodos(left: Todo, right: Todo): number {
+  const statusOrder = (todo: Todo): number => todo.status === 'open' ? 0 : 1
+  const statusDifference = statusOrder(left) - statusOrder(right)
+  if (statusDifference !== 0) return statusDifference
+
+  const leftDueAt = left.dueAt
+  const rightDueAt = right.dueAt
+  if (leftDueAt === undefined) return rightDueAt === undefined ? right.updatedAt - left.updatedAt : 1
+  if (rightDueAt === undefined) return -1
+  return leftDueAt - rightDueAt || right.updatedAt - left.updatedAt
+}
+
 /**
  * 将全量快照合并进现有状态，保留未变化 Todo 的引用以避免列表行无关重渲染。
  */
@@ -18,13 +31,13 @@ export function mergeTodoSnapshot(current: Todo[], snapshot: Todo[]): Todo[] {
   return merged.length === current.length && merged.every((todo, index) => todo === current[index]) ? current : merged
 }
 
-/** 将单个 Todo 更新合并到本地列表，不影响其余 Todo 的对象引用。 */
+/** 将单个 Todo 更新合并到本地列表，并保持与持久层一致的排序和其余对象引用。 */
 export function upsertTodo(current: Todo[], incoming: Todo): Todo[] {
   const index = current.findIndex((todo) => todo.id === incoming.id)
-  if (index < 0) return [...current, incoming]
+  if (index < 0) return [...current, incoming].sort(compareTodos)
   const existing = current[index]
   if (!existing || isSameTodo(existing, incoming)) return current
   const next = [...current]
   next[index] = incoming
-  return next
+  return next.sort(compareTodos)
 }

--- a/apps/electron/src/renderer/lib/todo-state.ts
+++ b/apps/electron/src/renderer/lib/todo-state.ts
@@ -1,0 +1,30 @@
+import type { Todo } from '@proma/shared'
+
+function isSameTodo(current: Todo, incoming: Todo): boolean {
+  if (current === incoming) return true
+  // 关联的标签、分组或原生来源可在 Todo 自身 updatedAt 不变时更新；不能只比较版本号。
+  return current.updatedAt === incoming.updatedAt && JSON.stringify(current) === JSON.stringify(incoming)
+}
+
+/**
+ * 将全量快照合并进现有状态，保留未变化 Todo 的引用以避免列表行无关重渲染。
+ */
+export function mergeTodoSnapshot(current: Todo[], snapshot: Todo[]): Todo[] {
+  const currentById = new Map(current.map((todo) => [todo.id, todo]))
+  const merged = snapshot.map((incoming) => {
+    const existing = currentById.get(incoming.id)
+    return existing && isSameTodo(existing, incoming) ? existing : incoming
+  })
+  return merged.length === current.length && merged.every((todo, index) => todo === current[index]) ? current : merged
+}
+
+/** 将单个 Todo 更新合并到本地列表，不影响其余 Todo 的对象引用。 */
+export function upsertTodo(current: Todo[], incoming: Todo): Todo[] {
+  const index = current.findIndex((todo) => todo.id === incoming.id)
+  if (index < 0) return [...current, incoming]
+  const existing = current[index]
+  if (!existing || isSameTodo(existing, incoming)) return current
+  const next = [...current]
+  next[index] = incoming
+  return next
+}

--- a/apps/electron/src/renderer/lib/todo-view.ts
+++ b/apps/electron/src/renderer/lib/todo-view.ts
@@ -14,13 +14,11 @@ export function selectVisibleTodos<T extends TodoViewItem>(
   view: TodoListView,
   todayEnd: number,
   weekEnd: number,
-  recentlyCompletedIds: ReadonlySet<string> = new Set(),
 ): T[] {
-  const isRecentlyCompleted = (todo: T): boolean => recentlyCompletedIds.has(todo.id)
-  if (view === 'all') return todos.filter((todo) => todo.status === 'open' || isRecentlyCompleted(todo))
-  if (view === 'today') return todos.filter((todo) => (todo.status === 'open' && todo.dueAt !== undefined && todo.dueAt <= todayEnd) || isRecentlyCompleted(todo))
+  if (view === 'all') return todos.filter((todo) => todo.status === 'open')
+  if (view === 'today') return todos.filter((todo) => todo.status === 'open' && todo.dueAt !== undefined && todo.dueAt <= todayEnd)
   if (view === 'upcoming') return todos.filter((todo) => todo.status === 'open' && todo.dueAt !== undefined && todo.dueAt > todayEnd && todo.dueAt <= weekEnd)
   if (view === 'completed') return todos.filter((todo) => todo.status === 'completed')
   const groupId = view.slice('group:'.length)
-  return todos.filter((todo) => (todo.status === 'open' || isRecentlyCompleted(todo)) && todo.groupId === groupId)
+  return todos.filter((todo) => todo.status === 'open' && todo.groupId === groupId)
 }

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -45,6 +45,7 @@ import {
 import { updateStatusAtom, initializeUpdater } from './atoms/updater'
 import { automationsAtom } from './atoms/automation-atoms'
 import { calendarEventsAtom, calendarPlanningGroupsAtom, planningTagsAtom, todoPlanningGroupsAtom, todosAtom } from './atoms/planning-atoms'
+import { mergeTodoSnapshot, upsertTodo } from './lib/todo-state'
 import {
   notificationsEnabledAtom,
   notificationSoundEnabledAtom,
@@ -478,7 +479,7 @@ function PlanningInitializer(): null {
     const loadTodos = (): void => {
       const requestId = ++latestRequest.todos
       void window.electronAPI.listTodos().then((todos) => {
-        if (!disposed && requestId === latestRequest.todos) setTodos(todos)
+        if (!disposed && requestId === latestRequest.todos) setTodos((current) => mergeTodoSnapshot(current, todos))
       }).catch((error: unknown) => console.error('[任务/日程] 加载 Todo 失败:', error))
     }
     const loadCalendarEvents = (): void => {
@@ -514,7 +515,10 @@ function PlanningInitializer(): null {
       if (includes('tags')) loadTags()
     }
     load()
-    const unsubscribe = window.electronAPI.onPlanningChanged((change) => load(change.resources))
+    const unsubscribe = window.electronAPI.onPlanningChanged((change) => {
+      if (change.resources.includes('todos') && change.todo) setTodos((current) => upsertTodo(current, change.todo!))
+      load(change.todo ? change.resources.filter((resource) => resource !== 'todos') : change.resources)
+    })
     return () => { disposed = true; unsubscribe() }
   }, [setCalendarEvents, setCalendarGroups, setTags, setTodoGroups, setTodos])
 

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -516,8 +516,13 @@ function PlanningInitializer(): null {
     }
     load()
     const unsubscribe = window.electronAPI.onPlanningChanged((change) => {
-      if (change.resources.includes('todos') && change.todo) setTodos((current) => upsertTodo(current, change.todo!))
-      load(change.todo ? change.resources.filter((resource) => resource !== 'todos') : change.resources)
+      const todo = change.todo
+      if (change.resources.includes('todos') && todo) {
+        // 使在途快照过期，避免它在增量事件之后返回并覆盖最新 Todo。
+        latestRequest.todos += 1
+        setTodos((current) => upsertTodo(current, todo))
+      }
+      load(todo ? change.resources.filter((resource) => resource !== 'todos') : change.resources)
     })
     return () => { disposed = true; unsubscribe() }
   }, [setCalendarEvents, setCalendarGroups, setTags, setTodoGroups, setTodos])

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2438,9 +2438,3 @@
 .ProseMirror-focused .ProseMirror-gapcursor {
   display: block;
 }
-
-@keyframes todo-complete {
-  0% { opacity: 1; transform: translateY(0); }
-  55% { opacity: 0.72; transform: translateY(2px); }
-  100% { opacity: 0; transform: translateY(5px); }
-}

--- a/packages/shared/src/types/planning.ts
+++ b/packages/shared/src/types/planning.ts
@@ -20,6 +20,8 @@ export type PlanningChangeResource = 'todos' | 'calendar_events' | 'todo_groups'
 
 export interface PlanningChange {
   resources: PlanningChangeResource[]
+  /** 单项 Todo 更新可直接增量合并，避免每个窗口重新读取完整列表。 */
+  todo?: Todo
 }
 
 /** macOS 中用户可选、且当前允许 Proma 写入的 Calendar / Reminders List。 */


### PR DESCRIPTION
## Summary

- Deliver single-Todo update payloads through planning change events, avoiding an originating-window full list reload.
- Invalidate in-flight Todo snapshots when an incremental update arrives, so stale reads cannot roll back newer state.
- Preserve the planning store’s status/date/update-time ordering after incremental upserts while reusing unchanged Todo references.
- Memoize Todo rows with stable handlers and refresh only at the next Todo deadline, so unaffected rows retain render isolation.
- Remove the transient completed, strike-through row; active Todo views now remove the item immediately while retaining the undo toast.
- Remove the ad-hoc test files as requested.

## Validation

- `bun run typecheck`
- renderer, main, and preload production builds
- `git diff --check`

Existing Vite chunk warnings are unchanged.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)