### PR TITLE
feat(markdown): add reusable live Markdown editor

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.64",
+  "version": "0.17.65",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -43,6 +43,10 @@
     "dist:debug": "bun run scripts/dist.ts --current-arch --verbose"
   },
   "dependencies": {
+    "@codemirror/lang-markdown": "^6.5.2",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.9",
     "@earendil-works/pi-agent-core": "0.84.2",
     "@earendil-works/pi-ai": "0.84.2",
     "@earendil-works/pi-coding-agent": "0.84.2",
@@ -53,6 +57,7 @@
     "adm-zip": "^0.5.17",
     "dompurify": "^3.4.5",
     "iconv-lite": "^0.6.3",
+    "ink-mde": "0.33.0",
     "mammoth": "^1.12.0",
     "pdfjs-dist": "^4.10.38",
     "sharp": "^0.35.3",

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react'
+import ink, { type Instance } from 'ink-mde'
+import { cn } from '@/lib/utils'
+import { createMarkdownEditorLifecycle } from './markdown-editor-lifecycle'
+import { markdownSyntaxVisibility } from './markdown-syntax-visibility'
+
+export interface LiveMarkdownEditorSelection {
+  start: number
+  end: number
+}
+
+export interface LiveMarkdownEditorScrollPosition {
+  top: number
+  left: number
+}
+
+export interface LiveMarkdownEditorHandle {
+  focus: () => void
+  getInstance: () => Instance | null
+}
+
+export interface LiveMarkdownEditorProps {
+  /** Controlled value. When omitted, the editor manages its initial defaultValue. */
+  value?: string
+  defaultValue?: string
+  onChange?: (value: string) => void
+  readOnly?: boolean
+  placeholder?: string
+  className?: string
+  onSave?: () => void
+  onSelectionChange?: (selection: LiveMarkdownEditorSelection) => void
+  onScrollPositionChange?: (position: LiveMarkdownEditorScrollPosition) => void
+}
+
+export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, LiveMarkdownEditorProps>(function LiveMarkdownEditor({
+  value,
+  defaultValue = '',
+  onChange,
+  readOnly = false,
+  placeholder,
+  className,
+  onSave,
+  onSelectionChange,
+  onScrollPositionChange,
+}, ref): React.ReactElement {
+  const hostRef = React.useRef<HTMLDivElement>(null)
+  const instanceRef = React.useRef<Instance | null>(null)
+  const lifecycleRef = React.useRef<ReturnType<typeof createMarkdownEditorLifecycle> | null>(null)
+  const valueRef = React.useRef(value ?? defaultValue)
+  const onChangeRef = React.useRef(onChange)
+  const onSaveRef = React.useRef(onSave)
+  const onSelectionChangeRef = React.useRef(onSelectionChange)
+  const onScrollPositionChangeRef = React.useRef(onScrollPositionChange)
+  const placeholderRef = React.useRef(placeholder)
+  const readOnlyRef = React.useRef(readOnly)
+  valueRef.current = value ?? valueRef.current
+  onChangeRef.current = onChange
+  onSaveRef.current = onSave
+  onSelectionChangeRef.current = onSelectionChange
+  onScrollPositionChangeRef.current = onScrollPositionChange
+  placeholderRef.current = placeholder
+  readOnlyRef.current = readOnly
+
+  React.useImperativeHandle(ref, () => ({
+    focus: () => instanceRef.current?.focus(),
+    getInstance: () => instanceRef.current,
+  }), [])
+
+  React.useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+
+    // ink-mde leaves its rendered container behind on destroy. An owned child
+    // mount prevents StrictMode's discarded effect from becoming an empty shell.
+    const mount = document.createElement('div')
+    mount.className = 'h-full min-h-0'
+    host.appendChild(mount)
+    const lifecycle = createMarkdownEditorLifecycle((initialValue, handleUpdate) => ink(mount, {
+      doc: initialValue,
+      placeholder: placeholderRef.current,
+      files: { clipboard: false, dragAndDrop: false, injectMarkup: true },
+      hooks: { afterUpdate: handleUpdate },
+      interface: {
+        appearance: 'auto',
+        attribution: false,
+        autocomplete: false,
+        images: false,
+        lists: true,
+        readonly: readOnlyRef.current,
+        spellcheck: false,
+        toolbar: false,
+      },
+      plugins: markdownSyntaxVisibility.map((extension) => ({ type: 'default' as const, value: extension })),
+      search: false,
+      toolbar: {
+        bold: false, code: false, codeBlock: false, heading: false, image: false,
+        italic: false, link: false, list: false, orderedList: false, quote: false,
+        taskList: false, upload: false,
+      },
+    }), (nextValue) => onChangeRef.current?.(nextValue))
+    lifecycleRef.current = lifecycle
+    lifecycle.mount(valueRef.current)
+
+    let frame = 0
+    let cancelled = false
+    const reportSelection = (): void => {
+      frame = 0
+      const selection = instanceRef.current?.selections()[0]
+      if (selection) onSelectionChangeRef.current?.({ start: selection.start, end: selection.end })
+    }
+    const scheduleSelectionReport = (): void => {
+      if (!frame) frame = requestAnimationFrame(reportSelection)
+    }
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+        event.preventDefault()
+        onSaveRef.current?.()
+      }
+    }
+    const handleScroll = (event: Event): void => {
+      const target = event.target
+      if (target instanceof HTMLElement) onScrollPositionChangeRef.current?.({ top: target.scrollTop, left: target.scrollLeft })
+    }
+    const attachInstance = (): void => {
+      if (cancelled) return
+      instanceRef.current = lifecycle.getInstance() as Instance | null
+      if (!instanceRef.current) {
+        requestAnimationFrame(attachInstance)
+        return
+      }
+      instanceRef.current.reconfigure({
+        placeholder: placeholderRef.current,
+        interface: { readonly: readOnlyRef.current },
+      })
+    }
+    host.addEventListener('keydown', handleKeyDown)
+    host.addEventListener('keyup', scheduleSelectionReport)
+    host.addEventListener('mouseup', scheduleSelectionReport)
+    host.addEventListener('scroll', handleScroll, true)
+    attachInstance()
+
+    return () => {
+      cancelled = true
+      if (frame) cancelAnimationFrame(frame)
+      host.removeEventListener('keydown', handleKeyDown)
+      host.removeEventListener('keyup', scheduleSelectionReport)
+      host.removeEventListener('mouseup', scheduleSelectionReport)
+      host.removeEventListener('scroll', handleScroll, true)
+      lifecycle.dispose()
+      if (lifecycleRef.current === lifecycle) lifecycleRef.current = null
+      instanceRef.current = null
+      mount.remove()
+    }
+  // The editor lifecycle is intentionally created once. Prop updates use the effects below.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  React.useEffect(() => {
+    if (value !== undefined) {
+      valueRef.current = value
+      lifecycleRef.current?.sync(value)
+    }
+  }, [value])
+
+  React.useEffect(() => {
+    instanceRef.current?.reconfigure({
+      placeholder,
+      interface: { readonly: readOnly },
+    })
+  }, [placeholder, readOnly])
+
+  return <div ref={hostRef} className={cn('markdown-live-editor h-full min-h-0', className)} />
+})

