### PR TITLE
feat(agent): 支持置顶 Skills 并优化斜杠菜单【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.64",
+  "version": "0.17.65",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -301,6 +301,7 @@ import {
   getAllWorkspaceSkills,
   getOtherWorkspaceSkills,
   getDefaultSkillSlugs,
+  setWorkspaceSkillPinned,
   getWorkspaceCapabilities,
   getAgentWorkspace,
   getProjectFilesPath,
@@ -2621,6 +2622,13 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.TOGGLE_SKILL,
     async (_, workspaceSlug: string, skillSlug: string, enabled: boolean): Promise<void> => {
       return toggleWorkspaceSkill(workspaceSlug, skillSlug, enabled)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.TOGGLE_SKILL_PIN,
+    async (_, workspaceSlug: string, skillSlug: string, pinned: boolean): Promise<void> => {
+      return setWorkspaceSkillPinned(workspaceSlug, skillSlug, pinned)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -695,7 +695,7 @@ export function saveWorkspaceMcpConfig(workspaceSlug: string, config: WorkspaceM
 
 /** 扫描工作区活跃 Skills，仅返回 skills/ 下的 Skill */
 export function getWorkspaceSkills(workspaceSlug: string): SkillMeta[] {
-  return scanSkillsInDir(getWorkspaceSkillsDir(workspaceSlug), true)
+  return applySkillPins(scanSkillsInDir(getWorkspaceSkillsDir(workspaceSlug), true), workspaceSlug)
 }
 
 /** 解析 SKILL.md 的 YAML frontmatter，支持单行值、block scalar（`|` / `>`）和多行缩进 */
@@ -781,6 +781,13 @@ export function deleteWorkspaceSkill(workspaceSlug: string, skillSlug: string): 
   }
 
   rmSyncWithRetry(skillPath, { recursive: true, force: true })
+  const config = readWorkspaceConfig(workspaceSlug)
+  if (config.pinnedSkillSlugs?.includes(skillSlug)) {
+    writeWorkspaceConfig(workspaceSlug, {
+      ...config,
+      pinnedSkillSlugs: config.pinnedSkillSlugs.filter((slug) => slug !== skillSlug),
+    })
+  }
   console.log(`[Agent 工作区] 已删除 Skill: ${workspaceSlug}/${skillSlug}`)
 }
 
@@ -853,7 +860,28 @@ export function getDefaultSkillSlugs(): string[] {
 export function getAllWorkspaceSkills(workspaceSlug: string): SkillMeta[] {
   const activeSkills = scanSkillsInDir(getWorkspaceSkillsDir(workspaceSlug), true)
   const inactiveSkills = scanSkillsInDir(getInactiveSkillsDir(workspaceSlug), false)
-  return [...activeSkills, ...inactiveSkills]
+  return applySkillPins([...activeSkills, ...inactiveSkills], workspaceSlug)
+}
+
+/** Sets the per-workspace priority used by the chat input's `/` Skill menu. */
+export function setWorkspaceSkillPinned(workspaceSlug: string, skillSlug: string, pinned: boolean): void {
+  if (!getAllWorkspaceSkills(workspaceSlug).some((skill) => skill.slug === skillSlug)) {
+    throw new Error(`Skill 不存在: ${skillSlug}`)
+  }
+
+  const config = readWorkspaceConfig(workspaceSlug)
+  const current = config.pinnedSkillSlugs ?? []
+  const pinnedSkillSlugs = pinned
+    ? [...new Set([...current, skillSlug])]
+    : current.filter((slug) => slug !== skillSlug)
+
+  writeWorkspaceConfig(workspaceSlug, { ...config, pinnedSkillSlugs })
+  console.log(`[Agent 工作区] Skill ${pinned ? '置顶' : '取消置顶'}: ${workspaceSlug}/${skillSlug}`)
+}
+
+function applySkillPins(skills: SkillMeta[], workspaceSlug: string): SkillMeta[] {
+  const pinnedSkillSlugs = new Set(readWorkspaceConfig(workspaceSlug).pinnedSkillSlugs ?? [])
+  return skills.map((skill) => ({ ...skill, pinned: pinnedSkillSlugs.has(skill.slug) }))
 }
 
 /** 在 skills/ 和 skills-inactive/ 之间移动来切换启用/禁用 */
@@ -1819,6 +1847,8 @@ interface WorkspaceConfig {
   attachedDirectories?: string[]
   attachedFiles?: string[]
   worktreeRepos?: import('@proma/shared').WorkspaceWorktreeRepo[]
+  /** Skill slugs surfaced before other matching Skills in the chat `/` menu. */
+  pinnedSkillSlugs?: string[]
   /** User consent for Agent-initiated maintenance of the two AGENTS.md files. */
   projectKnowledgeMaintenanceApproved?: boolean
   /** Internal scheduling metadata only; Markdown remains the long-term memory source. */
@@ -1850,6 +1880,9 @@ function readWorkspaceConfig(workspaceSlug: string): WorkspaceConfig {
         : undefined,
       worktreeRepos: Array.isArray(data.worktreeRepos)
         ? data.worktreeRepos.filter((r) => r && typeof r.name === 'string' && typeof r.repoPath === 'string' && typeof r.worktreesPath === 'string')
+        : undefined,
+      pinnedSkillSlugs: Array.isArray(data.pinnedSkillSlugs)
+        ? [...new Set(data.pinnedSkillSlugs.filter((slug): slug is string => typeof slug === 'string'))]
         : undefined,
       projectKnowledgeMaintenanceApproved: data.projectKnowledgeMaintenanceApproved === true ? true : undefined,
       // Read the prior public setting only to preserve its cooldown timestamp; its

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -652,6 +652,9 @@ export interface ElectronAPI {
   /** 切换工作区 Skill 启用/禁用 */
   toggleWorkspaceSkill: (workspaceSlug: string, skillSlug: string, enabled: boolean) => Promise<void>
 
+  /** 切换工作区 Skill 的置顶状态 */
+  setWorkspaceSkillPinned: (workspaceSlug: string, skillSlug: string, pinned: boolean) => Promise<void>
+
   /** 获取其他工作区的 Skill 列表 */
   getOtherWorkspaceSkills: (currentSlug: string) => Promise<OtherWorkspaceSkillsGroup[]>
 
@@ -1900,6 +1903,10 @@ const electronAPI: ElectronAPI = {
 
   toggleWorkspaceSkill: (workspaceSlug: string, skillSlug: string, enabled: boolean) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_SKILL, workspaceSlug, skillSlug, enabled)
+  },
+
+  setWorkspaceSkillPinned: (workspaceSlug: string, skillSlug: string, pinned: boolean) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_SKILL_PIN, workspaceSlug, skillSlug, pinned)
   },
 
   getOtherWorkspaceSkills: (currentSlug: string) => {

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -385,6 +385,7 @@ export function AgentSkillsView(): React.ReactElement {
               isBuiltin={(slug) => data.defaultSkillSlugs.has(slug)}
               onOpen={setSelectedSkillSlug}
               onToggle={data.toggleSkill}
+              onTogglePin={data.toggleSkillPin}
               onUpdate={data.updateSkill}
             />
           ) : tab === 'mcp' ? (
@@ -503,6 +504,7 @@ interface SkillsTabProps {
   isBuiltin: (slug: string) => boolean
   onOpen: (slug: string) => void
   onToggle: (slug: string, enabled: boolean) => void
+  onTogglePin: (slug: string, pinned: boolean) => void
   onUpdate: (slug: string) => void
 }
 
@@ -515,6 +517,7 @@ function SkillsTab({
   isBuiltin,
   onOpen,
   onToggle,
+  onTogglePin,
   onUpdate,
 }: SkillsTabProps): React.ReactElement {
   if (total === 0) {
@@ -532,10 +535,10 @@ function SkillsTab({
         </div>
       )}
       {customSkills.length > 0 && (
-        <SkillSection title="我的 Skills" skills={customSkills} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onUpdate={onUpdate} />
+        <SkillSection title="我的 Skills" skills={customSkills} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onTogglePin={onTogglePin} onUpdate={onUpdate} />
       )}
       {builtinSkills.length > 0 && (
-        <SkillSection title="PROMA 内置" skills={builtinSkills} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onUpdate={onUpdate} />
+        <SkillSection title="PROMA 内置" skills={builtinSkills} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onTogglePin={onTogglePin} onUpdate={onUpdate} />
       )}
     </div>
   )
@@ -548,10 +551,11 @@ interface SkillSectionProps {
   updatingSkill: string | null
   onOpen: (slug: string) => void
   onToggle: (slug: string, enabled: boolean) => void
+  onTogglePin: (slug: string, pinned: boolean) => void
   onUpdate: (slug: string) => void
 }
 
-function SkillSection({ title, skills, isBuiltin, updatingSkill, onOpen, onToggle, onUpdate }: SkillSectionProps): React.ReactElement {
+function SkillSection({ title, skills, isBuiltin, updatingSkill, onOpen, onToggle, onTogglePin, onUpdate }: SkillSectionProps): React.ReactElement {
   const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set())
   const groups = React.useMemo(() => groupSkills(skills), [skills])
 
@@ -594,6 +598,7 @@ function SkillSection({ title, skills, isBuiltin, updatingSkill, onOpen, onToggl
                       updating={updatingSkill === skill.slug}
                       onOpen={() => onOpen(skill.slug)}
                       onToggle={(enabled) => onToggle(skill.slug, enabled)}
+                      onTogglePin={(pinned) => onTogglePin(skill.slug, pinned)}
                       onUpdate={() => onUpdate(skill.slug)}
                     />
                   ))}

--- a/apps/electron/src/renderer/components/agent-skills/SkillCard.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillCard.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react'
-import { Sparkles, RefreshCw, ShieldCheck, ArrowDownToLine } from 'lucide-react'
+import { Sparkles, RefreshCw, ShieldCheck, ArrowDownToLine, Pin } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -17,10 +17,11 @@ interface SkillCardProps {
   updating: boolean
   onOpen: () => void
   onToggle: (enabled: boolean) => void
+  onTogglePin: (pinned: boolean) => void
   onUpdate: () => void
 }
 
-export function SkillCard({ skill, isBuiltin, updating, onOpen, onToggle, onUpdate }: SkillCardProps): React.ReactElement {
+export function SkillCard({ skill, isBuiltin, updating, onOpen, onToggle, onTogglePin, onUpdate }: SkillCardProps): React.ReactElement {
   return (
     <div
       role="button"
@@ -53,12 +54,31 @@ export function SkillCard({ skill, isBuiltin, updating, onOpen, onToggle, onUpda
           </div>
           <div className="mt-0.5 truncate text-xs text-muted-foreground">{skill.slug}</div>
         </div>
-        <Switch
-          checked={skill.enabled}
-          onCheckedChange={onToggle}
-          onClick={(e) => e.stopPropagation()}
-          className="shrink-0"
-        />
+        <div className="flex shrink-0 items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={skill.pinned ? '取消置顶 Skill' : '置顶 Skill'}
+                onClick={(e) => { e.stopPropagation(); onTogglePin(!skill.pinned) }}
+                className={cn(
+                  'flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[opacity,colors] hover:bg-muted hover:text-foreground',
+                  skill.pinned
+                    ? 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+                    : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100',
+                )}
+              >
+                <Pin size={14} fill={skill.pinned ? 'currentColor' : 'none'} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">{skill.pinned ? '取消置顶' : '置顶到 / 菜单顶部'}</TooltipContent>
+          </Tooltip>
+          <Switch
+            checked={skill.enabled}
+            onCheckedChange={onToggle}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
       </div>
 
       <p className="line-clamp-2 min-h-[40px] text-[13px] leading-6 text-muted-foreground">

--- a/apps/electron/src/renderer/components/agent-skills/skillGrouping.test.ts
+++ b/apps/electron/src/renderer/components/agent-skills/skillGrouping.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test'
+import { groupSkills } from './skillGrouping'
+
+test('places pinned Skills first within their own category without changing category order', () => {
+  const groups = groupSkills([
+    { slug: 'docs-first', name: 'Docs first', group: '文档', enabled: true },
+    { slug: 'docs-pinned', name: 'Docs pinned', group: '文档', enabled: true, pinned: true },
+    { slug: 'dev-pinned', name: 'Dev pinned', group: '开发', enabled: true, pinned: true },
+    { slug: 'dev-first', name: 'Dev first', group: '开发', enabled: true },
+  ])
+
+  expect(groups.map((group) => group.title)).toEqual(['开发', '文档'])
+  expect(groups.find((group) => group.title === '开发')?.skills.map((skill) => skill.slug)).toEqual([
+    'dev-pinned',
+    'dev-first',
+  ])
+  expect(groups.find((group) => group.title === '文档')?.skills.map((skill) => skill.slug)).toEqual([
+    'docs-pinned',
+    'docs-first',
+  ])
+})

--- a/apps/electron/src/renderer/components/agent-skills/skillGrouping.ts
+++ b/apps/electron/src/renderer/components/agent-skills/skillGrouping.ts
@@ -35,9 +35,17 @@ export function groupSkills(skills: SkillMeta[]): SkillGroup[] {
     .map(([title, groupSkills]) => ({
       id: title.toLowerCase(),
       title,
-      skills: groupSkills,
+      skills: orderPinnedSkills(groupSkills),
     }))
     .sort((a, b) => compareGroupTitle(a.title, b.title))
+}
+
+/** Keep categories in their existing order while surfacing pinned Skills within each category. */
+function orderPinnedSkills(skills: SkillMeta[]): SkillMeta[] {
+  return skills
+    .map((skill, index) => ({ skill, index }))
+    .sort((left, right) => Number(Boolean(right.skill.pinned)) - Number(Boolean(left.skill.pinned)) || left.index - right.index)
+    .map(({ skill }) => skill)
 }
 
 function compareGroupTitle(a: string, b: string): number {

--- a/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
+++ b/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
@@ -31,6 +31,7 @@ export interface AgentSkillsData {
   builtinMcpServers: BuiltinMcpServerSummary[]
   updatingSkill: string | null
   toggleSkill: (slug: string, enabled: boolean) => Promise<void>
+  toggleSkillPin: (slug: string, pinned: boolean) => Promise<void>
   deleteSkill: (slug: string, name: string) => Promise<boolean>
   updateSkill: (slug: string) => Promise<void>
   refreshMcpConfig: () => Promise<void>
@@ -102,6 +103,17 @@ export function useAgentSkillsData(): AgentSkillsData {
       toast.error('切换 Skill 状态失败')
     }
   }, [workspaceSlug])
+
+  const toggleSkillPin = React.useCallback(async (slug: string, pinned: boolean) => {
+    try {
+      await window.electronAPI.setWorkspaceSkillPinned(workspaceSlug, slug, pinned)
+      setSkills((prev) => prev.map((skill) => (skill.slug === slug ? { ...skill, pinned } : skill)))
+      bumpCapabilitiesVersion((v) => v + 1)
+    } catch (error) {
+      console.error('[Agent 技能] 切换 Skill 置顶状态失败:', error)
+      toast.error('切换 Skill 置顶状态失败')
+    }
+  }, [workspaceSlug, bumpCapabilitiesVersion])
 
   const deleteSkill = React.useCallback(async (slug: string, name: string): Promise<boolean> => {
     try {
@@ -203,6 +215,7 @@ export function useAgentSkillsData(): AgentSkillsData {
     builtinMcpServers,
     updatingSkill,
     toggleSkill,
+    toggleSkillPin,
     deleteSkill,
     updateSkill,
     refreshMcpConfig,

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -11,6 +11,7 @@ import type { SuggestionOptions } from '@tiptap/suggestion'
 import { CalendarDays, ListTodo, MessageSquareText, Sparkles, Server } from 'lucide-react'
 import { MentionList } from './MentionList'
 import type { MentionListRef } from './MentionList'
+import { orderSkillsForMention } from './skill-mention-ordering'
 import { createDebouncedSuggestionLoader, createLatestSuggestionRequestGuard, createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from './mention-popup-utils'
 import type { AgentSessionReferenceSearchResult } from '@proma/shared'
 import { shouldAllowMentionTrigger, shouldShowMentionSuggestion } from '@/components/ai-elements/mention-utils'
@@ -212,6 +213,7 @@ export interface SkillMentionItem {
   id: string
   name: string
   description?: string
+  pinned?: boolean
 }
 
 export function createSkillMentionSuggestion(
@@ -226,15 +228,15 @@ export function createSkillMentionSuggestion(
       emptyText: '无匹配 Skill',
       fetchItems: async (slug, q) => {
         const caps = await window.electronAPI.getWorkspaceCapabilities(slug)
-        return caps.skills
+        return orderSkillsForMention(caps.skills
           .filter((s) => s.enabled)
           .filter((s) => !q || s.name.toLowerCase().includes(q) || (s.slug ?? '').toLowerCase().includes(q))
-          .map((s) => ({ id: s.slug, name: s.name, description: s.description }))
+        ).map((s) => ({ id: s.slug, name: s.name, description: s.description, pinned: s.pinned }))
       },
       keyExtractor: (item) => item.id,
       renderItem: (item) => (
         <>
-          <Sparkles className="size-3.5 text-violet-500 flex-shrink-0" />
+          <Sparkles className={`size-3.5 flex-shrink-0 ${item.pinned ? 'text-yellow-500' : 'text-violet-500'}`} />
           <span className="truncate font-medium flex-1 min-w-0">{item.name}</span>
           {item.description && (
             <span className="truncate text-[10px] text-muted-foreground/50 max-w-[120px]">{item.description}</span>

--- a/apps/electron/src/renderer/components/agent/skill-mention-ordering.test.ts
+++ b/apps/electron/src/renderer/components/agent/skill-mention-ordering.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test'
+import { orderSkillsForMention } from './skill-mention-ordering'
+
+test('places pinned Skills first without changing the relative order within each group', () => {
+  const skills = [
+    { slug: 'first' },
+    { slug: 'pinned-first', pinned: true },
+    { slug: 'second' },
+    { slug: 'pinned-second', pinned: true },
+  ]
+
+  expect(orderSkillsForMention(skills).map((skill) => skill.slug)).toEqual([
+    'pinned-first',
+    'pinned-second',
+    'first',
+    'second',
+  ])
+})

--- a/apps/electron/src/renderer/components/agent/skill-mention-ordering.ts
+++ b/apps/electron/src/renderer/components/agent/skill-mention-ordering.ts
@@ -1,0 +1,6 @@
+export function orderSkillsForMention<T extends { pinned?: boolean }>(skills: readonly T[]): T[] {
+  return skills
+    .map((skill, index) => ({ skill, index }))
+    .sort((left, right) => Number(Boolean(right.skill.pinned)) - Number(Boolean(left.skill.pinned)) || left.index - right.index)
+    .map(({ skill }) => skill)
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1002,6 +1002,8 @@ export interface SkillMeta {
   icon?: string
   version?: string
   enabled: boolean
+  /** Whether this workspace prioritizes the Skill in the `/` command menu. */
+  pinned?: boolean
   /** 如果此 Skill 是从其他工作区导入的，则携带来源信息 */
   importSource?: SkillImportSource
   /** 是否有可用更新（源 Skill 版本 > importSource.sourceVersion） */
@@ -1739,6 +1741,8 @@ export const AGENT_IPC_CHANNELS = {
   DELETE_SKILL: 'agent:delete-skill',
   /** 切换工作区 Skill 启用/禁用 */
   TOGGLE_SKILL: 'agent:toggle-skill',
+  /** 切换工作区 Skill 的置顶状态 */
+  TOGGLE_SKILL_PIN: 'agent:toggle-skill-pin',
   /** 获取其他工作区的 Skill 列表 */
   GET_OTHER_WORKSPACE_SKILLS: 'agent:get-other-workspace-skills',
   /** 获取默认 Skills 的 slug 列表（来自 ~/.proma/default-skills/） */


### PR DESCRIPTION
## 概述

为每个 Agent 工作区增加可持久化的 Skill 置顶偏好。置顶项会在 Agent 技能页的所属分类中优先显示，并在聊天输入框的 `/` 调用列表中排在顶部、使用黄色图标标识。

## 改动

- `apps/electron/src/main/lib/agent-workspace-manager.ts` — 在工作区 `config.json` 中保存 `pinnedSkillSlugs`，读取能力时附加置顶状态，删除 Skill 时清理残留偏好。
- `packages/shared/src/types/agent.ts`、`apps/electron/src/main/ipc.ts`、`apps/electron/src/preload/index.ts` — 增加置顶 Skill 的共享类型和主进程 IPC 契约。
- `apps/electron/src/renderer/components/agent-skills/*` — 增加图钉交互；已置顶项常显，未置顶项只在 hover 或键盘聚焦时显示；分类内部将置顶项稳定排在最前。
- `apps/electron/src/renderer/components/agent/mention-suggestions.tsx` — `/` 菜单仅展示启用项，将置顶项稳定排到顶部，并用黄色 Sparkles 区分。
- `apps/electron/src/renderer/components/agent*/**/*.test.ts` — 新增 `/` 列表和分类内排序的稳定性测试。
- `apps/electron/package.json`、`packages/shared/package.json` — 分别递增至 `0.17.65` 与 `0.1.64`。

## 测试方法

1. 打开 Agent 技能页，悬浮未置顶 Skill，点击图钉并确认其在所属分类首位且图钉常显。
2. 在聊天输入框输入 `/`，确认已置顶且启用的 Skill 出现在匹配列表顶部，左侧图标为黄色；取消置顶后恢复紫色和原排序。
3. 禁用、重新启用或删除已置顶 Skill，确认 `/` 列表只显示启用项且删除后不保留置顶状态。
4. 运行 `bun test ./apps/electron/src/renderer/components/agent/skill-mention-ordering.test.ts ./apps/electron/src/renderer/components/agent-skills/skillGrouping.test.ts`。
5. 运行 `bun run --filter="@proma/shared" typecheck`、`bun run --filter="@proma/electron" build:main`、`build:preload` 与 `build:renderer`。

## 备注

- 改动已基于最新 `origin/main`（`9af18167`）重新应用并完成本地准 PR 审核，未发现阻断性缺陷。
- `/` 列表与分类排序均保持同一优先级内的原有相对顺序。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)