### PR TITLE
feat(agent): add exploration session tabs

### DIFF
--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -5,7 +5,7 @@
  * 拒绝直接灌 stdout，改为落盘并回执路径，提示用 --turns/--head/--tail 取片段。
  * 这样 Agent 不会因为一句 `export <id>` 就把一个 50MB 会话的清洗结果塞满上下文。
  *
- * 窗口优先级（见 selectTurns）：--turns > --head > --tail > --offset/--limit。
+ * 窗口优先级（见 selectTurns）：--after-message > --turns > --head > --tail > --offset/--limit。
  * --out FILE 显式落盘（存档用途，不受 max-bytes 护栏限制）。
  */
 import { mkdirSync, writeFileSync } from 'node:fs'
@@ -14,7 +14,7 @@ import { register } from '../registry'
 import { resolveSession } from '../sessions'
 import { emitJson, emitText, errorLine, info, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
 import { readSessionMessages } from '@proma/session-core/node'
-import { groupIntoTurns, toTranscript, selectTurns, renderTranscriptMarkdown } from '@proma/session-core'
+import { groupIntoTurns, toTranscript, selectTurns, renderTranscriptMarkdown, type MessageGroup } from '@proma/session-core'
 import { numFlag, strFlag, boolFlag, parseRange } from '../args'
 
 const DEFAULT_MAX_BYTES = 51200 // 50KB
@@ -22,7 +22,7 @@ const DEFAULT_MAX_BYTES = 51200 // 50KB
 register({
   name: 'export',
   summary: '把会话或 turn 子集渲染为干净 Markdown（含超预算落盘护栏）',
-  usage: 'session export <id|path> [--turns A-B | --head N | --tail N | --offset K --limit N] [--out FILE] [--stdout] [--max-bytes N] [--json]',
+  usage: 'session export <id|path> [--after-message UUID | --turns A-B | --head N | --tail N | --offset K --limit N] [--out FILE] [--stdout] [--max-bytes N] [--json]',
   run: (ctx) => {
     const target = ctx.args.positionals[0]
     if (!target) throw new UsageError('缺少会话 id 或路径')
@@ -32,17 +32,25 @@ register({
       return EXIT_ERROR
     }
 
-    const allTurns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+    const groups = groupIntoTurns(readSessionMessages(resolved.filePath))
+    const allTurns = toTranscript(groups)
 
     // 解析窗口
+    const afterMessageId = strFlag(ctx.args.flags, 'after-message')
     const range = parseRange(strFlag(ctx.args.flags, 'turns'))
     const head = numFlag(ctx.args.flags, 'head')
     const tail = numFlag(ctx.args.flags, 'tail')
     const offset = numFlag(ctx.args.flags, 'offset')
     const limit = numFlag(ctx.args.flags, 'limit')
-    const hasWindow = range !== undefined || head !== undefined || tail !== undefined || offset !== undefined || limit !== undefined
+    const hasWindow = afterMessageId !== undefined || range !== undefined || head !== undefined || tail !== undefined || offset !== undefined || limit !== undefined
+    const anchorTurnIndex = afterMessageId ? findAssistantAnchorTurnIndex(groups, afterMessageId) : undefined
+    if (afterMessageId && anchorTurnIndex === undefined) {
+      throw new UsageError(`找不到 assistant 消息锚点: ${afterMessageId}`)
+    }
 
-    const turns = hasWindow ? selectTurns(allTurns, { range, head, tail, offset, limit }) : allTurns
+    const turns = anchorTurnIndex !== undefined
+      ? allTurns.slice(anchorTurnIndex + 1)
+      : hasWindow ? selectTurns(allTurns, { range, head, tail, offset, limit }) : allTurns
     // 截取片段时省略顶部标题，便于直接拼接阅读
     const md = renderTranscriptMarkdown(turns, { sessionId: resolved.id, header: !hasWindow })
     const bytes = Buffer.byteLength(md, 'utf-8')
@@ -87,6 +95,12 @@ register({
     return EXIT_OK
   },
 })
+
+function findAssistantAnchorTurnIndex(groups: MessageGroup[], messageId: string): number | undefined {
+  const index = groups.findIndex((group) => group.type === 'assistant-turn'
+    && group.assistantMessages.some((message) => (message as { uuid?: unknown }).uuid === messageId))
+  return index >= 0 ? index : undefined
+}
 
 function writeFileTo(path: string, content: string): void {
   const dir = dirname(path)

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.64",
+  "version": "0.17.65",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 import { existsSync, realpathSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, AGENT_ISLAND_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
@@ -5385,6 +5385,18 @@ export function registerIpcHandlers(): void {
     async (_, id: string): Promise<void> => {
       if (!isNonEmptyString(id)) throw new Error('id 必填')
       await runAutomationNow(id)
+    }
+  )
+
+  // ===== Agent Island =====
+
+  // Renderer 在主窗口创建后即可上报“已查看”，而 Island 状态机稍后才初始化，
+  // 且在不支持的平台也不会初始化。handler 必须在 IPC 注册阶段无条件存在，避免启动竞态。
+  ipcMain.handle(
+    AGENT_ISLAND_IPC_CHANNELS.MARK_SESSION_VIEWED,
+    async (_, sessionId: unknown): Promise<void> => {
+      if (!isNonEmptyString(sessionId)) return
+      markAgentIslandSessionViewed(sessionId)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -13,9 +13,7 @@
  * 本服务只负责 Agent 会话状态，保持职责单一。
  */
 
-import { ipcMain } from 'electron'
 import {
-  AGENT_ISLAND_IPC_CHANNELS,
   type AgentIslandActivityLine,
   type AgentIslandPillSnapshot,
   type AgentIslandSessionSnapshot,
@@ -807,12 +805,6 @@ export function initAgentIslandService(deps: AgentIslandServiceDeps): void {
   disposeEventBus = agentEventBus.on((sessionId, payload) => {
     handleAgentEvent(sessionId, payload)
     schedulePush(requiresImmediateAgentIslandPush(payload) ? PUSH_THROTTLE_MS : AGENT_STREAM_PUSH_THROTTLE_MS)
-  })
-
-  // 仅保留主应用用于确认“完成会话已查看”的 IPC。
-  ipcMain.handle(AGENT_ISLAND_IPC_CHANNELS.MARK_SESSION_VIEWED, (_event, sessionId: unknown) => {
-    if (typeof sessionId !== 'string' || sessionId.length === 0) return
-    markAgentIslandSessionViewed(sessionId)
   })
 }
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -397,9 +397,10 @@ export class AgentOrchestrator {
   }
 
   /**
-   * 流完成后自动生成标题
+   * 流开始后自动生成标题。
    *
-   * 如果会话标题仍为默认值，自动调用标题生成并通过回调通知。
+   * 默认会话沿用首条消息自动命名；Pi `/tree` 探索分支则在首条**新增**用户消息时
+   * 重命名一次，摆脱「原标题 (fork)」，之后不再覆盖用户或分支自己的语义标题。
    */
   private async autoGenerateTitle(
     sessionId: string,
@@ -412,14 +413,34 @@ export class AgentOrchestrator {
     if (signal?.aborted) return
     try {
       const meta = getAgentSessionMeta(sessionId)
-      if (!meta || meta.title !== DEFAULT_SESSION_TITLE) return
+      if (!meta) return
+      const isDefaultSessionTitle = meta.title === DEFAULT_SESSION_TITLE
+      const isFirstExplorationMessage = Boolean(
+        meta.explorationParentSessionId
+        && !meta.explorationTitleInitializedAt,
+      )
+      if (!isDefaultSessionTitle && !isFirstExplorationMessage) return
+
+      // 分支的历史被 Pi fork 复制，不能按「第一条历史消息」命名；以首次继续发送的消息
+      // 作为唯一的命名信号。先持久化守卫，避免用户连发时启动多个竞争标题请求。
+      const explorationTitleInitializedAt = isFirstExplorationMessage ? Date.now() : undefined
+      if (explorationTitleInitializedAt) {
+        updateAgentSessionMeta(sessionId, { explorationTitleInitializedAt })
+      }
 
       const title = await this.generateTitle({ userMessage, channelId, modelId }, signal)
+        ?? (isFirstExplorationMessage ? createFallbackTitle(userMessage) : null)
       if (!title || signal?.aborted) return
 
       // 标题请求是异步的；请求期间用户可能已手动重命名，不能用旧结果覆盖。
       const latestMeta = getAgentSessionMeta(sessionId)
-      if (!latestMeta || latestMeta.title !== DEFAULT_SESSION_TITLE) return
+      const canApplyDefaultTitle = isDefaultSessionTitle && latestMeta?.title === DEFAULT_SESSION_TITLE
+      const canApplyExplorationTitle = Boolean(
+        isFirstExplorationMessage
+        && latestMeta?.title === meta.title
+        && latestMeta.explorationTitleInitializedAt === explorationTitleInitializedAt,
+      )
+      if (!latestMeta || (!canApplyDefaultTitle && !canApplyExplorationTitle)) return
 
       updateAgentSessionMeta(sessionId, { title })
       callbacks.onTitleUpdated(title)

--- a/apps/electron/src/main/lib/agent-session-context-prompt.ts
+++ b/apps/electron/src/main/lib/agent-session-context-prompt.ts
@@ -198,11 +198,19 @@ export function buildReferencedSessionsPrompt(
 
     const title = escapeContextAttr(meta.title)
     const historyPath = getSessionHistoryPath(referencedSessionId)
+    const explorationBoundary = meta.explorationParentSessionId && meta.explorationSourceMessageId
+      ? `\n<exploration_delta parentSessionId="${escapeContextAttr(meta.explorationParentSessionId)}" sourceMessageId="${escapeContextAttr(meta.explorationSourceMessageId)}">\n` +
+        '此会话是从主线分叉的探索分支；用户引用的仅是 sourceMessageId 之后新增的探索内容。\n' +
+        '分叉前复制的主线历史不是本次引用内容：不要读取、总结或重复处理它。\n' +
+        `请先用 ${getSessionCliCommandPrefix()} session export ${referencedSessionId} --tail 12 读取分叉后的最新内容；如不足，再逐步增大 tail 数量。\n` +
+        '仅当必须核验分支内更早的新增内容时，才按 outline → 局部 export 渐进读取；不要导出完整 fork 历史。\n' +
+        '</exploration_delta>'
+      : ''
     sessionBlocks.push(
       `<session id="${referencedSessionId}" title="${title}" updatedAt="${meta.updatedAt}">\n` +
       `CLI target: ${referencedSessionId}\n` +
       `History path: ${historyPath}\n` +
-      '</session>',
+      `</session>${explorationBoundary}`,
     )
   }
 

--- a/apps/electron/src/main/lib/agent-session-context-prompt.ts
+++ b/apps/electron/src/main/lib/agent-session-context-prompt.ts
@@ -202,8 +202,8 @@ export function buildReferencedSessionsPrompt(
       ? `\n<exploration_delta parentSessionId="${escapeContextAttr(meta.explorationParentSessionId)}" sourceMessageId="${escapeContextAttr(meta.explorationSourceMessageId)}">\n` +
         '此会话是从主线分叉的探索分支；用户引用的仅是 sourceMessageId 之后新增的探索内容。\n' +
         '分叉前复制的主线历史不是本次引用内容：不要读取、总结或重复处理它。\n' +
-        `请先用 ${getSessionCliCommandPrefix()} session export ${referencedSessionId} --tail 12 读取分叉后的最新内容；如不足，再逐步增大 tail 数量。\n` +
-        '仅当必须核验分支内更早的新增内容时，才按 outline → 局部 export 渐进读取；不要导出完整 fork 历史。\n' +
+        `请先用 ${getSessionCliCommandPrefix()} session export ${referencedSessionId} --after-message ${meta.explorationSourceMessageId} 精确读取分叉后的内容。\n` +
+        '仅当必须核验分支内更早的新增内容时，才在该边界之后渐进读取；不要导出完整 fork 历史。\n' +
         '</exploration_delta>'
       : ''
     sessionBlocks.push(

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -590,7 +590,7 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'codexFastMode' | 'reasoningLevel' | 'openAIThinkingLevel' | 'workspaceId' | 'activeWorktree' | 'pinned' | 'starred' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'codexFastMode' | 'reasoningLevel' | 'openAIThinkingLevel' | 'workspaceId' | 'activeWorktree' | 'pinned' | 'starred' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'explorationParentSessionId' | 'explorationSourceMessageId' | 'explorationSourceLabel' | 'explorationTitleInitializedAt' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -889,17 +889,24 @@ async function forkPiAgentSession(sourceMeta: AgentSessionMeta, input: ForkSessi
         .filter(([, mappedEntryId]) => Boolean(forkedManager.getEntry(mappedEntryId))),
     )
 
+    const explorationMeta = input.explorationSourceLabel ? {
+      explorationParentSessionId: sourceMeta.id,
+      explorationSourceMessageId: targetUuid,
+      explorationSourceLabel: input.explorationSourceLabel,
+    } : {}
     updateAgentSessionMeta(newMeta.id, {
       sdkSessionId: forkedManager.getSessionId(),
       piSessionFile,
       piEntryBindings: branchBindings,
       activeWorktree: sourceActiveWorktree,
       forkSourceDir: sourceDir,
+      ...explorationMeta,
     })
     newMeta.sdkSessionId = forkedManager.getSessionId()
     newMeta.piSessionFile = piSessionFile
     newMeta.piEntryBindings = branchBindings
     newMeta.activeWorktree = sourceActiveWorktree
+    Object.assign(newMeta, explorationMeta)
 
     if (sourceWorkbenchDir && destWorkbenchDir) copyForkWorkspaceFiles(sourceWorkbenchDir, destWorkbenchDir)
     await copyForkStoredSDKMessages({

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -604,9 +604,52 @@ export const agentFileSourceFilterMapAtom = atomWithStorage<Record<string, Agent
   { getOnInit: true },
 )
 
-export type AgentSidePanelBaseTab = 'files' | 'changes' | 'memory' | 'chat'
-/** 项目记忆、每个浏览器网页和文件预览都处于右侧工作区顶栏。 */
-export type AgentSidePanelTab = AgentSidePanelBaseTab | `browser:${string}` | `preview:${string}`
+export type AgentSidePanelBaseTab = 'files' | 'changes' | 'memory' | 'chat' | 'temporary-agent'
+/** 项目记忆、每个 Pi 探索分支、协作子 Agent、浏览器网页和文件预览都处于右侧工作区顶栏。 */
+export type AgentSidePanelTab = AgentSidePanelBaseTab | `exploration:${string}` | `delegation:${string}` | `browser:${string}` | `preview:${string}`
+
+/** Pi `/tree` 探索分支在右侧工作区的展示信息。 */
+export interface AgentExplorationBranchTab {
+  /** Pi 原生 fork 生成的独立 Proma session。 */
+  sessionId: string
+  /** 作为分叉锚点的 Proma assistant message UUID。 */
+  sourceMessageId: string
+  /** 给用户看的分叉来源。 */
+  sourceLabel: string
+}
+
+/**
+ * 右侧探索分支：key 为主线 Agent sessionId，value 为从其 Pi session tree 分叉出的已打开分支。
+ * 仅管理右侧展示；branch artifact 本身持久化在普通 Agent session 中，关闭 Tab 不会删除它。
+ */
+export const agentSideTemporaryAgentMapAtom = atom<Map<string, AgentExplorationBranchTab[]>>(new Map())
+
+export function getExplorationSidePanelTab(branchSessionId: string): AgentSidePanelTab {
+  return `exploration:${branchSessionId}`
+}
+
+/** 已在右侧打开的协作子 Agent：key 为父会话 ID，value 为子会话 ID 列表。 */
+export const agentSideDelegationMapAtom = atom<Map<string, string[]>>(new Map())
+
+export function getDelegationSidePanelTab(childSessionId: string): AgentSidePanelTab {
+  return `delegation:${childSessionId}`
+}
+
+export function getDelegationSessionIdFromSidePanelTab(tab: AgentSidePanelTab | 'delegation'): string | null {
+  return tab.startsWith('delegation:') ? tab.slice('delegation:'.length) : null
+}
+
+export function isDelegationSidePanelTab(tab: AgentSidePanelTab | 'delegation'): tab is `delegation:${string}` {
+  return tab.startsWith('delegation:')
+}
+
+export function getExplorationSessionIdFromSidePanelTab(tab: AgentSidePanelTab | 'exploration'): string | null {
+  return tab.startsWith('exploration:') ? tab.slice('exploration:'.length) : null
+}
+
+export function isExplorationSidePanelTab(tab: AgentSidePanelTab | 'exploration'): tab is `exploration:${string}` {
+  return tab.startsWith('exploration:')
+}
 
 export function getBrowserSidePanelTab(tabId: string): AgentSidePanelTab {
   return `browser:${tabId}`

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -6,8 +6,8 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { Check, ChevronDown, PanelRight, Pencil, X } from 'lucide-react'
-import { agentSessionsAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
+import { Check, ChevronDown, PanelRight, Pencil, Split, X } from 'lucide-react'
+import { agentSessionsAtom, agentSideTemporaryAgentMapAtom, agentDiffPanelTabAtom, currentSessionSidePanelOpenAtom, getExplorationSidePanelTab } from '@/atoms/agent-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { replaceAgentSessionInFreshnessOrder } from '@/lib/agent-session-list'
 import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
@@ -30,10 +30,34 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   const session = sessions.find((s) => s.id === sessionId) ?? null
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const setTabs = useSetAtom(tabsAtom)
+  const setSideTemporaryAgentMap = useSetAtom(agentSideTemporaryAgentMapAtom)
+  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const [isRightPanelOpen, setRightPanelOpen] = useAtom(currentSessionSidePanelOpenAtom)
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
+
+  const explorationBranches = React.useMemo(() => sessions
+    .filter((item) => item.explorationParentSessionId === sessionId && item.explorationSourceMessageId)
+    .sort((a, b) => b.updatedAt - a.updatedAt), [sessionId, sessions])
+
+  const reopenExploration = React.useCallback((branch: typeof explorationBranches[number]): void => {
+    const sourceMessageId = branch.explorationSourceMessageId
+    if (!sourceMessageId) return
+    setSideTemporaryAgentMap((prev) => {
+      const openBranches = prev.get(sessionId) ?? []
+      if (openBranches.some((item) => item.sessionId === branch.id)) return prev
+      const next = new Map(prev)
+      next.set(sessionId, [...openBranches, {
+        sessionId: branch.id,
+        sourceMessageId,
+        sourceLabel: branch.explorationSourceLabel || '主线探索节点',
+      }])
+      return next
+    })
+    setRightPanelOpen(true)
+    setSidePanelTabMap((prev) => new Map(prev).set(sessionId, getExplorationSidePanelTab(branch.id)))
+  }, [sessionId, setRightPanelOpen, setSidePanelTabMap, setSideTemporaryAgentMap])
 
   if (!session) return null
 
@@ -123,6 +147,35 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
               <Pencil className="size-3.5" />
               重命名
             </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {explorationBranches.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="titlebar-no-drag inline-flex h-10 shrink-0 items-center gap-1.5 rounded-lg px-2 text-xs text-muted-foreground transition-[background-color,color,transform] hover:bg-muted hover:text-foreground active:scale-[0.96]"
+              aria-label={`打开 ${explorationBranches.length} 个探索分支`}
+              title={`打开探索分支（${explorationBranches.length}）`}
+            >
+              <Split className="size-3.5" />
+              <span className="hidden sm:inline">探索</span>
+              {explorationBranches.length > 1 && <span className="tabular-nums">{explorationBranches.length}</span>}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="z-[100] w-64 titlebar-no-drag"
+            // 选择或失焦关闭后不要把焦点回跳到「探索」触发器，避免出现残留 focus 框。
+            onCloseAutoFocus={(event) => event.preventDefault()}
+          >
+            {explorationBranches.map((branch) => (
+              <DropdownMenuItem key={branch.id} onSelect={() => reopenExploration(branch)} className="flex items-center gap-2 py-2">
+                <Split className="size-3.5 shrink-0" />
+                <span className="min-w-0 truncate">{branch.title}</span>
+              </DropdownMenuItem>
+            ))}
           </DropdownMenuContent>
         </DropdownMenu>
       )}

--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -3,21 +3,15 @@
  *
  * 在 Agent 历史消息里划选文本后，提供两个轻量动作：
  * 1. 添加到当前 Agent 输入框引用
- * 2. 打开 Agent 右侧问答 Tab，用选区作为上下文提问
+ * 2. 从当前 assistant 节点创建 Pi `/tree` 探索分支，并在右侧继续工作
  */
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import {
-  agentSideChatMapAtom,
-  conversationsAtom,
-  conversationDraftsAtom,
-  selectedModelAtom,
-} from '@/atoms/chat-atoms'
+import { agentSessionsAtom, agentSideTemporaryAgentMapAtom, agentDiffPanelTabAtom, agentSidePanelOpenAtomFamily, getExplorationSidePanelTab } from '@/atoms/agent-atoms'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
-import { agentDiffPanelTabAtom, agentSidePanelOpenAtomFamily } from '@/atoms/agent-atoms'
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
 import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
@@ -47,6 +41,8 @@ interface AgentHistorySelectionLayerProps {
   rootRef: React.RefObject<HTMLDivElement>
   /** 同一消息内的历史选区优先插入当前 Agent 富文本输入框。 */
   onAddToAgent?: (quote: QuotedSelection) => boolean
+  /** 嵌入的探索分支自身不能继续在没有 SidePanel 容器的位置嵌套分叉。 */
+  explorationEnabled?: boolean
 }
 
 function getElementFromNode(node: Node | null): Element | null {
@@ -204,12 +200,12 @@ export function AgentHistorySelectionLayer({
   sessionId,
   rootRef,
   onAddToAgent,
+  explorationEnabled = true,
 }: AgentHistorySelectionLayerProps): React.ReactElement | null {
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
-  const selectedChatModel = useAtomValue(selectedModelAtom)
-  const setConversations = useSetAtom(conversationsAtom)
-  const setConversationDrafts = useSetAtom(conversationDraftsAtom)
-  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const setSideTemporaryAgentMap = useSetAtom(agentSideTemporaryAgentMapAtom)
   const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtomFamily(sessionId))
   const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const focusAgentSessionInput = useFocusAgentSessionInput()
@@ -217,7 +213,7 @@ export function AgentHistorySelectionLayer({
   const selectionRef = React.useRef<AgentHistorySelection | null>(null)
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
-  const openChatPendingRef = React.useRef(false)
+  const openTemporaryAgentPendingRef = React.useRef(false)
 
   const clearSelection = React.useCallback((): void => {
     selectionRef.current = null
@@ -402,40 +398,63 @@ export function AgentHistorySelectionLayer({
     toast.success('已添加到 Agent 引用')
   }, [clearSelection, createQuotedSelection, focusAgentSessionInput, onAddToAgent, sessionId, setQuotedSelectionMap])
 
-  const handleOpenChatTab = React.useCallback(async (): Promise<void> => {
+  const handleOpenExplorationBranch = React.useCallback(async (): Promise<void> => {
     const candidate = selectionRef.current
-    if (!candidate || openChatPendingRef.current) return
-    openChatPendingRef.current = true
+    if (!candidate || openTemporaryAgentPendingRef.current) return
+    if (candidate.messageRole !== 'assistant' || !candidate.messageId) {
+      toast.info('请在一条已完成的 Agent 回复中选择内容，再从该节点探索')
+      return
+    }
+
+    const parentSession = agentSessions.find((item) => item.id === sessionId)
+    if (!parentSession?.piEntryBindings?.[candidate.messageId]) {
+      toast.warning('这个回复没有可用的 Pi 分叉节点，暂时无法从这里探索')
+      return
+    }
+
+    openTemporaryAgentPendingRef.current = true
     try {
-      const conversation = await window.electronAPI.createConversation(
-        '历史选区问答',
-        selectedChatModel?.modelId,
-        selectedChatModel?.channelId,
-      )
+      // 必须使用 Pi 的 SessionManager 分叉，才能继承节点此前完整上下文与工具轨迹。
+      const branch = await window.electronAPI.forkAgentSession({
+        sessionId,
+        upToMessageUuid: candidate.messageId,
+        explorationSourceLabel: candidate.text.slice(0, 80),
+      })
       const quotedSelection = createQuotedSelection(candidate)
-      setConversations((prev) => prev.some((item) => item.id === conversation.id) ? prev : [conversation, ...prev])
-      setConversationDrafts((prev) => new Map(prev).set(conversation.id, '我的问题：'))
-      // 打开问答 Tab 同样是用户确认动作，允许写入目标会话的待引用 atom。
-      setQuotedSelectionMap((prev) => new Map(prev).set(conversation.id, quotedSelection))
-      setSideChatMap((prev) => new Map(prev).set(sessionId, conversation.id))
+      setAgentSessions((prev) => prev.some((item) => item.id === branch.id) ? prev : [branch, ...prev])
+      setQuotedSelectionMap((prev) => new Map(prev).set(branch.id, quotedSelection))
+      setSideTemporaryAgentMap((prev) => {
+        const openBranches = prev.get(sessionId) ?? []
+        const next = new Map(prev)
+        next.set(sessionId, openBranches.some((item) => item.sessionId === branch.id)
+          ? openBranches
+          : [...openBranches, {
+              sessionId: branch.id,
+              sourceMessageId: candidate.messageId!,
+              sourceLabel: candidate.text.slice(0, 80),
+            }])
+        return next
+      })
       setSidePanelOpen(true)
-      setSidePanelTabMap((prev) => new Map(prev).set(sessionId, 'chat'))
+      setSidePanelTabMap((prev) => new Map(prev).set(sessionId, getExplorationSidePanelTab(branch.id)))
       window.getSelection()?.removeAllRanges()
       clearSelection()
+      toast.success('已创建探索分支', { description: '它继承此回复之前的完整上下文；探索结论可带回主线。' })
     } catch (error) {
-      console.error('[AgentMessages] 打开历史选区聊天标签失败:', error)
-      toast.error('打开聊天标签失败')
+      console.error('[AgentHistorySelectionLayer] 创建探索分支失败:', error)
+      toast.error('创建探索分支失败', { description: error instanceof Error ? error.message : undefined })
     } finally {
-      openChatPendingRef.current = false
+      openTemporaryAgentPendingRef.current = false
     }
-  }, [clearSelection, createQuotedSelection, selectedChatModel, sessionId, setConversationDrafts, setConversations, setQuotedSelectionMap, setSideChatMap, setSidePanelOpen, setSidePanelTabMap])
+  }, [agentSessions, clearSelection, createQuotedSelection, sessionId, setAgentSessions, setQuotedSelectionMap, setSidePanelOpen, setSidePanelTabMap, setSideTemporaryAgentMap])
 
+  const canExplore = explorationEnabled && selection?.messageRole === 'assistant' && Boolean(selection.messageId)
   return selection && (
     <SelectionActionPopover
       x={selection.x}
       y={selection.y}
       onAddToAgent={handleAddToAgent}
-      onOpenChat={handleOpenChatTab}
+      {...(canExplore ? { onOpenExplorationBranch: handleOpenExplorationBranch } : {})}
     />
   )
 }

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -228,6 +228,8 @@ interface AgentMessagesProps {
   onCompact?: () => void
   /** 将单条 Agent 历史选区写为当前 RichTextInput 的内联 mention。 */
   onAddHistoryQuote?: (quote: QuotedSelection) => boolean
+  /** 嵌入在右侧探索分支时关闭嵌套探索入口，避免没有容器的二级分叉。 */
+  explorationEnabled?: boolean
   /** 已发送的 Agent 历史引用 chip 点击后请求定位与高亮。 */
   onAgentHistoryQuoteClick?: (quote: QuotedSelection) => void
   /** 输入框 quote chip 请求定位时的精确范围。 */
@@ -877,6 +879,7 @@ export const AgentMessages = React.memo(function AgentMessages({
   onCreateTodo,
   onCompact,
   onAddHistoryQuote,
+  explorationEnabled = true,
   onAgentHistoryQuoteClick,
   historyQuoteNavigation,
 }: AgentMessagesProps): React.ReactElement {
@@ -1252,6 +1255,7 @@ export const AgentMessages = React.memo(function AgentMessages({
             sessionId={sessionId}
             rootRef={historySelectionRootRef}
             onAddToAgent={onAddHistoryQuote}
+            explorationEnabled={explorationEnabled}
           />
         </div>
       </AgentBrowserLinkProvider>

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -107,6 +107,9 @@ import {
   allPendingPermissionRequestsAtom,
   allPendingExitPlanRequestsAtom,
   agentDiffPanelTabAtom,
+  agentSidePanelOpenAtomFamily,
+  agentSideTemporaryAgentMapAtom,
+  getExplorationSidePanelTab,
 } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
@@ -425,7 +428,13 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
   )
 }
 
-export function AgentView({ sessionId }: { sessionId: string }): React.ReactElement {
+interface AgentViewProps {
+  sessionId: string
+  /** 右侧临时 Agent Tab：保留完整对话与输入能力，但不重复渲染全局会话标题栏。 */
+  embedded?: boolean
+}
+
+export function AgentView({ sessionId, embedded = false }: AgentViewProps): React.ReactElement {
   const store = useStore()
   const initialCachedMessages = store.get(agentSDKMessagesCacheAtom).get(sessionId)
   const [persistedSDKMessages, setPersistedSDKMessages] = React.useState<SDKMessage[]>(
@@ -571,6 +580,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const suggestion = suggestionsMap.get(sessionId) ?? null
   const setPromptSuggestions = useSetAtom(agentPromptSuggestionsAtom)
   const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtomFamily(sessionId))
+  const setSideTemporaryAgentMap = useSetAtom(agentSideTemporaryAgentMapAtom)
   const openSession = useOpenSession()
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
@@ -2493,43 +2505,42 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, openSession, setAgentSessions, setStreamingStates, permissionMode])
 
-  /** 分叉会话：从指定消息处创建新会话并自动切换 */
+  /** 从回复节点创建 Pi `/tree` 探索分支，并在当前主线的右侧工作区继续。 */
   const handleFork = React.useCallback(async (upToMessageUuid: string): Promise<void> => {
-    if (agentModelId && agentChannelId && sessionMetaChannelId && agentChannelId !== sessionMetaChannelId) {
-      toast.error('分叉会话失败', {
-        description: '分叉只能使用源会话同一渠道下的模型，请切回当前会话渠道后再试。',
-      })
-      return
-    }
-    const forkModelId = agentChannelId === sessionMetaChannelId ? agentModelId || undefined : undefined
-
     try {
+      // 不传 modelId：探索必须继承分叉点的渠道与模型，不受当前全局选择器影响。
       const meta = await window.electronAPI.forkAgentSession({
         sessionId,
         upToMessageUuid,
-        modelId: forkModelId,
+        explorationSourceLabel: '这条 Agent 回复',
       })
-      setAgentSessions((prev) => [meta, ...prev])
-
-      // 切换到新会话 tab
-      openSession('agent', meta.id, meta.title)
-
-      toast.success('已创建分叉会话', {
-        description: meta.title,
+      setAgentSessions((prev) => prev.some((item) => item.id === meta.id) ? prev : [meta, ...prev])
+      setSideTemporaryAgentMap((prev) => {
+        const openBranches = prev.get(sessionId) ?? []
+        const next = new Map(prev)
+        next.set(sessionId, openBranches.some((item) => item.sessionId === meta.id)
+          ? openBranches
+          : [...openBranches, {
+              sessionId: meta.id,
+              sourceMessageId: upToMessageUuid,
+              sourceLabel: '这条 Agent 回复',
+            }])
+        return next
+      })
+      setSidePanelOpen(true)
+      setSidePanelTabMap((prev) => new Map(prev).set(sessionId, getExplorationSidePanelTab(meta.id)))
+      toast.success('已创建探索分支', {
+        description: '分支继承此处之前的完整上下文；结论可带回主线。',
       })
     } catch (error) {
-      console.error('[AgentView] 分叉会话失败:', error)
+      console.error('[AgentView] 创建探索分支失败:', error)
       const rawMsg = error instanceof Error ? error.message : '未知错误'
-      // SDK 偶尔会因为 sidechain/消息归属问题抛 "not found in session"，
-      // 这里给出更可操作的中文提示，而不是把 SDK 内部英文报错直接透传给用户
       const friendlyDesc = /not found in session/i.test(rawMsg)
-        ? '该消息无法作为分叉起点（可能属于子代理执行过程或已被清理）。请选择主对话中的其他消息再试。'
+        ? '该消息无法作为探索起点（可能属于子代理执行过程或已被清理）。请选择主对话中的其他回复再试。'
         : rawMsg
-      toast.error('分叉会话失败', {
-        description: friendlyDesc,
-      })
+      toast.error('创建探索分支失败', { description: friendlyDesc })
     }
-  }, [sessionId, agentChannelId, agentModelId, sessionMetaChannelId, openSession, setAgentSessions])
+  }, [sessionId, setAgentSessions, setSidePanelOpen, setSidePanelTabMap, setSideTemporaryAgentMap])
 
   /** 快照回退：同一会话内回退到指定消息点，恢复文件 + 截断对话 */
   const [rewindTargetUuid, setRewindTargetUuid] = React.useState<string | null>(null)
@@ -2727,7 +2738,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   // ===== 预览 Tab 快捷键 =====
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
-  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
 
   const togglePreviewPanel = React.useCallback(() => {
     const nextOpen = !(store.get(previewPanelOpenMapAtom).get(sessionId) ?? false)
@@ -2939,10 +2949,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   return (
     <>
       <div className="flex h-full min-h-0 flex-1 min-w-0 flex-col overflow-hidden">
-        {/* 头部保持全宽，宽屏时让标题与右侧工作区开关贴近主区域两端；历史和输入仍限制可读宽度。 */}
-        <AgentHeader sessionId={sessionId} />
+        {/* 临时 Agent 已由右侧 Tab 表明归属，避免在窄面板重复渲染全局标题栏。 */}
+        {!embedded && <AgentHeader sessionId={sessionId} />}
 
-        <div className="flex min-h-0 flex-1 w-full max-w-[min(72rem,100%)] flex-col overflow-hidden mx-auto">
+        <div className={cn(
+          'flex min-h-0 flex-1 w-full flex-col overflow-hidden',
+          embedded ? 'max-w-none' : 'max-w-[min(72rem,100%)] mx-auto',
+        )}>
         {/* 消息区域 */}
         <AgentMessages
           sessionId={sessionId}
@@ -2956,11 +2969,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onRetryInNewSession={handleRetryInNewSession}
           onRelinkProjectRoot={handleRelinkProjectRoot}
           onRestoreProjectRoot={handleOpenRestoreProjectRootDialog}
-          onFork={isLegacyTranscript ? undefined : handleFork}
+          onFork={embedded || isLegacyTranscript ? undefined : handleFork}
           onRewind={isLegacyTranscript ? undefined : handleRewindRequest}
           onCreateTodo={handleOpenReplyTodoDialog}
           onCompact={handleCompact}
           onAddHistoryQuote={handleAddHistoryQuote}
+          explorationEnabled={!embedded}
           onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
           historyQuoteNavigation={historyQuoteNavigation}
         />

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -606,7 +606,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
               </MessageAction>
             )}
             {onFork && lastUuid && (
-              <MessageAction tooltip="按当前模型从此处分叉" onClick={() => onFork(lastUuid)}>
+              <MessageAction tooltip="从此处探索（保留主线，结论可带回）" onClick={() => onFork(lastUuid)}>
                 <Split className="size-3.5" />
               </MessageAction>
             )}

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -7,8 +7,9 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { X, ExternalLink, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, MessageSquarePlus, FileDiff, FileText, FolderOpen, Globe, MessageCircle, Brain } from 'lucide-react'
+import { X, ExternalLink, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, GitBranch, GitMerge, MessageSquarePlus, FileDiff, FileText, FolderOpen, Globe, MessageCircle, Brain, Split } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   DropdownMenu,
@@ -17,11 +18,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
+import { markdownToHtml } from '@/lib/markdown-rich-text'
 import { FileBrowser, FileDropZone, FileTypeIcon, FileSearchBar, computeRevealAncestors, isPathUnderRoot, computeTreeRowLayout, AncestorGuides, STICKY_ROW_BASE_CLASS, canBeSticky } from '@/components/file-browser'
 import { DiffPanelTabBar } from '@/components/diff/DiffPanelTabBar'
 import type { WorkspacePanelTab } from '@/components/diff/DiffPanelTabBar'
 import { DiffChangesList } from '@/components/diff/DiffChangesList'
 import { ChatView } from '@/components/chat/ChatView'
+import { AgentView } from '@/components/agent/AgentView'
 import {
   currentSessionSidePanelOpenAtom,
   agentFileSourceFilterMapAtom,
@@ -41,10 +44,21 @@ import {
   agentSessionStreamingStateAtomFamily,
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
+  agentSideTemporaryAgentMapAtom,
+  agentSideDelegationMapAtom,
+  agentSDKMessagesCacheAtom,
+  agentLiveMessagesAtomFamily,
+  agentSessionDraftsAtom,
+  agentSessionDraftSyncVersionsAtom,
+  agentSessionDraftHtmlAtom,
 } from '@/atoms/agent-atoms'
 import {
   getBrowserSidePanelTab,
   getBrowserTabIdFromSidePanelTab,
+  getDelegationSessionIdFromSidePanelTab,
+  getDelegationSidePanelTab,
+  getExplorationSessionIdFromSidePanelTab,
+  getExplorationSidePanelTab,
   getPreviewIdFromSidePanelTab,
   getPreviewSidePanelTab,
 } from '@/atoms/agent-atoms'
@@ -64,7 +78,7 @@ import { getPreviewFileId, previewFileMapAtom, previewFilesMapAtom, previewPanel
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
-import type { FileEntry, AgentPendingFile } from '@proma/shared'
+import type { FileEntry, AgentPendingFile, SDKMessage } from '@proma/shared'
 import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
 
@@ -81,6 +95,70 @@ function getPathDirname(filePath: string): string {
 function joinPath(parentDir: string, name: string): string {
   const separator = parentDir.includes('\\') && !parentDir.includes('/') ? '\\' : '/'
   return parentDir ? `${parentDir}${separator}${name}` : name
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[char] ?? char)
+}
+
+function getLatestExplorationConclusion(messages: SDKMessage[], sourceMessageId: string): string {
+  // fork 会复制分叉点之前的完整历史；只能带回锚点之后的新 assistant 回复，
+  // 否则刚打开分支就会把主线已有结论误当作探索结果。
+  let sourceIndex = -1
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index] as { uuid?: unknown }
+    if (message.uuid === sourceMessageId) {
+      sourceIndex = index
+      break
+    }
+  }
+  if (sourceIndex < 0) return ''
+
+  for (let index = messages.length - 1; index > sourceIndex; index -= 1) {
+    const message = messages[index] as { type?: unknown; message?: { content?: unknown } }
+    if (message.type !== 'assistant' || !Array.isArray(message.message?.content)) continue
+    const text = message.message.content
+      .flatMap((block) => {
+        if (!block || typeof block !== 'object') return []
+        const record = block as { type?: unknown; text?: unknown }
+        return record.type === 'text' && typeof record.text === 'string' ? [record.text] : []
+      })
+      .join('\n')
+      .trim()
+    if (text) return text
+  }
+  return ''
+}
+
+/**
+ * 右侧嵌入 Agent 在切换时轻微淡入并横移 1px，缓和不同消息高度瞬间替换的视觉跳变。
+ * 首次打开不播放，且尊重系统的减少动态效果偏好。
+ */
+function SideAgentSessionContent({ contentKey, children }: { contentKey: string; children: React.ReactNode }): React.ReactElement {
+  const previousContentKeyRef = React.useRef<string | null>(null)
+  const shouldAnimate = previousContentKeyRef.current !== null && previousContentKeyRef.current !== contentKey
+
+  React.useEffect(() => {
+    previousContentKeyRef.current = contentKey
+  }, [contentKey])
+
+  return (
+    <div
+      key={contentKey}
+      className={cn(
+        'min-h-0 flex-1 overflow-hidden',
+        shouldAnimate && 'animate-in fade-in-0 slide-in-from-right-1 duration-150 motion-reduce:animate-none',
+      )}
+    >
+      {children}
+    </div>
+  )
 }
 
 interface SidePanelProps {
@@ -458,6 +536,36 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const sideChatMap = useAtomValue(agentSideChatMapAtom)
   const setSideChatMap = useSetAtom(agentSideChatMapAtom)
   const sideChatConversationId = sideChatMap.get(sessionId) ?? null
+  const sideTemporaryAgentMap = useAtomValue(agentSideTemporaryAgentMapAtom)
+  const setSideTemporaryAgentMap = useSetAtom(agentSideTemporaryAgentMapAtom)
+  const sideTemporaryAgents = sideTemporaryAgentMap.get(sessionId) ?? []
+  const sideDelegationMap = useAtomValue(agentSideDelegationMapAtom)
+  const setSideDelegationMap = useSetAtom(agentSideDelegationMapAtom)
+  const sideDelegationSessionIds = sideDelegationMap.get(sessionId) ?? []
+  const activeDelegationSessionId = getDelegationSessionIdFromSidePanelTab(activeTab)
+  const activeDelegationSession = activeDelegationSessionId
+    ? sessions.find((item) => item.id === activeDelegationSessionId && item.parentSessionId === sessionId && !!item.sourceDelegationId) ?? null
+    : null
+  const activeExplorationSessionId = getExplorationSessionIdFromSidePanelTab(activeTab)
+  const activeExplorationBranch = activeExplorationSessionId
+    ? sideTemporaryAgents.find((branch) => branch.sessionId === activeExplorationSessionId) ?? null
+    : null
+  const explorationMessagesCache = useAtomValue(agentSDKMessagesCacheAtom)
+  const explorationLiveMessages = useAtomValue(agentLiveMessagesAtomFamily(activeExplorationSessionId ?? ''))
+  const parentDrafts = useAtomValue(agentSessionDraftsAtom)
+  const parentDraftHtml = useAtomValue(agentSessionDraftHtmlAtom)
+  const setParentDrafts = useSetAtom(agentSessionDraftsAtom)
+  const setParentDraftSyncVersions = useSetAtom(agentSessionDraftSyncVersionsAtom)
+  const setParentDraftHtml = useSetAtom(agentSessionDraftHtmlAtom)
+  const latestExplorationConclusion = React.useMemo(
+    () => activeExplorationBranch
+      ? getLatestExplorationConclusion(
+          [...(explorationMessagesCache.get(activeExplorationBranch.sessionId) ?? []), ...explorationLiveMessages],
+          activeExplorationBranch.sourceMessageId,
+        )
+      : '',
+    [activeExplorationBranch, explorationLiveMessages, explorationMessagesCache],
+  )
   const [memoryTabOpen, setMemoryTabOpen] = useAtom(agentMemoryPanelOpenAtomFamily(sessionId))
   const isAgentRunning = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))?.running === true
   const memoryChangesMap = useAtomValue(workspaceMemoryChangesAtom)
@@ -467,9 +575,12 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const lastActivatedMemoryChangeRef = React.useRef<string | null>(null)
   const effectiveActiveTab: AgentSidePanelTab = activeTab === 'chat' && !sideChatConversationId
     ? 'files'
-    : activeTab === 'memory' && (!workspaceSlug || !memoryTabOpen)
+    // `temporary-agent` 是旧的单分支内存状态；新状态使用 exploration:<sessionId>。
+    : activeTab === 'temporary-agent' || (activeExplorationSessionId !== null && !activeExplorationBranch) || (activeDelegationSessionId !== null && !activeDelegationSession)
       ? 'files'
-      : activeTab
+      : activeTab === 'memory' && (!workspaceSlug || !memoryTabOpen)
+        ? 'files'
+        : activeTab
 
   // Agent 对当前项目记忆写入后，自动展开并激活完整编辑器这个独立工作区 Tab。
   // Watcher 同一事件可因重新挂载被读到多次，按路径和时间戳去重；仅流式 Agent 运行中
@@ -512,6 +623,100 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       onTabChange('files')
     }
   }, [activeTab, onTabChange, sessionId, setSideChatMap])
+
+  const handleCloseExplorationTab = React.useCallback((branchSessionId: string) => {
+    setSideTemporaryAgentMap((prev) => {
+      const openBranches = prev.get(sessionId) ?? []
+      const remaining = openBranches.filter((branch) => branch.sessionId !== branchSessionId)
+      if (remaining.length === openBranches.length) return prev
+      const next = new Map(prev)
+      if (remaining.length > 0) next.set(sessionId, remaining)
+      else next.delete(sessionId)
+      return next
+    })
+    if (getExplorationSessionIdFromSidePanelTab(activeTab) === branchSessionId) onTabChange('files')
+  }, [activeTab, onTabChange, sessionId, setSideTemporaryAgentMap])
+
+  const handleCloseDelegationTab = React.useCallback((childSessionId: string) => {
+    setSideDelegationMap((prev) => {
+      const openChildIds = prev.get(sessionId) ?? []
+      const remaining = openChildIds.filter((id) => id !== childSessionId)
+      if (remaining.length === openChildIds.length) return prev
+      const next = new Map(prev)
+      if (remaining.length > 0) next.set(sessionId, remaining)
+      else next.delete(sessionId)
+      return next
+    })
+    if (getDelegationSessionIdFromSidePanelTab(activeTab) === childSessionId) onTabChange('files')
+  }, [activeTab, onTabChange, sessionId, setSideDelegationMap])
+
+  const handleBringExplorationBack = React.useCallback(() => {
+    if (!activeExplorationBranch || !latestExplorationConclusion) {
+      toast.info('探索分支还没有可带回的 Agent 结论')
+      return
+    }
+    const branchTitle = sessions.find((item) => item.id === activeExplorationBranch.sessionId)?.title || '探索分支'
+    // `&session` mention 是 Agent 可直接查询会话的结构化标记；标签明确限定为分叉后的内容，
+    // 避免主线与探索共用的历史被再次当作新增上下文读取。
+    const referenceLabel = `探索后新增内容 · ${branchTitle}`
+    const referenceMarkdown = `这是探索后的新增内容：&session:${activeExplorationBranch.sessionId}::${encodeURIComponent(referenceLabel)}`
+    const referenceHtml = `<p>这是探索后的新增内容：<span data-type="mention" data-id="${escapeHtml(activeExplorationBranch.sessionId)}" data-label="${escapeHtml(referenceLabel)}" data-mention-suggestion-char="&">${escapeHtml(referenceLabel)}</span></p>`
+    setParentDraftSyncVersions((previous) => {
+      const next = new Map(previous)
+      next.set(sessionId, (next.get(sessionId) ?? 0) + 1)
+      return next
+    })
+    setParentDrafts((previous) => {
+      const next = new Map(previous)
+      const current = parentDrafts.get(sessionId)?.trim() ?? ''
+      next.set(sessionId, current ? `${current}\n\n${referenceMarkdown}` : referenceMarkdown)
+      return next
+    })
+    setParentDraftHtml((previous) => {
+      const currentHtml = parentDraftHtml.get(sessionId) || markdownToHtml(parentDrafts.get(sessionId) ?? '')
+      const nextHtml = currentHtml ? `${currentHtml}<p></p>${referenceHtml}` : referenceHtml
+      const next = new Map(previous)
+      next.set(sessionId, nextHtml)
+      return next
+    })
+    toast.success('已添加探索引用', { description: '探索 Tab 保持打开；主会话发送后 Agent 会读取该标记。' })
+  }, [activeExplorationBranch, latestExplorationConclusion, parentDraftHtml, parentDrafts, sessionId, sessions, setParentDraftHtml, setParentDrafts, setParentDraftSyncVersions])
+
+  // 分支是正常持久化会话，但若用户从左侧删除了它，右侧不能保留悬空 Tab。
+  React.useEffect(() => {
+    const validBranchIds = new Set(sessions.map((item) => item.id))
+    const remaining = sideTemporaryAgents.filter((branch) => validBranchIds.has(branch.sessionId))
+    if (remaining.length === sideTemporaryAgents.length) return
+    setSideTemporaryAgentMap((prev) => {
+      const current = prev.get(sessionId) ?? []
+      const nextRemaining = current.filter((branch) => validBranchIds.has(branch.sessionId))
+      if (nextRemaining.length === current.length) return prev
+      const next = new Map(prev)
+      if (nextRemaining.length > 0) next.set(sessionId, nextRemaining)
+      else next.delete(sessionId)
+      return next
+    })
+    if (activeExplorationSessionId && !validBranchIds.has(activeExplorationSessionId)) onTabChange('files')
+  }, [activeExplorationSessionId, onTabChange, sessionId, sessions, setSideTemporaryAgentMap, sideTemporaryAgents])
+
+  // 子 Agent 被从左侧删除后，同样移除右侧的悬空观察 Tab；不改变左侧树的现有渲染与排序。
+  React.useEffect(() => {
+    const validChildIds = new Set(sessions
+      .filter((item) => item.parentSessionId === sessionId && !!item.sourceDelegationId)
+      .map((item) => item.id))
+    const remaining = sideDelegationSessionIds.filter((id) => validChildIds.has(id))
+    if (remaining.length === sideDelegationSessionIds.length) return
+    setSideDelegationMap((prev) => {
+      const current = prev.get(sessionId) ?? []
+      const nextRemaining = current.filter((id) => validChildIds.has(id))
+      if (nextRemaining.length === current.length) return prev
+      const next = new Map(prev)
+      if (nextRemaining.length > 0) next.set(sessionId, nextRemaining)
+      else next.delete(sessionId)
+      return next
+    })
+    if (activeDelegationSessionId && !validChildIds.has(activeDelegationSessionId)) onTabChange('files')
+  }, [activeDelegationSessionId, onTabChange, sessionId, sessions, setSideDelegationMap, sideDelegationSessionIds])
 
   // 浏览器状态由 MainArea 的全局订阅同步到 atom；右侧工作区只负责呈现和显式打开。
   // 这样切换文件/改动时 BrowserSlot 会正确隐藏原生 WebContentsView，而不会销毁网页会话。
@@ -669,6 +874,23 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       closable: true,
     })),
     ...(sideChatConversationId ? [{ id: 'chat' as const, label: '问答', icon: <MessageCircle className="size-3.5" />, closable: true }] : []),
+    ...sideTemporaryAgents.map((branch) => ({
+      id: getExplorationSidePanelTab(branch.sessionId),
+      label: sessions.find((item) => item.id === branch.sessionId)?.title || '探索分支',
+      icon: <Split className="size-3.5" />,
+      closable: true,
+    })),
+    ...sideDelegationSessionIds.flatMap((childSessionId) => {
+      const child = sessions.find((item) => (
+        item.id === childSessionId && item.parentSessionId === sessionId && !!item.sourceDelegationId
+      ))
+      return child ? [{
+        id: getDelegationSidePanelTab(child.id),
+        label: child.title,
+        icon: <GitBranch className="size-3.5" />,
+        closable: true,
+      }] : []
+    }),
     ...(browserState?.tabs.map((tab) => ({
       id: getBrowserSidePanelTab(tab.tabId),
       label: tab.title || '新建标签页',
@@ -677,7 +899,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       closable: tab.tabId !== browserState.agentTabId,
       activity: showBrowserActivity && activeBrowserTabId !== tab.tabId && browserState.activeTabId === tab.tabId,
     })) ?? []),
-  ], [activeBrowserTabId, browserState, memoryTabOpen, previewFiles, showBrowserActivity, sideChatConversationId, workspaceSlug])
+  ], [activeBrowserTabId, browserState, memoryTabOpen, previewFiles, sessions, sessionId, showBrowserActivity, sideChatConversationId, sideDelegationSessionIds, sideTemporaryAgents, workspaceSlug])
 
   const handleCloseWorkspaceTab = React.useCallback((tab: AgentSidePanelTab) => {
     if (tab === 'memory') {
@@ -690,9 +912,13 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     const previewId = getPreviewIdFromSidePanelTab(tab)
     if (previewId) { handleClosePreviewTab(previewId); return }
     if (tab === 'chat') { handleCloseChatTab(); return }
+    const explorationSessionId = getExplorationSessionIdFromSidePanelTab(tab)
+    if (explorationSessionId) { handleCloseExplorationTab(explorationSessionId); return }
+    const delegationSessionId = getDelegationSessionIdFromSidePanelTab(tab)
+    if (delegationSessionId) { handleCloseDelegationTab(delegationSessionId); return }
     const browserTabId = getBrowserTabIdFromSidePanelTab(tab)
     if (browserTabId && browserTabId !== browserState?.agentTabId) void handleCloseBrowserTab(browserTabId)
-  }, [activeTab, browserState?.agentTabId, handleCloseBrowserTab, handleCloseChatTab, handleClosePreviewTab, memoryEditingState.dirty, onTabChange, setMemoryEditingState, setMemoryTabOpen])
+  }, [activeTab, browserState?.agentTabId, handleCloseBrowserTab, handleCloseChatTab, handleCloseDelegationTab, handleCloseExplorationTab, handleClosePreviewTab, memoryEditingState.dirty, onTabChange, setMemoryEditingState, setMemoryTabOpen])
 
   React.useEffect(() => {
     const handleCloseActiveWorkspaceTab = (event: Event) => {
@@ -733,6 +959,16 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
               setMemoryTabOpen(true)
               onTabChange('memory')
             }}
+            activeTabAction={activeExplorationBranch ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" className="size-7 active:scale-[0.96]" onClick={handleBringExplorationBack} disabled={!latestExplorationConclusion} aria-label="添加探索引用">
+                    <GitMerge className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{latestExplorationConclusion ? '将探索后新增内容作为会话引用添加到主线草稿；探索 Tab 保持打开，不会自动发送' : '完成一轮新的探索回复后即可添加引用'}</TooltipContent>
+              </Tooltip>
+            ) : undefined}
             onClose={() => setIsOpen(false)}
             isWindows={isWindows}
           />
@@ -755,6 +991,14 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">暂无问答会话</div>
             )
+          ) : activeExplorationBranch ? (
+            <SideAgentSessionContent contentKey={`exploration:${activeExplorationBranch.sessionId}`}>
+              <AgentView sessionId={activeExplorationBranch.sessionId} embedded />
+            </SideAgentSessionContent>
+          ) : activeDelegationSession ? (
+            <SideAgentSessionContent contentKey={`delegation:${activeDelegationSession.id}`}>
+              <AgentView sessionId={activeDelegationSession.id} embedded />
+            </SideAgentSessionContent>
           ) : effectiveActiveTab === 'memory' ? (
             workspaceSlug ? (
               <div className="min-h-0 flex-1 overflow-auto p-2">

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -62,7 +62,7 @@ import {
   getPreviewIdFromSidePanelTab,
   getPreviewSidePanelTab,
 } from '@/atoms/agent-atoms'
-import type { AgentSidePanelTab, AgentFileSourceFilter } from '@/atoms/agent-atoms'
+import type { AgentSidePanelTab, AgentFileSourceFilter, AgentExplorationBranchTab } from '@/atoms/agent-atoms'
 import { WorkspaceMemoryChangeDock } from '@/components/agent-skills/WorkspaceMemoryChangeDock'
 import { workspaceMemoryChangesAtom, workspaceMemoryEditingStateAtomFamily } from '@/atoms/memory-change-atoms'
 import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
@@ -78,7 +78,7 @@ import { getPreviewFileId, previewFileMapAtom, previewFilesMapAtom, previewPanel
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
-import type { FileEntry, AgentPendingFile, SDKMessage } from '@proma/shared'
+import type { FileEntry, AgentPendingFile, AgentSessionMeta, SDKMessage } from '@proma/shared'
 import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
 
@@ -158,6 +158,75 @@ function SideAgentSessionContent({ contentKey, children }: { contentKey: string;
     >
       {children}
     </div>
+  )
+}
+
+/**
+ * 探索分支正在流式输出时，只有带回按钮需要知道“是否已有新增 assistant 内容”。
+ * 将该订阅隔离在小组件中，避免每个 token 都重渲染整块文件/Tab 侧栏。
+ */
+function ExplorationBringBackAction({
+  parentSessionId,
+  branch,
+  sessions,
+}: {
+  parentSessionId: string
+  branch: AgentExplorationBranchTab
+  sessions: AgentSessionMeta[]
+}): React.ReactElement {
+  const explorationMessagesCache = useAtomValue(agentSDKMessagesCacheAtom)
+  const explorationLiveMessages = useAtomValue(agentLiveMessagesAtomFamily(branch.sessionId))
+  const parentDrafts = useAtomValue(agentSessionDraftsAtom)
+  const parentDraftHtml = useAtomValue(agentSessionDraftHtmlAtom)
+  const setParentDrafts = useSetAtom(agentSessionDraftsAtom)
+  const setParentDraftSyncVersions = useSetAtom(agentSessionDraftSyncVersionsAtom)
+  const setParentDraftHtml = useSetAtom(agentSessionDraftHtmlAtom)
+  const latestExplorationConclusion = React.useMemo(
+    () => getLatestExplorationConclusion(
+      [...(explorationMessagesCache.get(branch.sessionId) ?? []), ...explorationLiveMessages],
+      branch.sourceMessageId,
+    ),
+    [branch.sessionId, branch.sourceMessageId, explorationLiveMessages, explorationMessagesCache],
+  )
+  const handleBringExplorationBack = React.useCallback(() => {
+    if (!latestExplorationConclusion) {
+      toast.info('探索分支还没有可带回的 Agent 结论')
+      return
+    }
+    const branchTitle = sessions.find((item) => item.id === branch.sessionId)?.title || '探索分支'
+    const referenceLabel = `探索后新增内容 · ${branchTitle}`
+    const referenceMarkdown = `这是探索后的新增内容：&session:${branch.sessionId}::${encodeURIComponent(referenceLabel)}`
+    const referenceHtml = `<p>这是探索后的新增内容：<span data-type="mention" data-id="${escapeHtml(branch.sessionId)}" data-label="${escapeHtml(referenceLabel)}" data-mention-suggestion-char="&">${escapeHtml(referenceLabel)}</span></p>`
+    setParentDraftSyncVersions((previous) => {
+      const next = new Map(previous)
+      next.set(parentSessionId, (next.get(parentSessionId) ?? 0) + 1)
+      return next
+    })
+    setParentDrafts((previous) => {
+      const next = new Map(previous)
+      const current = parentDrafts.get(parentSessionId)?.trim() ?? ''
+      next.set(parentSessionId, current ? `${current}\n\n${referenceMarkdown}` : referenceMarkdown)
+      return next
+    })
+    setParentDraftHtml((previous) => {
+      const currentHtml = parentDraftHtml.get(parentSessionId) || markdownToHtml(parentDrafts.get(parentSessionId) ?? '')
+      const nextHtml = currentHtml ? `${currentHtml}<p></p>${referenceHtml}` : referenceHtml
+      const next = new Map(previous)
+      next.set(parentSessionId, nextHtml)
+      return next
+    })
+    toast.success('已添加探索引用', { description: '探索 Tab 保持打开；主会话发送后 Agent 会读取该标记。' })
+  }, [branch.sessionId, latestExplorationConclusion, parentDraftHtml, parentDrafts, parentSessionId, sessions, setParentDraftHtml, setParentDrafts, setParentDraftSyncVersions])
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-7 active:scale-[0.96]" onClick={handleBringExplorationBack} disabled={!latestExplorationConclusion} aria-label="添加探索引用">
+          <GitMerge className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{latestExplorationConclusion ? '将探索后新增内容作为会话引用添加到主线草稿；探索 Tab 保持打开，不会自动发送' : '完成一轮新的探索回复后即可添加引用'}</TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -550,22 +619,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const activeExplorationBranch = activeExplorationSessionId
     ? sideTemporaryAgents.find((branch) => branch.sessionId === activeExplorationSessionId) ?? null
     : null
-  const explorationMessagesCache = useAtomValue(agentSDKMessagesCacheAtom)
-  const explorationLiveMessages = useAtomValue(agentLiveMessagesAtomFamily(activeExplorationSessionId ?? ''))
-  const parentDrafts = useAtomValue(agentSessionDraftsAtom)
-  const parentDraftHtml = useAtomValue(agentSessionDraftHtmlAtom)
-  const setParentDrafts = useSetAtom(agentSessionDraftsAtom)
-  const setParentDraftSyncVersions = useSetAtom(agentSessionDraftSyncVersionsAtom)
-  const setParentDraftHtml = useSetAtom(agentSessionDraftHtmlAtom)
-  const latestExplorationConclusion = React.useMemo(
-    () => activeExplorationBranch
-      ? getLatestExplorationConclusion(
-          [...(explorationMessagesCache.get(activeExplorationBranch.sessionId) ?? []), ...explorationLiveMessages],
-          activeExplorationBranch.sourceMessageId,
-        )
-      : '',
-    [activeExplorationBranch, explorationLiveMessages, explorationMessagesCache],
-  )
   const [memoryTabOpen, setMemoryTabOpen] = useAtom(agentMemoryPanelOpenAtomFamily(sessionId))
   const isAgentRunning = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))?.running === true
   const memoryChangesMap = useAtomValue(workspaceMemoryChangesAtom)
@@ -649,38 +702,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     })
     if (getDelegationSessionIdFromSidePanelTab(activeTab) === childSessionId) onTabChange('files')
   }, [activeTab, onTabChange, sessionId, setSideDelegationMap])
-
-  const handleBringExplorationBack = React.useCallback(() => {
-    if (!activeExplorationBranch || !latestExplorationConclusion) {
-      toast.info('探索分支还没有可带回的 Agent 结论')
-      return
-    }
-    const branchTitle = sessions.find((item) => item.id === activeExplorationBranch.sessionId)?.title || '探索分支'
-    // `&session` mention 是 Agent 可直接查询会话的结构化标记；标签明确限定为分叉后的内容，
-    // 避免主线与探索共用的历史被再次当作新增上下文读取。
-    const referenceLabel = `探索后新增内容 · ${branchTitle}`
-    const referenceMarkdown = `这是探索后的新增内容：&session:${activeExplorationBranch.sessionId}::${encodeURIComponent(referenceLabel)}`
-    const referenceHtml = `<p>这是探索后的新增内容：<span data-type="mention" data-id="${escapeHtml(activeExplorationBranch.sessionId)}" data-label="${escapeHtml(referenceLabel)}" data-mention-suggestion-char="&">${escapeHtml(referenceLabel)}</span></p>`
-    setParentDraftSyncVersions((previous) => {
-      const next = new Map(previous)
-      next.set(sessionId, (next.get(sessionId) ?? 0) + 1)
-      return next
-    })
-    setParentDrafts((previous) => {
-      const next = new Map(previous)
-      const current = parentDrafts.get(sessionId)?.trim() ?? ''
-      next.set(sessionId, current ? `${current}\n\n${referenceMarkdown}` : referenceMarkdown)
-      return next
-    })
-    setParentDraftHtml((previous) => {
-      const currentHtml = parentDraftHtml.get(sessionId) || markdownToHtml(parentDrafts.get(sessionId) ?? '')
-      const nextHtml = currentHtml ? `${currentHtml}<p></p>${referenceHtml}` : referenceHtml
-      const next = new Map(previous)
-      next.set(sessionId, nextHtml)
-      return next
-    })
-    toast.success('已添加探索引用', { description: '探索 Tab 保持打开；主会话发送后 Agent 会读取该标记。' })
-  }, [activeExplorationBranch, latestExplorationConclusion, parentDraftHtml, parentDrafts, sessionId, sessions, setParentDraftHtml, setParentDrafts, setParentDraftSyncVersions])
 
   // 分支是正常持久化会话，但若用户从左侧删除了它，右侧不能保留悬空 Tab。
   React.useEffect(() => {
@@ -960,14 +981,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
               onTabChange('memory')
             }}
             activeTabAction={activeExplorationBranch ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button variant="ghost" size="icon" className="size-7 active:scale-[0.96]" onClick={handleBringExplorationBack} disabled={!latestExplorationConclusion} aria-label="添加探索引用">
-                    <GitMerge className="size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{latestExplorationConclusion ? '将探索后新增内容作为会话引用添加到主线草稿；探索 Tab 保持打开，不会自动发送' : '完成一轮新的探索回复后即可添加引用'}</TooltipContent>
-              </Tooltip>
+              <ExplorationBringBackAction parentSessionId={sessionId} branch={activeExplorationBranch} sessions={sessions} />
             ) : undefined}
             onClose={() => setIsOpen(false)}
             isWindows={isWindows}

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -35,6 +35,8 @@ const RIGHT_PANEL_MAX_VIEWPORT_RATIO = 3 / 5
 const WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO = 1 / 2
 // 窄窗口时优先保留主会话的最小可读宽度；Agent 侧栏的 480px 仅在空间足够时强制。
 const MIN_MAIN_AREA_WIDTH = 320
+const COLLAPSED_LEFT_SIDEBAR_WIDTH = 60
+const CLASSIC_LEFT_SIDEBAR_LEADING_PADDING = 8
 
 function getRightPanelMinWidth(isAgentSessionTab: boolean): number {
   return isAgentSessionTab ? MIN_AGENT_SESSION_PANEL_WIDTH : MIN_RIGHT_PANEL_WIDTH
@@ -153,7 +155,8 @@ export function AppShell(): React.ReactElement {
     activeRightPanelTab?.startsWith('exploration:') || activeRightPanelTab?.startsWith('delegation:'),
   )
   const rightPanelMinimumWidth = getRightPanelMinWidth(isAgentSessionRightTab)
-  const leftSidebarOccupiedWidth = sidebarCollapsed ? 0 : clampedLeftSidebarWidth + (isClassic ? 0 : 1)
+  const leftSidebarContentWidth = sidebarCollapsed ? COLLAPSED_LEFT_SIDEBAR_WIDTH : clampedLeftSidebarWidth
+  const leftSidebarOccupiedWidth = leftSidebarContentWidth + (isClassic ? CLASSIC_LEFT_SIDEBAR_LEADING_PADDING : 1)
   const clampedRightPanelWidth = clampRightPanelWidth(
     rightPanelLayout.width,
     viewportWidth,

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -33,18 +33,31 @@ const MIN_RIGHT_PANEL_WIDTH = 360
 const MIN_AGENT_SESSION_PANEL_WIDTH = 480
 const RIGHT_PANEL_MAX_VIEWPORT_RATIO = 3 / 5
 const WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO = 1 / 2
+// 窄窗口时优先保留主会话的最小可读宽度；Agent 侧栏的 480px 仅在空间足够时强制。
+const MIN_MAIN_AREA_WIDTH = 320
 
 function getRightPanelMinWidth(isAgentSessionTab: boolean): number {
   return isAgentSessionTab ? MIN_AGENT_SESSION_PANEL_WIDTH : MIN_RIGHT_PANEL_WIDTH
 }
 
-function getRightPanelMaxWidth(viewportWidth: number, minimumWidth: number): number {
-  return Math.max(minimumWidth, Math.floor(viewportWidth * RIGHT_PANEL_MAX_VIEWPORT_RATIO))
+function getRightPanelMaxWidth(viewportWidth: number, leftSidebarOccupiedWidth: number): number {
+  // 宽视图不超过 3/5；更重要的是右栏不能侵占主工作区的最小可读宽度。
+  return Math.max(0, Math.min(
+    Math.floor(viewportWidth * RIGHT_PANEL_MAX_VIEWPORT_RATIO),
+    viewportWidth - leftSidebarOccupiedWidth - MIN_MAIN_AREA_WIDTH,
+  ))
 }
 
-function clampRightPanelWidth(width: number, viewportWidth: number, minimumWidth = MIN_RIGHT_PANEL_WIDTH): number {
-  // 工作区可占整个应用的 3/5；避免窄窗口下最小宽度反而超过可用界面。
-  return Math.max(minimumWidth, Math.min(getRightPanelMaxWidth(viewportWidth, minimumWidth), width))
+function clampRightPanelWidth(
+  width: number,
+  viewportWidth: number,
+  minimumWidth = MIN_RIGHT_PANEL_WIDTH,
+  leftSidebarOccupiedWidth = 0,
+): number {
+  const maximumWidth = getRightPanelMaxWidth(viewportWidth, leftSidebarOccupiedWidth)
+  // 480px 是 Agent 会话的理想下限；在窄窗口中放宽它，而不是把中间会话挤到不可用。
+  const effectiveMinimumWidth = Math.min(minimumWidth, maximumWidth)
+  return Math.max(effectiveMinimumWidth, Math.min(maximumWidth, width))
 }
 
 const MIN_LEFT_SIDEBAR_WIDTH = 240
@@ -140,14 +153,20 @@ export function AppShell(): React.ReactElement {
     activeRightPanelTab?.startsWith('exploration:') || activeRightPanelTab?.startsWith('delegation:'),
   )
   const rightPanelMinimumWidth = getRightPanelMinWidth(isAgentSessionRightTab)
-  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelLayout.width, viewportWidth, rightPanelMinimumWidth)
+  const leftSidebarOccupiedWidth = sidebarCollapsed ? 0 : clampedLeftSidebarWidth + (isClassic ? 0 : 1)
+  const clampedRightPanelWidth = clampRightPanelWidth(
+    rightPanelLayout.width,
+    viewportWidth,
+    rightPanelMinimumWidth,
+    leftSidebarOccupiedWidth,
+  )
   const isWideRightWorkspace = Boolean(
     activeRightPanelTab?.startsWith('preview:') || activeRightPanelTab?.startsWith('browser:'),
   )
   // 首次打开预览/浏览器后，工作区维持宽视图；切回文件/改动不会自动收窄，交给用户拖拽决定。
   const effectiveWidePanelWidth = rightPanelLayout.widePanelWidthOverride === null
-    ? clampRightPanelWidth(Math.floor(viewportWidth * WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO), viewportWidth)
-    : clampRightPanelWidth(rightPanelLayout.widePanelWidthOverride, viewportWidth)
+    ? clampRightPanelWidth(Math.floor(viewportWidth * WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO), viewportWidth, MIN_RIGHT_PANEL_WIDTH, leftSidebarOccupiedWidth)
+    : clampRightPanelWidth(rightPanelLayout.widePanelWidthOverride, viewportWidth, MIN_RIGHT_PANEL_WIDTH, leftSidebarOccupiedWidth)
   // 浏览器/预览打开过的会话可继续在文件页保留宽视图；探索和子 Agent
   // 始终回到适中的 Agent 工作宽度，避免挤占主会话阅读区。
   const usesWidePanelLayout = rightPanelLayout.hasOpenedWideWorkspace && !isAgentSessionRightTab
@@ -198,7 +217,7 @@ export function AppShell(): React.ReactElement {
 
     const applyWidth = () => {
       const delta = startX - latestClientX
-      latestWidth = clampRightPanelWidth(startWidth + delta, viewportWidth, rightPanelMinimumWidth)
+      latestWidth = clampRightPanelWidth(startWidth + delta, viewportWidth, rightPanelMinimumWidth, leftSidebarOccupiedWidth)
       setDraggedRightPanelWidth(latestWidth)
     }
 
@@ -241,7 +260,7 @@ export function AppShell(): React.ReactElement {
     rightPanelDragCleanup.current = cancelDrag
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-  }, [currentSessionId, displayedRightPanelWidth, rightPanelMinimumWidth, setRightPanelLayout, usesWidePanelLayout, viewportWidth])
+  }, [currentSessionId, displayedRightPanelWidth, leftSidebarOccupiedWidth, rightPanelMinimumWidth, setRightPanelLayout, usesWidePanelLayout, viewportWidth])
 
   return (
     <>

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -28,16 +28,23 @@ import { cn } from '@/lib/utils'
 import { Toaster } from '@/components/ui/sonner'
 
 const MIN_RIGHT_PANEL_WIDTH = 360
+// 探索/委派 Agent 需要同时容纳消息正文、工具活动和输入区；略宽于普通文件栏，
+// 但显著小于浏览器/预览的半屏宽视图。
+const MIN_AGENT_SESSION_PANEL_WIDTH = 480
 const RIGHT_PANEL_MAX_VIEWPORT_RATIO = 3 / 5
 const WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO = 1 / 2
 
-function getRightPanelMaxWidth(viewportWidth: number): number {
-  return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.floor(viewportWidth * RIGHT_PANEL_MAX_VIEWPORT_RATIO))
+function getRightPanelMinWidth(isAgentSessionTab: boolean): number {
+  return isAgentSessionTab ? MIN_AGENT_SESSION_PANEL_WIDTH : MIN_RIGHT_PANEL_WIDTH
 }
 
-function clampRightPanelWidth(width: number, viewportWidth: number): number {
+function getRightPanelMaxWidth(viewportWidth: number, minimumWidth: number): number {
+  return Math.max(minimumWidth, Math.floor(viewportWidth * RIGHT_PANEL_MAX_VIEWPORT_RATIO))
+}
+
+function clampRightPanelWidth(width: number, viewportWidth: number, minimumWidth = MIN_RIGHT_PANEL_WIDTH): number {
   // 工作区可占整个应用的 3/5；避免窄窗口下最小宽度反而超过可用界面。
-  return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(getRightPanelMaxWidth(viewportWidth), width))
+  return Math.max(minimumWidth, Math.min(getRightPanelMaxWidth(viewportWidth, minimumWidth), width))
 }
 
 const MIN_LEFT_SIDEBAR_WIDTH = 240
@@ -129,7 +136,11 @@ export function AppShell(): React.ReactElement {
   const rightPanelDragCleanup = React.useRef<(() => void) | null>(null)
   const [draggedRightPanelWidth, setDraggedRightPanelWidth] = React.useState<number | null>(null)
   currentSessionIdRef.current = currentSessionId
-  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelLayout.width, viewportWidth)
+  const isAgentSessionRightTab = Boolean(
+    activeRightPanelTab?.startsWith('exploration:') || activeRightPanelTab?.startsWith('delegation:'),
+  )
+  const rightPanelMinimumWidth = getRightPanelMinWidth(isAgentSessionRightTab)
+  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelLayout.width, viewportWidth, rightPanelMinimumWidth)
   const isWideRightWorkspace = Boolean(
     activeRightPanelTab?.startsWith('preview:') || activeRightPanelTab?.startsWith('browser:'),
   )
@@ -137,7 +148,10 @@ export function AppShell(): React.ReactElement {
   const effectiveWidePanelWidth = rightPanelLayout.widePanelWidthOverride === null
     ? clampRightPanelWidth(Math.floor(viewportWidth * WIDE_RIGHT_PANEL_DEFAULT_VIEWPORT_RATIO), viewportWidth)
     : clampRightPanelWidth(rightPanelLayout.widePanelWidthOverride, viewportWidth)
-  const persistedRightPanelWidth = rightPanelLayout.hasOpenedWideWorkspace ? effectiveWidePanelWidth : clampedRightPanelWidth
+  // 浏览器/预览打开过的会话可继续在文件页保留宽视图；探索和子 Agent
+  // 始终回到适中的 Agent 工作宽度，避免挤占主会话阅读区。
+  const usesWidePanelLayout = rightPanelLayout.hasOpenedWideWorkspace && !isAgentSessionRightTab
+  const persistedRightPanelWidth = usesWidePanelLayout ? effectiveWidePanelWidth : clampedRightPanelWidth
   const displayedRightPanelWidth = draggedRightPanelWidth ?? persistedRightPanelWidth
 
   React.useEffect(() => {
@@ -175,7 +189,7 @@ export function AppShell(): React.ReactElement {
     const dragSessionId = currentSessionId
     const startX = e.clientX
     const startWidth = displayedRightPanelWidth
-    const isWideWorkspace = rightPanelLayout.hasOpenedWideWorkspace
+    const isWideWorkspace = usesWidePanelLayout
     // 记录最新光标位置，rAF 回调读取它而非调度时捕获的旧事件，避免快拖时坐标滞后
     let latestClientX = startX
     let latestWidth = startWidth
@@ -184,7 +198,7 @@ export function AppShell(): React.ReactElement {
 
     const applyWidth = () => {
       const delta = startX - latestClientX
-      latestWidth = clampRightPanelWidth(startWidth + delta, viewportWidth)
+      latestWidth = clampRightPanelWidth(startWidth + delta, viewportWidth, rightPanelMinimumWidth)
       setDraggedRightPanelWidth(latestWidth)
     }
 
@@ -227,7 +241,7 @@ export function AppShell(): React.ReactElement {
     rightPanelDragCleanup.current = cancelDrag
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-  }, [currentSessionId, displayedRightPanelWidth, rightPanelLayout.hasOpenedWideWorkspace, setRightPanelLayout, viewportWidth])
+  }, [currentSessionId, displayedRightPanelWidth, rightPanelMinimumWidth, setRightPanelLayout, usesWidePanelLayout, viewportWidth])
 
   return (
     <>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -55,6 +55,8 @@ import {
   agentDiffDataAtom,
   agentSidePanelOpenMapAtom,
   agentSidePanelOpenAtomFamily,
+  agentSideDelegationMapAtom,
+  getDelegationSidePanelTab,
   agentStreamingStatesAtom,
   liveMessagesMapAtom,
   agentSessionPendingFilesAtom,
@@ -916,6 +918,19 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       }
       return changed ? map : prev
     })
+    store.set(agentSideDelegationMapAtom, (prev) => {
+      let changed = false
+      const next = new Map(prev)
+      if (next.delete(id)) changed = true
+      for (const [parentSessionId, childSessionIds] of next) {
+        const remaining = childSessionIds.filter((childSessionId) => childSessionId !== id)
+        if (remaining.length === childSessionIds.length) continue
+        changed = true
+        if (remaining.length > 0) next.set(parentSessionId, remaining)
+        else next.delete(parentSessionId)
+      }
+      return changed ? next : prev
+    })
     setDiffPanelTab(deleteKey)
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)
@@ -1731,8 +1746,37 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     }
   }, [agentChannelId, agentModelId, openSession, setAgentSessions, setCurrentWorkspaceId, setWorkspaces])
 
-  /** 选择 Agent 会话（打开或聚焦标签页） */
+  /** 选择 Agent 会话（打开或聚焦标签页）。协作子 Agent 保持左侧树形条目，但在父会话右侧查看。 */
   const handleSelectAgentSession = React.useCallback((id: string, title: string): void => {
+    const selectedSession = agentSessions.find((session) => session.id === id)
+    if (selectedSession?.sourceDelegationId && selectedSession.parentSessionId) {
+      const parentSession = agentSessions.find((session) => session.id === selectedSession.parentSessionId)
+      if (parentSession) {
+        openSession('agent', parentSession.id, parentSession.title)
+        store.set(agentSideDelegationMapAtom, (previous) => {
+          const openChildIds = previous.get(parentSession.id) ?? []
+          if (openChildIds.includes(selectedSession.id)) return previous
+          const next = new Map(previous)
+          next.set(parentSession.id, [...openChildIds, selectedSession.id])
+          return next
+        })
+        store.set(agentSidePanelOpenAtomFamily(parentSession.id), true)
+        store.set(agentDiffPanelTabAtom, (previous) => {
+          const next = new Map(previous)
+          next.set(parentSession.id, getDelegationSidePanelTab(selectedSession.id))
+          return next
+        })
+        setActiveView('conversations')
+        setUnviewedCompleted((prev: Set<string>) => {
+          if (!prev.has(id)) return prev
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        })
+        return
+      }
+    }
+
     openSession('agent', id, title)
     setActiveView('conversations')
     // 清除该会话的"已完成未查看"标记
@@ -1742,7 +1786,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       next.delete(id)
       return next
     })
-  }, [openSession, setActiveView, setUnviewedCompleted])
+  }, [agentSessions, openSession, setActiveView, setUnviewedCompleted, store])
 
   const clearQuickSwitchHints = React.useCallback((): void => {
     for (const row of quickSwitchHintRowsRef.current) {

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -37,6 +37,8 @@ interface DiffPanelTabBarProps {
   onOpenFile: () => void
   onOpenMemory?: () => void
   onOpenChat?: () => void
+  /** 仅当前右侧 Tab 需要的紧凑动作，渲染于标签列表之后，不影响内容区布局。 */
+  activeTabAction?: React.ReactNode
   onClose?: () => void
   isWindows?: boolean
 }
@@ -50,6 +52,7 @@ export function DiffPanelTabBar({
   onOpenFile,
   onOpenMemory,
   onOpenChat,
+  activeTabAction,
   onClose,
   isWindows = false,
 }: DiffPanelTabBarProps): React.ReactElement {
@@ -121,6 +124,7 @@ export function DiffPanelTabBar({
             )
           })}
         </div>
+        {activeTabAction && <div className="ml-1 flex shrink-0 items-center titlebar-no-drag">{activeTabAction}</div>}
         <DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -17,15 +17,12 @@ import {
   agentDiffViewModeAtom,
   agentDiffRefreshVersionAtom,
   agentSidePanelOpenAtomFamily,
+  agentSessionsAtom,
+  agentSideTemporaryAgentMapAtom,
+  getExplorationSidePanelTab,
 } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import { previewCodeWrapAtom, quotedSelectionMapAtom } from '@/atoms/preview-atoms'
-import {
-  agentSideChatMapAtom,
-  conversationsAtom,
-  conversationDraftsAtom,
-  selectedModelAtom,
-} from '@/atoms/chat-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
 import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { useShortcut } from '@/hooks/useShortcut'
@@ -422,10 +419,9 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   // ===== 选中文本引用（Quoted Selection）=====
 
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
-  const selectedChatModel = useAtomValue(selectedModelAtom)
-  const setConversations = useSetAtom(conversationsAtom)
-  const setConversationDrafts = useSetAtom(conversationDraftsAtom)
-  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const setSideTemporaryAgentMap = useSetAtom(agentSideTemporaryAgentMapAtom)
   const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtomFamily(sessionId))
   const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const focusAgentSessionInput = useFocusAgentSessionInput()
@@ -435,7 +431,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const shadowRootsRef = React.useRef<Set<ShadowRoot>>(new Set())
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
-  const openSelectionChatPendingRef = React.useRef(false)
+  const openTemporaryAgentPendingRef = React.useRef(false)
   /** 当前正在展示的截断 toast id；选中回落到上限内或选区消失时主动 dismiss */
   const lastToastIdRef = React.useRef<string | null>(null)
 
@@ -1347,67 +1343,55 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     focusAgentSessionInput(sessionId)
   }, [clearPreviewSelection, focusAgentSessionInput, previewSelection, sessionId, setQuotedSelectionMap])
 
-  const handleOpenSelectionChat = React.useCallback(async (): Promise<void> => {
-    if (!previewSelection) return
-    if (openSelectionChatPendingRef.current) return
-    openSelectionChatPendingRef.current = true
+  const handleOpenExplorationBranch = React.useCallback(async (): Promise<void> => {
+    if (!previewSelection || openTemporaryAgentPendingRef.current) return
+    const parentSession = agentSessions.find((item) => item.id === sessionId)
+    // 文件预览不是一条对话消息；从当前主线最近一个可恢复的 Pi 节点分叉。
+    const sourceMessageId = Object.keys(parentSession?.piEntryBindings ?? {}).at(-1)
+    if (!sourceMessageId) {
+      toast.info('当前还没有可探索的 Agent 回复，请先完成一轮对话')
+      return
+    }
+
+    openTemporaryAgentPendingRef.current = true
     try {
-      const conversation = await window.electronAPI.createConversation(
-        '预览选区问答',
-        selectedChatModel?.modelId,
-        selectedChatModel?.channelId,
-      )
-      setConversations((prev) => {
-        if (prev.some((item) => item.id === conversation.id)) return prev
-        return [conversation, ...prev]
+      const branch = await window.electronAPI.forkAgentSession({
+        sessionId,
+        upToMessageUuid: sourceMessageId,
+        explorationSourceLabel: `当前节点 · ${getPreviewPathLabel(previewSelection.filePath)}`,
       })
-      setConversationDrafts((prev) => {
+      setAgentSessions((prev) => prev.some((item) => item.id === branch.id) ? prev : [branch, ...prev])
+      setQuotedSelectionMap((prev) => new Map(prev).set(branch.id, {
+        text: previewSelection.text,
+        filePath: previewSelection.filePath,
+        sourceType: 'file',
+        sourceLabel: previewSelection.filePath,
+        capturedAt: Date.now(),
+      }))
+      setSideTemporaryAgentMap((prev) => {
+        const openBranches = prev.get(sessionId) ?? []
         const next = new Map(prev)
-        next.set(conversation.id, '我的问题：')
-        return next
-      })
-      setQuotedSelectionMap((prev) => {
-        const next = new Map(prev)
-        next.set(conversation.id, {
-          text: previewSelection.text,
-          filePath: previewSelection.filePath,
-          sourceType: 'file',
-          sourceLabel: previewSelection.filePath,
-          capturedAt: Date.now(),
-        })
-        return next
-      })
-      setSideChatMap((prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, conversation.id)
+        next.set(sessionId, openBranches.some((item) => item.sessionId === branch.id)
+          ? openBranches
+          : [...openBranches, {
+              sessionId: branch.id,
+              sourceMessageId,
+              sourceLabel: `当前节点 · ${getPreviewPathLabel(previewSelection.filePath)}`,
+            }])
         return next
       })
       setSidePanelOpen(true)
-      setSidePanelTabMap((prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, 'chat')
-        return next
-      })
+      setSidePanelTabMap((prev) => new Map(prev).set(sessionId, getExplorationSidePanelTab(branch.id)))
       window.getSelection()?.removeAllRanges()
       clearPreviewSelection()
+      toast.success('已从当前节点创建探索分支', { description: '文件选区已带入分支；结论可回到主线输入框。' })
     } catch (error) {
-      console.error('[DiffTabContent] 打开预览选区聊天标签失败:', error)
-      toast.error('打开聊天标签失败')
+      console.error('[DiffTabContent] 创建文件探索分支失败:', error)
+      toast.error('创建探索分支失败', { description: error instanceof Error ? error.message : undefined })
     } finally {
-      openSelectionChatPendingRef.current = false
+      openTemporaryAgentPendingRef.current = false
     }
-  }, [
-    clearPreviewSelection,
-    previewSelection,
-    selectedChatModel,
-    sessionId,
-    setConversationDrafts,
-    setConversations,
-    setQuotedSelectionMap,
-    setSideChatMap,
-    setSidePanelOpen,
-    setSidePanelTabMap,
-  ])
+  }, [agentSessions, clearPreviewSelection, previewSelection, sessionId, setAgentSessions, setQuotedSelectionMap, setSidePanelOpen, setSidePanelTabMap, setSideTemporaryAgentMap])
 
   // persistRef 始终持有最新 persistMarkdownDraft，供 setTimeout / unmount cleanup 调用。
   // 用 effect 而非渲染期赋值，避免 React 19 严格模式下并发渲染中途读到中间态。
@@ -1920,7 +1904,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             x={previewSelection.x}
             y={previewSelection.y}
             onAddToAgent={handleAddSelectionToAgent}
-            onOpenChat={handleOpenSelectionChat}
+            onOpenExplorationBranch={handleOpenExplorationBranch}
           />
         )}
       </div>

--- a/apps/electron/src/renderer/components/selection/SelectionActionPopover.tsx
+++ b/apps/electron/src/renderer/components/selection/SelectionActionPopover.tsx
@@ -1,19 +1,27 @@
 import * as React from 'react'
-import { Bot, MessageCircle } from 'lucide-react'
+import { Bot, MessageSquarePlus } from 'lucide-react'
 
 interface SelectionActionPopoverProps {
   x: number
   y: number
   onAddToAgent: () => void
-  onOpenChat: () => void | Promise<void>
+  /** Pi `/tree`：从当前 Agent 历史节点创建右侧探索分支。 */
+  onOpenExplorationBranch?: () => void | Promise<void>
+  /** 兼容尚未迁移的临时 Agent 入口。 */
+  onOpenTemporaryAgent?: () => void | Promise<void>
+  /** 兼容尚未迁移的文件 / Scratch 选区入口。 */
+  onOpenChat?: () => void | Promise<void>
 }
 
 export function SelectionActionPopover({
   x,
   y,
   onAddToAgent,
+  onOpenExplorationBranch,
+  onOpenTemporaryAgent,
   onOpenChat,
 }: SelectionActionPopoverProps): React.ReactElement {
+  const openSideAssistant = onOpenExplorationBranch ?? onOpenTemporaryAgent ?? onOpenChat
   return (
     <div
       data-selection-action-popover
@@ -30,16 +38,18 @@ export function SelectionActionPopover({
           <Bot className="size-4" />
           为 Agent 引用
         </button>
-        <button
-          type="button"
-          className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
-          onClick={() => {
-            void onOpenChat()
-          }}
-        >
-          <MessageCircle className="size-4" />
-          打开右侧问答
-        </button>
+        {openSideAssistant && (
+          <button
+            type="button"
+            className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+            onClick={() => {
+              void openSideAssistant()
+            }}
+          >
+            <MessageSquarePlus className="size-4" />
+            {onOpenExplorationBranch ? '探索此分支' : onOpenTemporaryAgent ? '打开临时 Agent' : '打开右侧问答'}
+          </button>
+        )}
       </div>
     </div>
   )

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -135,7 +135,7 @@ export function GlobalShortcuts(): null {
       if (
         isActiveAgentSidePanelOpen
         && activeAgentSidePanelTab
-        && (activeAgentSidePanelTab === 'memory' || activeAgentSidePanelTab.startsWith('preview:') || activeAgentSidePanelTab.startsWith('browser:'))
+        && (activeAgentSidePanelTab === 'memory' || activeAgentSidePanelTab.startsWith('preview:') || activeAgentSidePanelTab.startsWith('browser:') || activeAgentSidePanelTab.startsWith('exploration:') || activeAgentSidePanelTab.startsWith('delegation:'))
       ) {
         window.dispatchEvent(new CustomEvent(CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT, {
           detail: { sessionId: activeTab.sessionId },

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -51,6 +51,8 @@ import {
   agentNonGitFileChangesAtom,
   agentFileChangesCurrentRunAtom,
   agentSidePanelOpenAtomFamily,
+  agentSideDelegationMapAtom,
+  getDelegationSidePanelTab,
   askUserDraftsAtom,
 } from '@/atoms/agent-atoms'
 import {
@@ -698,6 +700,26 @@ export function useGlobalAgentListeners(): void {
           map.set(event.sessionId, activation.streamState)
           return map
         })
+
+        // 协作子 Agent 是用户可检查的独立执行单元：启动时保持左侧树不变，
+        // 但将其自动聚焦到父会话右侧工作区，直接观察流式输出。
+        if (upserted.sourceDelegationId && upserted.parentSessionId) {
+          const parentSession = store.get(agentSessionsAtom).find((item) => item.id === upserted.parentSessionId)
+          makeNavigateToSession(upserted.parentSessionId, parentSession?.title ?? '父会话')()
+          store.set(agentSideDelegationMapAtom, (previous) => {
+            const openChildIds = previous.get(upserted.parentSessionId!) ?? []
+            if (openChildIds.includes(upserted.id)) return previous
+            const next = new Map(previous)
+            next.set(upserted.parentSessionId!, [...openChildIds, upserted.id])
+            return next
+          })
+          store.set(agentSidePanelOpenAtomFamily(upserted.parentSessionId), true)
+          store.set(agentDiffPanelTabAtom, (previous) => {
+            const next = new Map(previous)
+            next.set(upserted.parentSessionId!, getDelegationSidePanelTab(upserted.id))
+            return next
+          })
+        }
       }
 
       if (event.session) {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -769,6 +769,14 @@ export interface AgentSessionMeta {
   attachedFiles?: string[]
   /** 分叉来源：源会话的 Proma 工作目录（SDK session 文件在此目录的项目空间中，首次 resume 后清除） */
   forkSourceDir?: string
+  /** Pi `/tree` 探索分支所属的主线会话；仅探索分支设置，普通 fork 保持 undefined。 */
+  explorationParentSessionId?: string
+  /** Pi `/tree` 探索分支的 assistant 分叉锚点。 */
+  explorationSourceMessageId?: string
+  /** 用户可读的分叉来源，用于重新打开探索分支时恢复上下文提示。 */
+  explorationSourceLabel?: string
+  /** 探索分支的首条新增用户消息已触发过一次标题初始化，防止后续对话覆盖该名称。 */
+  explorationTitleInitializedAt?: number
   /** 历史兼容字段：旧版手动保留状态 */
   manualWorking?: boolean
   /** Agent 执行完成但用户尚未清除完成状态 */
@@ -1280,6 +1288,8 @@ export interface ForkSessionInput {
   upToMessageUuid?: string
   /** 目标模型 ID。省略时继承源会话模型；传入时必须属于源会话同一渠道且已启用 */
   modelId?: string
+  /** 标记为 Pi `/tree` 探索分支，并持久化其在主线中的来源，供关闭后重新打开。 */
+  explorationSourceLabel?: string
 }
 
 /** 快照回退输入（同一会话内回退到指定点） */


### PR DESCRIPTION
## Summary
- 将 Pi `/tree` 探索分支作为可并存、可重开的右侧 Agent Tab，并支持从回复与文件选区创建。
- 探索分支与协作子 Agent 统一嵌入式会话布局；带回时以“这是探索后的新增内容：”追加结构化 `&session` 引用，且保留探索 Tab。
- 修复 Agent Island 已读 IPC 在窗口启动早期缺少 handler 的竞态。

## Validation
- `bun run typecheck`
- `bun test apps/electron/src/main/lib/agent-session-manager.test.ts apps/electron/src/main/lib/macos-version.test.ts apps/electron/src/main/lib/windows-agent-island-surface.test.ts`
- `bun run --filter @proma/electron build:main`
- `bun run --filter @proma/electron build:renderer`
- Electron 启动冒烟（探索/Agent Island）
- `git diff --check`

## Performance
- 右侧 Tab 状态仅在创建、切换、关闭或会话元数据变更时更新；流式内容继续由既有会话级订阅渲染，未新增 IPC、计时器或全局轮询。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
