### PR TITLE
fix(renderer): prevent empty right workspace tabs

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.test.ts
@@ -6,8 +6,10 @@ import {
   agentStreamingStatesAtom,
   applyAgentEvent,
   clearAgentStreamError,
+  getDelegationTabLabel,
   isRetryEventForCurrentStream,
   isWorkspaceComponentTab,
+  sanitizeWorkspaceComponentTabs,
   workspaceComponentTabsAtomFamily,
   type AgentStreamState,
 } from './agent-atoms'
@@ -40,6 +42,16 @@ describe('右侧工作区组件', () => {
     expect(isWorkspaceComponentTab('memory')).toBe(true)
     expect(isWorkspaceComponentTab('browser:tab-1')).toBe(false)
     expect(isWorkspaceComponentTab('files')).toBe(false)
+  })
+
+  test('过滤旧版本或异常持久化的项目级 Tab', () => {
+    expect(sanitizeWorkspaceComponentTabs(['todos', '', 'legacy-memory', 'memory'])).toEqual(['todos', 'memory'])
+  })
+
+  test('委派子 Agent 标题为空时使用可见的默认 Tab 标签', () => {
+    expect(getDelegationTabLabel('  ')).toBe('委派任务')
+    expect(getDelegationTabLabel(undefined)).toBe('委派任务')
+    expect(getDelegationTabLabel('整理 PR')).toBe('整理 PR')
   })
 })
 

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -615,6 +615,18 @@ export function isWorkspaceComponentTab(tab: AgentSidePanelTab | string): tab is
   return (WORKSPACE_COMPONENT_TABS as readonly string[]).includes(tab)
 }
 
+/** 过滤旧版本或异常持久化数据，避免未知组件渲染成空的右侧 Tab。 */
+export function sanitizeWorkspaceComponentTabs(tabs: readonly string[]): WorkspaceComponentTab[] {
+  return tabs.every(isWorkspaceComponentTab)
+    ? tabs as WorkspaceComponentTab[]
+    : tabs.filter(isWorkspaceComponentTab)
+}
+
+/** 协作子 Agent 尚未提供标题时仍需有可见的 Tab 标签。 */
+export function getDelegationTabLabel(title: string | null | undefined): string {
+  return title?.trim() || '委派任务'
+}
+
 export type AgentSidePanelBaseTab = 'files' | 'changes' | 'chat' | 'temporary-agent' | WorkspaceComponentTab
 /** 工作区组件、每个 Pi 探索分支、协作子 Agent、浏览器网页和文件预览都处于右侧工作区顶栏。 */
 export type AgentSidePanelTab = AgentSidePanelBaseTab | `exploration:${string}` | `delegation:${string}` | `browser:${string}` | `preview:${string}` | `terminal:${string}`

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -43,6 +43,8 @@ import {
   workspaceComponentTabsAtomFamily,
   isWorkspaceComponentTab,
   isUserPriorityWorkspaceComponentTab,
+  sanitizeWorkspaceComponentTabs,
+  getDelegationTabLabel,
   agentSessionStreamingStateAtomFamily,
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
@@ -636,6 +638,13 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // Todo / 日程 / 能力 / 记忆是工作区组件，而不是会话附件；同一项目下切换会话仍保留打开状态。
   const [workspaceComponentTabs, setWorkspaceComponentTabs] = useAtom(workspaceComponentTabsAtomFamily(currentWorkspaceId ?? ''))
   const automationFormOpen = useAtomValue(automationFormAtom).open
+
+  React.useEffect(() => {
+    const validTabs = sanitizeWorkspaceComponentTabs(workspaceComponentTabs)
+    if (validTabs === workspaceComponentTabs) return
+    setWorkspaceComponentTabs(validTabs)
+  }, [setWorkspaceComponentTabs, workspaceComponentTabs])
+
   const agentStreamState = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))
   const memoryChangesMap = useAtomValue(workspaceMemoryChangesAtom)
   const setMemoryNavigationRequest = useSetAtom(memoryFileNavigationAtom)
@@ -961,7 +970,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       ))
       return child ? [{
         id: getDelegationSidePanelTab(child.id),
-        label: child.title,
+        label: getDelegationTabLabel(child.title),
         icon: <GitBranch className="size-3.5" />,
         closable: true,
       }] : []


### PR DESCRIPTION
## 概述

修复右侧工作区出现空 Tab 的问题：

- 委派子 Agent 会话标题为空或全为空白时，Tab 显示“委派任务”。
- 挂载右侧面板时清理历史持久化数据中的未知项目级 Tab，避免渲染出无文字或无图标的空 Tab。

本 PR 已基于最新 `main` 重建；此前与右侧工作区自动扩宽相关的改动已移除，因为 #1837 已统一处理该布局策略。

## 改动

- `apps/electron/src/renderer/atoms/agent-atoms.ts` — 增加持久化 Tab 清理与委派 Tab 标题兜底工具函数。
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 挂载时清理异常项目级 Tab，并采用委派标题兜底。
- `apps/electron/src/renderer/atoms/agent-atoms.test.ts` — 覆盖异常 Tab 清理、空白/缺失委派标题与正常标题路径。

## 性能影响

低风险：仅在右侧面板渲染时执行一次小型持久化 Tab 校验；有效数据直接复用原数组，不增加 IPC、定时器、流式更新或高频全局订阅。

## 验证

- `bun test apps/electron/src/renderer/atoms/agent-atoms.test.ts`
- `bun run --filter=@proma/electron typecheck`
- `bun run --filter=@proma/electron build:renderer`
- `git diff --check`

以上均已通过。未做 Electron 桌面端手动交互验证；本次为一次性状态清理与纯标签兜底，剩余风险低。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
