### PR TITLE
Fix renderer overlays hiding the agent browser

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -25,6 +25,7 @@ import { WindowControls } from '@/components/WindowControls'
 import { SettingsPanel } from '@/components/settings/SettingsPanel'
 import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
+import { Toaster } from '@/components/ui/sonner'
 
 const MIN_RIGHT_PANEL_WIDTH = 360
 const RIGHT_PANEL_MAX_VIEWPORT_RATIO = 3 / 5
@@ -231,6 +232,8 @@ export function AppShell(): React.ReactElement {
             <div className={cn('flex-1 min-w-0 relative z-[60]', isClassic && 'p-2')}>
               {/* 主内容区域（TabBar + TabContent） */}
               <MainArea />
+              {/* 全局 Toast 固定在 Agent 历史主区右上角，不进入右侧原生浏览器面板。 */}
+              <Toaster position="top-right" offset={{ top: 58, right: 12 }} className="agent-history-toaster" />
             </div>
 
             {/* 右侧边栏：Agent 文件面板 */}

--- a/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserSlot.tsx
@@ -3,96 +3,9 @@ import { nextBrowserLayoutRevision } from './browser-layout-revision'
 
 // 每次 publish（包括卸载隐藏）分配全局单调 revision。旧 slot 的 IPC 即使晚到，
 // 主进程也不会覆盖随后已挂载 tab 的可见性和边界。
-
-/**
- * WebContentsView 是原生子视图，天然盖在 renderer DOM 之上；CSS z-index 无法反转。
- * 应用级 Dialog / Select / Popover / Dropdown 与 Sonner 通知出现时，临时隐藏原生视图，
- * 让 portal 内容获得正确的层级；浮层关闭后立即恢复浏览器。
- */
-const APP_OVERLAY_LIFECYCLE_SELECTOR = [
-  '[role="dialog"]',
-  '[role="alertdialog"]',
-  '[data-sonner-toast]',
-  '[data-sonner-toaster]',
-  '[data-radix-popper-content-wrapper]',
-].join(', ')
-
-function hasBlockingAppOverlay(): boolean {
-  if (document.querySelector('[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]')) return true
-  if (document.querySelector('[data-sonner-toast][data-mounted="true"], [data-sonner-toast][data-visible="true"]')) return true
-
-  return Array.from(document.querySelectorAll<HTMLElement>('[data-radix-popper-content-wrapper]'))
-    .some((wrapper) => {
-      const openContent = wrapper.querySelector<HTMLElement>('[data-state="open"]')
-      // 浏览器自身的 Tooltip 不需要遮住网页；菜单、选择器与 Popover 则必须优先显示。
-      return !!openContent && openContent.getAttribute('role') !== 'tooltip'
-    })
-}
-
-function isAppOverlayElement(element: Element): boolean {
-  return element.matches(APP_OVERLAY_LIFECYCLE_SELECTOR)
-}
-
-function findAppOverlayElements(node: Node): Element[] {
-  if (!(node instanceof Element)) return []
-  const elements = isAppOverlayElement(node) ? [node] : []
-  return elements.concat(Array.from(node.querySelectorAll(APP_OVERLAY_LIFECYCLE_SELECTOR)))
-}
-
-/**
- * 只跟踪 portal/toast 生命周期，避免 Agent 流式渲染触发无意义的 layout IPC。
- *
- * body 只监听直接子节点：Radix/Toast portal 都挂在这里，普通消息 DOM 的深层
- * 更新不会进入 observer。识别出浮层根节点后，再把 attributes/subtree 监听限制
- * 在该浮层内部，以便捕获 data-state 等开关变化。
- */
-function observeAppOverlayLifecycle(onChange: () => void): () => void {
-  const overlayRoots = new Set<Element>()
-  const overlayObserver = new MutationObserver((mutations) => {
-    if (mutations.length > 0) onChange()
-  })
-  const bodyObserver = new MutationObserver((mutations) => {
-    let changed = false
-    for (const mutation of mutations) {
-      for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
-        const overlayElements = findAppOverlayElements(node)
-        if (overlayElements.length > 0) changed = true
-        for (const element of overlayElements) overlayRoots.add(element)
-      }
-    }
-    syncOverlayRoots()
-    if (changed) onChange()
-  })
-
-  function syncOverlayRoots(): void {
-    for (const root of overlayRoots) {
-      if (!root.isConnected) overlayRoots.delete(root)
-    }
-
-    for (const root of Array.from(document.body.children)) {
-      for (const element of findAppOverlayElements(root)) overlayRoots.add(element)
-    }
-
-    overlayObserver.disconnect()
-    for (const root of overlayRoots) {
-      overlayObserver.observe(root, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['data-mounted', 'data-state', 'data-visible', 'role'],
-      })
-    }
-  }
-
-  syncOverlayRoots()
-  bodyObserver.observe(document.body, { childList: true })
-
-  return () => {
-    bodyObserver.disconnect()
-    overlayObserver.disconnect()
-    overlayRoots.clear()
-  }
-}
+// WebContentsView 是原生子视图，天然盖在 renderer DOM 之上；CSS z-index 无法反转。
+// 它的可见性只由 BrowserSlot 的尺寸和 Tab 生命周期控制，不再因为任何应用浮层
+//（Dialog、Popover、Dropdown、Toast 等）出现而隐藏，避免右侧浏览器白屏。
 
 export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: string }): React.ReactElement {
   const ref = React.useRef<HTMLDivElement>(null)
@@ -128,12 +41,8 @@ export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: st
         commitLayout(visible, preserveSessionOnHide)
       })
     }