--- a/apps/electron/src/renderer/components/markdown/markdown-editor-lifecycle.test.ts
+++ b/apps/electron/src/renderer/components/markdown/markdown-editor-lifecycle.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import { createMarkdownEditorLifecycle, type MarkdownEditorInstance } from './markdown-editor-lifecycle'
+
+function editor(doc: string): MarkdownEditorInstance & { destroyed: boolean } {
+  return {
+    destroyed: false,
+    destroy() { this.destroyed = true },
+    getDoc() { return doc },
+    update(value) { doc = value },
+  }
+}
+
+describe('Markdown editor lifecycle', () => {
+  test('preserves a normal document and applies controlled updates', async () => {
+    const instance = editor('# Initial')
+    const lifecycle = createMarkdownEditorLifecycle(() => instance, () => {})
+    lifecycle.mount('# Initial')
+    await Promise.resolve()
+
+    lifecycle.sync('**Updated**')
+    expect(instance.getDoc()).toBe('**Updated**')
+  })
+
+  test('preserves an empty document', async () => {
+    const instance = editor('')
+    const lifecycle = createMarkdownEditorLifecycle(() => instance, () => {})
+    lifecycle.mount('')
+    await Promise.resolve()
+
+    expect(instance.getDoc()).toBe('')
+  })
+
+  test('destroys a late StrictMode instance and remounts with the latest body', async () => {
+    let resolveFirst: ((value: MarkdownEditorInstance) => void) | undefined
+    const first = editor('stale')
+    const discarded = createMarkdownEditorLifecycle(() => new Promise((resolve) => {
+      resolveFirst = resolve
+    }), () => {})
+    discarded.mount('stale')
+    discarded.dispose()
+    resolveFirst?.(first)
+    await Promise.resolve()
+    expect(first.destroyed).toBe(true)
+
+    const second = editor('start')
+    const live = createMarkdownEditorLifecycle(() => second, () => {})
+    live.mount('start')
+    live.sync('## Remounted body')
+    await Promise.resolve()
+    expect(second.getDoc()).toBe('## Remounted body')
+  })
+})

