### PR TITLE
Fix per-session right panel layouts

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -531,32 +531,33 @@ export const MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS = 50
 
 /**
  * 仅保留最近活动的 Session 布局，防止 localStorage 随历史会话无限增长。
- * 正在写入的 Session 视为最新交互，即使其元数据尚未更新也保留当前布局。
+ * 会话元数据可用时按 updatedAt 排序；冷启动尚未加载元数据时按存储顺序兜底。
+ * 正在写入的 Session 始终保留，即使其元数据尚未更新。
  */
 export function pruneAgentSidePanelLayouts(
   layouts: Record<string, AgentSidePanelLayout>,
   sessions: readonly AgentSessionMeta[],
   activeSessionId?: string,
 ): Record<string, AgentSidePanelLayout> {
-  // 冷启动时会话列表可能尚未加载；此时不能把有效缓存误判为孤立数据。
-  if (sessions.length === 0) return layouts
-
-  const recentSessionIds = sessions
-    .slice()
-    .sort((a, b) => b.updatedAt - a.updatedAt)
-    .slice(0, MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS)
-    .map((session) => session.id)
+  const layoutIds = Object.keys(layouts)
+  const recentSessionIds = sessions.length === 0
+    ? layoutIds.slice(-MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS)
+    : sessions
+      .slice()
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS)
+      .map((session) => session.id)
   const retainedIds = new Set(recentSessionIds)
 
   if (activeSessionId && !retainedIds.has(activeSessionId)) {
-    if (recentSessionIds.length === MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS) {
+    if (retainedIds.size === MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS) {
       retainedIds.delete(recentSessionIds.at(-1)!)
     }
     retainedIds.add(activeSessionId)
   }
 
   const entries = Object.entries(layouts).filter(([sessionId]) => retainedIds.has(sessionId))
-  if (entries.length === Object.keys(layouts).length) return layouts
+  if (entries.length === layoutIds.length) return layouts
   return Object.fromEntries(entries)
 }
 
@@ -583,7 +584,10 @@ export const agentSidePanelLayoutAtomFamily = atomFamily((sessionId: string) => 
         widePanelWidthOverride: null,
       }
       const next = typeof update === 'function' ? update(current) : update
-      return pruneAgentSidePanelLayouts({ ...previous, [sessionId]: next }, get(agentSessionsAtom), sessionId)
+      const nextLayouts = { ...previous, [sessionId]: next }
+      return Object.keys(nextLayouts).length > MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS
+        ? pruneAgentSidePanelLayouts(nextLayouts, get(agentSessionsAtom), sessionId)
+        : nextLayouts
     })
   },
 ))

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -510,8 +510,83 @@ export const agentSidePanelOpenAtomFamily = atomFamily((sessionId: string) => at
   },
 ))
 
