### PR TITLE
fix(browser): avoid empty tab for history links

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.65",
+  "version": "0.17.66",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -1020,7 +1020,9 @@ export class BrowserController {
 
   /** 用户在浏览器面板中新建 tab；不会抢占 Agent 的工作 tab。 */
   async createDisplayTab(sessionId: string, url?: string): Promise<BrowserViewState> {
-    const browserSession = this.getOrCreateSession(sessionId, [], false)
+    // 首次由历史链接携带 URL 创建时，此标签本身就是初始展示标签；不要先经
+    // getOrCreateSession 预建一个空白标签，否则会留下无用的空 Tab。
+    const browserSession = this.sessions.get(sessionId) ?? this.createSession(sessionId)
     this.assertRiskDisclaimerAcknowledged()
     this.markUserBrowserContext(browserSession)
     const tab = this.createTab(browserSession)


### PR DESCRIPTION
## Summary

- 6a3e1af6 fix(browser): avoid empty tab for history links

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)