--- a/apps/electron/src/renderer/components/markdown/markdown-editor-lifecycle.ts
+++ b/apps/electron/src/renderer/components/markdown/markdown-editor-lifecycle.ts
@@ -1,0 +1,49 @@
+export interface MarkdownEditorInstance {
+  destroy: () => void
+  getDoc: () => string
+  update: (value: string) => void
+}
+
+type CreateEditor = (value: string, onUpdate: (value: string) => void) => MarkdownEditorInstance | PromiseLike<MarkdownEditorInstance>
+
+/**
+ * Owns an asynchronously-created editor instance. Keeping this outside React
+ * makes a discarded StrictMode effect harmless: its late instance is destroyed
+ * instead of replacing the active editor.
+ */
+export function createMarkdownEditorLifecycle(createEditor: CreateEditor, onUpdate: (value: string) => void) {
+  let disposed = false
+  let ready = false
+  let instance: MarkdownEditorInstance | null = null
+  let latestValue = ''
+
+  return {
+    mount(value: string): void {
+      latestValue = value
+      void Promise.resolve(createEditor(value, (nextValue) => {
+        if (ready && !disposed) onUpdate(nextValue)
+      })).then((nextInstance) => {
+        if (disposed) {
+          nextInstance.destroy()
+          return
+        }
+        instance = nextInstance
+        if (instance.getDoc() !== latestValue) instance.update(latestValue)
+        ready = true
+      })
+    },
+    sync(value: string): void {
+      latestValue = value
+      if (instance && instance.getDoc() !== value) instance.update(value)
+    },
+    getInstance(): MarkdownEditorInstance | null {
+      return instance
+    },
+    dispose(): void {
+      disposed = true
+      ready = false
+      instance?.destroy()
+      instance = null
+    },
+  }
+}

--- a/apps/electron/src/renderer/components/markdown/markdown-syntax-visibility.test.ts
+++ b/apps/electron/src/renderer/components/markdown/markdown-syntax-visibility.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+import { markdown } from '@codemirror/lang-markdown'
+import { EditorState } from '@codemirror/state'
+import {
+  markdownSyntaxVisibilityField,
+  setMarkdownSyntaxFocused,
+} from './markdown-syntax-visibility'
+
+function hiddenRanges(state: EditorState): Array<{ from: number; to: number }> {
+  const ranges: Array<{ from: number; to: number }> = []
+  state.field(markdownSyntaxVisibilityField).decorations.between(0, state.doc.length, (from, to) => {
+    ranges.push({ from, to })
+  })
+  return ranges
+}
+
+function stateFor(doc: string): EditorState {
+  return EditorState.create({
+    doc,
+    extensions: [markdown(), markdownSyntaxVisibilityField],
+  })
+}
+
+describe('markdown syntax visibility', () => {
+  test('hides Markdown markers on unfocused title, emphasis, and link lines', () => {
+    const doc = '# Heading\nA **strong** [link](https://proma.cool)'
+    const ranges = hiddenRanges(stateFor(doc))
+
+    expect(ranges).toContainEqual({ from: 0, to: 1 })
+    expect(ranges).toContainEqual({ from: doc.indexOf('**'), to: doc.indexOf('**') + 2 })
+    expect(ranges.some((range) => range.from === doc.indexOf('['))).toBe(true)
+  })
+
+  test('shows markers on the current cursor line and keeps other lines compact', () => {
+    const doc = '# Heading\nA **strong** [link](https://proma.cool)'
+    const emphasisLine = doc.indexOf('**')
+    const state = stateFor(doc).update({
+      effects: setMarkdownSyntaxFocused(true),
+      selection: { anchor: emphasisLine },
+    }).state
+    const ranges = hiddenRanges(state)
+
+    expect(ranges).toContainEqual({ from: 0, to: 1 })
+    expect(ranges.some((range) => range.from === emphasisLine)).toBe(false)
+    expect(ranges.some((range) => range.from === doc.indexOf('['))).toBe(false)
+  })
+
+  test('supports an empty document without decorations', () => {
+    expect(hiddenRanges(stateFor(''))).toEqual([])
+  })
+})