-    const publishCurrentVisibility = (immediate = false) => {
-      const overlayOpen = hasBlockingAppOverlay()
-      publish(!overlayOpen, overlayOpen, immediate)
-    }
+    const publishCurrentVisibility = (immediate = false) => publish(true, false, immediate)
     const observer = new ResizeObserver(() => publishCurrentVisibility())
-    const disconnectOverlayObserver = observeAppOverlayLifecycle(() => publishCurrentVisibility())
     const publishBounded = () => publishCurrentVisibility()
     observer.observe(element)
     window.addEventListener('resize', publishBounded)
@@ -142,7 +51,6 @@ export function BrowserSlot({ sessionId, tabId }: { sessionId: string; tabId: st
     publishCurrentVisibility(true)
     return () => {
       observer.disconnect()
-      disconnectOverlayObserver()
       window.removeEventListener('resize', publishBounded)
       if (frame) cancelAnimationFrame(frame)
       void setLayout({ sessionId, tabId, revision: nextBrowserLayoutRevision(), visible: false, preserveSessionOnHide: false, bounds: { x: 0, y: 0, width: 0, height: 0 } })

--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -1,8 +1,8 @@
 /**
- * ModelSelector - 模型选择器（Dialog + Command 搜索）
+ * ModelSelector - 模型选择器（锚定 Popover + 搜索）
  *
  * 现代化设计：
- * - 大尺寸 Dialog，宽敞易读
+ * - 非模态 Popover 锚定触发按钮，向上展开（右对齐），避免 Dialog 全屏遮罩
  * - 按渠道分组，标题与模型项使用统一栅格对齐
  * - 选中项使用柔和底色与右侧勾选标记
  * - 触发按钮：模型 logo + 模型名 + Chevron
@@ -12,11 +12,10 @@ import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { Check, ChevronDown, Cpu, Search } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import {
   Tooltip,
   TooltipContent,
@@ -146,7 +145,7 @@ export function ModelSelector({
   // 外部模型优先 → per-conversation 模型
   const selectedModel = externalSelectedModel !== undefined ? externalSelectedModel : conversationModel
 
-  // 每次打开 Dialog 时刷新渠道列表，确保最新
+  // 每次打开 Popover 时刷新渠道列表，确保最新
   React.useEffect(() => {
     if (open) {
       window.electronAPI.listChannels().then(setChannels).catch(console.error)
@@ -274,143 +273,145 @@ export function ModelSelector({
   }
 
   return (
-    <>
+    <Popover open={open} onOpenChange={setOpen}>
       {/* 触发按钮 */}
       <Tooltip open={open || !displayModelInfo ? false : undefined}>
         <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => setOpen(true)}
-            className={cn(
-              'model-selector-trigger flex items-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-colors',
-              'hover:bg-accent hover:text-foreground focus:outline-none focus-visible:bg-accent focus-visible:text-foreground',
-              inputToolbarControlHeightClass,
-            )}
-          >
-            {displayModelInfo ? (
-              <img
-                src={getModelLogo(displayModelInfo.modelId, displayModelInfo.provider)}
-                alt={displayModelInfo.modelName}
-                className="size-4 rounded object-cover"
-              />
-            ) : (
-              <Cpu className="size-3.5" />
-            )}
-            <span className="max-w-[200px] truncate">
-              {displayModelInfo
-                ? (showChannelInTrigger ? `${displayModelInfo.channelName} · ${displayModelInfo.modelName}` : displayModelInfo.modelName)
-                : '选择模型'}
-            </span>
-            <ChevronDown className="size-3" />
-          </button>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                'model-selector-trigger flex items-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-colors',
+                'hover:bg-accent hover:text-foreground focus:outline-none focus-visible:bg-accent focus-visible:text-foreground',
+                inputToolbarControlHeightClass,
+              )}
+            >
+              {displayModelInfo ? (
+                <img
+                  src={getModelLogo(displayModelInfo.modelId, displayModelInfo.provider)}
+                  alt={displayModelInfo.modelName}
+                  className="size-4 rounded object-cover"
+                />
+              ) : (
+                <Cpu className="size-3.5" />
+              )}
+              <span className="max-w-[200px] truncate">
+                {displayModelInfo
+                  ? (showChannelInTrigger ? `${displayModelInfo.channelName} · ${displayModelInfo.modelName}` : displayModelInfo.modelName)
+                  : '选择模型'}
+              </span>
+              <ChevronDown className="size-3" />
+            </button>
+          </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent side="top">渠道：{displayModelInfo?.channelName}</TooltipContent>
       </Tooltip>
 
