### PR TITLE
fix(agent): 修复 mention chip 紧贴文本的边界解析【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.64",
+  "version": "0.17.65",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -146,6 +146,7 @@ function createMentionSuggestion<T>(
               onSelect: (item: T) => {
                 const cmd = config.toCommand(item)
                 props.command({ ...cmd, mentionSuggestionChar: config.char })
+                props.editor.chain().insertContent(' ').run()
               },
             },
             editor: props.editor,
@@ -174,6 +175,7 @@ function createMentionSuggestion<T>(
             onSelect: (item: T) => {
               const cmd = config.toCommand(item)
               props.command({ ...cmd, mentionSuggestionChar: config.char })
+              props.editor.chain().insertContent(' ').run()
             },
           })
           positionPopup(popup, props.clientRect?.())

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -41,6 +41,7 @@ import { CodeBlock, MermaidBlock } from '@proma/ui'
 import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isImageFilePath, isRelativeFilePath } from './file-path-chip'
 import { buildAgentHistoryQuoteLabel, parseAgentHistoryQuoteMention } from '@/lib/quoted-selection'
+import { createMentionPattern } from '@/lib/mention-patterns'
 import { useAgentBrowserLink } from '@/components/browser/AgentBrowserLinkProvider'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
@@ -412,8 +413,9 @@ export function remarkMentions() {
   return (tree: MdastParent) => {
     walkMdastText(tree, (node, index, parent) => {
       const text = node.value
-      // 每次调用创建独立正则实例，避免 /g 状态在并发 remark pipeline 间互相干扰
-      const mentionPattern = /@file:(\S+)|\/skill:(\S+)|#mcp:(\S+)|&session:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&quote:([A-Za-z0-9%_.!~*'()-]+)/g
+      // 每次调用创建独立正则实例，避免 /g 状态在并发 remark pipeline 间互相干扰。
+      // Mention 值已编码，遇到紧邻的 CJK 普通文本时应立即结束。
+      const mentionPattern = createMentionPattern()
       if (!mentionPattern.test(text)) return
       mentionPattern.lastIndex = 0
 

--- a/apps/electron/src/renderer/lib/agent-message-queue.test.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.test.ts
@@ -46,4 +46,20 @@ describe('queued message @file mention path decoding (Agent 侧真实路径)', (
       expect(fileRef.label).toBe('My report.pdf')
     }
   })
+
+  test('preserves text immediately after a file mention without whitespace', () => {
+    const text = '@file:Screenshot%202026-08-24%20at%2014.17.47.png还是做一个单独渲染的内容吧'
+    const result = parseQueuedMessageMentions(text)
+
+    expect(result.cleanedText).toBe('@file:Screenshot 2026-08-24 at 14.17.47.png还是做一个单独渲染的内容吧')
+    expect(getQueuedMessageDisplayParts(text)).toEqual([
+      {
+        type: 'reference',
+        referenceType: 'file',
+        id: 'Screenshot%202026-08-24%20at%2014.17.47.png',
+        label: 'Screenshot 2026-08-24 at 14.17.47.png',
+      },
+      { type: 'text', value: '还是做一个单独渲染的内容吧' },
+    ])
+  })
 })

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -5,6 +5,7 @@ import {
   expandAgentHistoryQuoteMentions,
   parseAgentHistoryQuoteMention,
 } from './quoted-selection'
+import { MENTION_VALUE_PATTERN } from './mention-patterns'
 
 export type QueueDropPlacement = 'before' | 'after'
 
@@ -203,8 +204,14 @@ export function queuedTextToParagraphHtml(text: string): string {
     .join('')
 }
 
-const REF_PATTERN = /\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?/g
-const DISPLAY_REFERENCE_PATTERN = /&quote:(?<quote>[A-Za-z0-9%_.!~*'()-]+)|@file:(?<file>\S+)|\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>\S+))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>\S+))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>\S+))?/g
+const REF_PATTERN = new RegExp(
+  String.raw`/skill:(?<skill>${MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?`,
+  'gu',
+)
+const DISPLAY_REFERENCE_PATTERN = new RegExp(
+  String.raw`&quote:(?<quote>[A-Za-z0-9%_.!~*'()-]+)|@file:(?<file>${MENTION_VALUE_PATTERN})|/skill:(?<skill>${MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>${MENTION_VALUE_PATTERN}))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>${MENTION_VALUE_PATTERN}))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>${MENTION_VALUE_PATTERN}))?`,
+  'gu',
+)
 
 function decodeReferenceLabel(value: string): string {
   try {
@@ -319,7 +326,7 @@ export function parseQueuedMessageMentions(text: string): ParsedQueuedMessageMen
       // @file: 路径在 htmlToMarkdown 序列化时已 encodeURIComponent（路径可能含空格），
       // 这里还原为真实路径，保证 Agent 侧读取的是可访问的完整路径；
       // 仅当含百分号编码时解码，避免破坏旧的未编码路径。
-      .replace(/@file:([^\s]+)/g, (full, encodedPath: string) =>
+      .replace(new RegExp(String.raw`@file:(${MENTION_VALUE_PATTERN})`, 'gu'), (full, encodedPath: string) =>
         /%[0-9A-Fa-f]{2}/.test(encodedPath)
           ? `@file:${decodeReferenceLabel(encodedPath)}`
           : full

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -170,6 +170,15 @@ describe('Agent mention serialization', () => {
     expect(markdown).toBe('@file:%2FUsers%2Fme%2FMy%20report.pdf')
   })
 
+  test('adds a separator when a mention is followed by adjacent English text', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown([
+      '<p>',
+      '<span data-type="mention" data-id="/Users/me/BPD与LD关系_综合研究报告.pdf" data-mention-suggestion-char="@">BPD与LD关系_综合研究报告.pdf</span>qwedqweq',
+      '</p>',
+    ].join('')))
+
+    expect(markdown).toBe(`@file:${encodeURIComponent('/Users/me/BPD与LD关系_综合研究报告.pdf')} qwedqweq`)
+  })
   test('serializes planning selections by reference type rather than the trigger character', () => {
     const markdown = withHtmlDocument(() => htmlToMarkdown([
       '<p>',

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -385,6 +385,11 @@ function serializeNamedMention(prefix: '&session' | '&todo' | '&calendar_event',
   return label ? `${prefix}:${id}::${encodeURIComponent(label)}` : `${prefix}:${id}`
 }
 
+function addMentionBoundary(serialized: string, element: HTMLElement): string {
+  const nextText = element.nextSibling?.textContent ?? ''
+  return nextText.length > 0 && !/^\s/u.test(nextText) ? `${serialized} ` : serialized
+}
+
 /** 将 TipTap 输出的 HTML 转换为 Markdown 格式 */
 export function htmlToMarkdown(
   html: string,
@@ -534,15 +539,20 @@ export function htmlToMarkdown(
         const referenceType = el.getAttribute('data-mention-reference-type')
         const agentHistoryQuote = el.getAttribute('data-mention-quote')
         if (dataType === 'mention') {
-          if (agentHistoryQuote) return `&quote:${agentHistoryQuote}`
-          if (referenceType === 'todo') return serializeNamedMention('&todo', dataId, dataLabel)
-          if (referenceType === 'calendar_event') return serializeNamedMention('&calendar_event', dataId, dataLabel)
-          if (suggestionChar === '/') return `/skill:${dataId}`
-          if (suggestionChar === '#') return `#mcp:${dataId}`
-          if (suggestionChar === '&') return serializeNamedMention('&session', dataId, dataLabel)
-          // 路径可能包含空格等字符，必须编码后再嵌入 @file: 协议，
-          // 否则展示层 @file:(\S+) 正则会在空格处截断（remarkMentions / MentionChip / 排队消息均内置解码）。
-          return `@file:${encodeURIComponent(dataId)}`
+          let serializedMention: string
+          if (agentHistoryQuote) serializedMention = `&quote:${agentHistoryQuote}`
+          else if (referenceType === 'todo') serializedMention = serializeNamedMention('&todo', dataId, dataLabel)
+          else if (referenceType === 'calendar_event') serializedMention = serializeNamedMention('&calendar_event', dataId, dataLabel)
+          else if (suggestionChar === '/') serializedMention = `/skill:${dataId}`
+          else if (suggestionChar === '#') serializedMention = `#mcp:${dataId}`
+          else if (suggestionChar === '&') serializedMention = serializeNamedMention('&session', dataId, dataLabel)
+          else {
+            // 路径可能包含空格等字符，必须编码后再嵌入 @file: 协议；
+            // 展示层和排队消息解析器会在显式空格或紧邻的 CJK 文本处结束 token；
+            // 序列化层会为未分隔的后续文本补充空格，避免 ASCII 后缀被吞进 chip。
+            serializedMention = `@file:${encodeURIComponent(dataId)}`
+          }
+          return addMentionBoundary(serializedMention, el)
         }
         return children
       }

--- a/apps/electron/src/renderer/lib/mention-patterns.test.ts
+++ b/apps/electron/src/renderer/lib/mention-patterns.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { createMentionPattern } from './mention-patterns'
+
+describe('mention token boundaries', () => {
+  test('stops a file chip before adjacent CJK text', () => {
+    const text = '@file:Screenshot%202026-08-24%20at%2014.17.47.png还是做一个单独渲染的内容吧'
+    const matches = Array.from(text.matchAll(createMentionPattern()))
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.[1]).toBe('Screenshot%202026-08-24%20at%2014.17.47.png')
+  })
+
+  test('keeps encoded named-reference labels intact before adjacent CJK text', () => {
+    const text = `&session:session-123::${encodeURIComponent('上下文整理')}继续查看`
+    const matches = Array.from(text.matchAll(createMentionPattern()))
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.[4]).toBe('session-123')
+    expect(matches[0]?.[5]).toBe(encodeURIComponent('上下文整理'))
+  })
+
+  test('still supports whitespace-delimited skill and MCP mentions', () => {
+    const text = '/skill:brainstorming #mcp:playwright 后续文本'
+    const matches = Array.from(text.matchAll(createMentionPattern()))
+
+    expect(matches.map((match) => match[0])).toEqual([
+      '/skill:brainstorming',
+      '#mcp:playwright',
+    ])
+  })
+})

--- a/apps/electron/src/renderer/lib/mention-patterns.ts
+++ b/apps/electron/src/renderer/lib/mention-patterns.ts
@@ -1,0 +1,15 @@
+/**
+ * Mention values are serialized as non-whitespace tokens. CJK characters are
+ * excluded as well because generated mention values use percent encoding;
+ * this lets `@file:foo.md后续文字` end at the file name without requiring a
+ * separator in the user message.
+ */
+export const MENTION_VALUE_PATTERN = String.raw`[^\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}，。！？；：、（）【】《》“”‘’]+`
+
+/** Create a fresh instance because mention parsing uses a global regexp. */
+export function createMentionPattern(): RegExp {
+  return new RegExp(
+    String.raw`@file:(${MENTION_VALUE_PATTERN})|/skill:(${MENTION_VALUE_PATTERN})|#mcp:(${MENTION_VALUE_PATTERN})|&session:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&quote:([A-Za-z0-9%_.!~*'()-]+)`,
+    'gu',
+  )
+}


### PR DESCRIPTION
## 概述
修复 Agent 对话中 mention chip 与后续文字紧贴时的边界解析问题。重点覆盖文件引用后直接输入英文或中文、排队消息展示与发送、以及 Skill/MCP/会话/Todo/日程引用的统一解析。

## 改动
- `apps/electron/src/renderer/lib/mention-patterns.ts` — 新增共享 mention token 边界规则，在空白、CJK 字符和中文标点处结束编码后的引用值。
- `apps/electron/src/renderer/components/ai-elements/message.tsx` — 正文消息渲染改用共享 mention 正则，避免正文 chip 吞并紧邻 CJK 文本。
- `apps/electron/src/renderer/lib/agent-message-queue.ts` — 排队消息展示和发送解析改用同一套边界规则，保持显示与实际发送一致。
- `apps/electron/src/renderer/components/agent/mention-suggestions.tsx` — 选择 mention 后自动插入空格，避免用户继续输入英文时与 chip 粘连。
- `apps/electron/src/renderer/lib/markdown-rich-text.ts` — 序列化时为没有显式分隔符的后续文本补充空格。
- `apps/electron/src/renderer/lib/*test.ts` — 增加 CJK/英文紧贴边界、编码路径和序列化回归测试。
- `apps/electron/package.json` — Electron patch 版本从 `0.17.64` 提升到 `0.17.65`。

## 测试方法
1. `bun test apps/electron/src/renderer/lib/markdown-rich-text.test.ts apps/electron/src/renderer/lib/mention-patterns.test.ts apps/electron/src/renderer/lib/agent-message-queue.test.ts`
2. `bun run --filter=@proma/electron typecheck`
3. `bun run --filter=@proma/electron build:renderer`
4. `bun install --frozen-lockfile --dry-run`

以上验证结果为：32 个测试通过，typecheck、renderer build 和 frozen lockfile 检查均通过。

## 备注
- 新生成的文件引用继续使用 `encodeURIComponent`，并通过空格明确区分 chip 与后续文本。
- 没有分隔符的历史未编码中文文件路径本身存在协议歧义；本 PR 不对无法判定的历史边界做猜测。
- 本分支基于最新 `upstream/main`：`9af1816783a2dcf6b999badc6f13472b45e24daf`。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)