### PR TITLE
feat(agent): unify right workspace tabs

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -511,7 +511,7 @@ export const agentSidePanelOpenAtomFamily = atomFamily((sessionId: string) => at
 ))
 
 /** 侧面板宽度（全局共享，用户拖拽后持久化） */
-export const agentSidePanelWidthAtom = atomWithStorage<number>('proma-agent-sidepanel-width', 280)
+export const agentSidePanelWidthAtom = atomWithStorage<number>('proma-agent-workspace-width', 460)
 
 /** 文件来源选择：按会话持久化，未存储的会话默认显示会话文件。 */
 export type AgentFileSourceFilter = 'session' | 'project'
@@ -522,7 +522,29 @@ export const agentFileSourceFilterMapAtom = atomWithStorage<Record<string, Agent
   { getOnInit: true },
 )
 
-export type AgentSidePanelTab = 'files' | 'changes' | 'chat'
+export type AgentSidePanelBaseTab = 'files' | 'changes' | 'memory' | 'chat'
+/** 项目记忆、每个浏览器网页和文件预览都处于右侧工作区顶栏。 */
+export type AgentSidePanelTab = AgentSidePanelBaseTab | `browser:${string}` | `preview:${string}`
+
+export function getBrowserSidePanelTab(tabId: string): AgentSidePanelTab {
+  return `browser:${tabId}`
+}
+
+export function getBrowserTabIdFromSidePanelTab(tab: AgentSidePanelTab | 'browser'): string | null {
+  return tab.startsWith('browser:') ? tab.slice('browser:'.length) : null
+}
+
+export function isBrowserSidePanelTab(tab: AgentSidePanelTab | 'browser' | 'preview'): tab is `browser:${string}` {
+  return tab.startsWith('browser:')
+}
+
+export function getPreviewSidePanelTab(previewId: string): AgentSidePanelTab {
+  return `preview:${previewId}`
+}
+
+export function getPreviewIdFromSidePanelTab(tab: AgentSidePanelTab | 'preview'): string | null {
+  return tab.startsWith('preview:') ? tab.slice('preview:'.length) : null
+}
 
 /** 当前会话的侧面板是否打开，并将写入定向到当前会话。 */
 export const currentSessionSidePanelOpenAtom = atom(
@@ -536,8 +558,11 @@ export const currentSessionSidePanelOpenAtom = atom(
   },
 )
 
-/** 侧面板当前 Tab：Files / 文件改动 / Chat（per-session Map） */
-export const agentDiffPanelTabAtom = atom<Map<string, AgentSidePanelTab>>(new Map())
+/** 项目记忆 Diff 预览是否已作为当前会话的可关闭工作区 Tab 打开。 */
+export const agentMemoryPanelOpenAtomFamily = atomFamily((sessionId: string) => atom(false))
+
+/** 侧面板当前工作区：基础视图或某个浏览器网页（per-session Map）。 */
+export const agentDiffPanelTabAtom = atom<Map<string, AgentSidePanelTab | 'browser' | 'preview'>>(new Map())
 
 /** Diff 视图模式：'split' | 'unified'，默认使用统一预览 */
 export const agentDiffViewModeAtom = atom<'split' | 'unified'>('unified')

--- a/apps/electron/src/renderer/atoms/memory-change-atoms.ts
+++ b/apps/electron/src/renderer/atoms/memory-change-atoms.ts
@@ -1,8 +1,21 @@
 import { atom } from 'jotai'
+import { atomFamily } from 'jotai/utils'
 import type { WorkspaceMemoryFileChange } from '@proma/shared'
 
 /** Renderer-lifetime presentation state for the global, current-workspace Memory change dock. */
 export const workspaceMemoryChangesAtom = atom<Map<string, WorkspaceMemoryFileChange[]>>(new Map())
+
+/** 当前会话内联记忆编辑器的未保存与外部更新状态，供 Tab 切换/关闭保护使用。 */
+export interface WorkspaceMemoryEditingState {
+  editingPath: string | null
+  dirty: boolean
+  remoteChanged: boolean
+}
+export const workspaceMemoryEditingStateAtomFamily = atomFamily((_sessionId: string) => atom<WorkspaceMemoryEditingState>({
+  editingPath: null,
+  dirty: false,
+  remoteChanged: false,
+}))
 
 /** One-shot route from the global dock into WorkspaceMemoryTab. */
 export const memoryFileNavigationAtom = atom<{

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -33,29 +33,22 @@ export interface PreviewFile {
 
 // ===== Atoms =====
 
+/** 预览 Tab 的稳定 key：同一文件在不同预览/比较上下文可独立打开。 */
+export function getPreviewFileId(file: PreviewFile): string {
+  return [file.filePath, file.previewOnly ? 'preview' : 'diff', file.gitRoot ?? '', file.baseRef ?? ''].join('\u0000')
+}
+
 /** 每会话预览面板开关 */
 export const previewPanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 
-/** 每会话当前预览的文件（null 时显示 DiffChangesList） */
+/** 每会话已打开的预览文件；非激活项只保留轻量元数据。 */
+export const previewFilesMapAtom = atom<Map<string, PreviewFile[]>>(new Map())
+
+/** 每会话当前预览的文件（兼容旧调用方的激活文件投影）。 */
 export const previewFileMapAtom = atom<Map<string, PreviewFile | null>>(new Map())
 
 /** 分栏比例（对话占比），持久化 */
 export const previewSplitRatioAtom = atomWithStorage<number>('proma-preview-split-ratio', 0.5, undefined, { getOnInit: true })
-
-/**
- * 预览默认展开方式，持久化。
- * - 'tab'   = 以预览标签页形式打开（旧版默认）
- * - 'split' = 在主区域右侧分屏展开（可同时看到 Agent 输出与文件内容）
- *
- * 用户仍可通过拖拽 Tab 出区域、PreviewPanel 顶栏按钮等即时切换。
- */
-export type PreviewModePreference = 'tab' | 'split'
-export const previewModePreferenceAtom = atomWithStorage<PreviewModePreference>(
-  'proma-preview-mode-pref',
-  'tab',
-  undefined,
-  { getOnInit: true },
-)
 
 /** 代码预览换行偏好（默认不换行，保持现有横向滚动行为） */
 export const previewCodeWrapAtom = atomWithStorage<boolean>(

--- a/apps/electron/src/renderer/atoms/sidebar-atoms.ts
+++ b/apps/electron/src/renderer/atoms/sidebar-atoms.ts
@@ -22,5 +22,5 @@ export const projectListHeightAtom = atomWithStorage<number>(
 /** 左侧边栏宽度（px），用户可拖拽调整，持久化到 localStorage */
 export const leftSidebarWidthAtom = atomWithStorage<number>(
   'proma-left-sidebar-width',
-  300,
+  240,
 )

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeDock.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeDock.tsx
@@ -6,6 +6,7 @@ import { WorkspaceMemoryChangeShelf } from './WorkspaceMemoryChangeShelf'
 
 interface WorkspaceMemoryChangeDockProps {
   workspaceSlug: string
+  sessionId: string
   className?: string
 }
 
@@ -21,7 +22,7 @@ function flattenMemoryFiles(nodes: SkillFileNode[]): MemoryFileListItem[] {
 }
 
 /** 紧凑项目记忆 Diff 预览；变更观察由 App Shell 常驻处理。 */
-export function WorkspaceMemoryChangeDock({ workspaceSlug, className }: WorkspaceMemoryChangeDockProps): React.ReactElement | null {
+export function WorkspaceMemoryChangeDock({ workspaceSlug, sessionId, className }: WorkspaceMemoryChangeDockProps): React.ReactElement | null {
   const updatesByWorkspace = useAtomValue(workspaceMemoryChangesAtom)
   const changes = updatesByWorkspace.get(workspaceSlug) ?? []
   const [memoryFiles, setMemoryFiles] = React.useState<MemoryFileListItem[]>([])
@@ -38,6 +39,7 @@ export function WorkspaceMemoryChangeDock({ workspaceSlug, className }: Workspac
   return (
     <WorkspaceMemoryChangeShelf
       workspaceSlug={workspaceSlug}
+      sessionId={sessionId}
       changes={changes}
       memoryFiles={memoryFiles}
       className={className ?? '-mx-2 -mb-2 mt-1 shrink-0 border-t border-border/70 bg-content-area'}

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeDock.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeDock.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import type { SkillFileNode, WorkspaceMemoryFileChange } from '@proma/shared'
+import type { SkillFileNode } from '@proma/shared'
 import { workspaceMemoryChangesAtom } from '@/atoms/memory-change-atoms'
 import { WorkspaceMemoryChangeShelf } from './WorkspaceMemoryChangeShelf'
 
 interface WorkspaceMemoryChangeDockProps {
   workspaceSlug: string
+  className?: string
 }
 
 interface MemoryFileListItem {
@@ -19,8 +20,8 @@ function flattenMemoryFiles(nodes: SkillFileNode[]): MemoryFileListItem[] {
     : [{ relativePath: node.relativePath, modifiedAt: node.modifiedAt }])
 }
 
-/** Embedded at the bottom of the right file panel; observation is handled by App Shell. */
-export function WorkspaceMemoryChangeDock({ workspaceSlug }: WorkspaceMemoryChangeDockProps): React.ReactElement | null {
+/** 紧凑项目记忆 Diff 预览；变更观察由 App Shell 常驻处理。 */
+export function WorkspaceMemoryChangeDock({ workspaceSlug, className }: WorkspaceMemoryChangeDockProps): React.ReactElement | null {
   const updatesByWorkspace = useAtomValue(workspaceMemoryChangesAtom)
   const changes = updatesByWorkspace.get(workspaceSlug) ?? []
   const [memoryFiles, setMemoryFiles] = React.useState<MemoryFileListItem[]>([])
@@ -34,21 +35,12 @@ export function WorkspaceMemoryChangeDock({ workspaceSlug }: WorkspaceMemoryChan
     void refreshMemoryFiles().catch(() => {})
   }, [refreshMemoryFiles, changes[0]?.changedAt])
 
-  const open = React.useCallback((change?: WorkspaceMemoryFileChange) => {
-    void window.electronAPI.openWorkspaceMemoryWindow(workspaceSlug, change?.relativePath)
-  }, [workspaceSlug])
-
-  const openFile = React.useCallback((relativePath: string) => {
-    void window.electronAPI.openWorkspaceMemoryWindow(workspaceSlug, relativePath)
-  }, [workspaceSlug])
-
   return (
     <WorkspaceMemoryChangeShelf
+      workspaceSlug={workspaceSlug}
       changes={changes}
       memoryFiles={memoryFiles}
-      onOpen={open}
-      onOpenFile={openFile}
-      className="-mx-2 -mb-2 mt-1 shrink-0 border-t border-border/70 bg-content-area"
+      className={className ?? '-mx-2 -mb-2 mt-1 shrink-0 border-t border-border/70 bg-content-area'}
     />
   )
 }

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
+import { useAtom } from 'jotai'
 import { ChevronLeft, ChevronRight, FileText, Loader2, Save, X } from 'lucide-react'
 import type { WorkspaceMemoryFileChange } from '@proma/shared'
 import { Button } from '@/components/ui/button'
+import { workspaceMemoryEditingStateAtomFamily } from '@/atoms/memory-change-atoms'
 
 interface MemoryFileListItem {
   relativePath: string
@@ -10,6 +12,7 @@ interface MemoryFileListItem {
 
 interface WorkspaceMemoryChangeShelfProps {
   workspaceSlug: string
+  sessionId: string
   changes: WorkspaceMemoryFileChange[]
   memoryFiles: MemoryFileListItem[]
   className?: string
@@ -32,10 +35,14 @@ function formatUpdatedAt(updatedAt?: number): string {
 }
 
 /** 项目记忆的紧凑 Diff 预览；文件可直接在右侧工作区 Tab 内编辑和保存。 */
-export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles, className }: WorkspaceMemoryChangeShelfProps): React.ReactElement {
+export function WorkspaceMemoryChangeShelf({ workspaceSlug, sessionId, changes, memoryFiles, className }: WorkspaceMemoryChangeShelfProps): React.ReactElement {
   const [index, setIndex] = React.useState(0)
   const [editingPath, setEditingPath] = React.useState<string | null>(null)
   const [editText, setEditText] = React.useState('')
+  const [initialText, setInitialText] = React.useState('')
+  const [editingState, setEditingState] = useAtom(workspaceMemoryEditingStateAtomFamily(sessionId))
+  const openedAtRef = React.useRef(0)
+  const ignoreNextLocalChangeRef = React.useRef<string | null>(null)
   const [loadingEditor, setLoadingEditor] = React.useState(false)
   const [saving, setSaving] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -44,14 +51,27 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles
 
   React.useEffect(() => setIndex(0), [changes[0]?.changedAt])
   React.useEffect(() => setIndex((current) => current >= changes.length ? 0 : current), [changes.length])
+  React.useEffect(() => () => setEditingState({ editingPath: null, dirty: false, remoteChanged: false }), [setEditingState])
+  React.useEffect(() => {
+    const latest = changes[0]
+    if (!editingPath || !latest || latest.relativePath !== editingPath || latest.changedAt < openedAtRef.current) return
+    if (ignoreNextLocalChangeRef.current === latest.relativePath) {
+      ignoreNextLocalChangeRef.current = null
+      return
+    }
+    setEditingState((previous) => ({ ...previous, remoteChanged: true }))
+  }, [changes, editingPath, setEditingState])
 
   const startEditing = React.useCallback(async (relativePath: string): Promise<void> => {
     setLoadingEditor(true)
     setError(null)
     try {
       const file = await window.electronAPI.readWorkspaceAutoMemoryFile(workspaceSlug, relativePath)
+      openedAtRef.current = Date.now()
       setEditingPath(file.relativePath)
       setEditText(file.content ?? '')
+      setInitialText(file.content ?? '')
+      setEditingState({ editingPath: file.relativePath, dirty: false, remoteChanged: false })
     } catch (cause) {
       console.error('[项目记忆] 读取文件失败:', cause)
       setError(cause instanceof Error ? cause.message : '读取记忆文件失败')
@@ -62,10 +82,18 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles
 
   const saveEditing = React.useCallback(async (): Promise<void> => {
     if (!editingPath) return
+    if (editingState.remoteChanged) {
+      setError('该文件在编辑期间已被外部更新。请返回预览后重新打开，避免覆盖新内容。')
+      return
+    }
     setSaving(true)
     setError(null)
     try {
       await window.electronAPI.writeWorkspaceAutoMemoryFile(workspaceSlug, editingPath, editText)
+      setInitialText(editText)
+      setEditingState({ editingPath, dirty: false, remoteChanged: false })
+      // watcher 会回传本次本地保存；只忽略这一个相同路径的最新事件。
+      ignoreNextLocalChangeRef.current = editingPath
     } catch (cause) {
       console.error('[项目记忆] 保存文件失败:', cause)
       setError(cause instanceof Error ? cause.message : '保存记忆文件失败')
@@ -73,7 +101,7 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles
     } finally {
       setSaving(false)
     }
-  }, [editText, editingPath, workspaceSlug])
+  }, [editText, editingPath, editingState.remoteChanged, setEditingState, workspaceSlug])
 
   if (editingPath) {
     return (
@@ -84,7 +112,12 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles
             <p className="mt-1 truncate font-mono text-xs text-muted-foreground" title={editingPath}>{editingPath}</p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={() => { setEditingPath(null); setError(null) }} disabled={saving}>返回预览</Button>
+            <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={() => {
+              if (editingState.dirty && !window.confirm('项目记忆有未保存修改。确定丢弃并返回预览吗？')) return
+              setEditingPath(null)
+              setError(null)
+              setEditingState({ editingPath: null, dirty: false, remoteChanged: false })
+            }} disabled={saving}>返回预览</Button>
             <Button size="sm" className="h-8 px-2 text-xs" onClick={() => void saveEditing()} disabled={saving}>
               {saving ? <Loader2 className="mr-1 size-3.5 animate-spin" /> : <Save className="mr-1 size-3.5" />}
               保存
@@ -94,11 +127,22 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles
         <textarea
           autoFocus
           value={editText}
-          onChange={(event) => setEditText(event.target.value)}
+          onChange={(event) => {
+            const nextText = event.target.value
+            setEditText(nextText)
+            setEditingState((previous) => ({ ...previous, dirty: nextText !== initialText }))
+          }}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+              event.preventDefault()
+              void saveEditing()
+            }
+          }}
           spellCheck={false}
           className="min-h-0 flex-1 resize-none rounded-lg border border-border/70 bg-background p-3 font-mono text-xs leading-5 text-foreground outline-none transition-[border-color,box-shadow] focus:border-primary focus:ring-2 focus:ring-primary/20"
           aria-label={`编辑 ${editingPath}`}
         />
+        {editingState.remoteChanged && <p className="mt-2 shrink-0 text-xs text-amber-600 dark:text-amber-400">文件已被外部更新；为避免覆盖，保存已暂停。请返回预览后重新打开。</p>}
         {error && <p className="mt-2 shrink-0 text-xs text-destructive">{error}</p>}
       </section>
     )
@@ -161,7 +205,17 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles
               ))}
             </div>
           ) : (
-            <p className="rounded-lg bg-muted/50 p-3 text-xs leading-relaxed text-muted-foreground">还没有记忆文件。</p>
+            <div className="rounded-lg bg-muted/50 p-3 text-xs leading-relaxed text-muted-foreground">
+              <p>还没有记忆文件。</p>
+              <Button size="sm" variant="ghost" className="mt-2 h-8 px-2 text-xs" onClick={() => {
+                const initial = '# 项目记忆\n\n'
+                openedAtRef.current = Date.now()
+                setEditingPath('MEMORY.md')
+                setEditText(initial)
+                setInitialText(initial)
+                setEditingState({ editingPath: 'MEMORY.md', dirty: true, remoteChanged: false })
+              }}>创建 MEMORY.md</Button>
+            </div>
           )}
         </div>
       )}

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
@@ -57,10 +57,17 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, sessionId, changes, 
     if (!editingPath || !latest || latest.relativePath !== editingPath || latest.changedAt < openedAtRef.current) return
     if (ignoreNextLocalChangeRef.current === latest.relativePath) {
       ignoreNextLocalChangeRef.current = null
+      // watcher 对短时间内的写入会合并。确认磁盘最终内容仍等于刚保存的文本后才
+      // 忽略该事件；若 Agent/外部进程紧接着又写入，必须标记冲突而非静默覆盖。
+      void window.electronAPI.readWorkspaceAutoMemoryFile(workspaceSlug, latest.relativePath)
+        .then((file) => {
+          if (file.content !== editText) setEditingState((previous) => ({ ...previous, remoteChanged: true }))
+        })
+        .catch(() => setEditingState((previous) => ({ ...previous, remoteChanged: true })))
       return
     }
     setEditingState((previous) => ({ ...previous, remoteChanged: true }))
-  }, [changes, editingPath, setEditingState])
+  }, [changes, editText, editingPath, setEditingState, workspaceSlug])
 
   const startEditing = React.useCallback(async (relativePath: string): Promise<void> => {
     setLoadingEditor(true)

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { createPortal } from 'react-dom'
-import { ChevronLeft, ChevronRight, ExternalLink, FileText } from 'lucide-react'
+import { ChevronLeft, ChevronRight, FileText, Loader2, Save, X } from 'lucide-react'
 import type { WorkspaceMemoryFileChange } from '@proma/shared'
 import { Button } from '@/components/ui/button'
 
@@ -10,10 +9,9 @@ interface MemoryFileListItem {
 }
 
 interface WorkspaceMemoryChangeShelfProps {
+  workspaceSlug: string
   changes: WorkspaceMemoryFileChange[]
   memoryFiles: MemoryFileListItem[]
-  onOpen: (change?: WorkspaceMemoryFileChange) => void
-  onOpenFile: (relativePath: string) => void
   className?: string
 }
 
@@ -33,136 +31,140 @@ function formatUpdatedAt(updatedAt?: number): string {
   })
 }
 
