### PR TITLE
fix(agent): isolate embedded model selector state

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2925,7 +2925,9 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
           externalSelectedModel={externalSelectedModel}
           onModelSelect={handleModelSelect}
           showChannelInTrigger
-          useSharedOpenState
+          // 全局打开状态只供主会话的“选择模型”引导使用；右侧嵌入会话必须保持独立，
+          // 否则任一触发器打开时会同时挂载两侧的 Popover，遮挡并阻断模型切换。
+          useSharedOpenState={!embedded}
         />
       </div>
       {sendControl}


### PR DESCRIPTION
## Summary
- Isolate the model-selector popover state of right-panel embedded Agent sessions.
- Prevent the main session and child/exploration sessions from opening duplicate popovers that block model switching.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`

## Performance
Low risk: embedded views now use component-local interaction state, with no added IPC, subscriptions, or high-frequency renders.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)