-/** 侧面板宽度（全局共享，用户拖拽后持久化） */
-export const agentSidePanelWidthAtom = atomWithStorage<number>('proma-agent-workspace-width', 460)
+const DEFAULT_AGENT_SIDE_PANEL_WIDTH = 460
+
+/**
+ * 旧版全局宽度只作为尚未保存新布局的 Session 的初始基线，避免升级后尺寸回退。
+ * 新布局写入后不再与其他 Session 共享。
+ */
+const legacyAgentSidePanelWidthAtom = atomWithStorage<number>(
+  'proma-agent-workspace-width',
+  DEFAULT_AGENT_SIDE_PANEL_WIDTH,
+)
+
+export interface AgentSidePanelLayout {
+  width: number
+  hasOpenedWideWorkspace: boolean
+  widePanelWidthOverride: number | null
+}
+
+export const MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS = 50
+
+/**
+ * 仅保留最近活动的 Session 布局，防止 localStorage 随历史会话无限增长。
+ * 正在写入的 Session 视为最新交互，即使其元数据尚未更新也保留当前布局。
+ */
+export function pruneAgentSidePanelLayouts(
+  layouts: Record<string, AgentSidePanelLayout>,
+  sessions: readonly AgentSessionMeta[],
+  activeSessionId?: string,
+): Record<string, AgentSidePanelLayout> {
+  // 冷启动时会话列表可能尚未加载；此时不能把有效缓存误判为孤立数据。
+  if (sessions.length === 0) return layouts
+
+  const recentSessionIds = sessions
+    .slice()
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS)
+    .map((session) => session.id)
+  const retainedIds = new Set(recentSessionIds)
+
+  if (activeSessionId && !retainedIds.has(activeSessionId)) {
+    if (recentSessionIds.length === MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS) {
+      retainedIds.delete(recentSessionIds.at(-1)!)
+    }
+    retainedIds.add(activeSessionId)
+  }
+
+  const entries = Object.entries(layouts).filter(([sessionId]) => retainedIds.has(sessionId))
+  if (entries.length === Object.keys(layouts).length) return layouts
+  return Object.fromEntries(entries)
+}
+
+/** 右侧工作区布局：按 Agent Session 持久化，包含普通与宽视图的尺寸。 */
+export const agentSidePanelLayoutMapAtom = atomWithStorage<Record<string, AgentSidePanelLayout>>(
+  'proma-agent-workspace-layout-by-session',
+  {},
+  undefined,
+  { getOnInit: true },
+)
+
+/** 指定 Agent Session 的右侧工作区布局。 */
+export const agentSidePanelLayoutAtomFamily = atomFamily((sessionId: string) => atom(
+  (get) => get(agentSidePanelLayoutMapAtom)[sessionId] ?? {
+    width: get(legacyAgentSidePanelWidthAtom),
+    hasOpenedWideWorkspace: false,
+    widePanelWidthOverride: null,
+  },
+  (get, set, update: AgentSidePanelLayout | ((previous: AgentSidePanelLayout) => AgentSidePanelLayout)) => {
+    set(agentSidePanelLayoutMapAtom, (previous) => {
+      const current = previous[sessionId] ?? {
+        width: get(legacyAgentSidePanelWidthAtom),
+        hasOpenedWideWorkspace: false,
+        widePanelWidthOverride: null,
+      }
+      const next = typeof update === 'function' ? update(current) : update
+      return pruneAgentSidePanelLayouts({ ...previous, [sessionId]: next }, get(agentSessionsAtom), sessionId)
+    })
+  },
+))
 
 /** 文件来源选择：按会话持久化，未存储的会话默认显示会话文件。 */
 export type AgentFileSourceFilter = 'session' | 'project'

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -551,7 +551,10 @@ export function pruneAgentSidePanelLayouts(
 
   if (activeSessionId && !retainedIds.has(activeSessionId)) {
     if (retainedIds.size === MAX_PERSISTED_AGENT_SIDE_PANEL_LAYOUTS) {
-      retainedIds.delete(recentSessionIds.at(-1)!)
+      const oldestRetainedId = sessions.length === 0
+        ? recentSessionIds[0]
+        : recentSessionIds.at(-1)
+      retainedIds.delete(oldestRetainedId!)
     }
     retainedIds.add(activeSessionId)
   }

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -124,6 +124,10 @@ export function AppShell(): React.ReactElement {
   const [rightPanelLayout, setRightPanelLayout] = useAtom(agentSidePanelLayoutAtomFamily(currentSessionId ?? ''))
   const [viewportWidth, setViewportWidth] = React.useState(() => window.innerWidth)
   const dragging = React.useRef(false)
+  const currentSessionIdRef = React.useRef(currentSessionId)
+  const rightPanelDragCleanup = React.useRef<(() => void) | null>(null)
+  const [draggedRightPanelWidth, setDraggedRightPanelWidth] = React.useState<number | null>(null)
+  currentSessionIdRef.current = currentSessionId
   const clampedRightPanelWidth = clampRightPanelWidth(rightPanelLayout.width, viewportWidth)
   const isWideRightWorkspace = Boolean(
     activeRightPanelTab?.startsWith('preview:') || activeRightPanelTab?.startsWith('browser:'),
@@ -132,10 +136,14 @@ export function AppShell(): React.ReactElement {
   const effectiveWidePanelWidth = rightPanelLayout.widePanelWidthOverride === null
     ? clampRightPanelWidth(Math.floor(viewportWidth * WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO), viewportWidth)
     : clampRightPanelWidth(rightPanelLayout.widePanelWidthOverride, viewportWidth)
-  const displayedRightPanelWidth = rightPanelLayout.hasOpenedWideWorkspace ? effectiveWidePanelWidth : clampedRightPanelWidth
+  const persistedRightPanelWidth = rightPanelLayout.hasOpenedWideWorkspace ? effectiveWidePanelWidth : clampedRightPanelWidth
+  const displayedRightPanelWidth = draggedRightPanelWidth ?? persistedRightPanelWidth
 
   React.useEffect(() => {
-    if (agentSessions.length === 0) return
+    return () => rightPanelDragCleanup.current?.()
+  }, [currentSessionId])
+
+  React.useEffect(() => {
     setRightPanelLayouts((previous) => pruneAgentSidePanelLayouts(previous, agentSessions, currentSessionId ?? undefined))
   }, [agentSessions, currentSessionId, setRightPanelLayouts])
 
@@ -158,21 +166,43 @@ export function AppShell(): React.ReactElement {
   }, [clampedRightPanelWidth, currentSessionId, rightPanelLayout.width, setRightPanelLayout])
 
   const handleMouseDown = React.useCallback((e: React.MouseEvent) => {
+    if (!currentSessionId) return
+
     e.preventDefault()
+    rightPanelDragCleanup.current?.()
     dragging.current = true
+    const dragSessionId = currentSessionId
     const startX = e.clientX
     const startWidth = displayedRightPanelWidth
+    const isWideWorkspace = rightPanelLayout.hasOpenedWideWorkspace
     // 记录最新光标位置，rAF 回调读取它而非调度时捕获的旧事件，避免快拖时坐标滞后
     let latestClientX = startX
+    let latestWidth = startWidth
     let rafId = 0
+    let cancelDrag: () => void
 
     const applyWidth = () => {
       const delta = startX - latestClientX
-      const nextWidth = clampRightPanelWidth(startWidth + delta, viewportWidth)
-      if (rightPanelLayout.hasOpenedWideWorkspace) {
-        setRightPanelLayout((previous) => ({ ...previous, widePanelWidthOverride: nextWidth }))
-      } else {
-        setRightPanelLayout((previous) => ({ ...previous, width: nextWidth }))
+      latestWidth = clampRightPanelWidth(startWidth + delta, viewportWidth)
+      setDraggedRightPanelWidth(latestWidth)
+    }
+
+    const finishDrag = (persist: boolean) => {
+      dragging.current = false
+      if (rafId) {
+        cancelAnimationFrame(rafId)
+        rafId = 0
+      }
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+      setDraggedRightPanelWidth(null)
+      if (rightPanelDragCleanup.current === cancelDrag) rightPanelDragCleanup.current = null
+
+      // 会话切换后取消旧拖拽，不能把旧闭包的尺寸写入先前的 Session。
+      if (persist && currentSessionIdRef.current === dragSessionId) {
+        setRightPanelLayout((previous) => isWideWorkspace
+          ? { ...previous, widePanelWidthOverride: latestWidth }
+          : { ...previous, width: latestWidth })
       }
     }
 
@@ -187,20 +217,16 @@ export function AppShell(): React.ReactElement {
     }
 
     const onMouseUp = () => {
-      dragging.current = false
-      if (rafId) {
-        cancelAnimationFrame(rafId)
-        rafId = 0
-      }
-      // 补一次最终 flush，保证落点停在光标实际位置而非上一帧
+      // 补一次最终 flush，保证落点停在光标实际位置而非上一帧。
       applyWidth()
-      document.removeEventListener('mousemove', onMouseMove)
-      document.removeEventListener('mouseup', onMouseUp)
+      finishDrag(true)
     }
 
+    cancelDrag = () => finishDrag(false)
+    rightPanelDragCleanup.current = cancelDrag
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-  }, [displayedRightPanelWidth, rightPanelLayout.hasOpenedWideWorkspace, setRightPanelLayout, viewportWidth])
+  }, [currentSessionId, displayedRightPanelWidth, rightPanelLayout.hasOpenedWideWorkspace, setRightPanelLayout, viewportWidth])
 
   return (
     <>

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -12,7 +12,7 @@ import { LeftSidebar } from './LeftSidebar'
 import { RightSidePanel } from './RightSidePanel'
 import { MainArea } from '@/components/tabs/MainArea'
 import { appModeAtom } from '@/atoms/app-mode'
-import { agentDiffPanelTabAtom, agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
+import { agentDiffPanelTabAtom, agentSessionsAtom, agentSidePanelLayoutAtomFamily, agentSidePanelLayoutMapAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom, pruneAgentSidePanelLayouts } from '@/atoms/agent-atoms'
 import { leftSidebarWidthAtom } from '@/atoms/sidebar-atoms'
 import { sidebarCollapsedAtom } from '@/atoms/tab-atoms'
 import { automationFormAtom } from '@/atoms/automation-atoms'
@@ -118,25 +118,32 @@ export function AppShell(): React.ReactElement {
     document.addEventListener('mouseup', onMouseUp)
   }, [clampedLeftSidebarWidth, setLeftSidebarWidth])
 
-  // 右侧工作区可拖拽到应用视口的 3/5，窗口尺寸变化时重新收敛持久化宽度。
-  const [rightPanelWidth, setRightPanelWidth] = useAtom(agentSidePanelWidthAtom)
+  // 右侧工作区可拖拽到应用视口的 3/5；每个 Session 恢复自己的普通与宽视图布局。
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const setRightPanelLayouts = useSetAtom(agentSidePanelLayoutMapAtom)
+  const [rightPanelLayout, setRightPanelLayout] = useAtom(agentSidePanelLayoutAtomFamily(currentSessionId ?? ''))
   const [viewportWidth, setViewportWidth] = React.useState(() => window.innerWidth)
   const dragging = React.useRef(false)
-  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelWidth, viewportWidth)
+  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelLayout.width, viewportWidth)
   const isWideRightWorkspace = Boolean(
     activeRightPanelTab?.startsWith('preview:') || activeRightPanelTab?.startsWith('browser:'),
   )
   // 首次打开预览/浏览器后，工作区维持宽视图；切回文件/改动不会自动收窄，交给用户拖拽决定。
-  const [hasOpenedWideWorkspace, setHasOpenedWideWorkspace] = React.useState(false)
-  const [widePanelWidthOverride, setWidePanelWidthOverride] = React.useState<number | null>(null)
-  const effectiveWidePanelWidth = widePanelWidthOverride === null
+  const effectiveWidePanelWidth = rightPanelLayout.widePanelWidthOverride === null
     ? clampRightPanelWidth(Math.floor(viewportWidth * WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO), viewportWidth)
-    : clampRightPanelWidth(widePanelWidthOverride, viewportWidth)
-  const displayedRightPanelWidth = hasOpenedWideWorkspace ? effectiveWidePanelWidth : clampedRightPanelWidth
+    : clampRightPanelWidth(rightPanelLayout.widePanelWidthOverride, viewportWidth)
+  const displayedRightPanelWidth = rightPanelLayout.hasOpenedWideWorkspace ? effectiveWidePanelWidth : clampedRightPanelWidth
 
   React.useEffect(() => {
-    if (isWideRightWorkspace) setHasOpenedWideWorkspace(true)
-  }, [isWideRightWorkspace])
+    if (agentSessions.length === 0) return
+    setRightPanelLayouts((previous) => pruneAgentSidePanelLayouts(previous, agentSessions, currentSessionId ?? undefined))
+  }, [agentSessions, currentSessionId, setRightPanelLayouts])
+
+  React.useEffect(() => {
+    if (isWideRightWorkspace && currentSessionId && !rightPanelLayout.hasOpenedWideWorkspace) {
+      setRightPanelLayout((previous) => ({ ...previous, hasOpenedWideWorkspace: true }))
+    }
+  }, [currentSessionId, isWideRightWorkspace, rightPanelLayout.hasOpenedWideWorkspace, setRightPanelLayout])
 
   React.useEffect(() => {
     const updateViewportWidth = () => setViewportWidth(window.innerWidth)
@@ -145,10 +152,10 @@ export function AppShell(): React.ReactElement {
   }, [])
 
   React.useEffect(() => {
-    if (clampedRightPanelWidth !== rightPanelWidth) {
-      setRightPanelWidth(clampedRightPanelWidth)
+    if (currentSessionId && clampedRightPanelWidth !== rightPanelLayout.width) {
+      setRightPanelLayout((previous) => ({ ...previous, width: clampedRightPanelWidth }))
     }
-  }, [clampedRightPanelWidth, rightPanelWidth, setRightPanelWidth])
+  }, [clampedRightPanelWidth, currentSessionId, rightPanelLayout.width, setRightPanelLayout])
 
   const handleMouseDown = React.useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -162,8 +169,11 @@ export function AppShell(): React.ReactElement {
     const applyWidth = () => {
       const delta = startX - latestClientX
       const nextWidth = clampRightPanelWidth(startWidth + delta, viewportWidth)
-      if (hasOpenedWideWorkspace) setWidePanelWidthOverride(nextWidth)
-      else setRightPanelWidth(nextWidth)
+      if (rightPanelLayout.hasOpenedWideWorkspace) {
+        setRightPanelLayout((previous) => ({ ...previous, widePanelWidthOverride: nextWidth }))
+      } else {
+        setRightPanelLayout((previous) => ({ ...previous, width: nextWidth }))
+      }
     }
 
     const onMouseMove = (ev: MouseEvent) => {
@@ -190,7 +200,7 @@ export function AppShell(): React.ReactElement {
 
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-  }, [displayedRightPanelWidth, hasOpenedWideWorkspace, setRightPanelWidth, viewportWidth])
+  }, [displayedRightPanelWidth, rightPanelLayout.hasOpenedWideWorkspace, setRightPanelLayout, viewportWidth])
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Persist right-side workspace width, wide-workspace state, and override by Agent Session.
- Retain at most 50 recent Session layout records and purge stale entries after the Session list loads.
- Preserve the prior global width as the migration baseline for Sessions without a per-Session record.
- Cancel an in-progress drag when its Session changes, preventing stale layout writes.

## Performance

- Dragging updates transient React state and persists the final layout only on mouseup. Cache pruning reads Session metadata only on final persistence and Session-list changes.

## Validation

- `bun test ./apps/electron/src/renderer/atoms/agent-atoms.test.ts`
- `bun run --filter='@proma/electron' build:renderer`
- `bun run --filter='@proma/electron' typecheck` remains blocked by the pre-existing `src/renderer/main.tsx:519` `PlanningChange.todo` error.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)