### PR TITLE
fix(renderer): 修复文件预览与浏览器侧栏联动【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.62",
+  "version": "0.17.63",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.63",
+  "version": "0.17.64",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/browser-atoms.ts
+++ b/apps/electron/src/renderer/atoms/browser-atoms.ts
@@ -1,5 +1,4 @@
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
 import type { BrowserViewState } from '@proma/shared'
 import { currentAgentSessionIdAtom } from './agent-atoms'
 
@@ -10,12 +9,6 @@ export const browserPanelMinimizedMapAtom = atom<Map<string, boolean>>(new Map()
 export const browserStateMapAtom = atom<Map<string, BrowserViewState>>(new Map())
 /** 首次风险确认完成后自动加载的 Agent 回复链接。 */
 export const browserPendingNavigationMapAtom = atom<Map<string, string>>(new Map())
-
-/** 用户手动恢复文件面板后，该会话再次打开浏览器时不再自动收起。 */
-export const browserFilePanelManualRestoreSessionIdsAtom = atomWithStorage<string[]>(
-  'proma-browser-file-panel-manual-restore-session-ids',
-  [],
-)
 
 export const currentSessionBrowserStateAtom = atom<BrowserViewState | null>((get) => {
   const sessionId = get(currentAgentSessionIdAtom)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -44,6 +44,7 @@ import { WorkspaceMemoryChangeDock } from '@/components/agent-skills/WorkspaceMe
 import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
+import { browserPanelMinimizedMapAtom, browserPanelOpenMapAtom } from '@/atoms/browser-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile } from '@proma/shared'
@@ -82,31 +83,49 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const selectedFilePath = previewFileMap.get(sessionId)?.filePath
 
   const openPreview = useOpenPreview()
+  const browserOpenMap = useAtomValue(browserPanelOpenMapAtom)
+  const setBrowserMinimizedMap = useSetAtom(browserPanelMinimizedMapAtom)
+  const setBrowserOpenMap = useSetAtom(browserPanelOpenMapAtom)
+
+  const minimizeBrowserForPreview = React.useCallback(async (): Promise<void> => {
+    if (!browserOpenMap.get(sessionId)) return
+    const minimizeBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).minimizeAgentBrowser
+    try {
+      if (typeof minimizeBrowser === 'function') await minimizeBrowser(sessionId)
+    } catch (error) {
+      console.error('[受管浏览器] 为打开文件预览而最小化失败:', error)
+    } finally {
+      setBrowserMinimizedMap((previous) => { const next = new Map(previous); next.set(sessionId, true); return next })
+      setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(sessionId, false); return next })
+    }
+  }, [browserOpenMap, sessionId, setBrowserMinimizedMap, setBrowserOpenMap])
 
   // 用 ref 存 basePaths 相关值，避免声明顺序问题
   const basePathsRef = React.useRef<string[]>([])
 
-  const handleFilePreview = React.useCallback((filePath: string) => {
+  const handleFilePreview = React.useCallback(async (filePath: string) => {
+    await minimizeBrowserForPreview()
     const bp = basePathsRef.current
     openPreview(sessionId, {
       filePath,
       previewOnly: true,
       basePaths: bp.length > 0 ? bp : undefined,
     })
-  }, [sessionId, openPreview])
+  }, [minimizeBrowserForPreview, sessionId, openPreview])
 
   // Worktree 选择状态（仅用于 diff 文件点击时传递 baseRef，选取逻辑已下沉至 DiffChangesList）
   const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
   const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
 
-  const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {
+  const handleDiffFileClick = React.useCallback(async (filePath: string, _isUntracked: boolean, gitRoot?: string) => {
+    await minimizeBrowserForPreview()
     openPreview(sessionId, {
       filePath,
       dirPath: sessionPath || undefined,
       gitRoot,
       baseRef: selectedWorktreePath ? 'origin/main' : undefined,
     })
-  }, [openPreview, sessionId, sessionPath, selectedWorktreePath])
+  }, [minimizeBrowserForPreview, openPreview, sessionId, sessionPath, selectedWorktreePath])
 
   // 动画标志：isOpen 变化时启用过渡动画，切换会话时即时显示
   const prevIsOpenRef = React.useRef(isOpen)

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -42,7 +42,7 @@ import { registerShortcut } from '@/lib/shortcut-registry'
 import { cn } from '@/lib/utils'
 import { shortcutGuideOpenAtom } from '@/atoms/shortcut-guide'
 import { faqDialogOpenAtom } from '@/atoms/faq-dialog'