-/**
- * Persistent file-panel status. Its body portal is deliberately outside SidePanel
- * so hover content cannot be clipped or obscured by panel layout layers.
- */
-export function WorkspaceMemoryChangeShelf({ changes, memoryFiles, onOpen, onOpenFile, className }: WorkspaceMemoryChangeShelfProps): React.ReactElement {
+/** 项目记忆的紧凑 Diff 预览；文件可直接在右侧工作区 Tab 内编辑和保存。 */
+export function WorkspaceMemoryChangeShelf({ workspaceSlug, changes, memoryFiles, className }: WorkspaceMemoryChangeShelfProps): React.ReactElement {
   const [index, setIndex] = React.useState(0)
-  const [hovered, setHovered] = React.useState(false)
-  const [anchorRect, setAnchorRect] = React.useState<DOMRect | null>(null)
-  const anchorRef = React.useRef<HTMLDivElement>(null)
-  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [editingPath, setEditingPath] = React.useState<string | null>(null)
+  const [editText, setEditText] = React.useState('')
+  const [loadingEditor, setLoadingEditor] = React.useState(false)
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
   const change = changes[index]
   const hasDiff = Boolean(change?.diffAvailable && change.diff && (change.diff.added.length > 0 || change.diff.removed.length > 0))
 
   React.useEffect(() => setIndex(0), [changes[0]?.changedAt])
   React.useEffect(() => setIndex((current) => current >= changes.length ? 0 : current), [changes.length])
-  React.useEffect(() => () => {
-    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
-  }, [])
 
-  const measureAnchor = React.useCallback(() => {
-    if (anchorRef.current) setAnchorRect(anchorRef.current.getBoundingClientRect())
-  }, [])
-  const keepOpen = React.useCallback(() => {
-    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
-    measureAnchor()
-    setHovered(true)
-  }, [measureAnchor])
-  const scheduleClose = React.useCallback(() => {
-    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
-    closeTimerRef.current = setTimeout(() => setHovered(false), 120)
-  }, [])
-
-  React.useEffect(() => {
-    if (!hovered) return
-    window.addEventListener('resize', measureAnchor)
-    window.addEventListener('scroll', measureAnchor, true)
-    return () => {
-      window.removeEventListener('resize', measureAnchor)
-      window.removeEventListener('scroll', measureAnchor, true)
+  const startEditing = React.useCallback(async (relativePath: string): Promise<void> => {
+    setLoadingEditor(true)
+    setError(null)
+    try {
+      const file = await window.electronAPI.readWorkspaceAutoMemoryFile(workspaceSlug, relativePath)
+      setEditingPath(file.relativePath)
+      setEditText(file.content ?? '')
+    } catch (cause) {
+      console.error('[项目记忆] 读取文件失败:', cause)
+      setError(cause instanceof Error ? cause.message : '读取记忆文件失败')
+    } finally {
+      setLoadingEditor(false)
     }
-  }, [hovered, measureAnchor])
+  }, [workspaceSlug])
 
-  const detail = hovered && anchorRect && typeof document !== 'undefined'
-    ? createPortal(
-        <div
-          role="dialog"
-          aria-label={change ? '记忆更新详情' : '工作区记忆文件'}
-          onMouseEnter={keepOpen}
-          onMouseLeave={scheduleClose}
-          className="fixed z-[1000] w-[min(440px,calc(100vw-32px))] rounded-xl border border-border/80 bg-popover p-3 shadow-2xl"
-          style={{
-            left: Math.max(16, Math.min(window.innerWidth - 456, anchorRect.right - 440)),
-            bottom: Math.max(16, window.innerHeight - anchorRect.top + 8),
-          }}
-        >
-          {change ? (
-            <>
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="text-xs font-semibold text-foreground">记忆更新</div>
-                  <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{change.relativePath}</div>
-                </div>
-                <span className="shrink-0 text-[11px] text-muted-foreground">{formatKind(change.kind)} · {index + 1}/{changes.length}</span>
-              </div>
-              {changes.length > 1 && (
-                <div className="mb-2 flex justify-end gap-1">
-                  <button type="button" aria-label="上一条记忆更新" className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground" onClick={() => setIndex((value) => (value - 1 + changes.length) % changes.length)}><ChevronLeft size={14} /></button>
-                  <button type="button" aria-label="下一条记忆更新" className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground" onClick={() => setIndex((value) => (value + 1) % changes.length)}><ChevronRight size={14} /></button>
-                </div>
-              )}
-              {hasDiff ? (
-                <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-2 font-mono text-[11px] leading-5">
-                  {change.diff?.context.map((line, lineIndex) => <div key={`context-${lineIndex}`} className="text-muted-foreground">  {line || ' '}</div>)}
-                  {change.diff?.removed.map((line, lineIndex) => <div key={`removed-${lineIndex}`} className="bg-red-500/10 px-1 text-red-700 dark:text-red-300">- {line || ' '}</div>)}
-                  {change.diff?.added.map((line, lineIndex) => <div key={`added-${lineIndex}`} className="bg-emerald-500/10 px-1 text-emerald-700 dark:text-emerald-300">+ {line || ' '}</div>)}
-                  {change.diff?.truncated && <div className="mt-1 text-muted-foreground">… 其余变更请打开文件查看</div>}
-                </pre>
-              ) : (
-                <p className="rounded-lg bg-muted/50 p-2 text-xs leading-relaxed text-muted-foreground">该文件已变化，但无法生成受限文本 diff。</p>
-              )}
-              {change.kind !== 'deleted' && <div className="mt-3 flex justify-end"><Button size="sm" variant="ghost" className="h-7 px-2 text-[11px]" onClick={() => onOpen(change)}>编辑文件 <ExternalLink size={12} className="ml-1" /></Button></div>}
-            </>
-          ) : (
-            <>
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div>
-                  <div className="text-xs font-semibold text-foreground">项目记忆</div>
-                  <div className="mt-0.5 text-[11px] text-muted-foreground">{memoryFiles.length} 个文件 · 点击即可编辑</div>
-                </div>
-                <Button size="sm" variant="ghost" className="h-7 px-2 text-[11px]" onClick={() => onOpen()}>打开编辑器 <ExternalLink size={12} className="ml-1" /></Button>
-              </div>
-              {memoryFiles.length > 0 ? (
-                <div className="max-h-56 overflow-y-auto rounded-lg border border-border/60 p-1">
-                  {memoryFiles.map((file) => (
-                    <button key={file.relativePath} type="button" className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs transition-colors hover:bg-accent" onClick={() => onOpenFile(file.relativePath)}>
-                      <FileText size={13} className="shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 flex-1 truncate font-mono text-foreground">{file.relativePath}</span>
-                      <span className="shrink-0 text-[10px] text-muted-foreground">{formatUpdatedAt(file.modifiedAt)}</span>
-                    </button>
-                  ))}
-                </div>
-              ) : (
-                <p className="rounded-lg bg-muted/50 p-2 text-xs leading-relaxed text-muted-foreground">还没有记忆文件。打开编辑器后可创建 `MEMORY.md`。</p>
-              )}
-            </>
-          )}
-        </div>,
-        document.body,
-      )
-    : null
+  const saveEditing = React.useCallback(async (): Promise<void> => {
+    if (!editingPath) return
+    setSaving(true)
+    setError(null)
+    try {
+      await window.electronAPI.writeWorkspaceAutoMemoryFile(workspaceSlug, editingPath, editText)
+    } catch (cause) {
+      console.error('[项目记忆] 保存文件失败:', cause)
+      setError(cause instanceof Error ? cause.message : '保存记忆文件失败')
+      return
+    } finally {
+      setSaving(false)
+    }
+  }, [editText, editingPath, workspaceSlug])
+
+  if (editingPath) {
+    return (
+      <section className={className ?? 'flex h-full min-h-0 flex-col bg-content-area p-3'} aria-label="编辑项目记忆">
+        <div className="mb-3 flex shrink-0 items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-foreground">编辑项目记忆</h2>
+            <p className="mt-1 truncate font-mono text-xs text-muted-foreground" title={editingPath}>{editingPath}</p>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={() => { setEditingPath(null); setError(null) }} disabled={saving}>返回预览</Button>
+            <Button size="sm" className="h-8 px-2 text-xs" onClick={() => void saveEditing()} disabled={saving}>
+              {saving ? <Loader2 className="mr-1 size-3.5 animate-spin" /> : <Save className="mr-1 size-3.5" />}
+              保存
+            </Button>
+          </div>
+        </div>
+        <textarea
+          autoFocus
+          value={editText}
+          onChange={(event) => setEditText(event.target.value)}
+          spellCheck={false}
+          className="min-h-0 flex-1 resize-none rounded-lg border border-border/70 bg-background p-3 font-mono text-xs leading-5 text-foreground outline-none transition-[border-color,box-shadow] focus:border-primary focus:ring-2 focus:ring-primary/20"
+          aria-label={`编辑 ${editingPath}`}
+        />
+        {error && <p className="mt-2 shrink-0 text-xs text-destructive">{error}</p>}
+      </section>
+    )
+  }
 
   return (
-    <>
-      <div
-        ref={anchorRef}
-        onMouseEnter={keepOpen}
-        onMouseLeave={scheduleClose}
-        className={className ?? 'shrink-0 border-t border-border/70'}
-      >
-        <button
-          type="button"
-          onClick={() => onOpen(change)}
-          className="flex h-10 w-full items-center gap-2 px-3 text-left text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-        >
-          <span className="font-medium">{change ? '项目记忆已更新' : '项目记忆'}</span>
-          {changes.length > 1 && <span className="text-[11px] tabular-nums text-muted-foreground">{changes.length}</span>}
-          {change && <span className="ml-auto text-[11px] text-muted-foreground">悬浮查看变更</span>}
-        </button>
-      </div>
-      {detail}
-    </>
+    <section className={className ?? 'h-full overflow-auto bg-content-area p-3'} aria-label="项目记忆">
+      {loadingEditor && (
+        <div className="mb-3 flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground"><Loader2 className="size-3.5 animate-spin" />正在打开编辑器…</div>
+      )}
+      {error && <div className="mb-3 flex items-center justify-between gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-xs text-destructive"><span>{error}</span><Button size="icon" variant="ghost" className="size-6 text-destructive" onClick={() => setError(null)} aria-label="关闭错误提示"><X size={14} /></Button></div>}
+      {change ? (
+        <div className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-foreground">项目记忆已更新</h2>
+              <p className="mt-1 truncate font-mono text-xs text-muted-foreground" title={change.relativePath}>{change.relativePath}</p>
+            </div>
+            <span className="shrink-0 text-xs text-muted-foreground">{formatKind(change.kind)} · {index + 1}/{changes.length}</span>
+          </div>
+
+          {changes.length > 1 && (
+            <div className="flex justify-end gap-1">
+              <Button size="icon" variant="ghost" className="size-7" aria-label="上一条记忆更新" onClick={() => setIndex((value) => (value - 1 + changes.length) % changes.length)}><ChevronLeft size={15} /></Button>
+              <Button size="icon" variant="ghost" className="size-7" aria-label="下一条记忆更新" onClick={() => setIndex((value) => (value + 1) % changes.length)}><ChevronRight size={15} /></Button>
+            </div>
+          )}
+
+          {hasDiff ? (
+            <pre className="max-h-[min(520px,calc(100vh-220px))] overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-3 font-mono text-xs leading-5">
+              {change.diff?.context.map((line, lineIndex) => <div key={`context-${lineIndex}`} className="text-muted-foreground">  {line || ' '}</div>)}
+              {change.diff?.removed.map((line, lineIndex) => <div key={`removed-${lineIndex}`} className="bg-red-500/10 px-1 text-red-700 dark:text-red-300">- {line || ' '}</div>)}
+              {change.diff?.added.map((line, lineIndex) => <div key={`added-${lineIndex}`} className="bg-emerald-500/10 px-1 text-emerald-700 dark:text-emerald-300">+ {line || ' '}</div>)}
+              {change.diff?.truncated && <div className="mt-1 text-muted-foreground">… 其余变更请打开文件查看</div>}
+            </pre>
+          ) : (
+            <p className="rounded-lg bg-muted/50 p-3 text-xs leading-relaxed text-muted-foreground">该文件已变化，但无法生成受限文本 Diff。</p>
+          )}
+
+          {change.kind !== 'deleted' && (
+            <div className="flex justify-end">
+              <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={() => void startEditing(change.relativePath)} disabled={loadingEditor}><FileText size={13} className="mr-1" />编辑文件</Button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground">项目记忆</h2>
+            <p className="mt-1 text-xs text-muted-foreground">{memoryFiles.length} 个文件 · 点击即可编辑</p>
+          </div>
+          {memoryFiles.length > 0 ? (
+            <div className="overflow-hidden rounded-lg border border-border/60">
+              {memoryFiles.map((file) => (
+                <button key={file.relativePath} type="button" className="flex w-full items-center gap-2 border-b border-border/50 px-3 py-2.5 text-left text-xs transition-colors last:border-b-0 hover:bg-accent" onClick={() => void startEditing(file.relativePath)} disabled={loadingEditor}>
+                  <FileText size={14} className="shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate font-mono text-foreground">{file.relativePath}</span>
+                  <span className="shrink-0 text-[11px] text-muted-foreground">{formatUpdatedAt(file.modifiedAt)}</span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="rounded-lg bg-muted/50 p-3 text-xs leading-relaxed text-muted-foreground">还没有记忆文件。</p>
+          )}
+        </div>
+      )}
+    </section>
   )
 }

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
@@ -43,6 +43,7 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, sessionId, changes, 
   const [editingState, setEditingState] = useAtom(workspaceMemoryEditingStateAtomFamily(sessionId))
   const openedAtRef = React.useRef(0)
   const ignoreNextLocalChangeRef = React.useRef<string | null>(null)
+  const lastHandledChangeIdRef = React.useRef<string | null>(null)
   const [loadingEditor, setLoadingEditor] = React.useState(false)
   const [saving, setSaving] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -55,6 +56,9 @@ export function WorkspaceMemoryChangeShelf({ workspaceSlug, sessionId, changes, 
   React.useEffect(() => {
     const latest = changes[0]
     if (!editingPath || !latest || latest.relativePath !== editingPath || latest.changedAt < openedAtRef.current) return
+    const changeId = `${latest.relativePath}:${latest.changedAt}`
+    if (lastHandledChangeIdRef.current === changeId) return
+    lastHandledChangeIdRef.current = changeId
     if (ignoreNextLocalChangeRef.current === latest.relativePath) {
       ignoreNextLocalChangeRef.current = null
       // watcher 对短时间内的写入会合并。确认磁盘最终内容仍等于刚保存的文本后才

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -1,18 +1,23 @@
 /**
  * AgentHeader — Agent 会话头部
  *
- * 显示会话标题（可点击编辑）。
- * 参照 ChatHeader 的编辑模式。
+ * 显示会话标题；通过标题下拉菜单进入重命名。
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
-import { Pencil, Check, X } from 'lucide-react'
-import { agentSessionsAtom } from '@/atoms/agent-atoms'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { Check, ChevronDown, PanelRight, Pencil, X } from 'lucide-react'
+import { agentSessionsAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { replaceAgentSessionInFreshnessOrder } from '@/lib/agent-session-list'
 import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 /** AgentHeader 属性接口 */
 interface AgentHeaderProps {
@@ -25,6 +30,7 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   const session = sessions.find((s) => s.id === sessionId) ?? null
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const setTabs = useSetAtom(tabsAtom)
+  const [isRightPanelOpen, setRightPanelOpen] = useAtom(currentSessionSidePanelOpenAtom)
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -80,7 +86,7 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
             onChange={(e) => setEditTitle(e.target.value)}
             onKeyDown={handleKeyDown}
             onBlur={saveTitle}
-            className="flex-1 bg-transparent text-sm font-medium border-b border-primary/50 outline-none px-0 py-0.5 min-w-0"
+            className="flex-1 bg-transparent text-[15px] font-normal border-b border-primary/50 outline-none px-0 py-0.5 min-w-0"
             maxLength={100}
           />
           <button
@@ -101,20 +107,34 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
           </button>
         </div>
       ) : (
-        <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          <span className="truncate text-sm font-medium text-foreground">
-            {session.title}
-          </span>
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={startEdit}
-            className="titlebar-no-drag p-1 text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="编辑标题"
-          >
-            <Pencil className="size-3.5" />
-          </button>
-        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="titlebar-no-drag group flex min-w-0 items-center gap-1.5 rounded-lg px-2 py-1 text-left transition-colors hover:bg-muted/60"
+              aria-label={`会话菜单：${session.title}`}
+            >
+              <span className="truncate text-[15px] font-normal text-foreground">{session.title}</span>
+              <ChevronDown className="size-3 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="z-[100] min-w-40 titlebar-no-drag">
+            <DropdownMenuItem onSelect={startEdit}>
+              <Pencil className="size-3.5" />
+              重命名
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {!isRightPanelOpen && (
+        <button
+          type="button"
+          onClick={() => setRightPanelOpen(true)}
+          className="titlebar-no-drag ml-auto inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-[background-color,color,transform] hover:bg-muted hover:text-foreground active:scale-[0.96]"
+          aria-label="展开右侧工作区"
+        >
+          <PanelRight className="size-4" />
+        </button>
       )}
     </div>
   )

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -62,7 +62,7 @@ import { cn } from '@/lib/utils'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { registerShortcut } from '@/lib/shortcut-registry'
 import { supportsChannelPlanQuota } from '@/lib/channel-plan-quota'
-import { previewPanelOpenMapAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
+import { previewFileMapAtom, previewPanelOpenMapAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
@@ -106,6 +106,7 @@ import {
   allPendingAskUserRequestsAtom,
   allPendingPermissionRequestsAtom,
   allPendingExitPlanRequestsAtom,
+  agentDiffPanelTabAtom,
 } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
@@ -2724,17 +2725,29 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setQueuedMessages((prev) => moveQueuedMessage(prev, sourceId, targetId, placement))
   }, [sessionId, setQueuedMessages])
 
-  // ===== 预览面板状态（toggle 快捷键，分屏布局在 MainArea） =====
+  // ===== 预览 Tab 快捷键 =====
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
+  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
 
   const togglePreviewPanel = React.useCallback(() => {
-    setPreviewOpenMap((prev) => {
-      const m = new Map(prev)
-      const current = m.get(sessionId) ?? false
-      m.set(sessionId, !current)
-      return m
+    const nextOpen = !(store.get(previewPanelOpenMapAtom).get(sessionId) ?? false)
+    const currentPreviewFile = store.get(previewFileMapAtom).get(sessionId) ?? null
+    if (nextOpen && currentPreviewFile) {
+      // 统一交给 opener：会复用/激活对应的动态预览 Tab，而非写入旧的 `preview` 状态。
+      openPreview(sessionId, currentPreviewFile)
+      return
+    }
+    setPreviewOpenMap((previous) => {
+      const next = new Map(previous)
+      next.set(sessionId, false)
+      return next
     })
-  }, [sessionId, setPreviewOpenMap])
+    setSidePanelTabMap((tabs) => {
+      const nextTabs = new Map(tabs)
+      nextTabs.set(sessionId, 'files')
+      return nextTabs
+    })
+  }, [openPreview, sessionId, setPreviewOpenMap, setSidePanelTabMap, store])
 
   React.useEffect(() => {
     return registerShortcut('toggle-preview-panel', togglePreviewPanel)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -50,7 +50,7 @@ import {
 } from '@/atoms/agent-atoms'
 import type { AgentSidePanelTab, AgentFileSourceFilter } from '@/atoms/agent-atoms'
 import { WorkspaceMemoryChangeDock } from '@/components/agent-skills/WorkspaceMemoryChangeDock'
-import { workspaceMemoryChangesAtom } from '@/atoms/memory-change-atoms'
+import { workspaceMemoryChangesAtom, workspaceMemoryEditingStateAtomFamily } from '@/atoms/memory-change-atoms'
 import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import {
@@ -461,6 +461,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const [memoryTabOpen, setMemoryTabOpen] = useAtom(agentMemoryPanelOpenAtomFamily(sessionId))
   const isAgentRunning = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))?.running === true
   const memoryChangesMap = useAtomValue(workspaceMemoryChangesAtom)
+  const memoryEditingState = useAtomValue(workspaceMemoryEditingStateAtomFamily(sessionId))
+  const setMemoryEditingState = useSetAtom(workspaceMemoryEditingStateAtomFamily(sessionId))
   const latestMemoryChange = workspaceSlug ? memoryChangesMap.get(workspaceSlug)?.[0] : undefined
   const lastActivatedMemoryChangeRef = React.useRef<string | null>(null)
   const effectiveActiveTab: AgentSidePanelTab = activeTab === 'chat' && !sideChatConversationId
@@ -580,6 +582,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   }, [publishBrowserState, sessionId])
 
   const handleWorkspaceTabChange = React.useCallback((tab: AgentSidePanelTab) => {
+    if (effectiveActiveTab === 'memory' && tab !== 'memory' && memoryEditingState.dirty && !window.confirm('项目记忆有未保存修改。确定丢弃并离开吗？')) return
     const previewId = getPreviewIdFromSidePanelTab(tab)
     if (previewId) {
       const file = previewFiles.find((item) => getPreviewFileId(item) === previewId)
@@ -596,7 +599,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     if (!browserTabId) return
     desiredBrowserTabIdRef.current = browserTabId
     flushBrowserTabSelection()
-  }, [flushBrowserTabSelection, onTabChange, previewFiles, sessionId, setPreviewFileMap])
+  }, [effectiveActiveTab, flushBrowserTabSelection, memoryEditingState.dirty, onTabChange, previewFiles, sessionId, setPreviewFileMap])
 
   const handleOpenBrowserTab = React.useCallback(async () => {
     try {
@@ -670,13 +673,16 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       id: getBrowserSidePanelTab(tab.tabId),
       label: tab.title || '新建标签页',
       icon: <Globe className="size-3.5" />,
-      closable: true,
+      // Agent 当前工作标签不能直接销毁，否则未指定 tabId 的后续浏览器工具会失去目标。
+      closable: tab.tabId !== browserState.agentTabId,
       activity: showBrowserActivity && activeBrowserTabId !== tab.tabId && browserState.activeTabId === tab.tabId,
     })) ?? []),
   ], [activeBrowserTabId, browserState, memoryTabOpen, previewFiles, showBrowserActivity, sideChatConversationId, workspaceSlug])
 
   const handleCloseWorkspaceTab = React.useCallback((tab: AgentSidePanelTab) => {
     if (tab === 'memory') {
+      if (memoryEditingState.dirty && !window.confirm('项目记忆有未保存修改。确定丢弃并关闭吗？')) return
+      setMemoryEditingState({ editingPath: null, dirty: false, remoteChanged: false })
       setMemoryTabOpen(false)
       if (activeTab === 'memory') onTabChange('files')
       return
@@ -685,8 +691,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     if (previewId) { handleClosePreviewTab(previewId); return }
     if (tab === 'chat') { handleCloseChatTab(); return }
     const browserTabId = getBrowserTabIdFromSidePanelTab(tab)
-    if (browserTabId) void handleCloseBrowserTab(browserTabId)
-  }, [activeTab, handleCloseBrowserTab, handleCloseChatTab, handleClosePreviewTab, onTabChange, setMemoryTabOpen])
+    if (browserTabId && browserTabId !== browserState?.agentTabId) void handleCloseBrowserTab(browserTabId)
+  }, [activeTab, browserState?.agentTabId, handleCloseBrowserTab, handleCloseChatTab, handleClosePreviewTab, memoryEditingState.dirty, onTabChange, setMemoryEditingState, setMemoryTabOpen])
 
   React.useEffect(() => {
     const handleCloseActiveWorkspaceTab = (event: Event) => {
@@ -722,7 +728,11 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             onTabChange={handleWorkspaceTabChange}
             onCloseTab={handleCloseWorkspaceTab}
             onOpenBrowser={() => void handleOpenBrowserTab()}
-            onOpenFile={() => onTabChange('files')}
+            onOpenFile={() => handleWorkspaceTabChange('files')}
+            onOpenMemory={() => {
+              setMemoryTabOpen(true)
+              onTabChange('memory')
+            }}
             onClose={() => setIsOpen(false)}
             isWindows={isWindows}
           />
@@ -748,7 +758,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
           ) : effectiveActiveTab === 'memory' ? (
             workspaceSlug ? (
               <div className="min-h-0 flex-1 overflow-auto p-2">
-                <WorkspaceMemoryChangeDock workspaceSlug={workspaceSlug} className="flex h-full min-h-0 flex-col bg-content-area p-3" />
+                <WorkspaceMemoryChangeDock key={sessionId} workspaceSlug={workspaceSlug} sessionId={sessionId} className="flex h-full min-h-0 flex-col bg-content-area p-3" />
               </div>
             ) : (
               <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">等待项目初始化...</div>

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { X, ExternalLink, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, MessageSquarePlus } from 'lucide-react'
+import { X, ExternalLink, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, MessageSquarePlus, FileDiff, FileText, FolderOpen, Globe, MessageCircle, Brain } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -19,6 +19,7 @@ import {
 import { cn } from '@/lib/utils'
 import { FileBrowser, FileDropZone, FileTypeIcon, FileSearchBar, computeRevealAncestors, isPathUnderRoot, computeTreeRowLayout, AncestorGuides, STICKY_ROW_BASE_CLASS, canBeSticky } from '@/components/file-browser'
 import { DiffPanelTabBar } from '@/components/diff/DiffPanelTabBar'
+import type { WorkspacePanelTab } from '@/components/diff/DiffPanelTabBar'
 import { DiffChangesList } from '@/components/diff/DiffChangesList'
 import { ChatView } from '@/components/chat/ChatView'
 import {
@@ -36,19 +37,36 @@ import {
   agentDiffRefreshVersionAtom,
   agentNonGitFileChangesAtom,
   agentFileChangesCurrentRunAtom,
+  agentMemoryPanelOpenAtomFamily,
+  agentSessionStreamingStateAtomFamily,
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
 } from '@/atoms/agent-atoms'
+import {
+  getBrowserSidePanelTab,
+  getBrowserTabIdFromSidePanelTab,
+  getPreviewIdFromSidePanelTab,
+  getPreviewSidePanelTab,
+} from '@/atoms/agent-atoms'
 import type { AgentSidePanelTab, AgentFileSourceFilter } from '@/atoms/agent-atoms'
 import { WorkspaceMemoryChangeDock } from '@/components/agent-skills/WorkspaceMemoryChangeDock'
+import { workspaceMemoryChangesAtom } from '@/atoms/memory-change-atoms'
 import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
-import { previewFileMapAtom } from '@/atoms/preview-atoms'
-import { browserPanelMinimizedMapAtom, browserPanelOpenMapAtom } from '@/atoms/browser-atoms'
+import {
+  browserPanelMinimizedMapAtom,
+  browserPanelOpenMapAtom,
+  browserPendingNavigationMapAtom,
+  browserStateMapAtom,
+} from '@/atoms/browser-atoms'
+import { BrowserPanel } from '@/components/browser/BrowserPanel'
+import { getPreviewFileId, previewFileMapAtom, previewFilesMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
+import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile } from '@proma/shared'
 import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
+import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
 
 function getPathBasename(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
@@ -73,59 +91,53 @@ interface SidePanelProps {
   width?: number
 }
 
-export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, width = 280 }: SidePanelProps): React.ReactElement {
+export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, width = 460 }: SidePanelProps): React.ReactElement {
   // 侧面板状态按 sessionId 持久化，切换会话不会互相覆盖。
   const [isOpen, setIsOpen] = useAtom(currentSessionSidePanelOpenAtom)
   const isWindows = React.useMemo(() => detectIsWindows(), [])
 
   // Tab 系统
   const previewFileMap = useAtomValue(previewFileMapAtom)
-  const selectedFilePath = previewFileMap.get(sessionId)?.filePath
+  const setPreviewFileMap = useSetAtom(previewFileMapAtom)
+  const previewFilesMap = useAtomValue(previewFilesMapAtom)
+  const setPreviewFilesMap = useSetAtom(previewFilesMapAtom)
+  const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
+  const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
+  const previewFiles = previewFilesMap.get(sessionId) ?? []
+  const requestedPreviewId = getPreviewIdFromSidePanelTab(activeTab)
+  const currentPreviewFile = (requestedPreviewId ? previewFiles.find((file) => getPreviewFileId(file) === requestedPreviewId) : null)
+    ?? previewFileMap.get(sessionId) ?? null
+  const previewOpen = previewFiles.length > 0 || previewOpenMap.get(sessionId) === true
+  const selectedFilePath = currentPreviewFile?.filePath
 
   const openPreview = useOpenPreview()
-  const browserOpenMap = useAtomValue(browserPanelOpenMapAtom)
-  const setBrowserMinimizedMap = useSetAtom(browserPanelMinimizedMapAtom)
   const setBrowserOpenMap = useSetAtom(browserPanelOpenMapAtom)
-
-  const minimizeBrowserForPreview = React.useCallback(async (): Promise<void> => {
-    if (!browserOpenMap.get(sessionId)) return
-    const minimizeBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).minimizeAgentBrowser
-    try {
-      if (typeof minimizeBrowser === 'function') await minimizeBrowser(sessionId)
-    } catch (error) {
-      console.error('[受管浏览器] 为打开文件预览而最小化失败:', error)
-    } finally {
-      setBrowserMinimizedMap((previous) => { const next = new Map(previous); next.set(sessionId, true); return next })
-      setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(sessionId, false); return next })
-    }
-  }, [browserOpenMap, sessionId, setBrowserMinimizedMap, setBrowserOpenMap])
+  const setBrowserMinimizedMap = useSetAtom(browserPanelMinimizedMapAtom)
 
   // 用 ref 存 basePaths 相关值，避免声明顺序问题
   const basePathsRef = React.useRef<string[]>([])
 
-  const handleFilePreview = React.useCallback(async (filePath: string) => {
-    await minimizeBrowserForPreview()
+  const handleFilePreview = React.useCallback((filePath: string) => {
     const bp = basePathsRef.current
     openPreview(sessionId, {
       filePath,
       previewOnly: true,
       basePaths: bp.length > 0 ? bp : undefined,
     })
-  }, [minimizeBrowserForPreview, sessionId, openPreview])
+  }, [sessionId, openPreview])
 
   // Worktree 选择状态（仅用于 diff 文件点击时传递 baseRef，选取逻辑已下沉至 DiffChangesList）
   const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
   const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
 
-  const handleDiffFileClick = React.useCallback(async (filePath: string, _isUntracked: boolean, gitRoot?: string) => {
-    await minimizeBrowserForPreview()
+  const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {
     openPreview(sessionId, {
       filePath,
       dirPath: sessionPath || undefined,
       gitRoot,
       baseRef: selectedWorktreePath ? 'origin/main' : undefined,
     })
-  }, [minimizeBrowserForPreview, openPreview, sessionId, sessionPath, selectedWorktreePath])
+  }, [openPreview, sessionId, sessionPath, selectedWorktreePath])
 
   // 动画标志：isOpen 变化时启用过渡动画，切换会话时即时显示
   const prevIsOpenRef = React.useRef(isOpen)
@@ -446,9 +458,46 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const sideChatMap = useAtomValue(agentSideChatMapAtom)
   const setSideChatMap = useSetAtom(agentSideChatMapAtom)
   const sideChatConversationId = sideChatMap.get(sessionId) ?? null
+  const [memoryTabOpen, setMemoryTabOpen] = useAtom(agentMemoryPanelOpenAtomFamily(sessionId))
+  const isAgentRunning = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))?.running === true
+  const memoryChangesMap = useAtomValue(workspaceMemoryChangesAtom)
+  const latestMemoryChange = workspaceSlug ? memoryChangesMap.get(workspaceSlug)?.[0] : undefined
+  const lastActivatedMemoryChangeRef = React.useRef<string | null>(null)
   const effectiveActiveTab: AgentSidePanelTab = activeTab === 'chat' && !sideChatConversationId
     ? 'files'
-    : activeTab
+    : activeTab === 'memory' && (!workspaceSlug || !memoryTabOpen)
+      ? 'files'
+      : activeTab
+
+  // Agent 对当前项目记忆写入后，自动展开并激活完整编辑器这个独立工作区 Tab。
+  // Watcher 同一事件可因重新挂载被读到多次，按路径和时间戳去重；仅流式 Agent 运行中
+  // 的改动会抢占当前视图，用户在记忆编辑器中的手动保存不会打断其他工作。
+  React.useEffect(() => {
+    if (!isAgentRunning || !latestMemoryChange) return
+    const changeId = `${latestMemoryChange.relativePath}:${latestMemoryChange.changedAt}`
+    if (lastActivatedMemoryChangeRef.current === changeId) return
+    lastActivatedMemoryChangeRef.current = changeId
+    setMemoryTabOpen(true)
+    setIsOpen(true)
+    onTabChange('memory')
+  }, [isAgentRunning, latestMemoryChange, onTabChange, setIsOpen, setMemoryTabOpen])
+
+  const handleClosePreviewTab = React.useCallback((previewId: string) => {
+    const remaining = previewFiles.filter((file) => getPreviewFileId(file) !== previewId)
+    setPreviewFilesMap((previous) => {
+      const next = new Map(previous)
+      if (remaining.length > 0) next.set(sessionId, remaining)
+      else next.delete(sessionId)
+      return next
+    })
+    const fallback = remaining.at(-1) ?? null
+    setPreviewOpenMap((previous) => {
+      const next = new Map(previous)
+      next.set(sessionId, fallback !== null)
+      return next
+    })
+    if (getPreviewIdFromSidePanelTab(activeTab) === previewId) onTabChange(fallback ? getPreviewSidePanelTab(getPreviewFileId(fallback)) : 'files')
+  }, [activeTab, onTabChange, previewFiles, sessionId, setPreviewFilesMap, setPreviewOpenMap])
 
   const handleCloseChatTab = React.useCallback(() => {
     setSideChatMap((prev) => {
@@ -462,6 +511,191 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     }
   }, [activeTab, onTabChange, sessionId, setSideChatMap])
 
+  // 浏览器状态由 MainArea 的全局订阅同步到 atom；右侧工作区只负责呈现和显式打开。
+  // 这样切换文件/改动时 BrowserSlot 会正确隐藏原生 WebContentsView，而不会销毁网页会话。
+  const browserStateMap = useAtomValue(browserStateMapAtom)
+  const setBrowserStateMap = useSetAtom(browserStateMapAtom)
+  const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
+  const browserState = browserStateMap.get(sessionId) ?? null
+  const openingBrowserSessionRef = React.useRef<string | null>(null)
+  // 右侧 Tab 可被快速连续点击。必须串行落盘到原生 controller，否则迟到的旧选择
+  // 会把 WebContentsView 切回已卸载的 Slot，造成页面不可见。
+  const desiredBrowserTabIdRef = React.useRef<string | null>(null)
+  const browserSelectionInFlightRef = React.useRef(false)
+
+  const publishBrowserState = React.useCallback((state: NonNullable<typeof browserState>) => {
+    setBrowserStateMap((previous) => {
+      const next = new Map(previous)
+      next.set(sessionId, state)
+      return next
+    })
+    setBrowserMinimizedMap((previous) => {
+      const next = new Map(previous)
+      next.delete(sessionId)
+      return next
+    })
+    setBrowserOpenMap((previous) => {
+      const next = new Map(previous)
+      next.set(sessionId, true)
+      return next
+    })
+  }, [sessionId, setBrowserMinimizedMap, setBrowserOpenMap, setBrowserStateMap])
+
+  const ensureBrowserOpen = React.useCallback(async () => {
+    if (openingBrowserSessionRef.current === sessionId) return null
+    const open = (window.electronAPI as Partial<typeof window.electronAPI>).openAgentBrowser
+    if (typeof open !== 'function') return null
+    openingBrowserSessionRef.current = sessionId
+    try {
+      const state = await open(sessionId)
+      publishBrowserState(state)
+      return state
+    } catch (error) {
+      console.error('[SidePanel] 打开受管浏览器失败:', error)
+      return null
+    } finally {
+      if (openingBrowserSessionRef.current === sessionId) openingBrowserSessionRef.current = null
+    }
+  }, [publishBrowserState, sessionId])
+
+  const flushBrowserTabSelection = React.useCallback(() => {
+    if (browserSelectionInFlightRef.current) return
+    browserSelectionInFlightRef.current = true
+    void (async () => {
+      try {
+        while (desiredBrowserTabIdRef.current) {
+          const targetTabId = desiredBrowserTabIdRef.current
+          desiredBrowserTabIdRef.current = null
+          const state = await window.electronAPI.selectAgentBrowserTab({ sessionId, tabId: targetTabId })
+          publishBrowserState(state)
+        }
+      } catch (error) {
+        console.error('[SidePanel] 切换受管浏览器标签失败:', error)
+      } finally {
+        browserSelectionInFlightRef.current = false
+        // 请求完成的瞬间可能又点击了其他标签，继续落到最终目标。
+        if (desiredBrowserTabIdRef.current) flushBrowserTabSelection()
+      }
+    })()
+  }, [publishBrowserState, sessionId])
+
+  const handleWorkspaceTabChange = React.useCallback((tab: AgentSidePanelTab) => {
+    const previewId = getPreviewIdFromSidePanelTab(tab)
+    if (previewId) {
+      const file = previewFiles.find((item) => getPreviewFileId(item) === previewId)
+      if (file) {
+        setPreviewFileMap((previous) => {
+          const next = new Map(previous)
+          next.set(sessionId, file)
+          return next
+        })
+      }
+    }
+    const browserTabId = getBrowserTabIdFromSidePanelTab(tab)
+    onTabChange(tab)
+    if (!browserTabId) return
+    desiredBrowserTabIdRef.current = browserTabId
+    flushBrowserTabSelection()
+  }, [flushBrowserTabSelection, onTabChange, previewFiles, sessionId, setPreviewFileMap])
+
+  const handleOpenBrowserTab = React.useCallback(async () => {
+    try {
+      const state = browserState
+        ? await window.electronAPI.createAgentBrowserTab({ sessionId })
+        : await ensureBrowserOpen()
+      if (!state) return
+      publishBrowserState(state)
+      onTabChange(getBrowserSidePanelTab(state.activeTabId))
+    } catch (error) {
+      console.error('[SidePanel] 新建受管浏览器标签失败:', error)
+    }
+  }, [browserState, ensureBrowserOpen, onTabChange, publishBrowserState, sessionId])
+
+  const handleCloseBrowserTab = React.useCallback(async (browserTabId: string) => {
+    try {
+      const state = await window.electronAPI.closeAgentBrowserTab({ sessionId, tabId: browserTabId })
+      if (state) {
+        publishBrowserState(state)
+        if (getBrowserTabIdFromSidePanelTab(activeTab) === browserTabId) {
+          onTabChange(getBrowserSidePanelTab(state.activeTabId))
+        }
+        return
+      }
+      setBrowserOpenMap((previous) => {
+        const next = new Map(previous)
+        next.set(sessionId, false)
+        return next
+      })
+      setBrowserMinimizedMap((previous) => {
+        const next = new Map(previous)
+        next.delete(sessionId)
+        return next
+      })
+      setBrowserStateMap((previous) => {
+        const next = new Map(previous)
+        next.delete(sessionId)
+        return next
+      })
+      setPendingNavigationMap((previous) => {
+        const next = new Map(previous)
+        next.delete(sessionId)
+        return next
+      })
+      onTabChange('files')
+    } catch (error) {
+      console.error('[SidePanel] 关闭受管浏览器标签失败:', error)
+    }
+  }, [activeTab, onTabChange, publishBrowserState, sessionId, setBrowserMinimizedMap, setBrowserOpenMap, setBrowserStateMap, setPendingNavigationMap])
+
+  const activeBrowserTabId = getBrowserTabIdFromSidePanelTab(effectiveActiveTab)
+  React.useEffect(() => {
+    if (activeBrowserTabId && !browserState?.tabs.some((tab) => tab.tabId === activeBrowserTabId)) {
+      onTabChange('files')
+    }
+  }, [activeBrowserTabId, browserState?.tabs, onTabChange])
+
+  const showBrowserActivity = Boolean(browserState?.activity && browserState.executionSource !== 'user')
+  const workspaceTabs = React.useMemo<WorkspacePanelTab[]>(() => [
+    { id: 'files', label: '文件', icon: <FolderOpen className="size-3.5" /> },
+    { id: 'changes', label: '改动', icon: <FileDiff className="size-3.5" /> },
+    ...(memoryTabOpen && workspaceSlug ? [{ id: 'memory' as const, label: '项目记忆', icon: <Brain className="size-3.5" />, closable: true }] : []),
+    ...previewFiles.map((file) => ({
+      id: getPreviewSidePanelTab(getPreviewFileId(file)),
+      label: file.filePath.split(/[\\/]/).pop() || '预览',
+      icon: <FileText className="size-3.5" />,
+      closable: true,
+    })),
+    ...(sideChatConversationId ? [{ id: 'chat' as const, label: '问答', icon: <MessageCircle className="size-3.5" />, closable: true }] : []),
+    ...(browserState?.tabs.map((tab) => ({
+      id: getBrowserSidePanelTab(tab.tabId),
+      label: tab.title || '新建标签页',
+      icon: <Globe className="size-3.5" />,
+      closable: true,
+      activity: showBrowserActivity && activeBrowserTabId !== tab.tabId && browserState.activeTabId === tab.tabId,
+    })) ?? []),
+  ], [activeBrowserTabId, browserState, memoryTabOpen, previewFiles, showBrowserActivity, sideChatConversationId, workspaceSlug])
+
+  const handleCloseWorkspaceTab = React.useCallback((tab: AgentSidePanelTab) => {
+    if (tab === 'memory') {
+      setMemoryTabOpen(false)
+      if (activeTab === 'memory') onTabChange('files')
+      return
+    }
+    const previewId = getPreviewIdFromSidePanelTab(tab)
+    if (previewId) { handleClosePreviewTab(previewId); return }
+    if (tab === 'chat') { handleCloseChatTab(); return }
+    const browserTabId = getBrowserTabIdFromSidePanelTab(tab)
+    if (browserTabId) void handleCloseBrowserTab(browserTabId)
+  }, [activeTab, handleCloseBrowserTab, handleCloseChatTab, handleClosePreviewTab, onTabChange, setMemoryTabOpen])
+
+  React.useEffect(() => {
+    const handleCloseActiveWorkspaceTab = (event: Event) => {
+      const { sessionId: targetSessionId } = (event as CustomEvent<{ sessionId?: string }>).detail ?? {}
+      if (targetSessionId === sessionId) handleCloseWorkspaceTab(activeTab)
+    }
+    window.addEventListener(CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT, handleCloseActiveWorkspaceTab)
+    return () => window.removeEventListener(CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT, handleCloseActiveWorkspaceTab)
+  }, [activeTab, handleCloseWorkspaceTab, sessionId])
 
   return (
     <div
@@ -483,21 +717,41 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
         )}
         >
           <DiffPanelTabBar
+            tabs={workspaceTabs}
             activeTab={effectiveActiveTab}
-            onTabChange={onTabChange}
+            onTabChange={handleWorkspaceTabChange}
+            onCloseTab={handleCloseWorkspaceTab}
+            onOpenBrowser={() => void handleOpenBrowserTab()}
+            onOpenFile={() => onTabChange('files')}
             onClose={() => setIsOpen(false)}
-            onCloseChat={handleCloseChatTab}
-            showChatTab={Boolean(sideChatConversationId)}
             isWindows={isWindows}
           />
 
-          {effectiveActiveTab === 'chat' ? (
+          {requestedPreviewId && currentPreviewFile ? (
+            <div className="min-h-0 flex-1 overflow-hidden"><PreviewPanel sessionId={sessionId} file={currentPreviewFile} onClose={() => handleClosePreviewTab(requestedPreviewId)} /></div>
+          ) : activeBrowserTabId ? (
+            browserState && browserState.tabs.some((tab) => tab.tabId === activeBrowserTabId) ? (
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <BrowserPanel sessionId={sessionId} tabId={activeBrowserTabId} state={browserState} />
+              </div>
+            ) : (
+              <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">浏览器标签已关闭</div>
+            )
+          ) : effectiveActiveTab === 'chat' ? (
             sideChatConversationId ? (
               <div className="min-h-0 flex-1 overflow-hidden">
                 <ChatView conversationId={sideChatConversationId} />
               </div>
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">暂无问答会话</div>
+            )
+          ) : effectiveActiveTab === 'memory' ? (
+            workspaceSlug ? (
+              <div className="min-h-0 flex-1 overflow-auto p-2">
+                <WorkspaceMemoryChangeDock workspaceSlug={workspaceSlug} className="flex h-full min-h-0 flex-col bg-content-area p-3" />
+              </div>
+            ) : (
+              <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">等待项目初始化...</div>
             )
           ) : effectiveActiveTab === 'changes' ? (
             sessionPath ? (
@@ -657,7 +911,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                       />
                     )}
                   </div>
-                  {workspaceSlug && <WorkspaceMemoryChangeDock workspaceSlug={workspaceSlug} />}
                 </>
               ) : (
                 <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -12,7 +12,7 @@ import { LeftSidebar } from './LeftSidebar'
 import { RightSidePanel } from './RightSidePanel'
 import { MainArea } from '@/components/tabs/MainArea'
 import { appModeAtom } from '@/atoms/app-mode'
-import { agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
+import { agentDiffPanelTabAtom, agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { leftSidebarWidthAtom } from '@/atoms/sidebar-atoms'
 import { sidebarCollapsedAtom } from '@/atoms/tab-atoms'
 import { automationFormAtom } from '@/atoms/automation-atoms'
@@ -26,14 +26,20 @@ import { SettingsPanel } from '@/components/settings/SettingsPanel'
 import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
-const MIN_RIGHT_PANEL_WIDTH = 300
-const MAX_RIGHT_PANEL_WIDTH = 560
+const MIN_RIGHT_PANEL_WIDTH = 360
+const RIGHT_PANEL_MAX_VIEWPORT_RATIO = 3 / 5
+const WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO = 1 / 2
 
-function clampRightPanelWidth(width: number): number {
-  return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(MAX_RIGHT_PANEL_WIDTH, width))
+function getRightPanelMaxWidth(viewportWidth: number): number {
+  return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.floor(viewportWidth * RIGHT_PANEL_MAX_VIEWPORT_RATIO))
 }
 
-const MIN_LEFT_SIDEBAR_WIDTH = 300
+function clampRightPanelWidth(width: number, viewportWidth: number): number {
+  // 工作区可占整个应用的 3/5；避免窄窗口下最小宽度反而超过可用界面。
+  return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(getRightPanelMaxWidth(viewportWidth), width))
+}
+
+const MIN_LEFT_SIDEBAR_WIDTH = 240
 const MAX_LEFT_SIDEBAR_WIDTH = 420
 
 function clampLeftSidebarWidth(width: number): number {
@@ -45,6 +51,7 @@ export function AppShell(): React.ReactElement {
   const { workspaces, currentWorkspaceId } = useProjectActions()
   const currentWorkspace = workspaces.find((workspace) => workspace.id === currentWorkspaceId)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
+  const activeRightPanelTab = useAtomValue(agentDiffPanelTabAtom).get(currentSessionId ?? '')
   const isPanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
   const automationForm = useAtomValue(automationFormAtom)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
@@ -111,10 +118,31 @@ export function AppShell(): React.ReactElement {
     document.addEventListener('mouseup', onMouseUp)
   }, [clampedLeftSidebarWidth, setLeftSidebarWidth])
 
-  // 右侧面板可拖拽宽度
+  // 右侧工作区可拖拽到应用视口的 3/5，窗口尺寸变化时重新收敛持久化宽度。
   const [rightPanelWidth, setRightPanelWidth] = useAtom(agentSidePanelWidthAtom)
+  const [viewportWidth, setViewportWidth] = React.useState(() => window.innerWidth)
   const dragging = React.useRef(false)
-  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelWidth)
+  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelWidth, viewportWidth)
+  const isWideRightWorkspace = Boolean(
+    activeRightPanelTab?.startsWith('preview:') || activeRightPanelTab?.startsWith('browser:'),
+  )
+  // 首次打开预览/浏览器后，工作区维持宽视图；切回文件/改动不会自动收窄，交给用户拖拽决定。
+  const [hasOpenedWideWorkspace, setHasOpenedWideWorkspace] = React.useState(false)
+  const [widePanelWidthOverride, setWidePanelWidthOverride] = React.useState<number | null>(null)
+  const effectiveWidePanelWidth = widePanelWidthOverride === null
+    ? clampRightPanelWidth(Math.floor(viewportWidth * WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO), viewportWidth)
+    : clampRightPanelWidth(widePanelWidthOverride, viewportWidth)
+  const displayedRightPanelWidth = hasOpenedWideWorkspace ? effectiveWidePanelWidth : clampedRightPanelWidth
+
+  React.useEffect(() => {
+    if (isWideRightWorkspace) setHasOpenedWideWorkspace(true)
+  }, [isWideRightWorkspace])
+
+  React.useEffect(() => {
+    const updateViewportWidth = () => setViewportWidth(window.innerWidth)
+    window.addEventListener('resize', updateViewportWidth)
+    return () => window.removeEventListener('resize', updateViewportWidth)
+  }, [])
 
   React.useEffect(() => {
     if (clampedRightPanelWidth !== rightPanelWidth) {
@@ -126,14 +154,16 @@ export function AppShell(): React.ReactElement {
     e.preventDefault()
     dragging.current = true
     const startX = e.clientX
-    const startWidth = clampedRightPanelWidth
+    const startWidth = displayedRightPanelWidth
     // 记录最新光标位置，rAF 回调读取它而非调度时捕获的旧事件，避免快拖时坐标滞后
     let latestClientX = startX
     let rafId = 0
 
     const applyWidth = () => {
       const delta = startX - latestClientX
-      setRightPanelWidth(clampRightPanelWidth(startWidth + delta))
+      const nextWidth = clampRightPanelWidth(startWidth + delta, viewportWidth)
+      if (hasOpenedWideWorkspace) setWidePanelWidthOverride(nextWidth)
+      else setRightPanelWidth(nextWidth)
     }
 
     const onMouseMove = (ev: MouseEvent) => {
@@ -160,7 +190,7 @@ export function AppShell(): React.ReactElement {
 
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-  }, [clampedRightPanelWidth, setRightPanelWidth])
+  }, [displayedRightPanelWidth, hasOpenedWideWorkspace, setRightPanelWidth, viewportWidth])
 
   return (
     <>
@@ -227,7 +257,7 @@ export function AppShell(): React.ReactElement {
                     onMouseDown={handleMouseDown}
                   />
                 )}
-                <RightSidePanel width={clampedRightPanelWidth} />
+                <RightSidePanel width={displayedRightPanelWidth} />
               </div>
             )}
         </div>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, ChevronDown, ChevronUp, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
+import { Pin, PinOff, Star, Settings, Plus, CirclePlus, Trash2, Pencil, PanelLeft, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, ChevronDown, ChevronUp, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -3300,35 +3300,38 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                 'sidebar-collapse-button mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 titlebar-no-drag transition-[background-color,color] duration-150'
               )}
             >
-              <PanelLeftClose size={14} />
+              <PanelLeft size={14} />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">收起侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+Shift+E'})</TooltipContent>
         </Tooltip>
       </div>
 
-      {/* 新对话/新会话按钮 + 搜索按钮 */}
-      <div className="px-3 pt-2 flex items-center gap-1.5">
+      {/* 新建任务/对话与搜索：默认无底色，降低左侧栏高频操作的视觉权重。 */}
+      <div className="flex items-center gap-1 px-3 pt-2">
         <Tooltip>
           <TooltipTrigger asChild>
             <button
               type="button"
-              aria-label={mode === 'agent' ? '新建 Agent 会话' : '新建 Chat 对话'}
+              aria-label={mode === 'agent' ? '新建任务' : '新建对话'}
               onClick={() => { void (mode === 'agent' ? createAgentSessionInWorkspace() : createChat()) }}
-              className="flex-1 h-10 flex items-center gap-2 px-2.5 rounded-xl text-[13px] font-medium text-foreground/70 sidebar-control-surface hover:text-foreground transition-colors duration-100 titlebar-no-drag border border-transparent"
+              className="group flex h-9 min-w-0 flex-1 items-center gap-3 rounded-lg px-0 text-[13px] font-medium text-foreground/70 transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-foreground active:scale-[0.96] titlebar-no-drag"
             >
-              <Plus size={14} />
-              <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
+              <CirclePlus size={16} className="shrink-0" />
+              <span>{mode === 'agent' ? '新建任务' : '新建对话'}</span>
+              <span className="ml-auto flex shrink-0 items-center opacity-70 group-hover:opacity-100">
+                <ShortcutKeycaps
+                  shortcutId="new-session"
+                  keycapClassName="h-5 min-w-5 px-1 text-[11px]"
+                  separatorClassName="text-[10px]"
+                />
+              </span>
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
             <span className="flex items-center gap-2">
-              <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
-              <ShortcutKeycaps
-                shortcutId="new-session"
-                keycapClassName="h-5 min-w-5 px-1 text-[11px]"
-                separatorClassName="text-[10px]"
-              />
+              <span>{mode === 'agent' ? '新建任务' : '新建对话'}</span>
+              <ShortcutKeycaps shortcutId="new-session" keycapClassName="h-5 min-w-5 px-1 text-[11px]" separatorClassName="text-[10px]" />
             </span>
           </TooltipContent>
         </Tooltip>
@@ -3338,9 +3341,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               type="button"
               onClick={() => setSearchDialogOpen(true)}
               aria-label="搜索"
-              className="flex-shrink-0 size-10 flex items-center justify-center rounded-xl text-foreground/40 sidebar-control-surface hover:text-foreground/70 transition-colors duration-100 titlebar-no-drag"
+              className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-foreground/45 transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-foreground active:scale-[0.96] titlebar-no-drag"
             >
-              <Search size={14} />
+              <Search size={16} />
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -70,7 +70,7 @@ import {
   automationGroupOrderAtom,
 } from '@/atoms/agent-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
-import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
+import { previewPanelOpenMapAtom, previewFileMapAtom, previewFilesMapAtom } from '@/atoms/preview-atoms'
 import { clearPreviewCacheForSession } from '@/components/diff/DiffTabContent'
 import {
   tabsAtom,
@@ -873,6 +873,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setConvPromptId = useSetAtom(conversationPromptIdAtom)
   const setPreviewPanelOpen = useSetAtom(previewPanelOpenMapAtom)
   const setPreviewFile = useSetAtom(previewFileMapAtom)
+  const setPreviewFiles = useSetAtom(previewFilesMapAtom)
   const setAgentSideChatMap = useSetAtom(agentSideChatMapAtom)
   const setDiffPanelTab = useSetAtom(agentDiffPanelTabAtom)
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
@@ -902,6 +903,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setConvPromptId(deleteKey)
     setPreviewPanelOpen(deleteKey)
     setPreviewFile(deleteKey)
+    setPreviewFiles(deleteKey)
     setAgentSideChatMap((prev) => {
       let changed = false
       const map = new Map(prev)

--- a/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
@@ -11,11 +11,16 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { appModeAtom } from '@/atoms/app-mode'
 import {
   currentAgentSessionIdAtom,
+  currentSessionSidePanelOpenAtom,
   agentSessionPathMapAtom,
   agentDiffPanelTabAtom,
+  getBrowserSidePanelTab,
+  getPreviewSidePanelTab,
 } from '@/atoms/agent-atoms'
 import type { AgentSidePanelTab } from '@/atoms/agent-atoms'
 import { SidePanel } from '@/components/agent/SidePanel'
+import { browserPanelOpenMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
+import { getPreviewFileId, previewFileMapAtom } from '@/atoms/preview-atoms'
 
 export function RightSidePanel({ width }: { width?: number }): React.ReactElement | null {
   const appMode = useAtomValue(appModeAtom)
@@ -23,6 +28,15 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
   const sessionPathMap = useAtomValue(agentSessionPathMapAtom)
   const diffPanelTabMap = useAtomValue(agentDiffPanelTabAtom)
   const setDiffPanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const setSidePanelOpen = useSetAtom(currentSessionSidePanelOpenAtom)
+  const browserOpenMap = useAtomValue(browserPanelOpenMapAtom)
+  const browserStateMap = useAtomValue(browserStateMapAtom)
+  const browserOpen = currentSessionId ? browserOpenMap.get(currentSessionId) === true : false
+  const browserState = currentSessionId ? browserStateMap.get(currentSessionId) ?? null : null
+  const previewFileMap = useAtomValue(previewFileMapAtom)
+  const currentPreviewFile = currentSessionId ? previewFileMap.get(currentSessionId) ?? null : null
+  const previousBrowserStateRef = React.useRef<{ sessionId: string | null; open: boolean }>({ sessionId: null, open: false })
+  const pendingBrowserActivationRef = React.useRef<string | null>(null)
 
   const setActiveTab = React.useCallback((tab: AgentSidePanelTab) => {
     if (!currentSessionId) return
@@ -33,12 +47,36 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
     })
   }, [currentSessionId, setDiffPanelTabMap])
 
+  // Agent 或回复链接在当前会话首次打开浏览器时，直接让右侧工作区承接它。
+  // 切换到一个已有浏览器的会话时不抢占用户当前视图，保留该会话上次的外层 Tab。
+  React.useEffect(() => {
+    const previous = previousBrowserStateRef.current
+    const openedInCurrentSession = previous.sessionId === currentSessionId && !previous.open && browserOpen
+    previousBrowserStateRef.current = { sessionId: currentSessionId, open: browserOpen }
+    if (openedInCurrentSession && currentSessionId) pendingBrowserActivationRef.current = currentSessionId
+    if (!currentSessionId || pendingBrowserActivationRef.current !== currentSessionId || !browserState?.activeTabId) return
+
+    setSidePanelOpen(true)
+    setDiffPanelTabMap((prev) => {
+      const next = new Map(prev)
+      next.set(currentSessionId, getBrowserSidePanelTab(browserState.activeTabId))
+      return next
+    })
+    pendingBrowserActivationRef.current = null
+  }, [browserOpen, browserState?.activeTabId, currentSessionId, setDiffPanelTabMap, setSidePanelOpen])
+
   if (appMode !== 'agent' || !currentSessionId) {
     return null
   }
 
   const sessionPath = sessionPathMap.get(currentSessionId) ?? null
-  const activeTab = diffPanelTabMap.get(currentSessionId) ?? 'files'
+  const storedTab = diffPanelTabMap.get(currentSessionId) ?? 'files'
+  // 兼容这次扁平化前内存中的旧“浏览器”工作区值。
+  const activeTab: AgentSidePanelTab = storedTab === 'browser'
+    ? browserState?.activeTabId ? getBrowserSidePanelTab(browserState.activeTabId) : 'files'
+    : storedTab === 'preview'
+      ? currentPreviewFile ? getPreviewSidePanelTab(getPreviewFileId(currentPreviewFile)) : 'files'
+      : storedTab
 
   return (
     <SidePanel

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -54,8 +54,8 @@ export function BrowserPanel({ sessionId, tabId, state }: BrowserPanelProps): Re
     const value = url.trim()
     const navigateBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).navigateAgentBrowser
     if (!value || typeof navigateBrowser !== 'function') return
-    try { await navigateBrowser({ sessionId, url: value }) } catch (error) { console.error('[受管浏览器] 导航失败:', error) }
-  }, [sessionId, url])
+    try { await navigateBrowser({ sessionId, tabId, url: value }) } catch (error) { console.error('[受管浏览器] 导航失败:', error) }
+  }, [sessionId, tabId, url])
 
   const closeBrowser = React.useCallback(async () => {
     try {
@@ -109,16 +109,19 @@ export function BrowserPanel({ sessionId, tabId, state }: BrowserPanelProps): Re
   }, [sessionId, state?.executionSource])
 
   const riskBlocked = riskAcknowledged !== true
+  // 外层右侧 Tab 会先更新 UI，再异步激活 controller 中的原生标签；激活完成前禁用
+  // 依赖 controller.activeTabId 的历史操作，导航则始终显式携带当前 tabId。
+  const isControllerTabActive = state?.activeTabId === tabId
   const isBackgroundRun = state?.executionSource === 'automation' || state?.executionSource === 'delegation'
   const isWindows = React.useMemo(() => detectIsWindows(), [])
   return (
     <div className="flex h-full min-w-0 flex-col overflow-hidden border-l border-border/80 bg-content-area titlebar-no-drag">
       <div className={cn('flex items-center h-[42px] gap-1 px-2 border-b border-border/40 bg-muted/20', getWindowControlsPaddingClass(isWindows))}>
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !state?.canGoBack} onClick={() => void window.electronAPI.goBackAgentBrowser?.(sessionId)}><ChevronLeft className="size-5" /></Button></TooltipTrigger><TooltipContent>后退</TooltipContent></Tooltip>
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !state?.canGoForward} onClick={() => void window.electronAPI.goForwardAgentBrowser?.(sessionId)}><ChevronRight className="size-5" /></Button></TooltipTrigger><TooltipContent>前进</TooltipContent></Tooltip>
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked} onClick={() => void window.electronAPI.reloadAgentBrowser?.(sessionId)}><RotateCw className="size-[18px]" /></Button></TooltipTrigger><TooltipContent>刷新</TooltipContent></Tooltip>
+        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !isControllerTabActive || !state?.canGoBack} onClick={() => void window.electronAPI.goBackAgentBrowser?.(sessionId)}><ChevronLeft className="size-5" /></Button></TooltipTrigger><TooltipContent>后退</TooltipContent></Tooltip>
+        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !isControllerTabActive || !state?.canGoForward} onClick={() => void window.electronAPI.goForwardAgentBrowser?.(sessionId)}><ChevronRight className="size-5" /></Button></TooltipTrigger><TooltipContent>前进</TooltipContent></Tooltip>
+        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !isControllerTabActive} onClick={() => void window.electronAPI.reloadAgentBrowser?.(sessionId)}><RotateCw className="size-[18px]" /></Button></TooltipTrigger><TooltipContent>刷新</TooltipContent></Tooltip>
         <form className="flex-1 min-w-0" onSubmit={(event) => { event.preventDefault(); if (!riskBlocked) void navigate() }}>
-          <Input disabled={riskBlocked} value={url} onChange={(event) => setUrl(event.target.value)} placeholder="输入网址或搜索内容" className="h-7 bg-background/70 text-xs text-muted-foreground/70" aria-label="浏览器地址" />
+          <Input disabled={riskBlocked || !isControllerTabActive} value={url} onChange={(event) => setUrl(event.target.value)} placeholder="输入网址或搜索内容" className="h-7 bg-background/70 text-xs text-muted-foreground/70" aria-label="浏览器地址" />
         </form>
         {state?.loading && <LoaderCircle className="size-3.5 text-muted-foreground animate-spin" />}
         {isBackgroundRun && (

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import type { BrowserViewState } from '@proma/shared'
-import { ArrowLeft, ArrowRight, ExternalLink, Globe2, LoaderCircle, Minus, Plus, RefreshCw, ShieldAlert, Square, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight, LoaderCircle, RotateCw, ShieldAlert, Square } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -23,19 +23,20 @@ import { shouldReuseInitialBrowserTab } from './agent-browser-link-utils'
 
 interface BrowserPanelProps {
   sessionId: string
+  /** 由右侧统一顶栏选中的网页。 */
+  tabId: string
   state: BrowserViewState | null
-  onMinimize: () => void
-  onClose: () => void
 }
 
-export function BrowserPanel({ sessionId, state, onMinimize, onClose }: BrowserPanelProps): React.ReactElement {
+export function BrowserPanel({ sessionId, tabId, state }: BrowserPanelProps): React.ReactElement {
   const [url, setUrl] = React.useState(state?.url ?? '')
   const [riskAcknowledged, setRiskAcknowledged] = React.useState<boolean | null>(null)
   const [savingRiskAcknowledgement, setSavingRiskAcknowledgement] = React.useState(false)
   const pendingNavigationUrl = useAtomValue(browserPendingNavigationMapAtom).get(sessionId)
   const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
 
-  React.useEffect(() => setUrl(state?.url ?? ''), [state?.url])
+  const selectedTab = state?.tabs.find((tab) => tab.tabId === tabId) ?? null
+  React.useEffect(() => setUrl(selectedTab?.url ?? ''), [selectedTab?.url])
   React.useEffect(() => {
     let cancelled = false
     void window.electronAPI.getSettings()
@@ -56,32 +57,13 @@ export function BrowserPanel({ sessionId, state, onMinimize, onClose }: BrowserP
     try { await navigateBrowser({ sessionId, url: value }) } catch (error) { console.error('[受管浏览器] 导航失败:', error) }
   }, [sessionId, url])
 
-  const openInDefaultBrowser = React.useCallback(() => {
-    const value = url.trim()
-    if (value.startsWith('http://') || value.startsWith('https://')) void window.electronAPI.openExternal(value)
-  }, [url])
-
-  const close = React.useCallback(async () => {
-    const closeBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).closeAgentBrowser
-    if (typeof closeBrowser !== 'function') { onClose(); return }
+  const closeBrowser = React.useCallback(async () => {
     try {
-      await closeBrowser(sessionId)
-      onClose()
+      await window.electronAPI.closeAgentBrowser(sessionId)
     } catch (error) {
       console.error('[受管浏览器] 关闭失败:', error)
     }
-  }, [onClose, sessionId])
-
-  const minimize = React.useCallback(async () => {
-    const minimizeBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).minimizeAgentBrowser
-    try {
-      if (typeof minimizeBrowser === 'function') await minimizeBrowser(sessionId)
-    } catch (error) {
-      console.error('[受管浏览器] 最小化失败:', error)
-    } finally {
-      onMinimize()
-    }
-  }, [onMinimize, sessionId])
+  }, [sessionId])
 
   const acceptRiskDisclaimer = React.useCallback(async () => {
     setSavingRiskAcknowledgement(true)
@@ -126,82 +108,25 @@ export function BrowserPanel({ sessionId, state, onMinimize, onClose }: BrowserP
     }
   }, [sessionId, state?.executionSource])
 
-  const activeTabId = state?.activeTabId ?? ''
-  const tabs = state?.tabs ?? []
   const riskBlocked = riskAcknowledged !== true
   const isBackgroundRun = state?.executionSource === 'automation' || state?.executionSource === 'delegation'
-
-  const selectTab = React.useCallback(async (tabId: string) => {
-    const select = (window.electronAPI as Partial<typeof window.electronAPI>).selectAgentBrowserTab
-    if (typeof select !== 'function') return
-    try { await select({ sessionId, tabId }) } catch (error) { console.error('[受管浏览器] 切换标签失败:', error) }
-  }, [sessionId])
-
-  const createTab = React.useCallback(async () => {
-    const create = (window.electronAPI as Partial<typeof window.electronAPI>).createAgentBrowserTab
-    if (typeof create !== 'function') return
-    try { await create({ sessionId }) } catch (error) { console.error('[受管浏览器] 新建标签失败:', error) }
-  }, [sessionId])
-
-  const closeTab = React.useCallback(async (tabId: string) => {
-    const closeBrowserTab = (window.electronAPI as Partial<typeof window.electronAPI>).closeAgentBrowserTab
-    if (typeof closeBrowserTab !== 'function') return
-    try {
-      const next = await closeBrowserTab({ sessionId, tabId })
-      if (!next) onClose()
-    } catch (error) { console.error('[受管浏览器] 关闭标签失败:', error) }
-  }, [onClose, sessionId])
-
-  const title = state?.title || '受管浏览器'
   const isWindows = React.useMemo(() => detectIsWindows(), [])
   return (
-    <div className="flex flex-col h-full min-w-0 overflow-hidden bg-content-area titlebar-no-drag">
+    <div className="flex h-full min-w-0 flex-col overflow-hidden border-l border-border/80 bg-content-area titlebar-no-drag">
       <div className={cn('flex items-center h-[42px] gap-1 px-2 border-b border-border/40 bg-muted/20', getWindowControlsPaddingClass(isWindows))}>
-        <Globe2 className="size-4 shrink-0 text-primary ml-1" />
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" disabled={riskBlocked || !state?.canGoBack} onClick={() => void window.electronAPI.goBackAgentBrowser?.(sessionId)}><ArrowLeft className="size-3.5" /></Button></TooltipTrigger><TooltipContent>后退</TooltipContent></Tooltip>
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" disabled={riskBlocked || !state?.canGoForward} onClick={() => void window.electronAPI.goForwardAgentBrowser?.(sessionId)}><ArrowRight className="size-3.5" /></Button></TooltipTrigger><TooltipContent>前进</TooltipContent></Tooltip>
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" disabled={riskBlocked} onClick={() => void window.electronAPI.reloadAgentBrowser?.(sessionId)}><RefreshCw className="size-3.5" /></Button></TooltipTrigger><TooltipContent>刷新</TooltipContent></Tooltip>
+        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !state?.canGoBack} onClick={() => void window.electronAPI.goBackAgentBrowser?.(sessionId)}><ChevronLeft className="size-5" /></Button></TooltipTrigger><TooltipContent>后退</TooltipContent></Tooltip>
+        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !state?.canGoForward} onClick={() => void window.electronAPI.goForwardAgentBrowser?.(sessionId)}><ChevronRight className="size-5" /></Button></TooltipTrigger><TooltipContent>前进</TooltipContent></Tooltip>
+        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked} onClick={() => void window.electronAPI.reloadAgentBrowser?.(sessionId)}><RotateCw className="size-[18px]" /></Button></TooltipTrigger><TooltipContent>刷新</TooltipContent></Tooltip>
         <form className="flex-1 min-w-0" onSubmit={(event) => { event.preventDefault(); if (!riskBlocked) void navigate() }}>
-          <Input disabled={riskBlocked} value={url} onChange={(event) => setUrl(event.target.value)} placeholder="输入网址或搜索内容" className="h-7 text-xs bg-background/70" aria-label="浏览器地址" />
+          <Input disabled={riskBlocked} value={url} onChange={(event) => setUrl(event.target.value)} placeholder="输入网址或搜索内容" className="h-7 bg-background/70 text-xs text-muted-foreground/70" aria-label="浏览器地址" />
         </form>
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" disabled={!url.startsWith('http://') && !url.startsWith('https://')} onClick={openInDefaultBrowser} aria-label="在系统默认浏览器中打开当前网页"><ExternalLink className="size-3.5" /></Button></TooltipTrigger><TooltipContent>在系统默认浏览器中打开</TooltipContent></Tooltip>
         {state?.loading && <LoaderCircle className="size-3.5 text-muted-foreground animate-spin" />}
         {isBackgroundRun && (
           <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7 text-amber-600 hover:text-amber-700" onClick={() => void stopBackgroundRun()} aria-label="停止当前后台 Agent"><Square className="size-3.5 fill-current" /></Button></TooltipTrigger><TooltipContent>停止当前{state?.executionSource === 'automation' ? '自动任务' : '委派'}运行</TooltipContent></Tooltip>
         )}
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" onClick={() => void minimize()} aria-label="最小化受管浏览器"><Minus className="size-3.5" /></Button></TooltipTrigger><TooltipContent>最小化浏览器</TooltipContent></Tooltip>
-        <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7" onClick={() => void close()}><X className="size-3.5" /></Button></TooltipTrigger><TooltipContent>关闭并销毁受管浏览器</TooltipContent></Tooltip>
-      </div>
-      <div className="flex items-center h-8 gap-1 px-2 border-b border-border/30 bg-muted/10 overflow-x-auto scrollbar-none">
-        {tabs.map((tab) => (
-          <button
-            key={tab.tabId}
-            type="button"
-            disabled={riskBlocked}
-            onClick={() => void selectTab(tab.tabId)}
-            className={`group flex items-center gap-1.5 h-6 min-w-[120px] max-w-[220px] px-2 rounded text-[11px] disabled:cursor-not-allowed disabled:opacity-50 ${tab.tabId === activeTabId ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'}`}
-            aria-label={`切换到 ${tab.title || '新建标签页'}${tab.openedByAgent ? '（由 Agent 创建）' : tab.openedByPopup ? '（由网页新窗口创建）' : ''}`}
-          >
-            <Globe2 className="size-3 shrink-0" />
-            <span className="truncate flex-1 text-left">{tab.title || '新建标签页'}</span>
-            {tab.openedByAgent && <span className="shrink-0 rounded bg-primary/10 px-1 py-px text-[9px] font-medium text-primary">Agent</span>}
-            {tab.openedByPopup && <span className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">Popup</span>}
-            <span
-              role="button"
-              tabIndex={0}
-              className="shrink-0 rounded p-0.5 opacity-50 hover:bg-muted hover:opacity-100"
-              aria-label={`关闭 ${tab.title || '标签'}`}
-              onClick={(event) => { event.stopPropagation(); void closeTab(tab.tabId) }}
-              onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); event.stopPropagation(); void closeTab(tab.tabId) } }}
-            >
-              <X className="size-3" />
-            </span>
-          </button>
-        ))}
-        <Tooltip><TooltipTrigger asChild><Button type="button" variant="ghost" size="icon" className="size-6 shrink-0" disabled={riskBlocked} onClick={() => void createTab()} aria-label="新建浏览器标签"><Plus className="size-3.5" /></Button></TooltipTrigger><TooltipContent>新建标签</TooltipContent></Tooltip>
       </div>
       {riskAcknowledged === true ? (
-        <BrowserSlot key={activeTabId} sessionId={sessionId} tabId={activeTabId} />
+        <BrowserSlot key={tabId} sessionId={sessionId} tabId={tabId} />
       ) : (
         <div className="flex flex-1 min-h-0 items-center justify-center bg-muted/15 px-8 text-center">
           <div className="max-w-sm space-y-2 text-muted-foreground">
@@ -211,7 +136,7 @@ export function BrowserPanel({ sessionId, state, onMinimize, onClose }: BrowserP
           </div>
         </div>
       )}
-      <AlertDialog open={riskAcknowledged === false} onOpenChange={(open) => { if (!open && !savingRiskAcknowledgement) void close() }}>
+      <AlertDialog open={riskAcknowledged === false} onOpenChange={(open) => { if (!open && !savingRiskAcknowledgement) void closeBrowser() }}>
         <AlertDialogContent className="max-w-xl">
           <AlertDialogHeader>
             <div className="mb-1 flex size-10 items-center justify-center rounded-xl bg-amber-500/10 text-amber-600 dark:text-amber-400">
@@ -234,13 +159,6 @@ export function BrowserPanel({ sessionId, state, onMinimize, onClose }: BrowserP
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      {state && state.trace.length > 0 && (
-        <div className="flex items-center h-7 px-3 gap-2 border-t border-border/30 text-[11px] text-muted-foreground bg-muted/15">
-          <span className="shrink-0 text-primary/80">Agent 操作</span>
-          <span className="truncate">{state.trace[state.trace.length - 1]?.summary}</span>
-          <span className="ml-auto shrink-0 hidden lg:inline">点击与输入目标会短暂高亮</span>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
@@ -102,33 +102,44 @@ export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: st
     const setLayout = (window.electronAPI as Partial<typeof window.electronAPI>).setAgentBrowserLayout
     if (!element || typeof setLayout !== 'function') return
     let frame = 0
-    const publish = (visible: boolean, preserveSessionOnHide = false) => {
-      if (frame) cancelAnimationFrame(frame)
-      frame = requestAnimationFrame(() => {
-        const rect = element.getBoundingClientRect()
-        void setLayout({
-          sessionId,
-          tabId,
-          revision: nextBrowserLayoutRevision(),
-          visible: visible && rect.width > 4 && rect.height > 4,
-          preserveSessionOnHide,
-          bounds: {
-            x: Math.round(rect.x), y: Math.round(rect.y),
-            width: Math.round(rect.width), height: Math.round(rect.height),
-          },
-        })
+    const commitLayout = (visible: boolean, preserveSessionOnHide: boolean) => {
+      const rect = element.getBoundingClientRect()
+      void setLayout({
+        sessionId,
+        tabId,
+        revision: nextBrowserLayoutRevision(),
+        visible: visible && rect.width > 4 && rect.height > 4,
+        preserveSessionOnHide,
+        bounds: {
+          x: Math.round(rect.x), y: Math.round(rect.y),
+          width: Math.round(rect.width), height: Math.round(rect.height),
+        },
       })
     }
-    const publishCurrentVisibility = () => {
-      const overlayOpen = hasBlockingAppOverlay()
-      publish(!overlayOpen, overlayOpen)
+    const publish = (visible: boolean, preserveSessionOnHide = false, immediate = false) => {
+      if (frame) cancelAnimationFrame(frame)
+      if (immediate) {
+        frame = 0
+        commitLayout(visible, preserveSessionOnHide)
+        return
+      }
+      frame = requestAnimationFrame(() => {
+        frame = 0
+        commitLayout(visible, preserveSessionOnHide)
+      })
     }
-    const observer = new ResizeObserver(publishCurrentVisibility)
-    const disconnectOverlayObserver = observeAppOverlayLifecycle(publishCurrentVisibility)
+    const publishCurrentVisibility = (immediate = false) => {
+      const overlayOpen = hasBlockingAppOverlay()
+      publish(!overlayOpen, overlayOpen, immediate)
+    }
+    const observer = new ResizeObserver(() => publishCurrentVisibility())
+    const disconnectOverlayObserver = observeAppOverlayLifecycle(() => publishCurrentVisibility())
     const publishBounded = () => publishCurrentVisibility()
     observer.observe(element)
     window.addEventListener('resize', publishBounded)
-    publishCurrentVisibility()
+    // Tab 切换时先前 Slot 会立即发出 hide。新 Slot 不能再等一帧才 show，
+    // 否则快速左右切换时原生视图会停留在隐藏状态，表现为页面内容消失。
+    publishCurrentVisibility(true)
     return () => {
       observer.disconnect()
       disconnectOverlayObserver()

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -13,7 +13,6 @@ import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
 import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom, agentSessionsAtom, workspaceGitDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
 import { WorktreeSelector } from './WorktreeSelector'
-import { WorkspaceMemoryChangeDock } from '@/components/agent-skills/WorkspaceMemoryChangeDock'
 import { groupSessionFileChanges } from '@/lib/session-file-changes'
 import type { SessionFileChange } from '@/lib/session-file-changes'
 import { buildDiffFileTree } from './diff-file-tree'
@@ -318,7 +317,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       {!hasAnyVisibleChanges && (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
           <p className="text-[12px] text-center">
-            {isGitRepo ? (hasFetched ? '没有文件改动' : '加载中…') : '当前目录不是 Git 仓库'}
+            {isGitRepo ? (hasFetched ? '没有文件改动' : '加载中…') : '当前目录不是 Git 仓库，或暂无文件改动'}
           </p>
         </div>
       )}
@@ -368,7 +367,6 @@ export const DiffChangesList = React.memo(function DiffChangesList({
         </>
       )}
       </div>
-      {workspaceSlug && <WorkspaceMemoryChangeDock workspaceSlug={workspaceSlug} />}
     </div>
   )
 })

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { FolderOpen, Globe, MessageCircle, PanelRight, Plus, X } from 'lucide-react'
+import { Brain, FolderOpen, Globe, MessageCircle, PanelRight, Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -35,6 +35,7 @@ interface DiffPanelTabBarProps {
   onCloseTab: (tab: AgentSidePanelTab) => void
   onOpenBrowser: () => void
   onOpenFile: () => void
+  onOpenMemory?: () => void
   onOpenChat?: () => void
   onClose?: () => void
   isWindows?: boolean
@@ -47,6 +48,7 @@ export function DiffPanelTabBar({
   onCloseTab,
   onOpenBrowser,
   onOpenFile,
+  onOpenMemory,
   onOpenChat,
   onClose,
   isWindows = false,
@@ -143,6 +145,12 @@ export function DiffPanelTabBar({
               <FolderOpen className="size-3.5" />
               打开文件
             </DropdownMenuItem>
+            {onOpenMemory && (
+              <DropdownMenuItem onSelect={onOpenMemory}>
+                <Brain className="size-3.5" />
+                打开项目记忆
+              </DropdownMenuItem>
+            )}
             {onOpenChat && (
               <>
                 <DropdownMenuSeparator />

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -1,169 +1,172 @@
 /**
- * DiffPanelTabBar — 右侧面板顶部 Tab 栏
+ * DiffPanelTabBar — 右侧工作区的统一顶栏。
  *
- * 切换「文件」和「代码改动」视图。文件内同时展示会话文件与项目文件。
+ * 文件、改动、预览、问答和每个浏览器网页位于同一层级；网页不再拥有嵌套 Tab 栏。
  */
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { PanelRightClose, X } from 'lucide-react'
+import { FolderOpen, Globe, MessageCircle, PanelRight, Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import type { AgentSidePanelTab } from '@/atoms/agent-atoms'
-import { interfaceVariantAtom } from '@/atoms/theme'
+
+export interface WorkspacePanelTab {
+  id: AgentSidePanelTab
+  label: string
+  icon: React.ReactNode
+  closable?: boolean
+  activity?: boolean
+}
 
 interface DiffPanelTabBarProps {
+  tabs: WorkspacePanelTab[]
   activeTab: AgentSidePanelTab
   onTabChange: (tab: AgentSidePanelTab) => void
+  onCloseTab: (tab: AgentSidePanelTab) => void
+  onOpenBrowser: () => void
+  onOpenFile: () => void
+  onOpenChat?: () => void
   onClose?: () => void
-  onCloseChat?: () => void
-  showChatTab?: boolean
   isWindows?: boolean
 }
 
-interface PreviousTabState {
-  sessionId: string | null
-  activeTab: AgentSidePanelTab
-}
-
 export function DiffPanelTabBar({
+  tabs,
   activeTab,
   onTabChange,
+  onCloseTab,
+  onOpenBrowser,
+  onOpenFile,
+  onOpenChat,
   onClose,
-  onCloseChat,
-  showChatTab = false,
   isWindows = false,
 }: DiffPanelTabBarProps): React.ReactElement {
   const unseenMap = useAtomValue(agentDiffUnseenChangesAtom)
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
-  const interfaceVariant = useAtomValue(interfaceVariantAtom)
-  const isClassic = interfaceVariant === 'classic'
   const unseenChanges = unseenMap.get(currentSessionId ?? '') ?? false
-  const prevTabStateRef = React.useRef<PreviousTabState>({ sessionId: currentSessionId, activeTab })
 
-  const clearUnseen = React.useCallback((sessionId = currentSessionId) => {
-    if (!sessionId) return
-    setUnseenMap((prev) => {
-      if (prev.get(sessionId) === false) return prev
-      const m = new Map(prev)
-      m.set(sessionId, false)
-      return m
-    })
-  }, [currentSessionId, setUnseenMap])
-
-  // 同一会话内，从「文件改动」切走时，说明用户已经看过当前改动。
-  React.useEffect(() => {
-    const previous = prevTabStateRef.current
-    if (previous.sessionId === currentSessionId && previous.activeTab === 'changes' && activeTab !== 'changes') {
-      clearUnseen(currentSessionId)
+  const selectTab = React.useCallback((tab: AgentSidePanelTab) => {
+    if (tab === 'changes' && currentSessionId) {
+      setUnseenMap((previous) => {
+        if (previous.get(currentSessionId) === false) return previous
+        const next = new Map(previous)
+        next.set(currentSessionId, false)
+        return next
+      })
     }
-    prevTabStateRef.current = { sessionId: currentSessionId, activeTab }
-  }, [activeTab, currentSessionId, clearUnseen])
-
-  const handleChangesClick = () => {
-    clearUnseen()
-    if (activeTab !== 'changes') {
-      onTabChange('changes')
-    }
-  }
+    onTabChange(tab)
+  }, [currentSessionId, onTabChange, setUnseenMap])
 
   return (
-    <div className="flex items-end h-[34px] tabbar-bg relative flex-shrink-0">
-      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
-      <div className="relative flex items-end flex-1 titlebar-no-drag">
-        <button
-          type="button"
-          onClick={() => onTabChange('files')}
-          className={cn(
-            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer whitespace-nowrap overflow-hidden',
-            isClassic ? 'rounded-t-lg' : 'rounded-none',
-            'border-t border-l border-r',
-            activeTab === 'files'
-              ? isClassic
-                ? 'bg-content-area text-foreground border-border/50'
-                : 'app-tab-active text-foreground border-border/80'
-              : isClassic
-                ? 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50'
-                : 'app-tab-inactive text-muted-foreground border-transparent hover:text-foreground',
-          )}
-        >
-          文件
-        </button>
-        <button
-          type="button"
-          onClick={handleChangesClick}
-          className={cn(
-            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer relative whitespace-nowrap overflow-hidden',
-            isClassic ? 'rounded-t-lg' : 'rounded-none',
-            'border-t border-l border-r',
-            activeTab === 'changes'
-              ? isClassic
-                ? 'bg-content-area text-foreground border-border/50'
-                : 'app-tab-active text-foreground border-border/80'
-              : isClassic
-                ? 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50'
-                : 'app-tab-inactive text-muted-foreground border-transparent hover:text-foreground',
-          )}
-        >
-          <span className="inline-flex items-center gap-1">
-            {unseenChanges && activeTab !== 'changes' && (
-              <span className="size-2 rounded-full bg-primary ring-1 ring-background shrink-0" />
-            )}
-            文件改动
-          </span>
-        </button>
-        {showChatTab && (
-          <div
-            className={cn(
-              'flex-1 h-[34px] text-xs transition-colors select-none relative whitespace-nowrap overflow-hidden',
-              isClassic ? 'rounded-t-lg' : 'rounded-none',
-              'border-t border-l border-r',
-              activeTab === 'chat'
-                ? isClassic
-                  ? 'bg-content-area text-foreground border-border/50'
-                  : 'app-tab-active text-foreground border-border/80'
-                : isClassic
-                  ? 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50'
-                  : 'app-tab-inactive text-muted-foreground border-transparent hover:text-foreground',
-            )}
-          >
-            <div className="flex h-full items-center">
-              <button
-                type="button"
-                onClick={() => onTabChange('chat')}
-                className="min-w-0 flex-1 self-stretch px-2 text-left"
+    <div className="relative flex h-9 shrink-0 items-center border-b border-border/50 bg-content-area">
+      <div className={cn('pointer-events-none absolute inset-0 titlebar-drag-region', isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
+      <div className="relative flex min-w-0 flex-1 items-center titlebar-no-drag">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto overscroll-x-contain px-2 py-1 scrollbar-none" role="tablist" aria-label="右侧工作区">
+          {tabs.map((tab) => {
+            const selected = activeTab === tab.id
+            const isChangesTab = tab.id === 'changes'
+            return (
+              <div
+                key={tab.id}
+                className={cn(
+                  'group flex h-8 min-w-[84px] max-w-60 shrink-0 items-center rounded-lg transition-[background-color,box-shadow,color] duration-150',
+                  selected
+                    ? 'bg-muted/80 text-foreground shadow-sm shadow-black/[0.08] dark:shadow-black/20'
+                    : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+                )}
               >
-                <span className="block truncate text-center">问答</span>
-              </button>
-              {onCloseChat && (
                 <button
                   type="button"
-                  className="mr-1 inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/70 hover:text-foreground"
-                  aria-label="关闭问答 Tab"
-                  onClick={onCloseChat}
+                  role="tab"
+                  aria-selected={selected}
+                  onClick={() => selectTab(tab.id)}
+                  className="flex min-w-0 flex-1 items-center gap-2 self-stretch px-3 text-left text-[13px] outline-none"
                 >
-                  <X className="size-3" />
+                  {tab.activity || (isChangesTab && unseenChanges && !selected) ? (
+                    <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-label="有未查看更新" />
+                  ) : (
+                    <span className={cn('shrink-0', selected ? 'text-foreground' : 'text-muted-foreground/80')}>{tab.icon}</span>
+                  )}
+                  <span className="truncate">{tab.label}</span>
                 </button>
-              )}
-            </div>
-          </div>
-        )}
-        {/* 右侧关闭按钮（常驻，三个 tab 下都可见） */}
+                {tab.closable && (
+                  <button
+                    type="button"
+                    onClick={() => onCloseTab(tab.id)}
+                    className={cn(
+                      'inline-flex h-7 shrink-0 items-center justify-center overflow-hidden rounded-md text-muted-foreground transition-[width,margin,background-color,color,opacity,transform] hover:bg-background/70 hover:text-foreground active:scale-[0.96]',
+                      selected
+                        ? 'mr-1 w-7 opacity-60 hover:opacity-100'
+                        : 'mr-0 w-0 opacity-0 group-hover:mr-1 group-hover:w-7 group-hover:opacity-60 group-hover:hover:opacity-100',
+                    )}
+                    aria-label={`关闭 ${tab.label}`}
+                  >
+                    <X className="size-3" />
+                  </button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="mr-1 inline-flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-[background-color,color,transform] hover:bg-muted hover:text-foreground active:scale-[0.96]"
+                  aria-label="添加右侧工作区标签"
+                >
+                  <Plus className="size-4" />
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">添加标签</TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent align="end" className="z-[100] min-w-40 titlebar-no-drag">
+            <DropdownMenuItem onSelect={onOpenBrowser}>
+              <Globe className="size-3.5" />
+              新建浏览器标签
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onOpenFile}>
+              <FolderOpen className="size-3.5" />
+              打开文件
+            </DropdownMenuItem>
+            {onOpenChat && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={onOpenChat}>
+                  <MessageCircle className="size-3.5" />
+                  打开问答
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
         {onClose && (
           <Tooltip>
             <TooltipTrigger asChild>
               <button
                 type="button"
                 onClick={onClose}
-                className="flex items-center justify-center size-[28px] mr-1 mb-[3px] rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
+                className="mr-2 inline-flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-[background-color,color,transform] hover:bg-muted hover:text-foreground active:scale-[0.96]"
+                aria-label="折叠右侧工作区"
               >
-                <PanelRightClose className="size-4" />
+                <PanelRight className="size-4" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">折叠文件面板 ({navigator.platform.includes('Mac') ? '⌘⇧B' : 'Ctrl+Shift+B'})</TooltipContent>
+            <TooltipContent side="bottom">折叠右侧工作区 ({navigator.platform.includes('Mac') ? '⌘⇧B' : 'Ctrl+Shift+B'})</TooltipContent>
           </Tooltip>
         )}
       </div>

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { ChevronRight, Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, WrapText, X } from 'lucide-react'
+import { ChevronRight, Code2, Copy, Check, Eye, FolderOpen, List, Pencil, RotateCw, Save, WrapText, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
@@ -33,6 +33,7 @@ import { initShortcutRegistry } from '@/lib/shortcut-registry'
 import { DiffView } from './DiffView'
 import { MarkdownRichEditor } from './MarkdownRichEditor'
 import { getPreviewCandidateBasePaths, isAbsoluteFilePath } from './preview-open-path'
+import { DefaultAppOpenButton } from './DefaultAppOpenButton'
 import { PreviewFindBar } from './PreviewFindBar'
 import { MarkdownToc } from './MarkdownToc'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -63,6 +64,19 @@ const DOCX_EXTS = new Set(['.docx'])
 const OFFICE_PREVIEW_EXTS = new Set(['.xlsx', '.pptx'])
 const LEGACY_OFFICE_EXTS = new Set(['.doc', '.xls', '.ppt'])
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.ico'])
+
+function getPreviewPathLabel(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).at(-1) || filePath
+}
+
+function getPreviewTargetPath(filePath: string, dirPath: string): string {
+  return isAbsoluteFilePath(filePath) ? filePath : `${dirPath.replace(/[\\/]+$/, '')}/${filePath}`
+}
+
+function getParentFolderPath(filePath: string): string {
+  const separator = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
+  return separator > 0 ? filePath.slice(0, separator) : filePath
+}
 const FILE_FIND_SHORTCUT_OPTIONS = { exclusive: true }
 
 /**
@@ -267,7 +281,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const isEditableText = isMarkdown || isPlainTextEditable
   const isPdf = previewOnly && PDF_EXTS.has(ext)
   const isDocx = previewOnly && DOCX_EXTS.has(ext)
-  const isOfficePreview = previewOnly && OFFICE_PREVIEW_EXTS.has(ext)
+  // XLSX/PPTX 没有可读的文本 diff；无论从文件区还是改动区打开都走 Office 预览。
+  const isOfficePreview = OFFICE_PREVIEW_EXTS.has(ext)
   const isLegacyOffice = previewOnly && LEGACY_OFFICE_EXTS.has(ext)
   const isImage = previewOnly && IMAGE_EXTS.has(ext)
   const markdownEditorCacheKey = React.useMemo(
@@ -844,6 +859,17 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         let htmlUrl = cached?.htmlPreviewUrl ?? ''
 
         if (!cached) {
+          // 即使从「改动」列表点开，XLSX/PPTX 也应保留原有的 Office 内联预览。
+          if (isOfficePreview) {
+            const result = await window.electronAPI.officeToHtml(filePath, fileAccess)
+            if (cancelled) return
+            const html = DOMPurify.sanitize(result?.html ?? '')
+            const text = result?.text ?? ''
+            setOfficeHtml(html)
+            setOfficeText(text)
+            cacheSet(cacheKey, { oldContent: '', newContent: '', officeHtml: html, officeText: text })
+            return
+          }
           if (previewOnly) {
             if (isPdf) {
               const result = await window.electronAPI.preparePdfPreview(filePath, fileAccess)
@@ -873,16 +899,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               const html = DOMPurify.sanitize(result?.html ?? '')
               setDocxHtml(html)
               cacheSet(cacheKey, { oldContent: '', newContent: '', docxHtml: html })
-              return
-            }
-            if (isOfficePreview) {
-              const result = await window.electronAPI.officeToHtml(filePath, fileAccess)
-              if (cancelled) return
-              const html = DOMPurify.sanitize(result?.html ?? '')
-              const text = result?.text ?? ''
-              setOfficeHtml(html)
-              setOfficeText(text)
-              cacheSet(cacheKey, { oldContent: '', newContent: '', officeHtml: html, officeText: text })
               return
             }
             if (isLegacyOffice) {
@@ -978,17 +994,17 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     emptyDiffFiredRef.current = false
   }, [filePath, sessionId])
   React.useEffect(() => {
-    if (previewOnly || loading || emptyDiffFiredRef.current) return
+    if (previewOnly || isOfficePreview || loading || emptyDiffFiredRef.current) return
     if (oldContent === newContent) {
       emptyDiffFiredRef.current = true
       onEmptyDiff?.()
     }
-  }, [previewOnly, loading, oldContent, newContent, onEmptyDiff])
+  }, [previewOnly, isOfficePreview, loading, oldContent, newContent, onEmptyDiff])
 
   // previewOnly 模式：加载完成后若内容无法预览，弹 Toast 通知用户
   const toastedPreviewFailRef = React.useRef('')
   React.useEffect(() => {
-    if (!previewOnly || loading) return
+    if ((!previewOnly && !isOfficePreview) || loading) return
     const key = `${filePath}:${ext}`
     if (toastedPreviewFailRef.current === key) return
     let message: string | null = null
@@ -1007,7 +1023,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       toastedPreviewFailRef.current = key
       toast.warning(message)
     }
-  }, [previewOnly, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, isDocx, docxHtml, isOfficePreview, officeHtml, isImage, imageDataUrl])
+  }, [previewOnly, isOfficePreview, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, isDocx, docxHtml, officeHtml, isImage, imageDataUrl])
 
   // scrollPosition persistent: module-level Map scoped by session, file path, and resolution context
   // content changes (refreshVersion bump) → delete stored position;
@@ -1495,12 +1511,43 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filePath, fileAccess, isEditableText, markdownEditorCacheKey, readOnly, sessionId])
 
+  const previewTargetPath = getPreviewTargetPath(filePath, dirPath)
+  const handleOpenCurrentFolder = React.useCallback(() => {
+    window.electronAPI.systemOpenFile(getParentFolderPath(previewTargetPath), undefined, fileAccess).catch((error) => {
+      console.error('[DiffTabContent] 打开当前文件夹失败:', error)
+      toast.error('无法打开当前文件夹')
+    })
+  }, [fileAccess, previewTargetPath])
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-3 py-1.5 flex-shrink-0">
         <span className="min-w-0 flex-1 text-[12px] text-foreground/60 truncate" title={filePath}>
-          {filePath}
+          {getPreviewPathLabel(filePath)}
         </span>
+
+        {previewOnly && (
+          <>
+            <DefaultAppOpenButton
+              filePath={previewTargetPath}
+              access={fileAccess}
+              variant="labeled"
+            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleOpenCurrentFolder}
+                  className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                  aria-label="打开当前文件夹"
+                >
+                  <FolderOpen className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">打开当前文件夹</TooltipContent>
+            </Tooltip>
+          </>
+        )}
 
         {!previewOnly && (
           <div
@@ -1600,7 +1647,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0"
           title="刷新文件内容（检测外部编辑器的修改）"
         >
-          <RefreshCw className="size-3.5" />
+          <RotateCw className="size-3.5" />
         </button>
 
         {canTogglePreviewWrap && (
@@ -1673,7 +1720,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         <div ref={scrollContainerRef} onScroll={handleScroll} className="h-full flex-1 min-w-0 overflow-auto scrollbar-thin relative">
           {loading ? (
             <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">加载中...</div>
-          ) : previewOnly ? (
+          ) : (previewOnly || isOfficePreview) ? (
             unsupportedPreviewReason ? (
               <div className="flex h-full items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
                 {unsupportedPreviewReason}

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -1,204 +1,39 @@
-/**
- * PreviewPanel — 内联预览/Diff 面板
- *
- * 嵌入 AgentView 右侧，始终显示当前选中文件的 diff。
- * Agent 修改文件时自动切换到最新修改的文件。
- */
+/** 右侧工作区中的单个文件预览内容。标题与关闭由外层动态 Tab 承担。 */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { Maximize2, PanelRight, X } from 'lucide-react'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import {
-  previewPanelOpenMapAtom,
-  previewFileMapAtom,
-  previewModePreferenceAtom,
-} from '@/atoms/preview-atoms'
-import {
-  agentSessionPathMapAtom,
-  currentSessionSidePanelOpenAtom,
-} from '@/atoms/agent-atoms'
-import {
-  activeTabIdAtom,
-  getPreviewTabTitle,
-  openTab,
-  tabsAtom,
-} from '@/atoms/tab-atoms'
-import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
-import { detectIsWindows } from '@/lib/platform'
-import { cn } from '@/lib/utils'
+import { useAtomValue } from 'jotai'
+import type { PreviewFile } from '@/atoms/preview-atoms'
+import { agentSessionPathMapAtom } from '@/atoms/agent-atoms'
 import { DiffTabContent } from './DiffTabContent'
 import { PreviewContentErrorBoundary } from './PreviewContentErrorBoundary'
-import { DefaultAppOpenButton } from './DefaultAppOpenButton'
-import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
 interface PreviewPanelProps {
   sessionId: string
+  file: PreviewFile
+  onClose: () => void
 }
 
-const WINDOWS_WINDOW_CONTROLS_SAFE_AREA = 126
-
-export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactElement {
-  const fileMap = useAtomValue(previewFileMapAtom)
-  const setOpenMap = useSetAtom(previewPanelOpenMapAtom)
-  const tabs = useAtomValue(tabsAtom)
-  const setTabs = useSetAtom(tabsAtom)
-  const setActiveTabId = useSetAtom(activeTabIdAtom)
-  const isSidePanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
-  const [previewModePref, setPreviewModePref] = useAtom(previewModePreferenceAtom)
-
-  const currentFile = fileMap.get(sessionId) ?? null
-
-  const sessionPathMap = useAtomValue(agentSessionPathMapAtom)
-  const sessionPath = sessionPathMap.get(sessionId) ?? ''
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
-  const useStackedWindowsHeader = isWindows && !isSidePanelOpen
-
-  const handleClosePanel = React.useCallback(() => {
-    setOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, false); return m })
-  }, [sessionId, setOpenMap])
-
-  const handleOpenPreviewTab = React.useCallback(() => {
-    if (!currentFile) return
-    const result = openTab(tabs, {
-      type: 'preview',
-      sessionId,
-      title: getPreviewTabTitle(currentFile.filePath),
-    })
-    setTabs(result.tabs)
-    setActiveTabId(result.activeTabId)
-    setOpenMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, false)
-      return m
-    })
-  }, [currentFile, sessionId, setActiveTabId, setOpenMap, setTabs, tabs])
-
-  const fileName = currentFile ? currentFile.filePath.split(/[\\/]/).pop() || currentFile.filePath : '文件预览'
-  const defaultAppTargetPath = currentFile ? getDefaultAppTargetPath(currentFile, sessionPath) : ''
-  const defaultAppAccess = currentFile ? getPreviewFileAccess(sessionId, currentFile, sessionPath) : undefined
-
-  const renderPreviewActions = (): React.ReactElement => (
-    <div className="ml-auto flex items-center gap-0.5 shrink-0">
-      {currentFile && (
-        <DefaultAppOpenButton
-          filePath={defaultAppTargetPath}
-          access={defaultAppAccess}
-        />
-      )}
-      {currentFile && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => setPreviewModePref((p) => (p === 'split' ? 'tab' : 'split'))}
-              className={cn(
-                'flex items-center justify-center size-6 shrink-0 rounded transition-colors',
-                previewModePref === 'split'
-                  ? 'text-primary bg-primary/10'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-              )}
-              aria-label={previewModePref === 'split' ? '默认展开方式：侧边分屏，点击改为标签页' : '默认展开方式：标签页，点击改为侧边分屏'}
-            >
-              <PanelRight className="size-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p>
-              {previewModePref === 'split'
-                ? '默认展开方式：侧边分屏 · 点击改为「标签页」（仅影响下次打开，不改变当前预览）'
-                : '默认展开方式：标签页 · 点击改为「侧边分屏」（仅影响下次打开，不改变当前预览）'}
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      )}
-      {currentFile && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={handleOpenPreviewTab}
-              className="flex items-center justify-center size-6 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors"
-              aria-label="作为标签页打开预览"
-            >
-              <Maximize2 className="size-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p>作为标签页打开预览</p>
-          </TooltipContent>
-        </Tooltip>
-      )}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={handleClosePanel}
-            className="flex items-center justify-center size-6 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors"
-            aria-label="关闭预览面板"
-          >
-            <X className="size-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <p>关闭预览面板 ({getAcceleratorDisplay(getActiveAccelerator('toggle-preview-panel'))})</p>
-        </TooltipContent>
-      </Tooltip>
-    </div>
-  )
-
+export function PreviewPanel({ sessionId, file, onClose }: PreviewPanelProps): React.ReactElement {
+  const sessionPath = useAtomValue(agentSessionPathMapAtom).get(sessionId) ?? ''
   return (
-    <div className="flex flex-col h-full overflow-hidden bg-content-area titlebar-no-drag">
-      {/* 顶部栏：文件名 + 预览操作 */}
-      <div className={cn('flex-shrink-0 border-b border-border/30 titlebar-no-drag', useStackedWindowsHeader && 'bg-content-area')}>
-        {useStackedWindowsHeader ? (
-          <>
-            <div
-              className="flex items-center h-[34px] pl-3"
-              style={{ paddingRight: WINDOWS_WINDOW_CONTROLS_SAFE_AREA }}
-            >
-              <span className="text-xs text-muted-foreground truncate">
-                {fileName}
-              </span>
-            </div>
-            <div className="flex items-center h-[30px] px-3 border-t border-border/20 bg-muted/20">
-              {renderPreviewActions()}
-            </div>
-          </>
-        ) : (
-          <div className="flex items-center h-[34px] px-3">
-            <span className="text-xs text-muted-foreground truncate">
-              {fileName}
-            </span>
-            {renderPreviewActions()}
-          </div>
-        )}
-      </div>
-
-      {/* 内容区 */}
-      <div className="flex-1 min-h-0 overflow-hidden">
-        {currentFile ? (
-          <PreviewContentErrorBoundary resetKey={`${sessionId}:${currentFile.filePath}`}>
-            <DiffTabContent
-              key={`${sessionId}:${currentFile.filePath}`}
-              filePath={currentFile.filePath}
-              dirPath={currentFile.dirPath || sessionPath}
-              sessionId={sessionId}
-              gitRoot={currentFile.gitRoot}
-              previewOnly={currentFile.previewOnly}
-              readOnly={currentFile.readOnly}
-              basePaths={currentFile.basePaths}
-              workspaceSkillSlug={currentFile.workspaceSkillSlug}
-              legacySkillFilePath={currentFile.legacySkillFilePath}
-              baseRef={currentFile.baseRef}
-              onEmptyDiff={handleClosePanel}
-            />
-          </PreviewContentErrorBoundary>
-        ) : (
-          <div className="flex items-center justify-center h-full text-muted-foreground text-xs">
-            点击文件查看预览
-          </div>
-        )}
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-content-area titlebar-no-drag">
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <PreviewContentErrorBoundary resetKey={`${sessionId}:${file.filePath}`}>
+          <DiffTabContent
+            key={`${sessionId}:${file.filePath}`}
+            filePath={file.filePath}
+            dirPath={file.dirPath || sessionPath}
+            sessionId={sessionId}
+            gitRoot={file.gitRoot}
+            previewOnly={file.previewOnly}
+            readOnly={file.readOnly}
+            basePaths={file.basePaths}
+            workspaceSkillSlug={file.workspaceSkillSlug}
+            legacySkillFilePath={file.legacySkillFilePath}
+            baseRef={file.baseRef}
+            onEmptyDiff={onClose}
+          />
+        </PreviewContentErrorBoundary>
       </div>
     </div>
   )

--- a/apps/electron/src/renderer/components/diff/preview-opener.ts
+++ b/apps/electron/src/renderer/components/diff/preview-opener.ts
@@ -1,100 +1,74 @@
 /**
  * useOpenPreview — 统一的预览入口 Hook
  *
- * 把分散在 SidePanel / PreviewOpenButton / AgentView 等处的「打开预览」逻辑收敛到一处，
- * 按用户偏好（previewModePreferenceAtom）路由到 Tab 或右侧分屏。
- *
- * 用户仍可通过：
- *   - 拖拽 preview Tab 出 TabBar（即时切换为分屏）
- *   - PreviewPanel 顶栏 Maximize2（即时切换为 Tab）
- *   - PreviewTabContent 顶栏「切换为侧边分屏」按钮（即时切换为分屏）
- * 在两种模式间即时切换，本 hook 仅控制默认行为。
+ * 把分散在 SidePanel / PreviewOpenButton / AgentView 等处的「打开预览」逻辑收敛到一处。
+ * 文件、Markdown 与 Diff 一律在右侧工作区的预览 Tab 打开，不再占用主内容区。
  */
 
 import * as React from 'react'
 import { useStore } from 'jotai'
 import {
+  getPreviewFileId,
   previewFileMapAtom,
+  previewFilesMapAtom,
   previewPanelOpenMapAtom,
-  previewModePreferenceAtom,
   type PreviewFile,
-  type PreviewModePreference,
 } from '@/atoms/preview-atoms'
 import {
   activeTabIdAtom,
   closeTab,
-  getPreviewTabTitle,
   isPreviewTab,
-  openTab,
   sessionViewStateMapAtom,
   tabsAtom,
 } from '@/atoms/tab-atoms'
+import { agentDiffPanelTabAtom, agentSidePanelOpenAtomFamily, getPreviewSidePanelTab } from '@/atoms/agent-atoms'
 
 /** Jotai store 类型（从 useStore 推导，避免直接 import 内部 Store 类型） */
 type JotaiStore = ReturnType<typeof useStore>
 
+/** 兼容旧调用方；右侧工作区方案下不再使用 mode。 */
 export interface OpenPreviewOptions {
-  /** Override the user's default preview target for this one open action. */
-  mode?: PreviewModePreference
-}
-
-export function resolvePreviewMode(
-  options: OpenPreviewOptions | undefined,
-  userPreference: PreviewModePreference,
-): PreviewModePreference {
-  return options?.mode ?? userPreference
+  mode?: 'tab' | 'split'
 }
 
 export function useOpenPreview() {
   const store = useStore()
 
   return React.useCallback(
-    (sessionId: string, file: PreviewFile, options?: OpenPreviewOptions) => {
-      // 1. 文件状态两种模式都需要，先写入
+    (sessionId: string, file: PreviewFile, _options?: OpenPreviewOptions) => {
+      const previewId = getPreviewFileId(file)
+      store.set(previewFilesMapAtom, (prev) => {
+        const next = new Map(prev)
+        const files = next.get(sessionId) ?? []
+        next.set(sessionId, files.some((item) => getPreviewFileId(item) === previewId) ? files : [...files, file])
+        return next
+      })
       store.set(previewFileMapAtom, (prev) => {
-        const m = new Map(prev)
-        m.set(sessionId, file)
-        return m
+        const next = new Map(prev)
+        next.set(sessionId, file)
+        return next
       })
-
-      const preferSplit = resolvePreviewMode(options, store.get(previewModePreferenceAtom)) === 'split'
-
-      if (preferSplit) {
-        // 分屏：开启预览面板，不创建 Tab
-        store.set(previewPanelOpenMapAtom, (prev) => {
-          const m = new Map(prev)
-          m.set(sessionId, true)
-          return m
-        })
-        return
-      }
-
-      // Tab：保持旧行为（关闭分屏 + 创建/复用 preview Tab）
       store.set(previewPanelOpenMapAtom, (prev) => {
-        const m = new Map(prev)
-        m.set(sessionId, false)
-        return m
+        const next = new Map(prev)
+        next.set(sessionId, true)
+        return next
       })
-      const result = openTab(store.get(tabsAtom), {
-        type: 'preview',
-        sessionId,
-        title: getPreviewTabTitle(file.filePath),
+      // 所有入口都复用同一右侧工作区，并以会话为粒度隔离预览状态。
+      store.set(agentSidePanelOpenAtomFamily(sessionId), true)
+      store.set(agentDiffPanelTabAtom, (prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, getPreviewSidePanelTab(previewId))
+        return next
       })
-      store.set(tabsAtom, result.tabs)
-      store.set(activeTabIdAtom, result.activeTabId)
     },
     [store],
   )
 }
 
 /**
- * tearOffPreviewToSplit — 把 preview Tab 即时切换为右侧分屏。
+ * tearOffPreviewToSplit — 兼容旧 preview Tab：将其迁入右侧工作区预览。
  *
- * 用于「拖拽 preview Tab 出 TabBar」与「PreviewTabContent 顶栏切换按钮」两条入口共用。
- * 流程：关闭 preview Tab → 激活对应会话的 agent Tab → 开启右侧分屏。
- * previewFileMap 中保留的文件就是分屏要显示的内容，无需重新打开。
- *
- * 若传入的 tabId 不是 preview Tab、已找不到，或该会话没有可承载分屏的 agent Tab，则不做任何事。
+ * 保留此导出供旧的拖拽和预览 Tab 操作调用；新预览不会再创建主内容区 Tab。
  */
 export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
   const tabs = store.get(tabsAtom)
@@ -103,11 +77,10 @@ export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
 
   const sessionId = tab.sessionId
 
-  // 分屏渲染在该会话的 agent 视图内，若没有对应 agent Tab 则无处承载，保持 Tab 模式不动
   const agentTab = tabs.find((t) => t.type === 'agent' && t.sessionId === sessionId)
   if (!agentTab) return
 
-  // 关闭 preview Tab，并激活该会话的 agent Tab，让右侧分屏可见
+  // 关闭旧 preview Tab，并激活对应 Agent 会话，让右侧工作区可见
   const closed = closeTab(store.get(tabsAtom), store.get(activeTabIdAtom), tabId)
   store.set(tabsAtom, closed.tabs)
   store.set(activeTabIdAtom, agentTab.id)
@@ -119,10 +92,15 @@ export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
     return m
   })
 
-  // 开启右侧分屏
   store.set(previewPanelOpenMapAtom, (prev) => {
-    const m = new Map(prev)
-    m.set(sessionId, true)
-    return m
+    const next = new Map(prev)
+    next.set(sessionId, true)
+    return next
+  })
+  store.set(agentSidePanelOpenAtomFamily(sessionId), true)
+  store.set(agentDiffPanelTabAtom, (prev) => {
+    const next = new Map(prev)
+    next.set(sessionId, 'preview')
+    return next
   })
 }

--- a/apps/electron/src/renderer/components/diff/preview-opener.ts
+++ b/apps/electron/src/renderer/components/diff/preview-opener.ts
@@ -40,7 +40,12 @@ export function useOpenPreview() {
       store.set(previewFilesMapAtom, (prev) => {
         const next = new Map(prev)
         const files = next.get(sessionId) ?? []
-        next.set(sessionId, files.some((item) => getPreviewFileId(item) === previewId) ? files : [...files, file])
+        // 同一预览身份再次打开时保留 Tab 顺序，但采用最新权限、根目录与解析上下文。
+        // 否则先以只读/Skill 上下文打开后会永久复用过期元数据。
+        const existingIndex = files.findIndex((item) => getPreviewFileId(item) === previewId)
+        next.set(sessionId, existingIndex === -1
+          ? [...files, file]
+          : files.map((item, index) => index === existingIndex ? file : item))
         return next
       })
       store.set(previewFileMapAtom, (prev) => {

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -16,7 +16,7 @@ import { toast } from 'sonner'
 import {
   ChevronRight,
   Trash2,
-  RefreshCw,
+  RotateCw,
   ExternalLink,
   FolderSearch,
   Terminal,
@@ -437,7 +437,7 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
             onClick={loadRoot}
             disabled={loading}
           >
-            <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
+            <RotateCw className={cn('size-3.5', loading && 'animate-spin')} />
           </Button>
         </div>
       )}

--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -30,7 +30,6 @@ import {
   markdownFontSizeAtom,
   updateMarkdownFontSize,
 } from '@/atoms/markdown-font-size'
-import { previewModePreferenceAtom, type PreviewModePreference } from '@/atoms/preview-atoms'
 import { cn } from '@/lib/utils'
 import { detectIsWindows } from '@/lib/platform'
 import type { InterfaceVariant, ThemeMode, ThemeStyle, MarkdownFontSize } from '../../../types'
@@ -78,12 +77,6 @@ const MARKDOWN_FONT_SIZE_OPTIONS = [
   { value: 'small', label: '小' },
   { value: 'medium', label: '中' },
   { value: 'large', label: '大' },
-]
-
-/** 预览默认展开方式 */
-const PREVIEW_MODE_OPTIONS: { value: PreviewModePreference; label: string }[] = [
-  { value: 'tab', label: '标签页' },
-  { value: 'split', label: '侧边分屏' },
 ]
 
 /** 特殊风格 ID（排除 default） */
@@ -191,7 +184,6 @@ export function AppearanceSettings(): React.ReactElement {
   const [interfaceVariant, setInterfaceVariant] = useAtom(interfaceVariantAtom)
   const systemIsDark = useAtomValue(systemIsDarkAtom)
   const [markdownFontSize, setMarkdownFontSize] = useAtom(markdownFontSizeAtom)
-  const [previewModePref, setPreviewModePref] = useAtom(previewModePreferenceAtom)
 
   /** 切换主题模式 */
   const handleThemeChange = React.useCallback((value: string) => {
@@ -283,13 +275,6 @@ export function AppearanceSettings(): React.ReactElement {
             options={MARKDOWN_FONT_SIZE_OPTIONS}
           />
 
-          <SettingsSegmentedControl
-            label="Agent 预览展开方式"
-            description="点击文件、工具结果「预览」按钮时的默认展开位置；拖拽预览 Tab 出标签栏可即时切换为侧边分屏"
-            value={previewModePref}
-            onValueChange={(v) => setPreviewModePref(v as PreviewModePreference)}
-            options={PREVIEW_MODE_OPTIONS}
-          />
         </SettingsCard>
       </SettingsSection>
 

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -17,6 +17,7 @@ import { searchDialogOpenAtom } from '@/atoms/search-atoms'
 import {
   tabsAtom,
   activeTabIdAtom,
+  activeTabAtom,
   sidebarCollapsedAtom,
   openTab,
 } from '@/atoms/tab-atoms'
@@ -34,6 +35,8 @@ import {
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   agentAttachedFilesMapAtom,
+  agentDiffPanelTabAtom,
+  currentSessionSidePanelOpenAtom,
 } from '@/atoms/agent-atoms'
 import {
   chatPendingMessageAtom,
@@ -52,6 +55,7 @@ import {
   updateShortcutOverrides,
 } from '@/lib/shortcut-registry'
 import { getFileParentPath } from '@/lib/file-utils'
+import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
 import {
   shouldFallbackVoiceDictationToActiveTab,
   VOICE_DICTATION_CLEAR_PREVIEW_EVENT,
@@ -78,6 +82,9 @@ export function GlobalShortcuts(): null {
 
   // Tab 管理（用于关闭标签页）
   const activeTabId = useAtomValue(activeTabIdAtom)
+  const activeTab = useAtomValue(activeTabAtom)
+  const activeAgentSidePanelTab = useAtomValue(agentDiffPanelTabAtom).get(activeTab?.type === 'agent' ? activeTab.sessionId : '')
+  const isActiveAgentSidePanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
 
   // 统一关闭逻辑：与 TabBar.handleClose 共用
   // 含 Agent 子进程 stop + 流式中的确认对话框（修复 Issue #357）
@@ -123,9 +130,23 @@ export function GlobalShortcuts(): null {
       return
     }
 
+    if (activeTab?.type === 'agent') {
+      // Agent 会话常驻左侧历史，不再由 Cmd+W 关闭；仅关闭右侧可关闭工作区 Tab。
+      if (
+        isActiveAgentSidePanelOpen
+        && activeAgentSidePanelTab
+        && (activeAgentSidePanelTab === 'memory' || activeAgentSidePanelTab.startsWith('preview:') || activeAgentSidePanelTab.startsWith('browser:'))
+      ) {
+        window.dispatchEvent(new CustomEvent(CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT, {
+          detail: { sessionId: activeTab.sessionId },
+        }))
+      }
+      return
+    }
+
     if (!activeTabId) return
     requestClose(activeTabId)
-  }, [shortcutGuideOpen, setShortcutGuideOpen, settingsOpen, setSettingsOpen, channelFormDirty, setSettingsCloseRequested, searchOpen, setSearchOpen, activeTabId, requestClose])
+  }, [shortcutGuideOpen, setShortcutGuideOpen, settingsOpen, setSettingsOpen, channelFormDirty, setSettingsCloseRequested, searchOpen, setSearchOpen, activeTab, activeAgentSidePanelTab, isActiveAgentSidePanelOpen, activeTabId, requestClose])
 
   // 监听菜单 IPC 事件（Cmd+W 被 Electron 菜单拦截后通过 IPC 转发）
   useEffect(() => {

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -1,26 +1,23 @@
 /**
  * MainArea — 主内容区域
  *
- * 组合 TabBar + TabContent。Agent 模式下若预览面板打开，则在同一个 Panel 内分屏：
- * 顶部一行：左侧 TabBar + 右侧预览顶栏（含文件名、复制按钮）
- * 主体：左侧 TabContent + 右侧预览内容
+ * 组合 TabBar + TabContent。文件、Markdown 和 Diff 预览统一由右侧工作区承载；
+ * MainArea 仅保留对话主区，以及 Scratch Pad 的临时分屏。
  */
 
 import * as React from 'react'
-import type { BrowserStateChange, BrowserViewState } from '@proma/shared'
-import { useAtomValue, useSetAtom, useAtom, useStore } from 'jotai'
+import type { BrowserStateChange } from '@proma/shared'
+import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import {
   tabsAtom,
   activeTabIdAtom,
   activeTabAtom,
   scratchPadPanelOpenAtom,
-  rightWorkspaceSplitRatioAtom,
 } from '@/atoms/tab-atoms'
 import { Panel } from '@/components/app-shell/Panel'
 import { WelcomeView } from '@/components/welcome/WelcomeView'
-import { previewPanelOpenMapAtom, previewSplitRatioAtom } from '@/atoms/preview-atoms'
-import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { ScratchPadPane } from '@/components/scratch-pad/ScratchPadView'
+import { previewSplitRatioAtom } from '@/atoms/preview-atoms'
 import { closeScratchInSplit } from '@/components/scratch-pad/scratch-pad-opener'
 import { useTrackSessionView } from '@/hooks/useTrackSessionView'
 import { TabBar } from './TabBar'
@@ -32,11 +29,21 @@ import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { cn } from '@/lib/utils'
-import { browserPanelMinimizedMapAtom, browserPanelOpenMapAtom, browserPendingNavigationMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
-import { BrowserPanel } from '@/components/browser/BrowserPanel'
+import { registerShortcut } from '@/lib/shortcut-registry'
+import {
+  agentDiffPanelTabAtom,
+  agentSidePanelOpenAtomFamily,
+  currentSessionSidePanelOpenAtom,
+  getBrowserSidePanelTab,
+} from '@/atoms/agent-atoms'
+import {
+  browserPanelMinimizedMapAtom,
+  browserPanelOpenMapAtom,
+  browserPendingNavigationMapAtom,
+  browserStateMapAtom,
+} from '@/atoms/browser-atoms'
 
 export function MainArea(): React.ReactElement {
-  // 记录每个会话上次停留的视图（对话 / 预览），供切回时重建预览 Tab
   useTrackSessionView()
 
   const tabs = useAtomValue(tabsAtom)
@@ -49,24 +56,29 @@ export function MainArea(): React.ReactElement {
   const isClassic = interfaceVariant === 'classic'
   const store = useStore()
 
-  // Tab 内容渲染降级为非紧急：TabBar 立即高亮新 tab，主区域昂贵渲染（含 PreviewPanel 中
-  // DiffTabContent → ProseMirror editor mount + Shiki tokenize）让出主线程，避免点击 tab
-  // 后必须等主区域渲染完才能看到 tab 切换效果
+  // TabBar 立即反馈，较重的中心内容可让出当前交互帧；Agent 历史则保持当前会话避免旧内容占屏。
   const deferredActiveTabId = React.useDeferredValue(activeTabId)
-  // Agent 历史当前是完整 DOM，切换时使用当前 active tab，避免 deferred value 让旧会话继续占屏。
-  // Chat/Preview 仍保留 deferred 渲染，避免它们的重型编辑器阻塞 TabBar 响应。
   const contentTabId = activeTab?.type === 'agent' ? activeTabId : deferredActiveTabId
+  // Agent 会话从左侧历史列表切换，中心区不再重复展示同一组顶部 Tab。
+  const showCenterTabBar = activeTab?.type !== 'agent'
+  const [isRightPanelOpen, setRightPanelOpen] = useAtom(currentSessionSidePanelOpenAtom)
+  const toggleRightPanel = React.useCallback(() => {
+    if (activeTab?.type !== 'agent') return
+    setRightPanelOpen(!isRightPanelOpen)
+  }, [activeTab?.type, isRightPanelOpen, setRightPanelOpen])
 
-  const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
-  const [browserOpenMap, setBrowserOpenMap] = useAtom(browserPanelOpenMapAtom)
+  // 不能依赖 TabBar 注册：Agent 会话已不渲染中心 TabBar，快捷键需要在常驻主内容区监听。
+  React.useEffect(() => registerShortcut('toggle-right-panel', toggleRightPanel), [toggleRightPanel])
+
+  // 浏览器状态仍由主内容区常驻订阅，右侧工作区只读取 atom 渲染，避免侧栏收起时遗漏状态更新。
+  const setBrowserOpenMap = useSetAtom(browserPanelOpenMapAtom)
   const setBrowserMinimizedMap = useSetAtom(browserPanelMinimizedMapAtom)
-  const [browserStateMap, setBrowserStateMap] = useAtom(browserStateMapAtom)
+  const setBrowserStateMap = useSetAtom(browserStateMapAtom)
   const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
-  const [splitRatio, setSplitRatio] = useAtom(previewSplitRatioAtom)
-  const [rightWorkspaceRatio, setRightWorkspaceRatio] = useAtom(rightWorkspaceSplitRatioAtom)
-  const previewDragging = React.useRef(false)
-  const rightWorkspaceDragging = React.useRef(false)
+  const setAgentSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const browserSessionId = activeTab?.type === 'agent' ? activeTab.sessionId : null
+  // 同一条状态会因原生视图显示/隐藏重复广播；仅新的 Agent 浏览器活动才激活对应右侧 Tab。
+  const handledBrowserActivityIdsRef = React.useRef(new Map<string, string>())
 
   const publishBrowserState = React.useCallback((state: BrowserStateChange) => {
     if ('closed' in state) {
@@ -79,11 +91,28 @@ export function MainArea(): React.ReactElement {
     setBrowserStateMap((previous) => { const next = new Map(previous); next.set(state.sessionId, state); return next })
     const isMinimized = store.get(browserPanelMinimizedMapAtom).get(state.sessionId) === true
     setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(state.sessionId, !isMinimized); return next })
-  }, [setBrowserOpenMap, setBrowserMinimizedMap, setBrowserStateMap, setPendingNavigationMap, store])
+
+    const activity = state.activity
+    const shouldActivateAgentBrowserTab = Boolean(
+      activity
+      && activeTab?.type === 'agent'
+      && activeTab.sessionId === state.sessionId
+      && state.agentTabId === state.activeTabId
+      && activity.tabId === state.activeTabId
+      && handledBrowserActivityIdsRef.current.get(state.sessionId) !== activity.id,
+    )
+    if (shouldActivateAgentBrowserTab) {
+      handledBrowserActivityIdsRef.current.set(state.sessionId, activity!.id)
+      store.set(agentSidePanelOpenAtomFamily(state.sessionId), true)
+      setAgentSidePanelTabMap((previous) => {
+        const next = new Map(previous)
+        next.set(state.sessionId, getBrowserSidePanelTab(state.activeTabId))
+        return next
+      })
+    }
+  }, [activeTab, setAgentSidePanelTabMap, setBrowserOpenMap, setBrowserMinimizedMap, setBrowserStateMap, setPendingNavigationMap, store])
 
   React.useEffect(() => {
-    // Vite renderer 可在 preload 热重载前先更新；旧 bridge 时浏览器功能不可用，
-    // 但绝不能让整个主界面崩溃。完整 Electron preload 就绪后会正常订阅。
     const subscribe = (window.electronAPI as Partial<typeof window.electronAPI>).onAgentBrowserStateChanged
     if (typeof subscribe !== 'function') return
     return subscribe(publishBrowserState)
@@ -95,262 +124,92 @@ export function MainArea(): React.ReactElement {
     if (typeof getState !== 'function') return
     let cancelled = false
     void getState(browserSessionId)
-      .then((state) => {
-        if (!cancelled && state) publishBrowserState(state)
-      })
-      // 后台会话及已删除会话会被主进程拒绝或返回空状态；无需打断当前界面。
+      .then((state) => { if (!cancelled && state) publishBrowserState(state) })
       .catch(() => undefined)
     return () => { cancelled = true }
   }, [browserSessionId, publishBrowserState])
 
-  const showBrowserPanel = !!browserSessionId && (browserOpenMap.get(browserSessionId) ?? false) && activeView === 'conversations'
-  const browserState = browserSessionId ? browserStateMap.get(browserSessionId) ?? null : null
-  const previewOpen =
-    activeTab?.type === 'agent' && (previewOpenMap.get(activeTab.sessionId) ?? false) && !showBrowserPanel
-  const previewSessionId = activeTab?.type === 'agent' ? activeTab.sessionId : null
   const scratchPanelOpen = useAtomValue(scratchPadPanelOpenAtom)
-  const showScratchPanel =
-    activeTab?.type === 'agent' && scratchPanelOpen && activeView === 'conversations' && !showBrowserPanel
+  const showScratchPanel = activeTab?.type === 'agent' && scratchPanelOpen && activeView === 'conversations'
+  // Scratch 复用旧的预览分栏比例，保持已有用户布局。
+  const [scratchSplitRatio, setScratchSplitRatio] = useAtom(previewSplitRatioAtom)
+  const scratchDragging = React.useRef(false)
 
-  // 关闭动画状态：当 previewOpen 从 true → false 时，播放退出动画再移除 DOM
-  // 在 render 阶段同步派生 closing，避免中间帧出现 flex: 1 1 auto 导致左侧瞬间跳到 100% 宽
-  // （flex-basis: auto 与 calc() 之间无法插值，transition 不生效，视觉上会被解读为"重新渲染"）
-  const [closingState, setClosingState] = React.useState(false)
-  const prevPreviewStateRef = React.useRef({ open: previewOpen, sessionId: previewSessionId })
-
-  let closing = closingState
-  const prev = prevPreviewStateRef.current
-  if (prev.open && !previewOpen && prev.sessionId === previewSessionId) {
-    closing = true
-  }
-  if (previewOpen || prev.sessionId !== previewSessionId) {
-    closing = false
-  }
-  if (closing !== closingState) {
-    setClosingState(closing)
-  }
-
-  React.useEffect(() => {
-    prevPreviewStateRef.current = { open: previewOpen, sessionId: previewSessionId }
-  }, [previewOpen, previewSessionId])
-
-  const showPreview = (previewOpen || closing) && previewSessionId && activeView === 'conversations'
-  const showPreviewClosingOnly = closing && !previewOpen
-  const showPreviewPane = !!showPreview && !(showPreviewClosingOnly && showScratchPanel)
-  const showBothRightPanels = showPreviewPane && showScratchPanel
-
-  const handlePreviewDragStart = React.useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    previewDragging.current = true
-    const startX = e.clientX
-    const startRatio = splitRatio
-    const containerEl = (e.currentTarget as HTMLElement).closest('[data-split-container]') as HTMLElement | null
-    const containerWidth = containerEl?.clientWidth ?? 1
+  const handleScratchDragStart = React.useCallback((event: React.MouseEvent) => {
+    event.preventDefault()
+    scratchDragging.current = true
+    const startX = event.clientX
+    const startRatio = scratchSplitRatio
+    const container = (event.currentTarget as HTMLElement).closest('[data-scratch-split-container]') as HTMLElement | null
+    const containerWidth = container?.clientWidth ?? 1
+    let latestClientX = startX
     let rafId = 0
 
     document.body.style.userSelect = 'none'
     document.body.style.cursor = 'col-resize'
-    document.querySelectorAll('iframe').forEach((f) => { (f as HTMLElement).style.pointerEvents = 'none' })
-
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!previewDragging.current) return
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      if (!scratchDragging.current) return
+      latestClientX = moveEvent.clientX
       if (rafId) return
       rafId = requestAnimationFrame(() => {
         rafId = 0
-        const delta = ev.clientX - startX
-        const newRatio = Math.max(0.3, Math.min(0.8, startRatio + delta / containerWidth))
-        setSplitRatio(newRatio)
+        const nextRatio = Math.max(0.3, Math.min(0.8, startRatio + (latestClientX - startX) / containerWidth))
+        setScratchSplitRatio(nextRatio)
       })
     }
     const onMouseUp = () => {
-      previewDragging.current = false
+      scratchDragging.current = false
       if (rafId) cancelAnimationFrame(rafId)
       document.body.style.userSelect = ''
       document.body.style.cursor = ''
-      document.querySelectorAll('iframe').forEach((f) => { (f as HTMLElement).style.pointerEvents = '' })
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp)
     }
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-  }, [splitRatio, setSplitRatio])
+  }, [scratchSplitRatio, setScratchSplitRatio])
 
-  const handleRightWorkspaceDragStart = React.useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    rightWorkspaceDragging.current = true
-    const startX = e.clientX
-    const startRatio = rightWorkspaceRatio
-    const containerEl = (e.currentTarget as HTMLElement).closest('[data-right-workspace]') as HTMLElement | null
-    const containerWidth = containerEl?.clientWidth ?? 1
-    let rafId = 0
-
-    document.body.style.userSelect = 'none'
-    document.body.style.cursor = 'col-resize'
-    document.querySelectorAll('iframe').forEach((f) => { (f as HTMLElement).style.pointerEvents = 'none' })
-
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!rightWorkspaceDragging.current) return
-      if (rafId) return
-      rafId = requestAnimationFrame(() => {
-        rafId = 0
-        const delta = ev.clientX - startX
-        const newRatio = Math.max(0.3, Math.min(0.7, startRatio + delta / containerWidth))
-        setRightWorkspaceRatio(newRatio)
-      })
-    }
-    const onMouseUp = () => {
-      rightWorkspaceDragging.current = false
-      if (rafId) cancelAnimationFrame(rafId)
-      document.body.style.userSelect = ''
-      document.body.style.cursor = ''
-      document.querySelectorAll('iframe').forEach((f) => { (f as HTMLElement).style.pointerEvents = '' })
-      document.removeEventListener('mousemove', onMouseMove)
-      document.removeEventListener('mouseup', onMouseUp)
-    }
-    document.addEventListener('mousemove', onMouseMove)
-    document.addEventListener('mouseup', onMouseUp)
-  }, [rightWorkspaceRatio, setRightWorkspaceRatio])
-
-  const handleCloseScratchPanel = React.useCallback(() => {
-    closeScratchInSplit(store)
-  }, [store])
+  const handleCloseScratchPanel = React.useCallback(() => closeScratchInSplit(store), [store])
 
   React.useEffect(() => {
-    if (tabs.length === 0) {
-      console.warn('[FLASH-DEBUG] MainArea: tabs.length === 0, showing WelcomeView!', new Error().stack)
-    }
-  }, [tabs.length])
-
-  React.useEffect(() => {
-    if (tabs.length > 0 && !activeTabId) {
-      setActiveTabId(tabs[0]!.id)
-    }
+    if (tabs.length > 0 && !activeTabId) setActiveTabId(tabs[0]!.id)
   }, [tabs, activeTabId, setActiveTabId])
 
-  // 关闭动画期间右侧面板的定位样式（脱离 flex 流，保持原宽度，translateX 向右滑出）
-  const closingOverlayStyle: React.CSSProperties | undefined = closing
-    ? {
-        position: 'absolute',
-        top: 0,
-        bottom: 0,
-        left: `${splitRatio * 100}%`,
-        width: `${(1 - splitRatio) * 100}%`,
-        zIndex: 1,
-        display: 'flex',
-        pointerEvents: 'none',
-      }
-    : undefined
-
-  // 左侧容器宽度：右侧工作区打开时固定占 splitRatio；其他情况（含 closing 动画期间）
-  // 直接 1 1 auto 占满——closing 时右侧 absolute 脱离 flex 流，所以左侧自然占 100%。
-  const showRightPanel = showBrowserPanel || showScratchPanel || showPreviewPane
-  const leftFlexStyle: React.CSSProperties = showRightPanel
-    ? { flex: `0 0 calc(${splitRatio * 100}% - 6px)` }
-    : { flex: '1 1 auto' }
-  const previewPaneStyle: React.CSSProperties = showBothRightPanels
-    ? { flex: `0 0 calc(${rightWorkspaceRatio * 100}% - 4px)` }
-    : { flex: '1 1 auto' }
-  const scratchPaneStyle: React.CSSProperties = showBothRightPanels
-    ? { flex: `0 0 calc(${(1 - rightWorkspaceRatio) * 100}% - 4px)` }
+  const leftFlexStyle: React.CSSProperties = showScratchPanel
+    ? { flex: `0 0 calc(${scratchSplitRatio * 100}% - 6px)` }
     : { flex: '1 1 auto' }
 
   return (
-    <>
-      <Panel
-        variant="grow"
-        className={cn('bg-content-area', isClassic && 'rounded-2xl shadow-xl dark:shadow-sm')}
-      >
-        <div className="flex flex-1 min-h-0 relative overflow-hidden" data-split-container>
-          {/* 左侧：TabBar + TabContent（始终保持在同一 DOM 位置，避免 Tab 切换时 unmount）
-              注：宽度变化不用 transition——文字逐帧 reflow 会导致行末字符抖动，
-              视觉上像"内容从右向左推送"。让左侧瞬间变宽，由右侧 absolute 滑出动画
-              覆盖期内呈现"被剥离"的视觉效果。 */}
-          <div
-            className={cn('flex flex-col min-w-0 h-full relative', showPreview && 'mr-0.5')}
-            style={leftFlexStyle}
-          >
-            {activeView === 'planning' ? (
-              automationFormOpen ? (
-                // 自动化设置页：与任务/日程同层级替换中间区，不经过 TabBar。
+    <Panel variant="grow" className={cn('bg-content-area', isClassic && 'rounded-2xl shadow-xl dark:shadow-sm')}>
+      <div className="flex flex-1 min-h-0 overflow-hidden" data-scratch-split-container>
+        <div className="flex flex-col min-w-0 h-full" style={leftFlexStyle}>
+          {activeView === 'planning' ? (
+            automationFormOpen ? <AutomationFormView /> : <PlanningView />
+          ) : activeView === 'agent-skills' ? (
+            <AgentSkillsView />
+          ) : (
+            <>
+              {showCenterTabBar && <TabBar />}
+              {automationFormOpen ? (
                 <AutomationFormView />
-              ) : (
-                <PlanningView />
-              )
-            ) : activeView === 'agent-skills' ? (
-              // Agent 技能视图：全屏取代 TabBar + TabContent
-              <AgentSkillsView />
-            ) : (
-              <>
-                <TabBar />
-                {automationFormOpen ? (
-                  // 兼容从会话内入口打开任务设置的场景。
-                  <AutomationFormView />
-                ) : tabs.length === 0 ? (
-                  <WelcomeView />
-                ) : contentTabId ? (
-                  <div className="flex-1 min-h-0 titlebar-no-drag">
-                    <TabContent tabId={contentTabId} />
-                  </div>
-                ) : null}
-              </>
-            )}
-          </div>
-
-          {/* 右侧：预览/草稿工作区。Preview 和草稿可在同一右侧槽位内并排显示。 */}
-          {showRightPanel && (
-            <div
-              className={cn(closing && !showScratchPanel ? 'animate-preview-slide-out' : 'flex flex-1 min-w-0')}
-              style={closing && !showScratchPanel ? closingOverlayStyle : undefined}
-              onAnimationEnd={(e) => {
-                if (closing && e.target === e.currentTarget) setClosingState(false)
-              }}
-            >
-              {!(closing && !showScratchPanel) && (
-                <div
-                  className="w-[8px] cursor-col-resize bg-border/40 hover:bg-primary/30 active:bg-primary/50 transition-colors flex-shrink-0 self-stretch"
-                  onMouseDown={handlePreviewDragStart}
-                />
-              )}
-              <div className="flex flex-1 min-w-0 h-full overflow-hidden" data-right-workspace>
-                {showBrowserPanel && browserSessionId && (
-                  <div className="min-w-0 h-full overflow-hidden flex-1">
-                    <BrowserPanel
-                      sessionId={browserSessionId}
-                      state={browserState}
-                      onMinimize={() => {
-                        setBrowserMinimizedMap((previous) => { const next = new Map(previous); next.set(browserSessionId, true); return next })
-                        setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(browserSessionId, false); return next })
-                      }}
-                      onClose={() => {
-                        setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(browserSessionId, false); return next })
-                        setBrowserMinimizedMap((previous) => { const next = new Map(previous); next.delete(browserSessionId); return next })
-                        setBrowserStateMap((previous) => { const next = new Map(previous); next.delete(browserSessionId); return next })
-                        setPendingNavigationMap((previous) => { const next = new Map(previous); next.delete(browserSessionId); return next })
-                      }}
-                    />
-                  </div>
-                )}
-                {showPreviewPane && previewSessionId && (
-                  <div className="min-w-0 h-full overflow-hidden" style={previewPaneStyle}>
-                    <PreviewPanel sessionId={previewSessionId} />
-                  </div>
-                )}
-                {showBothRightPanels && (
-                  <div
-                    className="w-[8px] cursor-col-resize bg-border/40 hover:bg-primary/30 active:bg-primary/50 transition-colors flex-shrink-0 self-stretch"
-                    onMouseDown={handleRightWorkspaceDragStart}
-                  />
-                )}
-                {showScratchPanel && (
-                  <div className="min-w-0 h-full overflow-hidden" style={scratchPaneStyle}>
-                    <ScratchPadPane onClose={handleCloseScratchPanel} />
-                  </div>
-                )}
-              </div>
-            </div>
+              ) : tabs.length === 0 ? (
+                <WelcomeView />
+              ) : contentTabId ? (
+                <div className="flex-1 min-h-0 titlebar-no-drag"><TabContent tabId={contentTabId} /></div>
+              ) : null}
+            </>
           )}
         </div>
-      </Panel>
-    </>
+        {showScratchPanel && (
+          <>
+            <div
+              className="w-[8px] cursor-col-resize bg-border/40 hover:bg-primary/30 active:bg-primary/50 transition-colors flex-shrink-0 self-stretch"
+              onMouseDown={handleScratchDragStart}
+            />
+            <div className="flex-1 min-w-0 h-full overflow-hidden"><ScratchPadPane onClose={handleCloseScratchPanel} /></div>
+          </>
+        )}
+      </div>
+    </Panel>
   )
 }

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
-import { HelpCircle, Keyboard, Globe2, PanelRight } from 'lucide-react'
+import { HelpCircle, Keyboard, Globe, PanelRight } from 'lucide-react'
 import {
   tabsAtom,
   activeTabIdAtom,
@@ -26,6 +26,8 @@ import {
   agentWorkspacesAtom,
   currentAgentSessionIdAtom,
   currentAgentWorkspaceIdAtom,
+  agentDiffPanelTabAtom,
+  getBrowserSidePanelTab,
   unviewedCompletedSessionIdsAtom,
 } from '@/atoms/agent-atoms'
 import { appModeAtom } from '@/atoms/app-mode'
@@ -38,7 +40,6 @@ import { TabBarItem } from './TabBarItem'
 import { getTabBarActionLayout } from './tab-bar-action-layout'
 import { useCloseTab } from '@/hooks/useCloseTab'
 import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
-import { registerShortcut } from '@/lib/shortcut-registry'
 import { cn } from '@/lib/utils'
 import { shortcutGuideOpenAtom } from '@/atoms/shortcut-guide'
 import { faqDialogOpenAtom } from '@/atoms/faq-dialog'
@@ -251,9 +252,8 @@ function TabBarInner({
   const setBrowserMinimizedMap = useSetAtom(browserPanelMinimizedMapAtom)
   const browserStateMap = useAtomValue(browserStateMapAtom)
   const setBrowserStateMap = useSetAtom(browserStateMapAtom)
-  const activeBrowserIsOpen = activeAgentSession ? browserOpenMap.get(activeAgentSession.id) === true : false
+  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const hasMinimizedBrowser = Boolean(activeAgentSession && browserStateMap.has(activeAgentSession.id) && browserMinimizedMap.get(activeAgentSession.id) === true)
-  const priorBrowserStateRef = React.useRef<{ sessionId: string | null; open: boolean }>({ sessionId: null, open: false })
   const actionLayout = getTabBarActionLayout(isWindows, showOpenPanelButton, showBrowserButton)
 
   const togglePanel = React.useCallback(() => {
@@ -269,23 +269,13 @@ function TabBarInner({
     setBrowserStateMap((previous) => { const next = new Map(previous); next.set(activeAgentSession.id, state); return next })
     setBrowserMinimizedMap((previous) => { const next = new Map(previous); next.delete(activeAgentSession.id); return next })
     setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(activeAgentSession.id, true); return next })
-  }, [activeAgentSession, setBrowserMinimizedMap, setBrowserOpenMap, setBrowserStateMap])
-
-  React.useEffect(() => {
-    const sessionId = activeAgentSession?.id ?? null
-    const previous = priorBrowserStateRef.current
-    const shouldAutoCollapse = Boolean(
-      sessionId &&
-      previous.sessionId === sessionId &&
-      !previous.open &&
-      activeBrowserIsOpen &&
-      isPanelOpen,
-    )
-    priorBrowserStateRef.current = { sessionId, open: activeBrowserIsOpen }
-
-    if (!shouldAutoCollapse) return
-    setSidePanelOpen(false)
-  }, [activeAgentSession?.id, activeBrowserIsOpen, isPanelOpen, setSidePanelOpen])
+    setSidePanelOpen(true)
+    setSidePanelTabMap((previous) => {
+      const next = new Map(previous)
+      next.set(activeAgentSession.id, getBrowserSidePanelTab(state.activeTabId))
+      return next
+    })
+  }, [activeAgentSession, setBrowserMinimizedMap, setBrowserOpenMap, setBrowserStateMap, setSidePanelOpen, setSidePanelTabMap])
 
   const openShortcutGuide = React.useCallback(() => {
     setShortcutGuideOpen(true)
@@ -294,10 +284,6 @@ function TabBarInner({
   const openFaqDialog = React.useCallback(() => {
     setFaqDialogOpen(true)
   }, [setFaqDialogOpen])
-
-  React.useEffect(() => {
-    return registerShortcut('toggle-right-panel', togglePanel)
-  }, [togglePanel])
 
   // 滚动容器 ref
   const scrollRef = React.useRef<HTMLDivElement>(null)
@@ -542,7 +528,7 @@ function ShortcutGuideButton({
               )}
               onClick={() => void onOpenBrowser()}
             >
-              <Globe2 className="size-3.5" />
+              <Globe className="size-3.5" />
               <span className="sr-only">打开受管浏览器</span>
             </Button>
           </TooltipTrigger>

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -23,6 +23,7 @@ import {
   SCRATCH_PAD_TITLE,
 } from '@/atoms/tab-atoms'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
+import { workspaceMemoryEditingStateAtomFamily } from '@/atoms/memory-change-atoms'
 import { getInitialTabSwitchIndex, promoteTabMru } from '@/lib/tab-switching'
 import { appModeAtom } from '@/atoms/app-mode'
 import { activeViewAtom } from '@/atoms/active-view'
@@ -95,6 +96,8 @@ export function TabSwitcher(): ReactElement | null {
   const setActiveView = useSetAtom(activeViewAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
   const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
+  const currentAgentSessionId = useAtomValue(currentAgentSessionIdAtom)
+  const currentMemoryEditingState = useAtomValue(workspaceMemoryEditingStateAtomFamily(currentAgentSessionId ?? ''))
   const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const setCurrentAgentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
@@ -256,6 +259,9 @@ export function TabSwitcher(): ReactElement | null {
 
   const activateCandidate = useCallback(
     (candidate: SwitchCandidate): void => {
+      if (currentAgentSessionId && candidate.id !== currentAgentSessionId && currentMemoryEditingState.dirty) {
+        if (!window.confirm('项目记忆有未保存修改。确定丢弃并切换会话吗？')) return
+      }
       // 快速切换器全局挂载；确认候选时必须退出任务/技能等覆盖视图，
       // 否则 activeTab 已变更而 TabContent 仍不可见。
       setAutomationForm({ open: false, draft: null })
@@ -330,6 +336,8 @@ export function TabSwitcher(): ReactElement | null {
     },
     [
       appMode,
+      currentAgentSessionId,
+      currentMemoryEditingState.dirty,
       setActiveTabId,
       setActiveView,
       setScratchPadPanelOpen,

--- a/apps/electron/src/renderer/hooks/useOpenSession.ts
+++ b/apps/electron/src/renderer/hooks/useOpenSession.ts
@@ -16,6 +16,7 @@ import {
   type TabType,
 } from '@/atoms/tab-atoms'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
+import { workspaceMemoryEditingStateAtomFamily } from '@/atoms/memory-change-atoms'
 import { appModeAtom } from '@/atoms/app-mode'
 import { activeViewAtom } from '@/atoms/active-view'
 import { automationFormAtom } from '@/atoms/automation-atoms'
@@ -46,6 +47,8 @@ export function useOpenSession(): OpenSessionFn {
   const setActiveView = useSetAtom(activeViewAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
   const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
+  const currentAgentSessionId = useAtomValue(currentAgentSessionIdAtom)
+  const currentMemoryEditingState = useAtomValue(workspaceMemoryEditingStateAtomFamily(currentAgentSessionId ?? ''))
   const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const agentSessions = useAtomValue(agentSessionsAtom)
   const setCurrentAgentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
@@ -60,6 +63,9 @@ export function useOpenSession(): OpenSessionFn {
       if (!options?.bypassSettingsGuard && settingsOpen && channelFormDirty) {
         setPendingSessionNavigation({ type, sessionId, title })
         return
+      }
+      if (currentAgentSessionId && sessionId !== currentAgentSessionId && currentMemoryEditingState.dirty) {
+        if (!window.confirm('项目记忆有未保存修改。确定丢弃并切换会话吗？')) return
       }
 
       setSettingsOpen(false)
@@ -107,6 +113,6 @@ export function useOpenSession(): OpenSessionFn {
         setCurrentAgentSessionId(null)
       }
     },
-    [tabs, setTabs, setActiveTabId, setAutomationForm, setActiveView, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, agentSessions, setCurrentAgentWorkspaceId, setUnviewedCompleted, settingsOpen, channelFormDirty, setSettingsOpen, setPendingSessionNavigation],
+    [tabs, setTabs, setActiveTabId, setAutomationForm, setActiveView, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, agentSessions, setCurrentAgentWorkspaceId, setUnviewedCompleted, settingsOpen, channelFormDirty, setSettingsOpen, setPendingSessionNavigation, currentAgentSessionId, currentMemoryEditingState.dirty],
   )
 }

--- a/apps/electron/src/renderer/lib/right-workspace-events.ts
+++ b/apps/electron/src/renderer/lib/right-workspace-events.ts
@@ -1,0 +1,2 @@
+/** 右侧工作区与全局快捷键之间的轻量事件协议。 */
+export const CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT = 'proma:close-active-right-workspace-tab'

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -187,7 +187,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   {
     id: 'close-tab',
     name: '关闭当前标签',
-    description: '关闭当前活跃的 Chat 或 Agent 标签页',
+    description: '关闭当前 Chat 标签页，或 Agent 右侧的项目记忆/预览/浏览器标签',
     defaultMac: 'Cmd+W',
     defaultWin: 'Ctrl+W',
     category: 'app',


### PR DESCRIPTION
## Summary
- Unify files, changes, previews, project-memory updates, Q&A, and browser pages in the Agent right workspace tab bar.
- Add closable dynamic preview, project-memory, and browser tabs with Cmd/Ctrl+W support.
- Preserve browser WebContentsView state across right-workspace tab changes and serialize rapid browser-tab activation.
- Improve workspace widths, tab affordances, Office previews, and sidebar alignment.

## Review follow-up
- Restored a discoverable project-memory entry and `MEMORY.md` initialization.
- Added unsaved-edit discard confirmation, Cmd/Ctrl+S, and external-change protection for inline project-memory edits.
- Prevented destructive closing of the Agent current browser work tab.
- Reopening an existing preview tab now refreshes its current access and parsing context.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run electron:build`
- `git diff --check`

## Performance
- Browser layout updates remain rAF-coalesced for resize and overlays; a newly selected Slot publishes synchronously to avoid a hidden-view race.
- Rapid browser-tab clicks are serialized to the final target, avoiding stale IPC activation.
- The project-memory editor loads only after user interaction; no polling or added long-lived subscriptions.

## Remaining manual verification
- Full Electron GUI regression for multiple browser tabs, rapid A → B → A switching, WebContentsView overlays, and real XLSX rendering.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)