### PR TITLE
Fix Agent workspace layout and changes activation

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -75,7 +75,7 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   }
 
   return (
-    <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px]">
+    <div className="relative z-[51] flex items-center gap-2 px-3 h-[48px]">
       {/* 拖拽层覆盖整行（Windows 避开右上角 WindowControls ~126px），编辑/标题按钮内部已自带 titlebar-no-drag。 */}
       <div className={cn("absolute inset-0 titlebar-drag-region pointer-events-none", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
       {editing ? (

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2938,10 +2938,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   return (
     <>
-      <div className="flex h-full min-h-0 flex-1 min-w-0 max-w-[min(72rem,100%)] flex-col overflow-hidden mx-auto">
-        {/* Agent Header */}
+      <div className="flex h-full min-h-0 flex-1 min-w-0 flex-col overflow-hidden">
+        {/* 头部保持全宽，宽屏时让标题与右侧工作区开关贴近主区域两端；历史和输入仍限制可读宽度。 */}
         <AgentHeader sessionId={sessionId} />
 
+        <div className="flex min-h-0 flex-1 w-full max-w-[min(72rem,100%)] flex-col overflow-hidden mx-auto">
         {/* 消息区域 */}
         <AgentMessages
           sessionId={sessionId}
@@ -3111,6 +3112,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           </div>
         </div>
         )}
+        </div>
       </div>
 
     <Dialog open={todoDialogOpen} onOpenChange={setTodoDialogOpen}>

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -241,7 +241,7 @@ export function AppShell(): React.ReactElement {
                   isClassic
                     ? 'transition-[padding] duration-300 ease-in-out'
                     : '',
-                  isClassic && (isPanelOpen ? 'p-2 pl-0' : 'p-0')
+                  isClassic && (isPanelOpen ? 'p-2' : 'p-0')
                 )}
               >
                 {!isClassic && (

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -3317,7 +3317,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               type="button"
               aria-label={mode === 'agent' ? '新建任务' : '新建对话'}
               onClick={() => { void (mode === 'agent' ? createAgentSessionInWorkspace() : createChat()) }}
-              className="group flex h-9 min-w-0 flex-1 items-center gap-3 rounded-lg px-0 text-[13px] font-medium text-foreground/70 transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-foreground active:scale-[0.96] titlebar-no-drag"
+              className="group flex h-9 min-w-0 flex-1 items-center gap-3 rounded-lg px-3 text-[13px] font-medium text-foreground/70 transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-foreground active:scale-[0.96] titlebar-no-drag"
             >
               <CirclePlus size={16} className="shrink-0" />
               <span>{mode === 'agent' ? '新建任务' : '新建对话'}</span>

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -71,7 +71,7 @@ export function DiffPanelTabBar({
   }, [currentSessionId, onTabChange, setUnseenMap])
 
   return (
-    <div className="relative flex h-9 shrink-0 items-center border-b border-border/50 bg-content-area">
+    <div className="relative flex h-10 shrink-0 items-center border-b border-border/50 bg-content-area">
       <div className={cn('pointer-events-none absolute inset-0 titlebar-drag-region', isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
       <div className="relative flex min-w-0 flex-1 items-center titlebar-no-drag">
         <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto overscroll-x-contain px-2 py-1 scrollbar-none" role="tablist" aria-label="右侧工作区">
@@ -82,9 +82,9 @@ export function DiffPanelTabBar({
               <div
                 key={tab.id}
                 className={cn(
-                  'group flex h-8 min-w-[84px] max-w-60 shrink-0 items-center rounded-lg transition-[background-color,box-shadow,color] duration-150',
+                  'group flex h-7 min-w-[84px] max-w-60 shrink-0 items-center rounded-lg transition-[background-color,color] duration-150',
                   selected
-                    ? 'bg-muted/80 text-foreground shadow-sm shadow-black/[0.08] dark:shadow-black/20'
+                    ? 'bg-foreground/[0.08] text-foreground'
                     : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
                 )}
               >

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -829,6 +829,30 @@ export function useGlobalAgentListeners(): void {
 
     const isWindows = detectIsWindows()
 
+    /**
+     * 当前前台会话在本轮首次产生文件改动时，自动展开右侧工作区并切到「改动」。
+     * Git 与非 Git 文件都应触发；前者由 Git diff 展示，后者由会话改动记录补充。
+     */
+    const activateChangesTabForCurrentRun = (sessionId: string, runId: string): void => {
+      const activeTabId = store.get(activeTabIdAtom)
+      const activeTab = store.get(tabsAtom).find((tab) => tab.id === activeTabId)
+      const isViewingSession = (activeTab?.type === 'agent' || activeTab?.type === 'preview')
+        && activeTab.sessionId === sessionId
+      if (
+        store.get(currentAgentSessionIdAtom) !== sessionId
+        || !isViewingSession
+        || autoActivatedChangeTurns.get(sessionId) === runId
+      ) return
+
+      autoActivatedChangeTurns.set(sessionId, runId)
+      store.set(agentSidePanelOpenAtomFamily(sessionId), true)
+      store.set(agentDiffPanelTabAtom, (prev) => {
+        const map = new Map(prev)
+        map.set(sessionId, 'changes')
+        return map
+      })
+    }
+
     const cleanupWatchedFileChanges = window.electronAPI.onWorkspaceFilesChanged((changedPaths) => {
       const filePaths = (changedPaths ?? []).filter(isAbsolutePath)
       if (filePaths.length === 0) return
@@ -870,30 +894,20 @@ export function useGlobalAgentListeners(): void {
             ?? String(streamingStates.get(sessionId)?.startedAt ?? Date.now())
           for (const changedPath of uniquelyMatchingPaths) {
             const previewFile = await buildWrittenFilePreviewInfo(sessionId, changedPath)
-            if (!previewFile.previewOnly) continue
-            store.set(agentNonGitFileChangesAtom, (prev) => {
-              const map = new Map(prev)
-              const current = map.get(sessionId) ?? []
-              map.set(sessionId, upsertSessionFileChange(current, {
-                path: changedPath,
-                kind: 'edited',
-                runId,
-                updatedAt: Date.now(),
-              }, isWindows))
-              return map
-            })
-            if (
-              store.get(currentAgentSessionIdAtom) === sessionId
-              && autoActivatedChangeTurns.get(sessionId) !== runId
-            ) {
-              autoActivatedChangeTurns.set(sessionId, runId)
-              store.set(agentSidePanelOpenAtomFamily(sessionId), true)
-              store.set(agentDiffPanelTabAtom, (prev) => {
+            if (previewFile.previewOnly) {
+              store.set(agentNonGitFileChangesAtom, (prev) => {
                 const map = new Map(prev)
-                map.set(sessionId, 'changes')
+                const current = map.get(sessionId) ?? []
+                map.set(sessionId, upsertSessionFileChange(current, {
+                  path: changedPath,
+                  kind: 'edited',
+                  runId,
+                  updatedAt: Date.now(),
+                }, isWindows))
                 return map
               })
             }
+            activateChangesTabForCurrentRun(sessionId, runId)
           }
         }
       })().catch(() => { /* 文件监听不应影响会话流 */ })
@@ -1162,7 +1176,7 @@ export function useGlobalAgentListeners(): void {
             }
           }
 
-          // 非 Git 文件写入时自动打开“文件改动”；Git Diff 的面板状态仍由用户控制。
+          // 当前前台会话本轮首次写入时自动打开“文件改动”，并刷新 Git / 非 Git 改动数据。
 
           // Agent 修改文件时，记入「最近修改」状态，用于 60s 内左侧竖条标记
           if (event.type === 'tool_start' && WRITE_TOOLS.has(event.toolName)) {
@@ -1253,20 +1267,9 @@ export function useGlobalAgentListeners(): void {
                       }, isWindows))
                       return m
                     })
-
-                    if (
-                      store.get(currentAgentSessionIdAtom) === sessionId
-                      && autoActivatedChangeTurns.get(sessionId) !== entry.runId
-                    ) {
-                      autoActivatedChangeTurns.set(sessionId, entry.runId)
-                      store.set(agentSidePanelOpenAtomFamily(sessionId), true)
-                      store.set(agentDiffPanelTabAtom, (prev) => {
-                        const m = new Map(prev)
-                        m.set(sessionId, 'changes')
-                        return m
-                      })
-                    }
                   }
+
+                  activateChangesTabForCurrentRun(sessionId, entry.runId)
 
                 }).catch(() => { /* 改动提示不应影响流式输出 */ })
               }


### PR DESCRIPTION
## Summary

- Refine the Agent workspace layout: right-panel padding, full-width header alignment, compact selected workspace tabs, and sidebar action alignment.
- Restore automatic activation of the right-side “Changes” tab for the active Agent session after its first Git or non-Git file write in a run.

## Validation

- `git diff --check`
- Renderer entry-point Bun parse build
- `bun test` — 471 passed; 4 pre-existing Electron runtime/environment failures in untouched main-process tests.

Performance impact: low. The changes are static layout styles; file-change activation remains per-session/per-run deduplicated.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)