### PR TITLE
Fix preview metadata fallback

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3571,7 +3571,7 @@ export function registerIpcHandlers(): void {
   // 解析文件路径并读取内容（供内联预览使用）
   ipcMain.handle(
     'file:resolve-and-read',
-    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<{ resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null> => {
+    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<import('@proma/shared').FilePreviewReadResult | null> => {
       const { resolveAndReadFile, resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
       const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -12,7 +12,7 @@ import { createRequire } from 'node:module'
 import { createHash } from 'node:crypto'
 import AdmZip from 'adm-zip'
 import { DOMParser } from '@xmldom/xmldom'
-import type { OfficePreviewResult } from '@proma/shared'
+import type { FilePreviewReadResult, OfficePreviewResult } from '@proma/shared'
 
 const require = createRequire(__filename)
 const PDFJS_PACKAGE = 'pdfjs-dist'
@@ -570,20 +570,26 @@ function readSafeText(content: Buffer): string | null {
 }
 
 /** 解析文件路径并读取内容（供内联文本/代码预览使用） */
-export function resolveAndReadFile(filePath: string, basePaths?: string[]): { resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null {
+export function resolveAndReadFile(filePath: string, basePaths?: string[]): FilePreviewReadResult | null {
   const safePath = resolveTargetPath(filePath, basePaths)
   if (!existsSync(safePath)) return null
   try {
     const st = statSync(safePath)
+    const metadata = {
+      name: basename(safePath),
+      extension: extname(safePath).toLowerCase(),
+      size: st.size,
+      modifiedAt: st.mtimeMs,
+    }
     if (st.size > MAX_TEXT_PREVIEW_SIZE) {
-      return { resolvedPath: safePath, content: '', isBinary: false, isTooLarge: true }
+      return { resolvedPath: safePath, content: '', isBinary: false, isTooLarge: true, metadata }
     }
     const rawContent = readFileSync(safePath)
     const content = readSafeText(rawContent)
     if (content === null) {
-      return { resolvedPath: safePath, content: '', isBinary: true, isTooLarge: false }
+      return { resolvedPath: safePath, content: '', isBinary: true, isTooLarge: false, metadata }
     }
-    return { resolvedPath: safePath, content, isBinary: false, isTooLarge: false }
+    return { resolvedPath: safePath, content, isBinary: false, isTooLarge: false, metadata }
   } catch {
     return null
   }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -885,7 +885,7 @@ export interface ElectronAPI {
   showItemInFolder: (filePath: string, candidateBasePaths?: string[]) => Promise<boolean>
 
   /** 解析文件路径并读取内容（供内联预览使用） */
-  resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<{ resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null>
+  resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<import('@proma/shared').FilePreviewReadResult | null>
 
   /** 写入文本文件（供 Markdown 内联编辑使用） */
   writeTextFile: (filePath: string, content: string, access?: import('@proma/shared').FileAccessOptions) => Promise<boolean>
@@ -2269,7 +2269,7 @@ const electronAPI: ElectronAPI = {
   },
 
   resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
-    return ipcRenderer.invoke('file:resolve-and-read', filePath, access) as Promise<{ resolvedPath: string; content: string; isBinary: boolean; isTooLarge: boolean } | null>
+    return ipcRenderer.invoke('file:resolve-and-read', filePath, access) as Promise<import('@proma/shared').FilePreviewReadResult | null>
   },
 
   writeTextFile: (filePath: string, content: string, access?: import('@proma/shared').FileAccessOptions) => {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -11,6 +11,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
 import { toast } from 'sonner'
+import type { FilePreviewMetadata } from '@proma/shared'
 import { cn } from '@/lib/utils'
 import {
   agentDiffPanelTabAtom,
@@ -31,6 +32,7 @@ import { DiffView } from './DiffView'
 import { MarkdownRichEditor } from './MarkdownRichEditor'
 import { getPreviewCandidateBasePaths, isAbsoluteFilePath } from './preview-open-path'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
+import { UnsupportedFilePreview } from './UnsupportedFilePreview'
 import { PreviewFindBar } from './PreviewFindBar'
 import { MarkdownToc } from './MarkdownToc'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -98,6 +100,8 @@ type CacheEntry = {
   htmlPreviewUrl?: string
   /** 二进制或其他不可安全内联渲染的文件提示 */
   unsupportedPreviewReason?: string
+  /** 无法内联预览时由主进程返回的安全基础元数据。 */
+  previewMetadata?: FilePreviewMetadata
 }
 
 interface DeepSelection {
@@ -296,6 +300,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [oldContent, setOldContent] = React.useState('')
   const [newContent, setNewContent] = React.useState('')
   const [unsupportedPreviewReason, setUnsupportedPreviewReason] = React.useState('')
+  const [previewMetadata, setPreviewMetadata] = React.useState<FilePreviewMetadata | undefined>()
   const [markdownEditing, setMarkdownEditing] = React.useState(
     () => Boolean(initialMarkdownEditorState?.editing),
   )
@@ -810,6 +815,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       setOfficeText(cached.officeText ?? '')
       setHtmlPreviewUrl(cached.htmlPreviewUrl ?? '')
       setUnsupportedPreviewReason(cached.unsupportedPreviewReason ?? '')
+      setPreviewMetadata(cached.previewMetadata)
       setPdfSrc(cached.pdfSrc ?? '')
       setPdfZoom(100)
       setImagePath(cached.imagePath ?? '')
@@ -832,6 +838,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         setOfficeText('')
         setHtmlPreviewUrl('')
         setUnsupportedPreviewReason('')
+        setPreviewMetadata(undefined)
         setPdfSrc('')
         setPdfZoom(100)
         setImagePath('')
@@ -907,7 +914,13 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                 ? '此文本文件超过 5 MB，无法安全进行内联预览，请使用默认应用打开。'
                 : '此二进制或编码异常文件暂不支持内联预览，请使用默认应用打开。'
               setUnsupportedPreviewReason(reason)
-              cacheSet(cacheKey, { oldContent: '', newContent: '', unsupportedPreviewReason: reason })
+              setPreviewMetadata(result.metadata)
+              cacheSet(cacheKey, {
+                oldContent: '',
+                newContent: '',
+                unsupportedPreviewReason: reason,
+                previewMetadata: result.metadata,
+              })
               return
             }
             content = result?.content ?? ''
@@ -1706,9 +1719,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">加载中...</div>
           ) : (previewOnly || isOfficePreview) ? (
             unsupportedPreviewReason ? (
-              <div className="flex h-full items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
-                {unsupportedPreviewReason}
-              </div>
+              <UnsupportedFilePreview
+                filePath={previewTargetPath}
+                access={fileAccess}
+                reason={unsupportedPreviewReason}
+                metadata={previewMetadata}
+              />
             ) : isPdf ? (
               pdfSrc ? (
                 <div className="relative h-full">

--- a/apps/electron/src/renderer/components/diff/UnsupportedFilePreview.tsx
+++ b/apps/electron/src/renderer/components/diff/UnsupportedFilePreview.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import { FileWarning } from 'lucide-react'
+import type { FileAccessOptions, FilePreviewMetadata } from '@proma/shared'
+import { DefaultAppOpenButton } from './DefaultAppOpenButton'
+
+interface UnsupportedFilePreviewProps {
+  filePath: string
+  access?: FileAccessOptions
+  reason: string
+  metadata?: FilePreviewMetadata
+}
+
+function formatFileSize(size: number): string {
+  if (size < 1024) return `${size} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = size
+  let index = -1
+  do {
+    value /= 1024
+    index += 1
+  } while (value >= 1024 && index < units.length - 1)
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${units[index]}`
+}
+
+function formatModifiedAt(modifiedAt: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(modifiedAt)
+}
+
+/**
+ * 二进制、超限或编码异常文件的安全降级卡片。
+ *
+ * 只展示来自主进程 stat 的基础元数据，绝不尝试读取或解码原始内容。
+ */
+export function UnsupportedFilePreview({
+  filePath,
+  access,
+  reason,
+  metadata,
+}: UnsupportedFilePreviewProps): React.ReactElement {
+  return (
+    <div className="flex h-full items-center justify-center px-6 py-10 text-center">
+      <div className="w-full max-w-sm rounded-xl bg-muted/35 p-5 shadow-[0_1px_2px_rgba(0,0,0,0.06),0_8px_24px_rgba(0,0,0,0.05)]">
+        <FileWarning className="mx-auto size-7 text-muted-foreground/80" aria-hidden="true" />
+        <h2 className="mt-3 text-sm font-medium text-foreground text-balance">无法安全内联预览</h2>
+        <p className="mt-1.5 text-[13px] leading-5 text-muted-foreground text-pretty">{reason}</p>
+
+        {metadata && (
+          <dl className="mt-4 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 rounded-lg bg-background/70 px-3 py-2.5 text-left text-xs">
+            <dt className="text-muted-foreground">文件</dt>
+            <dd className="truncate text-foreground" title={metadata.name}>{metadata.name}</dd>
+            <dt className="text-muted-foreground">类型</dt>
+            <dd className="text-foreground">{metadata.extension || '无扩展名'}</dd>
+            <dt className="text-muted-foreground">大小</dt>
+            <dd className="tabular-nums text-foreground">{formatFileSize(metadata.size)}</dd>
+            <dt className="text-muted-foreground">修改时间</dt>
+            <dd className="tabular-nums text-foreground">{formatModifiedAt(metadata.modifiedAt)}</dd>
+          </dl>
+        )}
+
+        <DefaultAppOpenButton
+          filePath={filePath}
+          access={access}
+          variant="labeled"
+          className="mx-auto mt-4 h-9 max-w-[220px] border border-border/60 bg-background px-3 shadow-sm"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -274,6 +274,32 @@ export interface DefaultAppInfo {
   iconDataUrl: string
 }
 
+/** 无法内联渲染时仍可安全展示的基础文件信息。 */
+export interface FilePreviewMetadata {
+  /** 已解析文件的名称，不包含目录。 */
+  name: string
+  /** 小写扩展名，包含点；无扩展名时为空字符串。 */
+  extension: string
+  /** 文件大小（字节）。 */
+  size: number
+  /** 最近修改时间（Unix milliseconds）。 */
+  modifiedAt: number
+}
+
+/** 主进程完成安全文本检测后的预览读取结果。 */
+export interface FilePreviewReadResult {
+  /** 已解析的本机绝对路径，仅用于现有受控预览链路。 */
+  resolvedPath: string
+  /** 仅当 isBinary/isTooLarge 均为 false 时返回安全文本。 */
+  content: string
+  /** 内容不是可安全传给文本高亮器的 UTF-8 文本。 */
+  isBinary: boolean
+  /** 文件超过内联文本预览的大小上限。 */
+  isTooLarge: boolean
+  /** 无论是否可内联预览都返回的基础元数据。 */
+  metadata: FilePreviewMetadata
+}
+
 /** Windows Agent Shell 偏好：默认自动选择 Git Bash，用户可显式改用 WSL。 */
 export type WindowsShellPreference = 'auto' | 'git-bash' | 'wsl'
 


### PR DESCRIPTION
## Summary

- Return safe file metadata with unsupported binary and oversized preview results.
- Render a metadata fallback card with the system-default app open action.
- Bump the Electron app patch version.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run electron:build`
- [ ] Manually open a `.dmg` preview in Electron and confirm the fallback card and default-app action.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)