--- a/apps/electron/src/renderer/components/markdown/markdown-syntax-visibility.ts
+++ b/apps/electron/src/renderer/components/markdown/markdown-syntax-visibility.ts
@@ -1,0 +1,73 @@
+import { syntaxTree } from '@codemirror/language'
+import { RangeSetBuilder, StateEffect, StateField, type EditorState } from '@codemirror/state'
+import { Decoration, EditorView, type DecorationSet } from '@codemirror/view'
+
+const markdownSyntaxFocusEffect = StateEffect.define<boolean>()
+const markdownSyntaxMarkerNames = new Set([
+  'CodeMark',
+  'EmphasisMark',
+  'HeaderMark',
+  'LinkMark',
+  'QuoteMark',
+])
+const hiddenMarkdownSyntax = Decoration.replace({ class: 'markdown-live-editor__syntax-hidden' })
+
+export function activeMarkdownCursorLines(state: EditorState, focused: boolean): Set<number> {
+  if (!focused) return new Set()
+  return new Set(state.selection.ranges.map((range) => state.doc.lineAt(range.head).number))
+}
+
+function markdownSyntaxDecorations(state: EditorState, focused: boolean): DecorationSet {
+  const activeLines = activeMarkdownCursorLines(state, focused)
+  const builder = new RangeSetBuilder<Decoration>()
+  syntaxTree(state).iterate({
+    enter: ({ type, from, to }) => {
+      if (!markdownSyntaxMarkerNames.has(type.name)) return
+      if (activeLines.has(state.doc.lineAt(from).number)) return
+      builder.add(from, to, hiddenMarkdownSyntax)
+    },
+  })
+  return builder.finish()
+}
+
+interface MarkdownSyntaxVisibility {
+  focused: boolean
+  decorations: DecorationSet
+}
+
+export const markdownSyntaxVisibilityField = StateField.define<MarkdownSyntaxVisibility>({
+  create: (state) => ({
+    focused: false,
+    decorations: markdownSyntaxDecorations(state, false),
+  }),
+  update: (value, transaction) => {
+    let focused = value.focused
+    for (const effect of transaction.effects) {
+      if (effect.is(markdownSyntaxFocusEffect)) focused = effect.value
+    }
+    if (!transaction.docChanged && transaction.selection === undefined && focused === value.focused) return value
+    return {
+      focused,
+      decorations: markdownSyntaxDecorations(transaction.state, focused),
+    }
+  },
+  provide: (field) => EditorView.decorations.from(field, (value) => value.decorations),
+})
+
+export const markdownSyntaxVisibility = [
+  markdownSyntaxVisibilityField,
+  EditorView.domEventHandlers({
+    focus: (_event, view) => {
+      view.dispatch({ effects: markdownSyntaxFocusEffect.of(true) })
+      return false
+    },
+    blur: (_event, view) => {
+      view.dispatch({ effects: markdownSyntaxFocusEffect.of(false) })
+      return false
+    },
+  }),
+]
+
+export function setMarkdownSyntaxFocused(focused: boolean) {
+  return markdownSyntaxFocusEffect.of(focused)
+}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2,6 +2,46 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .markdown-live-editor .ink-mde,
+  .markdown-live-editor .ink-mde-editor,
+  .markdown-live-editor .cm-editor {
+    min-height: 100%;
+    height: 100%;
+  }
+
+  .markdown-live-editor .cm-scroller {
+    overflow: auto;
+    font: inherit;
+  }
+
+  .markdown-live-editor .cm-content {
+    min-height: 100%;
+    padding: 0.75rem 1rem;
+    color: hsl(var(--foreground));
+    caret-color: hsl(var(--primary));
+  }
+
+  .markdown-live-editor .cm-gutters {
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--background));
+    border-color: hsl(var(--border));
+  }
+
+  .markdown-live-editor .cm-activeLine,
+  .markdown-live-editor .cm-activeLineGutter {
+    background: hsl(var(--accent) / 0.45);
+  }
+
+  .markdown-live-editor .cm-selectionBackground {
+    background: hsl(var(--primary) / 0.20) !important;
+  }
+
+  .markdown-live-editor__syntax-hidden {
+    display: none;
+  }
+}
+
 /* ===== 全局字体与渲染优化 =====
  * 优先 Inter Variable（自托管，见 main.tsx 引入） → SF Pro Text（macOS 系统） → system-ui；
  * 数字使用 tabular-nums，配合 cv11/ss01/ss03 让字形接近 Vercel / Linear 的现代感。

--- a/bun.lock
+++ b/bun.lock
@@ -36,8 +36,12 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.17.27",
+      "version": "0.17.65",
       "dependencies": {
+        "@codemirror/lang-markdown": "^6.5.2",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.9",
         "@earendil-works/pi-agent-core": "0.84.2",
         "@earendil-works/pi-ai": "0.84.2",
         "@earendil-works/pi-coding-agent": "0.84.2",
@@ -48,6 +52,7 @@
         "adm-zip": "^0.5.17",
         "dompurify": "^3.4.5",
         "iconv-lite": "^0.6.3",
+        "ink-mde": "0.33.0",
         "mammoth": "^1.12.0",
         "pdfjs-dist": "^4.10.38",
         "sharp": "^0.35.3",
@@ -315,6 +320,66 @@
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.11.0", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.7.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA=="],
+
+    "@codemirror/lang-angular": ["@codemirror/lang-angular@0.1.4", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.3" } }, "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g=="],
+
+    "@codemirror/lang-cpp": ["@codemirror/lang-cpp@6.0.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/cpp": "^1.0.0" } }, "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-go": ["@codemirror/lang-go@6.0.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/go": "^1.0.0" } }, "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.12", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w=="],
+
+    "@codemirror/lang-java": ["@codemirror/lang-java@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/java": "^1.0.0" } }, "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-jinja": ["@codemirror/lang-jinja@6.0.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.4.0" } }, "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw=="],
+
+    "@codemirror/lang-json": ["@codemirror/lang-json@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/json": "^1.0.0" } }, "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ=="],
+
+    "@codemirror/lang-less": ["@codemirror/lang-less@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ=="],
+
+    "@codemirror/lang-liquid": ["@codemirror/lang-liquid@6.3.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw=="],
+
+    "@codemirror/lang-php": ["@codemirror/lang-php@6.0.2", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/php": "^1.0.0" } }, "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA=="],
+
+    "@codemirror/lang-python": ["@codemirror/lang-python@6.2.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.3.2", "@codemirror/language": "^6.8.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/python": "^1.1.4" } }, "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw=="],
+
+    "@codemirror/lang-rust": ["@codemirror/lang-rust@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/rust": "^1.0.0" } }, "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA=="],
+
+    "@codemirror/lang-sass": ["@codemirror/lang-sass@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/sass": "^1.0.0" } }, "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q=="],
+
+    "@codemirror/lang-sql": ["@codemirror/lang-sql@6.10.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w=="],
+
+    "@codemirror/lang-vue": ["@codemirror/lang-vue@0.1.3", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug=="],
+
+    "@codemirror/lang-wast": ["@codemirror/lang-wast@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q=="],
+
+    "@codemirror/lang-xml": ["@codemirror/lang-xml@6.1.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/xml": "^1.0.0" } }, "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg=="],
+
+    "@codemirror/lang-yaml": ["@codemirror/lang-yaml@6.1.3", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.0.0", "@lezer/yaml": "^1.0.0" } }, "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.4", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A=="],
+
+    "@codemirror/language-data": ["@codemirror/language-data@6.5.2", "", { "dependencies": { "@codemirror/lang-angular": "^0.1.0", "@codemirror/lang-cpp": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-go": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-java": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-jinja": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-less": "^6.0.0", "@codemirror/lang-liquid": "^6.0.0", "@codemirror/lang-markdown": "^6.0.0", "@codemirror/lang-php": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-rust": "^6.0.0", "@codemirror/lang-sass": "^6.0.0", "@codemirror/lang-sql": "^6.0.0", "@codemirror/lang-vue": "^0.1.1", "@codemirror/lang-wast": "^6.0.0", "@codemirror/lang-xml": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.4.0" } }, "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg=="],
+
+    "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.3", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.7", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg=="],
+
+    "@codemirror/search": ["@codemirror/search@6.7.1", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA=="],
+
+    "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
+
+    "@codemirror/view": ["@codemirror/view@6.43.9", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw=="],
+
     "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.2", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.2", "@earendil-works/pi-telemetry": "^0.84.2", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA=="],
@@ -491,9 +556,45 @@
 
     "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.73.0", "", { "dependencies": { "axios": "^1.16.0", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-gs4EiupJ6RdYAEJGtuYrCVsB7wSMBwtUDK+ilpmOHD6RTvbtciW6AWciQO9coOQVuBZfh7hvAi25dPfCsny/nA=="],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/cpp": ["@lezer/cpp@1.1.6", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA=="],
+
+    "@lezer/css": ["@lezer/css@1.3.6", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g=="],
+
+    "@lezer/go": ["@lezer/go@1.0.1", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/java": ["@lezer/java@1.1.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/json": ["@lezer/json@1.0.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.7.2", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ=="],
+
+    "@lezer/php": ["@lezer/php@1.0.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.1.0" } }, "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA=="],
+
+    "@lezer/python": ["@lezer/python@1.1.19", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ=="],
+
+    "@lezer/rust": ["@lezer/rust@1.0.2", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg=="],
+
+    "@lezer/sass": ["@lezer/sass@1.1.0", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ=="],
+
+    "@lezer/xml": ["@lezer/xml@1.0.6", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww=="],
+
+    "@lezer/yaml": ["@lezer/yaml@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
+
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
 
@@ -684,6 +785,10 @@
     "@radix-ui/rect": ["@radix-ui/rect@1.1.3", "", {}, "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw=="],
 
     "@react-symbols/icons": ["@react-symbols/icons@1.4.1", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-LJ9eiCJOoWrT4sjsamUBoSjbRkEeo6CYxqbEuicYib/cwwbN0ndTTGFx4at9D9CwEVdFxW/ZZfNrIdzjA4scIg=="],
+
+    "@replit/codemirror-vim": ["@replit/codemirror-vim@6.4.0", "", { "dependencies": { "@replit/codemirror-vim-core": "^0.1.0" }, "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-t9UMDNhkmeAkl0uRbiJVotv97bGD6mf4GyJJoEbrjUqa/Pov0s9eL+4AaI0Xto3OGri17i9qwIpT0JbVlVXt8A=="],
+
+    "@replit/codemirror-vim-core": ["@replit/codemirror-vim-core@0.1.0", "", {}, "sha512-1i6EBKpcNfDKvTmTh6N6g9lL6udD5t+uFNh4JCqozRnVlvUGOps7h/QzS2ne4zcvPUjvApKpmcP7Grc3fNbZiQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -1229,6 +1334,8 @@
 
     "crc32-stream": ["crc32-stream@4.0.3", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^3.4.0" } }, "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw=="],
 
+    "crelt": ["crelt@1.0.7", "", {}, "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
@@ -1636,6 +1743,8 @@
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ink-mde": ["ink-mde@0.33.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.16.0", "@codemirror/commands": "^6.5.0", "@codemirror/lang-markdown": "^6.2.5", "@codemirror/language": "^6.10.1", "@codemirror/language-data": "^6.5.1", "@codemirror/search": "^6.5.6", "@codemirror/state": "^6.4.1", "@codemirror/view": "^6.26.3", "@lezer/common": "^1.2.1", "@lezer/highlight": "^1.2.0", "@lezer/markdown": "^1.3.0", "@replit/codemirror-vim": "^6.2.1", "katex": "^0.16.9", "solid-js": "^1.8.7", "style-mod": "^4.1.2" }, "peerDependencies": { "svelte": "^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["svelte", "vue"] }, "sha512-kymsm0x3y/LcWNctSSTXo8jdADIMG82BrVNZiLtQGyu5mEoDVzFUdbIJgDBhssh6YdJJn2ElG3rCqWDSpxwWXA=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -2263,6 +2372,10 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
+    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
@@ -2303,6 +2416,8 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@7.0.0", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww=="],
 
+    "solid-js": ["solid-js@1.9.15", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg=="],
+
     "sonner": ["sonner@2.0.8", "", { "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -2336,6 +2451,8 @@
     "strip-dirs": ["strip-dirs@2.1.0", "", { "dependencies": { "is-natural-number": "^4.0.1" } }, "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g=="],
 
     "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
+
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 


### PR DESCRIPTION
## Summary
- add a standalone React Markdown editor backed by ink-mde and CodeMirror
- hide Markdown markers outside the active cursor line without reserving layout space
- preserve controlled updates and StrictMode/remount lifecycle safety

## Validation
- bun test apps/electron/src/renderer/components/markdown/markdown-syntax-visibility.test.ts apps/electron/src/renderer/components/markdown/markdown-editor-lifecycle.test.ts
- bun run typecheck
- bun run --filter='@proma/electron' build:renderer
- git diff --check

Excluded: Vault file APIs, Obsidian wiki links, reference pickers/chips, frontmatter/properties widgets, Vault table/Mermaid widgets, and Vault-specific CSS/events.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)