### PR TITLE
fix: preserve user-selected workspace tabs

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -619,6 +619,13 @@ export type AgentSidePanelBaseTab = 'files' | 'changes' | 'chat' | 'temporary-ag
 /** 工作区组件、每个 Pi 探索分支、协作子 Agent、浏览器网页和文件预览都处于右侧工作区顶栏。 */
 export type AgentSidePanelTab = AgentSidePanelBaseTab | `exploration:${string}` | `delegation:${string}` | `browser:${string}` | `preview:${string}`
 
+/** 用户主动进入这些项目级能力时，Agent 后续的改动提示不得抢走当前视图。 */
+export function isUserPriorityWorkspaceComponentTab(
+  tab: AgentSidePanelTab | 'browser' | 'preview' | undefined,
+): tab is Extract<WorkspaceComponentTab, 'skills' | 'memory'> {
+  return tab === 'skills' || tab === 'memory'
+}
+
 /** Pi `/tree` 探索分支在右侧工作区的展示信息。 */
 export interface AgentExplorationBranchTab {
   /** Pi 原生 fork 生成的独立 Proma session。 */
@@ -732,6 +739,38 @@ export const openWorkspaceComponentAtom = atom(
     set(workspaceComponentTabsAtomFamily(workspaceId), (previous) => (
       previous.includes(component) ? previous : [...previous, component]
     ))
+    set(agentSidePanelOpenAtomFamily(sessionId), true)
+    set(agentDiffPanelTabAtom, (previous) => {
+      if (previous.get(sessionId) === component) return previous
+      const next = new Map(previous)
+      next.set(sessionId, component)
+      return next
+    })
+  },
+)
+
+/**
+ * Agent 改动项目级数据时展示对应 Tab。若用户当前正在查看 Skills 或项目记忆，
+ * 仅打开变更对应的 Tab，不改变用户显式选择的焦点。
+ */
+export const revealChangedWorkspaceComponentAtom = atom(
+  null,
+  (get, set, component: WorkspaceComponentTab) => {
+    const sessionId = get(currentAgentSessionIdAtom)
+    if (!sessionId) return
+    const workspaceId = get(agentSessionsAtom).find((session) => session.id === sessionId)?.workspaceId
+      ?? get(currentAgentWorkspaceIdAtom)
+    if (!workspaceId) return
+
+    set(workspaceComponentTabsAtomFamily(workspaceId), (previous) => (
+      previous.includes(component) ? previous : [...previous, component]
+    ))
+
+    const activeTab = get(agentDiffPanelTabAtom).get(sessionId)
+    const preservesUserFocus = get(agentSidePanelOpenAtomFamily(sessionId))
+      && isUserPriorityWorkspaceComponentTab(activeTab)
+    if (preservesUserFocus) return
+
     set(agentSidePanelOpenAtomFamily(sessionId), true)
     set(agentDiffPanelTabAtom, (previous) => {
       if (previous.get(sessionId) === component) return previous

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -42,6 +42,7 @@ import {
   agentFileChangesCurrentRunAtom,
   workspaceComponentTabsAtomFamily,
   isWorkspaceComponentTab,
+  isUserPriorityWorkspaceComponentTab,
   agentSessionStreamingStateAtomFamily,
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
@@ -641,27 +642,24 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
         ? 'files'
         : activeTab
 
-  // Agent 对当前项目记忆写入后，自动展开并激活完整编辑器这个独立工作区 Tab。
-  // 记忆 watcher 按 workspace 缓存最新事件；必须排除本轮开始前的陈旧事件，否则用户
-  // 一发送新消息，旧变更就会随着 running 状态被再次消费并抢占当前视图。
-  // 用户在记忆编辑器中的手动保存仍不会打断其他工作。
+  // Agent 对当前项目记忆写入后，默认展开并激活完整编辑器这个独立工作区 Tab。
+  // 记忆 watcher 按 workspace 缓存最新事件，必须排除本轮开始前的陈旧事件。
+  // 用户正在查看 Skills 或项目记忆时，变更只在后台保留为可见的 Memory Tab，
+  // 不抢焦点，也不重置其正在阅读或编辑的文件。
   React.useEffect(() => {
     const runStartedAt = agentStreamState?.startedAt
     if (!agentStreamState?.running || !runStartedAt || !latestMemoryChange || latestMemoryChange.changedAt < runStartedAt) return
     const changeId = `${latestMemoryChange.relativePath}:${latestMemoryChange.changedAt}`
     if (lastActivatedMemoryChangeRef.current === changeId) return
-    // 用户已停留在项目记忆中时，不用同一事件重置其阅读/编辑位置；标记为已消费，
-    // 同时避免本地自动保存经 watcher 回传后把用户切回局部 Diff。
-    if (effectiveActiveTab === 'memory') {
-      lastActivatedMemoryChangeRef.current = changeId
-      return
-    }
     lastActivatedMemoryChangeRef.current = changeId
     setWorkspaceComponentTabs((previous) => previous.includes('memory') ? previous : [...previous, 'memory'])
+
+    if (isOpen && isUserPriorityWorkspaceComponentTab(effectiveActiveTab)) return
+
     setMemoryNavigationRequest({ workspaceSlug: workspaceSlug!, relativePath: latestMemoryChange.relativePath, mode: 'change' })
     setIsOpen(true)
     onTabChange('memory')
-  }, [agentStreamState?.running, agentStreamState?.startedAt, effectiveActiveTab, latestMemoryChange, onTabChange, setIsOpen, setMemoryNavigationRequest, setWorkspaceComponentTabs, workspaceSlug])
+  }, [agentStreamState?.running, agentStreamState?.startedAt, effectiveActiveTab, isOpen, latestMemoryChange, onTabChange, setIsOpen, setMemoryNavigationRequest, setWorkspaceComponentTabs, workspaceSlug])
 
   const handleClosePreviewTab = React.useCallback((previewId: string) => {
     const remaining = previewFiles.filter((file) => getPreviewFileId(file) !== previewId)

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -50,7 +50,7 @@ import {
   agentNonGitFileChangesAtom,
   agentFileChangesCurrentRunAtom,
   agentSidePanelOpenAtomFamily,
-  openWorkspaceComponentAtom,
+  revealChangedWorkspaceComponentAtom,
   agentSideDelegationMapAtom,
   getDelegationSidePanelTab,
   askUserDraftsAtom,
@@ -1102,7 +1102,7 @@ export function useGlobalAgentListeners(): void {
               const activeWorkspaceId = sessions.find((session) => session.id === activeSessionId)?.workspaceId
               const sourceWorkspaceId = sessions.find((session) => session.id === sessionId)?.workspaceId
               if (activeSessionId === sessionId || (activeWorkspaceId && activeWorkspaceId === sourceWorkspaceId)) {
-                store.set(openWorkspaceComponentAtom, changedComponent)
+                store.set(revealChangedWorkspaceComponentAtom, changedComponent)
               }
             }
           }


### PR DESCRIPTION
## Summary
- Preserve the currently active Skills or project-memory workspace tab when Agent changes open another component.
- Keep memory changes visible without replacing the user's current memory-file selection.

## Validation
- `bun run typecheck`

## Performance impact
- Low risk: this only adds a one-time focus guard on existing component-change and memory-watcher events; it creates no new subscriptions, IPC calls, or render/update loops.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