-      {/* 模型选择 Dialog */}
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="p-0 gap-0 max-w-lg" aria-describedby={undefined}>
-          <DialogHeader className="sr-only">
-            <DialogTitle>选择模型</DialogTitle>
-          </DialogHeader>
+      {/* 模型选择 Popover — 锚定触发按钮，向上展开（end 对齐，内容向左上延伸） */}
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={8}
+        collisionPadding={12}
+        className="w-[320px] p-0"
+        aria-label="选择模型"
+      >
+        {/* 搜索栏 */}
+        <div className="flex items-center gap-2 px-3.5 py-2.5 border-b border-border/60">
+          <Search className="size-4 text-muted-foreground/60 flex-shrink-0" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="搜索模型..."
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/50"
+            autoFocus
+          />
+        </div>
 
-          {/* 搜索栏 */}
-          <div className="flex items-center gap-2.5 px-4 py-3 border-b border-border/60">
-            <Search className="size-5 text-muted-foreground/60 flex-shrink-0" />
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              onKeyDown={handleSearchKeyDown}
-              placeholder="搜索模型..."
-              className="flex-1 bg-transparent text-base outline-none placeholder:text-muted-foreground/50"
-              autoFocus
-            />
-          </div>
+        {/* 模型列表 */}
+        <div className="max-h-[min(360px,55vh)] overflow-y-auto scrollbar-thin">
+          {filteredGrouped.size === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              未找到模型
+            </div>
+          ) : (
+            (() => {
+              let flatIndex = 0
+              return Array.from(filteredGrouped.entries()).map(([channelId, options]) => {
+                const first = options[0]
+                if (!first) return null
+                const channel = channels.find((c) => c.id === channelId)
 
-          {/* 模型列表 */}
-          <div className="max-h-[420px] overflow-y-auto scrollbar-thin">
-            {filteredGrouped.size === 0 ? (
-              <div className="py-10 text-center text-sm text-muted-foreground">
-                未找到模型
-              </div>
-            ) : (
-              (() => {
-                let flatIndex = 0
-                return Array.from(filteredGrouped.entries()).map(([channelId, options]) => {
-                  const first = options[0]
-                  if (!first) return null
-                  const channel = channels.find((c) => c.id === channelId)
-
-                  return (
-                    <div
-                      key={channelId}
-                      role="group"
-                      aria-label={first.channelName}
-                      className="border-b border-border/40 py-1.5 last:border-b-0"
-                    >
-                      {/* 渠道标题与模型行共用栅格，仅通过字号和色阶区分层级。 */}
-                      <div className={cn(MODEL_SELECTOR_ROW_LAYOUT, 'min-h-8 py-1')}>
-                        <ModelSelectorListIcon
-                          src={channel ? getChannelLogo(channel) : DefaultLogo}
-                        />
-                        <span className="min-w-0 truncate text-xs font-medium text-muted-foreground/80">
-                          {first.channelName}
-                        </span>
-                        {channel ? <ChannelPlanQuotaBadge channel={channel} /> : null}
-                      </div>
-
-                      {/* 该渠道下的模型列表 */}
-                      {options.map((option) => {
-                        const isSelected =
-                          selectedModel?.channelId === option.channelId &&
-                          selectedModel?.modelId === option.modelId
-                        const currentFlatIndex = flatIndex++
-                        const isHighlighted = currentFlatIndex === highlightIndex
-                        const visualState = getModelSelectorOptionVisualState(isSelected, isHighlighted)
-
-                        return (
-                          <button
-                            key={`${option.channelId}:${option.modelId}`}
-                            ref={(el) => {
-                              if (el) itemRefs.current.set(currentFlatIndex, el)
-                              else itemRefs.current.delete(currentFlatIndex)
-                            }}
-                            type="button"
-                            aria-pressed={isSelected}
-                            onClick={() => handleSelect(option)}
-                            onMouseEnter={() => setHighlightIndex(currentFlatIndex)}
-                            className={cn(
-                              MODEL_SELECTOR_ROW_LAYOUT,
-                              'min-h-10 rounded-lg py-2 text-left transition-colors',
-                              'hover:bg-accent/60 focus:outline-none focus-visible:bg-accent/70',
-                              visualState === 'highlighted' && 'bg-accent/60',
-                              visualState === 'selected' && 'bg-accent',
-                            )}
-                          >
-                            <ModelSelectorListIcon
-                              src={getModelLogo(option.modelId, option.provider)}
-                            />
-                            <span className={cn(
-                              'min-w-0 truncate text-sm',
-                              isSelected ? 'font-medium text-foreground' : 'text-foreground/80',
-                            )}>
-                              {option.modelName}
-                            </span>
-                            <span className="flex size-5 items-center justify-center" aria-hidden="true">
-                              {isSelected ? <Check className="size-4 text-primary" strokeWidth={2.5} /> : null}
-                            </span>
-                          </button>
-                        )
-                      })}
+                return (
+                  <div
+                    key={channelId}
+                    role="group"
+                    aria-label={first.channelName}
+                    className="border-b border-border/40 py-1 last:border-b-0"
+                  >
+                    {/* 渠道标题与模型行共用栅格，仅通过字号和色阶区分层级。 */}
+                    <div className={cn(MODEL_SELECTOR_ROW_LAYOUT, 'min-h-7 py-0.5')}>
+                      <ModelSelectorListIcon
+                        src={channel ? getChannelLogo(channel) : DefaultLogo}
+                      />
+                      <span className="min-w-0 truncate text-xs font-medium text-muted-foreground/80">
+                        {first.channelName}
+                      </span>
+                      {channel ? <ChannelPlanQuotaBadge channel={channel} /> : null}
                     </div>
-                  )
-                })
-              })()
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
-    </>
+
+                    {/* 该渠道下的模型列表 */}
+                    {options.map((option) => {
+                      const isSelected =
+                        selectedModel?.channelId === option.channelId &&
+                        selectedModel?.modelId === option.modelId
+                      const currentFlatIndex = flatIndex++
+                      const isHighlighted = currentFlatIndex === highlightIndex
+                      const visualState = getModelSelectorOptionVisualState(isSelected, isHighlighted)
+
+                      return (
+                        <button
+                          key={`${option.channelId}:${option.modelId}`}
+                          ref={(el) => {
+                            if (el) itemRefs.current.set(currentFlatIndex, el)
+                            else itemRefs.current.delete(currentFlatIndex)
+                          }}
+                          type="button"
+                          aria-pressed={isSelected}
+                          onClick={() => handleSelect(option)}
+                          onMouseEnter={() => setHighlightIndex(currentFlatIndex)}
+                          className={cn(
+                            MODEL_SELECTOR_ROW_LAYOUT,
+                            'min-h-9 rounded-lg py-1.5 text-left transition-colors',
+                            'hover:bg-accent/60 focus:outline-none focus-visible:bg-accent/70',
+                            visualState === 'highlighted' && 'bg-accent/60',
+                            visualState === 'selected' && 'bg-accent',
+                          )}
+                        >
+                          <ModelSelectorListIcon
+                            src={getModelLogo(option.modelId, option.provider)}
+                          />
+                          <span className={cn(
+                            'min-w-0 truncate text-sm',
+                            isSelected ? 'font-medium text-foreground' : 'text-foreground/80',
+                          )}>
+                            {option.modelName}
+                          </span>
+                          <span className="flex size-5 items-center justify-center" aria-hidden="true">
+                            {isSelected ? <Check className="size-4 text-primary" strokeWidth={2.5} /> : null}
+                          </span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )
+              })
+            })()
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/electron/src/renderer/components/ui/sonner.tsx
+++ b/apps/electron/src/renderer/components/ui/sonner.tsx
@@ -10,8 +10,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
-      position="top-center"
-      offset={58}
+      position="top-right"
+      offset={{ top: 58, right: 12 }}
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -1101,7 +1101,7 @@ if (isQuickTaskWindow) {
         <ThemeInitializer />
         <MarkdownFontSizeInitializer />
         <DetachedPreviewApp />
-        <Toaster position="bottom-right" />
+        <Toaster position="top-right" offset={{ top: 58, right: 12 }} />
       </React.StrictMode>
     )
   })
@@ -1115,7 +1115,7 @@ if (isQuickTaskWindow) {
         <AutomationInitializer />
         <PlanningInitializer />
         <PlanningWindowApp />
-        <Toaster position="bottom-right" />
+        <Toaster position="top-right" offset={{ top: 58, right: 12 }} />
       </React.StrictMode>
     )
   })
@@ -1125,7 +1125,7 @@ if (isQuickTaskWindow) {
       <React.StrictMode>
         <ThemeInitializer />
         <WorkspaceMemoryWindowApp />
-        <Toaster position="bottom-right" />
+        <Toaster position="top-right" offset={{ top: 58, right: 12 }} />
       </React.StrictMode>
     )
   })
@@ -1162,7 +1162,6 @@ if (isQuickTaskWindow) {
       <GlobalShortcuts />
       <TabSwitcher />
       <App />
-      <Toaster position="bottom-right" />
     </React.StrictMode>
   )
 }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -532,6 +532,12 @@
   }
 }
 
+/* 主窗口全局 Toast 只占用 Agent 历史主区，避免覆盖右侧原生浏览器面板。 */
+.agent-history-toaster[data-sonner-toaster] {
+  position: absolute;
+  bottom: auto;
+}
+
 /* Draggable title bar region for Electron window */
 .titlebar-drag-region {
   -webkit-app-region: drag;


### PR DESCRIPTION
## Summary

- 将 ModelSelector 从居中 Dialog 改为锚定 Popover，向上左展开并收窄列表。
- 移除 BrowserSlot 根据 Dialog、Popover、Dropdown、Toast 隐藏原生 WebContentsView 的逻辑，避免右侧浏览器 Tab 白屏。
- 将主窗口全局 Toast 锚定到 Agent 历史主区右上角；独立窗口统一使用右上角。
- 移除临时 Toast 可视化测试入口。

## Performance

低风险交互级变更。浮层仍只在用户操作时挂载；移除了 BrowserSlot 对全局 portal/Toast 生命周期的 MutationObserver，不新增 IPC、持续定时器或流式渲染路径。

## Verification

- `bun run typecheck` 通过
- `git diff --check` 通过
- 全量测试此前结果：471 通过，4 个既有 Electron 测试环境/依赖失败

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)