### PR TITLE
Fix right tab menu overlay

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -899,6 +899,9 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   }, [activeBrowserTabId, browserState?.tabs, onTabChange])
 
   const showBrowserActivity = Boolean(browserState?.activity && browserState.executionSource !== 'user')
+  // WebContentsView 是原生子视图，会盖住 renderer 的 portal。加号菜单打开时，
+  // BrowserPanel 为它保留一个固定避让区，而非 setVisible(false)。
+  const [isAddTabMenuOpen, setIsAddTabMenuOpen] = React.useState(false)
   const workspaceTabs = React.useMemo<WorkspacePanelTab[]>(() => [
     { id: 'files', label: '文件', icon: <FolderOpen className="size-3.5" /> },
     { id: 'changes', label: '改动', icon: <FileDiff className="size-3.5" /> },
@@ -998,7 +1001,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             onTabChange={handleWorkspaceTabChange}
             onCloseTab={handleCloseWorkspaceTab}
             onOpenBrowser={() => void handleOpenBrowserTab()}
-            onOpenFile={() => handleWorkspaceTabChange('files')}
+            onAddTabMenuOpenChange={setIsAddTabMenuOpen}
             onOpenWorkspaceComponent={(component) => {
               setWorkspaceComponentTabs((previous) => previous.includes(component) ? previous : [...previous, component])
               onTabChange(component)
@@ -1015,7 +1018,12 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
           ) : activeBrowserTabId ? (
             browserState && browserState.tabs.some((tab) => tab.tabId === activeBrowserTabId) ? (
               <div className="min-h-0 flex-1 overflow-hidden">
-                <BrowserPanel sessionId={sessionId} tabId={activeBrowserTabId} state={browserState} />
+                <BrowserPanel
+                  sessionId={sessionId}
+                  tabId={activeBrowserTabId}
+                  state={browserState}
+                  isAddTabMenuOpen={isAddTabMenuOpen}
+                />
               </div>
             ) : (
               <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">浏览器标签已关闭</div>

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -21,14 +21,19 @@ import { browserPendingNavigationMapAtom } from '@/atoms/browser-atoms'
 import { BrowserSlot } from './BrowserSlot'
 import { shouldReuseInitialBrowserTab } from './agent-browser-link-utils'
 
+/** 加号菜单最多 7 项；为原生 WebContentsView 预留完整菜单及安全间距。 */
+const ADD_TAB_MENU_CLEARANCE_PX = 256
+
 interface BrowserPanelProps {
   sessionId: string
   /** 由右侧统一顶栏选中的网页。 */
   tabId: string
   state: BrowserViewState | null
+  /** 右侧加号菜单展开时，原生浏览器必须避让其 renderer 区域。 */
+  isAddTabMenuOpen?: boolean
 }
 
-export function BrowserPanel({ sessionId, tabId, state }: BrowserPanelProps): React.ReactElement {
+export function BrowserPanel({ sessionId, tabId, state, isAddTabMenuOpen = false }: BrowserPanelProps): React.ReactElement {
   const [url, setUrl] = React.useState(state?.url ?? '')
   const [riskAcknowledged, setRiskAcknowledged] = React.useState<boolean | null>(null)
   const [savingRiskAcknowledgement, setSavingRiskAcknowledgement] = React.useState(false)
@@ -129,7 +134,12 @@ export function BrowserPanel({ sessionId, tabId, state }: BrowserPanelProps): Re
         )}
       </div>
       {riskAcknowledged === true ? (
-        <BrowserSlot key={tabId} sessionId={sessionId} tabId={tabId} />
+        <div
+          className="flex flex-1 min-h-0 flex-col"
+          style={isAddTabMenuOpen ? { paddingTop: ADD_TAB_MENU_CLEARANCE_PX } : undefined}
+        >
+          <BrowserSlot key={tabId} sessionId={sessionId} tabId={tabId} />
+        </div>
       ) : (
         <div className="flex flex-1 min-h-0 items-center justify-center bg-muted/15 px-8 text-center">
           <div className="max-w-sm space-y-2 text-muted-foreground">

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Blocks, Brain, CalendarDays, FolderOpen, Globe, ListTodo, MessageCircle, PanelRight, Plus, Repeat2, ServerCog, X } from 'lucide-react'
+import { Blocks, Brain, CalendarDays, Clock, Globe, ListTodo, MessageCircle, PanelRight, Plus, ServerCog, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -34,7 +34,8 @@ interface DiffPanelTabBarProps {
   onTabChange: (tab: AgentSidePanelTab) => void
   onCloseTab: (tab: AgentSidePanelTab) => void
   onOpenBrowser: () => void
-  onOpenFile: () => void
+  /** 加号菜单是否展开；供原生浏览器视图临时避让。 */
+  onAddTabMenuOpenChange?: (open: boolean) => void
   onOpenWorkspaceComponent?: (component: WorkspaceComponentTab) => void
   onOpenChat?: () => void
   /** 仅当前右侧 Tab 需要的紧凑动作，渲染于标签列表之后，不影响内容区布局。 */
@@ -49,7 +50,7 @@ export function DiffPanelTabBar({
   onTabChange,
   onCloseTab,
   onOpenBrowser,
-  onOpenFile,
+  onAddTabMenuOpenChange,
   onOpenWorkspaceComponent,
   onOpenChat,
   activeTabAction,
@@ -60,6 +61,17 @@ export function DiffPanelTabBar({
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const unseenChanges = unseenMap.get(currentSessionId ?? '') ?? false
+  const [isAddTabMenuOpen, setIsAddTabMenuOpen] = React.useState(false)
+  // 仅鼠标在菜单外取消时抑制 Radix 的回焦；Esc 与键盘选择必须保留可见焦点。
+  const suppressPointerDismissFocusRestoreRef = React.useRef(false)
+
+  React.useEffect(() => () => onAddTabMenuOpenChange?.(false), [onAddTabMenuOpenChange])
+
+  const handleAddTabMenuOpenChange = React.useCallback((open: boolean) => {
+    if (open) suppressPointerDismissFocusRestoreRef.current = false
+    setIsAddTabMenuOpen(open)
+    onAddTabMenuOpenChange?.(open)
+  }, [onAddTabMenuOpenChange])
 
   const selectTab = React.useCallback((tab: AgentSidePanelTab) => {
     if (tab === 'changes' && currentSessionId) {
@@ -125,7 +137,7 @@ export function DiffPanelTabBar({
           })}
         </div>
         {activeTabAction && <div className="ml-1 flex shrink-0 items-center titlebar-no-drag">{activeTabAction}</div>}
-        <DropdownMenu>
+        <DropdownMenu open={isAddTabMenuOpen} onOpenChange={handleAddTabMenuOpenChange}>
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
@@ -140,14 +152,19 @@ export function DiffPanelTabBar({
             </TooltipTrigger>
             <TooltipContent side="bottom">添加标签</TooltipContent>
           </Tooltip>
-          <DropdownMenuContent align="end" className="z-[100] min-w-40 titlebar-no-drag">
+          <DropdownMenuContent
+            align="end"
+            className="z-[100] min-w-40 titlebar-no-drag"
+            onPointerDownOutside={() => { suppressPointerDismissFocusRestoreRef.current = true }}
+            onCloseAutoFocus={(event) => {
+              if (!suppressPointerDismissFocusRestoreRef.current) return
+              suppressPointerDismissFocusRestoreRef.current = false
+              event.preventDefault()
+            }}
+          >
             <DropdownMenuItem onSelect={onOpenBrowser}>
               <Globe className="size-3.5" />
               新建浏览器标签
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={onOpenFile}>
-              <FolderOpen className="size-3.5" />
-              打开文件
             </DropdownMenuItem>
             {onOpenWorkspaceComponent && (
               <>
@@ -159,10 +176,6 @@ export function DiffPanelTabBar({
                 <DropdownMenuItem onSelect={() => onOpenWorkspaceComponent('calendar')}>
                   <CalendarDays className="size-3.5" />
                   打开日程
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => onOpenWorkspaceComponent('automations')}>
-                  <Repeat2 className="size-3.5" />
-                  打开定时任务
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => onOpenWorkspaceComponent('skills')}>
                   <Blocks className="size-3.5" />
@@ -186,6 +199,12 @@ export function DiffPanelTabBar({
                   打开问答
                 </DropdownMenuItem>
               </>
+            )}
+            {onOpenWorkspaceComponent && (
+              <DropdownMenuItem onSelect={() => onOpenWorkspaceComponent('automations')}>
+                <Clock className="size-3.5" />
+                打开定时任务
+              </DropdownMenuItem>
             )}
           </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
## Summary

- 移除右侧 Tab 加号菜单中的“打开文件”，并将“打开定时任务”移至底部、改用时钟图标。
- 菜单展开时为原生 WebContentsView 预留空间，避免遮挡菜单且不隐藏浏览器会话。
- 取消菜单后不再让焦点回到加号按钮。

## Performance

- 菜单开合是低频交互，仅更新右侧面板局部状态；每次开合只触发既有浏览器视图的一次 bounds 重算。
- 未增加持续 timer、listener 或 IPC 订阅；不涉及流式输出、长列表或主线程热路径。

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`
- [x] `bun run --filter='@proma/electron' build:renderer`
- [x] 在 Electron 中验证：浏览器 Tab 下菜单可见，取消菜单后加号无残留 focus 状态。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)