### PR TITLE
fix(agent): restore running session indicators

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -47,6 +47,7 @@ import type {
   FileOrFolderDialogResult,
   RecentMessagesResult,
   AgentSessionMeta,
+  AgentActiveSessionSnapshot,
   SetAgentSessionActiveWorktreeInput,
   AgentSendInput,
   AgentThinkingLevel,
@@ -278,7 +279,7 @@ import {
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, isAgentSessionBusy, reserveAgentSessionStart, queueAgentMessage, submitOrEnqueueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, isAgentSessionBusy, listActiveAgentSessionSnapshots, reserveAgentSessionStart, queueAgentMessage, submitOrEnqueueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -2059,6 +2060,12 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_ACTIVE_SESSIONS,
     async (): Promise<AgentSessionMeta[]> => listActiveAgentSessions(),
+  )
+
+  // 获取当前主进程仍在执行的 Agent 会话快照，供 renderer 重载后恢复运行态
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.ACTIVE_SESSIONS_SNAPSHOT,
+    async (): Promise<AgentActiveSessionSnapshot[]> => listActiveAgentSessionSnapshots(),
   )
 
   // 获取归档会话列表（进入归档视图时按需加载）

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { accessSync, constants, existsSync, mkdirSync, realpathSync } from 'node:fs'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
 import { app } from 'electron'
