### PR TITLE
fix: keep active right workspace tab visible

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.69",
+  "version": "0.17.70",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -9,6 +9,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { Blocks, Brain, CalendarDays, FolderOpen, Globe, ListTodo, MessageCircle, PanelRight, Plus, Repeat2, ServerCog, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
+import { getScrollLeftToRevealTab } from '@/lib/tab-visibility'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import {
   DropdownMenu,
@@ -60,6 +61,19 @@ export function DiffPanelTabBar({
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const unseenChanges = unseenMap.get(currentSessionId ?? '') ?? false
+  const tabListRef = React.useRef<HTMLDivElement>(null)
+  const tabRefs = React.useRef(new Map<AgentSidePanelTab, HTMLDivElement>())
+
+  React.useLayoutEffect(() => {
+    const tabList = tabListRef.current
+    const activeTabElement = tabRefs.current.get(activeTab)
+    if (!tabList || !activeTabElement) return
+
+    const nextScrollLeft = getScrollLeftToRevealTab(tabList, activeTabElement)
+    if (nextScrollLeft !== tabList.scrollLeft) {
+      tabList.scrollTo({ left: nextScrollLeft, behavior: 'smooth' })
+    }
+  }, [activeTab, tabs.length])
 
   const selectTab = React.useCallback((tab: AgentSidePanelTab) => {
     if (tab === 'changes' && currentSessionId) {
@@ -77,13 +91,17 @@ export function DiffPanelTabBar({
     <div className="relative flex h-10 shrink-0 items-center border-b border-border/50 bg-content-area">
       <div className={cn('pointer-events-none absolute inset-0 titlebar-drag-region', isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
       <div className="relative flex min-w-0 flex-1 items-center titlebar-no-drag">
-        <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto overscroll-x-contain px-2 py-1 scrollbar-none" role="tablist" aria-label="右侧工作区">
+        <div ref={tabListRef} className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto overscroll-x-contain px-2 py-1 scrollbar-none" role="tablist" aria-label="右侧工作区">
           {tabs.map((tab) => {
             const selected = activeTab === tab.id
             const isChangesTab = tab.id === 'changes'
             return (
               <div
                 key={tab.id}
+                ref={(element) => {
+                  if (element) tabRefs.current.set(tab.id, element)
+                  else tabRefs.current.delete(tab.id)
+                }}
                 className={cn(
                   'group flex h-7 min-w-[84px] max-w-60 shrink-0 items-center rounded-lg transition-[background-color,color] duration-150',
                   selected

--- a/apps/electron/src/renderer/lib/tab-visibility.ts
+++ b/apps/electron/src/renderer/lib/tab-visibility.ts
@@ -1,0 +1,33 @@
+export interface HorizontalScrollViewport {
+  scrollLeft: number
+  clientWidth: number
+  scrollWidth: number
+}
+
+export interface HorizontalTabBounds {
+  offsetLeft: number
+  offsetWidth: number
+}
+
+/**
+ * 返回让 Tab 完整出现在横向滚动视口中的目标 scrollLeft。
+ * Tab 宽度大于视口时优先展示其起始位置。
+ */
+export function getScrollLeftToRevealTab(
+  viewport: HorizontalScrollViewport,
+  tab: HorizontalTabBounds,
+): number {
+  const maxScrollLeft = Math.max(0, viewport.scrollWidth - viewport.clientWidth)
+  const tabRight = tab.offsetLeft + tab.offsetWidth
+
+  if (tab.offsetWidth >= viewport.clientWidth || tab.offsetLeft < viewport.scrollLeft) {
+    return Math.min(Math.max(0, tab.offsetLeft), maxScrollLeft)
+  }
+
+  const viewportRight = viewport.scrollLeft + viewport.clientWidth
+  if (tabRight > viewportRight) {
+    return Math.min(tabRight - viewport.clientWidth, maxScrollLeft)
+  }
+
+  return viewport.scrollLeft
+}


### PR DESCRIPTION
## Summary
- Ensure the active right-workspace tab scrolls into the visible horizontal region.
- Keep the scroll calculation bounded and only run it on tab activation or tab-count changes.
- Bump the Electron app patch version to 0.17.70.

## Validation
- `bun run typecheck`
- `bun run --filter='@proma/electron' build:renderer`

## Performance
Low risk: the behavior runs once per activation/new-tab interaction, performs constant-time layout reads, and adds no listener, timer, IPC, or state-update path.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)