-import { browserFilePanelManualRestoreSessionIdsAtom, browserPanelMinimizedMapAtom, browserPanelOpenMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
+import { browserPanelMinimizedMapAtom, browserPanelOpenMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
 // 浏览器入口对所有 Agent 会话开放；来源限制由主进程浏览器策略处理。
 
 export function TabBar(): React.ReactElement {
@@ -251,7 +251,6 @@ function TabBarInner({
   const setBrowserMinimizedMap = useSetAtom(browserPanelMinimizedMapAtom)
   const browserStateMap = useAtomValue(browserStateMapAtom)
   const setBrowserStateMap = useSetAtom(browserStateMapAtom)
-  const [browserFilePanelManualRestoreSessionIds, setBrowserFilePanelManualRestoreSessionIds] = useAtom(browserFilePanelManualRestoreSessionIdsAtom)
   const activeBrowserIsOpen = activeAgentSession ? browserOpenMap.get(activeAgentSession.id) === true : false
   const hasMinimizedBrowser = Boolean(activeAgentSession && browserStateMap.has(activeAgentSession.id) && browserMinimizedMap.get(activeAgentSession.id) === true)
   const priorBrowserStateRef = React.useRef<{ sessionId: string | null; open: boolean }>({ sessionId: null, open: false })
@@ -259,13 +258,8 @@ function TabBarInner({
 
   const togglePanel = React.useCallback(() => {
     if (!isAgentContextTab(activeTab)) return
-    if (!isPanelOpen && activeAgentSession && browserOpenMap.get(activeAgentSession.id)) {
-      setBrowserFilePanelManualRestoreSessionIds((previous) => (
-        previous.includes(activeAgentSession.id) ? previous : [...previous, activeAgentSession.id]
-      ))
-    }
     setSidePanelOpen(!isPanelOpen)
-  }, [activeAgentSession, activeTab, browserOpenMap, isPanelOpen, setBrowserFilePanelManualRestoreSessionIds, setSidePanelOpen])
+  }, [activeTab, isPanelOpen, setSidePanelOpen])
 
   const openBrowser = React.useCallback(async () => {
     if (!activeAgentSession) return
@@ -285,14 +279,13 @@ function TabBarInner({
       previous.sessionId === sessionId &&
       !previous.open &&
       activeBrowserIsOpen &&
-      isPanelOpen &&
-      !browserFilePanelManualRestoreSessionIds.includes(sessionId),
+      isPanelOpen,
     )
     priorBrowserStateRef.current = { sessionId, open: activeBrowserIsOpen }
 
     if (!shouldAutoCollapse) return
     setSidePanelOpen(false)
-  }, [activeAgentSession?.id, activeBrowserIsOpen, browserFilePanelManualRestoreSessionIds, isPanelOpen, setSidePanelOpen])
+  }, [activeAgentSession?.id, activeBrowserIsOpen, isPanelOpen, setSidePanelOpen])
 
   const openShortcutGuide = React.useCallback(() => {
     setShortcutGuideOpen(true)


### PR DESCRIPTION
## 概述

修复受管浏览器与右侧文件预览之间的显示优先级：点击具体文件时会先最小化浏览器并打开预览；每次打开浏览器时仍会自动折叠当前会话的 Files 边栏。

## 改动

- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 在 Files、附加文件/目录和 Changes 的文件预览入口中，先最小化可见的受管浏览器，再调用既有预览流程，避免 `MainArea` 的浏览器优先级遮挡预览。
- `apps/electron/src/renderer/components/tabs/TabBar.tsx` — 恢复浏览器由关闭变为打开时总是折叠当前会话 Files 的行为，并移除手动恢复 Files 的例外。
- `apps/electron/src/renderer/atoms/browser-atoms.ts` — 删除已不符合当前交互规则的持久化手动恢复状态。
- `apps/electron/package.json` — 将 `@proma/electron` patch 版本递增至 `0.17.64`。

## 测试方法

1. 打开一个 Agent 会话并保持右侧 Files 面板打开。
2. 打开受管浏览器，确认 Files 自动折叠。
3. 在浏览器可见时重新展开 Files，并点击任一具体文件行。
4. 确认浏览器最小化且对应文件预览可见。
5. 在 Files、附加目录、附加文件和 Changes 中重复步骤 3-4。

## 备注

- 已运行 `bun run typecheck`。
- 已运行 `bun run --filter='@proma/electron' build:renderer`。
- 已运行 `git diff --check`。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)