-import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, SDKMessage, SDKAssistantMessage, AgentStreamPayload, AgentAssistantDeltaPayload, RewindSessionResult, SkillActivation } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, AgentActiveSessionSnapshot, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, SDKMessage, SDKAssistantMessage, AgentStreamPayload, AgentAssistantDeltaPayload, RewindSessionResult, SkillActivation } from '@proma/shared'
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
@@ -229,6 +229,7 @@ export class AgentOrchestrator {
   private adapter: AgentProviderAdapter
   private eventBus: AgentEventBus
   private activeSessions = new Map<string, number>()
+  private activeSessionStartedAt = new Map<string, number>()
   private nextRunGeneration = 0
 
   /** 队列消息本地记录（sessionId → UUID 集合，用于防重） */
@@ -890,6 +891,7 @@ export class AgentOrchestrator {
     }
     const runGeneration = ++this.nextRunGeneration
     this.activeSessions.set(sessionId, runGeneration)
+    this.activeSessionStartedAt.set(sessionId, streamStartedAt)
     callbacks.onRunStarted?.({ startedAt: streamStartedAt })
 
     const releaseActiveRun = (): void => {
@@ -898,6 +900,7 @@ export class AgentOrchestrator {
       const ownsActiveRun = this.activeSessions.get(sessionId) === runGeneration
       if (ownsActiveRun) {
         this.activeSessions.delete(sessionId)
+        this.activeSessionStartedAt.delete(sessionId)
         this.sessionPermissionModes.delete(sessionId)
         this.queuedMessageUuids.delete(sessionId)
       }
@@ -2133,6 +2136,7 @@ export class AgentOrchestrator {
   stop(sessionId: string, stopBeforeRun = false): void {
     const runGeneration = this.activeSessions.get(sessionId)
     this.activeSessions.delete(sessionId)
+    this.activeSessionStartedAt.delete(sessionId)
     this.sessionPermissionModes.delete(sessionId)
     browserController.cancelSession(sessionId)
     if (runGeneration != null) {
@@ -2150,6 +2154,14 @@ export class AgentOrchestrator {
   /** 检查指定会话是否正在处理中 */
   isActive(sessionId: string): boolean {
     return this.activeSessions.has(sessionId)
+  }
+
+  /** 返回主进程当前仍在执行的 Agent，会话重载时供 renderer 恢复运行指示。 */
+  listActiveSessionSnapshots(): AgentActiveSessionSnapshot[] {
+    return [...this.activeSessions.keys()].map((sessionId) => ({
+      sessionId,
+      startedAt: this.activeSessionStartedAt.get(sessionId) ?? Date.now(),
+    }))
   }
 
   /** 是否存在任意运行中 Agent（含后台运行与外部触发的会话）。 */
@@ -2243,6 +2255,7 @@ export class AgentOrchestrator {
     // 即便 activeSessions 为空，也要调 dispose 清理可能残留的 pidMap / 子进程
     this.adapter.dispose()
     this.activeSessions.clear()
+    this.activeSessionStartedAt.clear()
     this.sessionPermissionModes.clear()
     this.stoppedBeforeRunSessions.clear()
     this.queuedMessageUuids.clear()
@@ -2361,6 +2374,7 @@ export class AgentOrchestrator {
       if (isMissingActiveQueueChannelError(error)) {
         console.warn(`[Agent 编排] 队列注入失败且消息通道已失效，释放陈旧运行状态: sessionId=${sessionId}`)
         this.activeSessions.delete(sessionId)
+        this.activeSessionStartedAt.delete(sessionId)
         this.sessionPermissionModes.delete(sessionId)
         this.queuedMessageUuids.delete(sessionId)
       }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -32,6 +32,7 @@ import type {
   AgentMoveQueuedMessageInput,
   PromaPermissionMode,
   AgentExternalRunSource,
+  AgentActiveSessionSnapshot,
   AgentMessage,
 } from '@proma/shared'
 import { PiAgentAdapter } from './adapters/pi-agent-adapter'
@@ -488,6 +489,10 @@ export function isAgentSessionActive(sessionId: string): boolean {
 /** 是否存在任意运行中 Agent，供更新器等全局生命周期服务安全判断。 */
 export function hasActiveAgentSessions(): boolean {
   return orchestrator.hasActiveSessions()
+}
+
+export function listActiveAgentSessionSnapshots(): AgentActiveSessionSnapshot[] {
+  return orchestrator.listActiveSessionSnapshots()
 }
 
 /** 中止所有活跃的 Agent 会话（应用退出时调用） */

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -38,6 +38,7 @@ import type {
   RecentMessagesResult,
   MessageSearchResult,
   AgentSessionMeta,
+  AgentActiveSessionSnapshot,
   SetAgentSessionActiveWorktreeInput,
   SDKMessage,
   AgentSendInput,
@@ -518,6 +519,9 @@ export interface ElectronAPI {
 
   /** 创建 Agent 会话 */
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => Promise<AgentSessionMeta>
+
+  /** 获取当前主进程仍在执行的 Agent 会话，供 renderer 重载后恢复运行态 */
+  listActiveAgentSessionSnapshots: () => Promise<AgentActiveSessionSnapshot[]>
 
   /** 获取 Agent 会话 SDKMessage（Phase 4 新格式） */
   getAgentSessionSDKMessages: (id: string) => Promise<SDKMessage[]>
@@ -1717,6 +1721,10 @@ const electronAPI: ElectronAPI = {
 
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CREATE_SESSION, title, channelId, workspaceId, modelId)
+  },
+
+  listActiveAgentSessionSnapshots: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ACTIVE_SESSIONS_SNAPSHOT)
   },
 
   getAgentSessionSDKMessages: (id: string) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -851,6 +851,9 @@ export function useGlobalAgentListeners(): void {
     }
 
     const isWindows = detectIsWindows()
+    // 初始化快照与 STREAM_COMPLETE 可跨 IPC channel 乱序抵达。完成处理回收
+    // startedAt 后仍需保留一个短生命周期的终态标记，避免迟到快照复活旧 run。
+    const latestTerminalRunStartedAt = new Map<string, number>()
 
     /**
      * 当前前台会话在本轮首次产生文件改动时，自动展开右侧工作区并切到「改动」。
@@ -943,7 +946,11 @@ export function useGlobalAgentListeners(): void {
       unstable_batchedUpdates(() => {
         for (const snapshot of snapshots) {
           store.set(agentSessionStreamingStateAtomFamily(snapshot.sessionId), (existing) => {
-            return mergeActiveAgentSessionSnapshot(existing, snapshot)
+            return mergeActiveAgentSessionSnapshot(
+              existing,
+              snapshot,
+              latestTerminalRunStartedAt.get(snapshot.sessionId),
+            )
           })
         }
       })
@@ -972,6 +979,10 @@ export function useGlobalAgentListeners(): void {
           ? payload.event
           : null
         if (runStartedEvent) {
+          const latestTerminalStartedAt = latestTerminalRunStartedAt.get(sessionId)
+          if (latestTerminalStartedAt != null && runStartedEvent.startedAt > latestTerminalStartedAt) {
+            latestTerminalRunStartedAt.delete(sessionId)
+          }
           // 队列 run 会先通过独立 IPC 发送 started 投影，但该投影可能在窗口
           // 重载或跨 renderer 路由时丢失。run_started 是同一轮的第二个权威启动信号，
           // 必须在首个 SDK/tool 事件之前恢复 running、startedAt 和正常的 live UI。
@@ -1461,6 +1472,12 @@ export function useGlobalAgentListeners(): void {
         // 不发"任务已完成"通知（任务并未真正完成）、不清后台任务列表、不重载消息——
         // 等后台任务完成时 Agent 会自动唤醒续轮。
         const backgroundTasksPending = data.backgroundTasksPending === true
+        if (!backgroundTasksPending && data.startedAt != null) {
+          const previousTerminalStartedAt = latestTerminalRunStartedAt.get(data.sessionId)
+          if (previousTerminalStartedAt == null || data.startedAt > previousTerminalStartedAt) {
+            latestTerminalRunStartedAt.set(data.sessionId, data.startedAt)
+          }
+        }
         const hasStreamError = store.get(agentStreamErrorsAtom).has(data.sessionId)
 
         // 主进程随完成事件携带刚落盘的单条 meta；不要为此重新拉取整个会话索引。

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -84,6 +84,7 @@ import { getSessionFileChangeKind, getOwnedSessionWatcherPaths, upsertSessionFil
 import { removeQueuedMessage, createQueuedAgentStreamState } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
 import { getChangedWorkspaceComponentFromSdkMessage } from '@/lib/agent-component-activation'
+import { mergeActiveAgentSessionSnapshot } from '@/lib/agent-active-session-snapshot'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -935,7 +936,19 @@ export function useGlobalAgentListeners(): void {
       })().catch(() => { /* 文件监听不应影响会话流 */ })
     })
 
-    // ===== 0. 初始化：从持久化 meta 恢复 stoppedByUser 状态 =====
+    // ===== 0. 初始化：恢复 stoppedByUser 与主进程真实运行态 =====
+    // 运行态不落盘，窗口重载或 renderer 晚订阅时必须从主进程 activeSessions
+    // 补一份快照；快照只提升缺失/更旧的状态，不覆盖已收到的完成态。
+    window.electronAPI.listActiveAgentSessionSnapshots().then((snapshots) => {
+      unstable_batchedUpdates(() => {
+        for (const snapshot of snapshots) {
+          store.set(agentSessionStreamingStateAtomFamily(snapshot.sessionId), (existing) => {
+            return mergeActiveAgentSessionSnapshot(existing, snapshot)
+          })
+        }
+      })
+    }).catch(console.error)
+
     window.electronAPI.listActiveAgentSessions().then((sessions) => {
       const stoppedIds = new Set<string>(
         sessions.filter((s) => s.stoppedByUser).map((s) => s.id)

--- a/apps/electron/src/renderer/lib/agent-active-session-snapshot.test.ts
+++ b/apps/electron/src/renderer/lib/agent-active-session-snapshot.test.ts
@@ -24,4 +24,8 @@ describe('mergeActiveAgentSessionSnapshot', () => {
 
     expect(mergeActiveAgentSessionSnapshot(current, snapshot)).toBe(current)
   })
+
+  test('does not resurrect a completed run after its renderer state was reclaimed', () => {
+    expect(mergeActiveAgentSessionSnapshot(undefined, snapshot, 100)).toBeUndefined()
+  })
 })

--- a/apps/electron/src/renderer/lib/agent-active-session-snapshot.test.ts
+++ b/apps/electron/src/renderer/lib/agent-active-session-snapshot.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { mergeActiveAgentSessionSnapshot } from './agent-active-session-snapshot'
+
+describe('mergeActiveAgentSessionSnapshot', () => {
+  const snapshot = { sessionId: 'session-1', startedAt: 100 }
+
+  test('restores a missing renderer stream state from the main-process snapshot', () => {
+    expect(mergeActiveAgentSessionSnapshot(undefined, snapshot)).toMatchObject({
+      running: true,
+      startedAt: 100,
+    })
+  })
+
+  test('does not resurrect a completed stream with an equal or newer run marker', () => {
+    const completedCurrent = { running: false, startedAt: 100 }
+    const newerCurrent = { running: false, startedAt: 200 }
+
+    expect(mergeActiveAgentSessionSnapshot(completedCurrent, snapshot)).toBe(completedCurrent)
+    expect(mergeActiveAgentSessionSnapshot(newerCurrent, snapshot)).toBe(newerCurrent)
+  })
+
+  test('keeps the current run when it is at least as new as the snapshot', () => {
+    const current = { running: true, startedAt: 100, model: 'gpt-5.6' }
+
+    expect(mergeActiveAgentSessionSnapshot(current, snapshot)).toBe(current)
+  })
+})

--- a/apps/electron/src/renderer/lib/agent-active-session-snapshot.ts
+++ b/apps/electron/src/renderer/lib/agent-active-session-snapshot.ts
@@ -9,7 +9,11 @@ import { createQueuedAgentStreamState } from './agent-message-queue'
 export function mergeActiveAgentSessionSnapshot(
   current: AgentStreamState | undefined,
   snapshot: AgentActiveSessionSnapshot,
+  latestTerminalStartedAt?: number,
 ): AgentStreamState | undefined {
+  // 完成处理可能已回收 state.startedAt；单独保留本次挂载期间收到的终态标记，
+  // 防止 IPC 快照先在主进程取到、却在完成事件之后才抵达 renderer 时复活旧 run。
+  if (latestTerminalStartedAt != null && latestTerminalStartedAt >= snapshot.startedAt) return current
   if (current?.startedAt != null && current.startedAt >= snapshot.startedAt) return current
   return createQueuedAgentStreamState(current, snapshot.startedAt)
 }

--- a/apps/electron/src/renderer/lib/agent-active-session-snapshot.ts
+++ b/apps/electron/src/renderer/lib/agent-active-session-snapshot.ts
@@ -1,0 +1,15 @@
+import type { AgentActiveSessionSnapshot } from '@proma/shared'
+import type { AgentStreamState } from '@/atoms/agent-atoms'
+import { createQueuedAgentStreamState } from './agent-message-queue'
+
+/**
+ * 将主进程快照合并到 renderer 的运行态。旧快照不能覆盖已收到的更晚状态，
+ * 防止初始化 IPC 与同一会话的完成事件交错时重新显示已结束的 Agent。
+ */
+export function mergeActiveAgentSessionSnapshot(
+  current: AgentStreamState | undefined,
+  snapshot: AgentActiveSessionSnapshot,
+): AgentStreamState | undefined {
+  if (current?.startedAt != null && current.startedAt >= snapshot.startedAt) return current
+  return createQueuedAgentStreamState(current, snapshot.startedAt)
+}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1328,6 +1328,12 @@ export interface AgentStreamEvent {
   event?: AgentEvent
 }
 
+export interface AgentActiveSessionSnapshot {
+  sessionId: string
+  /** 对应当前运行实例的启动时间，用于拒绝陈旧的 renderer 恢复快照。 */
+  startedAt: number
+}
+
 /**
  * Agent 流式完成事件载荷（主进程 → 渲染进程）
  * 包含已持久化的消息列表，避免异步重新加载的竞态窗口。
@@ -1655,6 +1661,8 @@ export const AGENT_IPC_CHANNELS = {
   COUNT_ARCHIVED_SESSIONS: 'agent:count-archived-sessions',
   /** 创建会话 */
   CREATE_SESSION: 'agent:create-session',
+  /** 获取当前主进程仍在执行的 Agent 会话快照 */
+  ACTIVE_SESSIONS_SNAPSHOT: 'agent:active-sessions-snapshot',
   /** 获取会话 SDKMessage（Phase 4 新格式） */
   GET_SDK_MESSAGES: 'agent:get-sdk-messages',
   /** 更新会话标题 */


### PR DESCRIPTION
## Summary

- Restore renderer running indicators from the main-process active Agent session snapshot after renderer reload or late event subscription.
- Preserve newer renderer lifecycle state so completed or stopped runs cannot be resurrected by an older snapshot.
- Add regression coverage for missing, completed, and current run states.

## Test plan

- [x] bun test ./apps/electron/src/renderer/lib/agent-active-session-snapshot.test.ts
- [x] bun run typecheck
- [x] bun run electron:build

Performance impact: one lightweight IPC snapshot when the global Agent listener mounts; no polling or additional streaming-path updates.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)