### PR TITLE
feat(sidebar): 宽栏同时展示会话文件与项目文件【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.70",
+  "version": "0.17.71",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -91,6 +91,7 @@ import type { FileEntry, AgentPendingFile, AgentSessionMeta, SDKMessage } from '
 import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
 import { TerminalTabContent } from '@/components/tabs/TerminalTabContent'
+import { shouldShowBothFileSources } from './file-panel-layout'
 
 function getPathBasename(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
@@ -249,6 +250,7 @@ interface SidePanelProps {
 }
 
 export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, width = 460 }: SidePanelProps): React.ReactElement {
+  const showBothFileSources = shouldShowBothFileSources(width)
   // 侧面板状态按 sessionId 持久化，切换会话不会互相覆盖。
   const [isOpen, setIsOpen] = useAtom(currentSessionSidePanelOpenAtom)
   const isWindows = React.useMemo(() => detectIsWindows(), [])
@@ -593,13 +595,23 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       return { ...prev, [sessionId]: source }
     })
   }, [sessionId, setFileSourceFilterMap])
-  const showSessionFiles = fileSourceFilter === 'session'
-  const showProjectFiles = fileSourceFilter === 'project'
+  const showSessionFiles = showBothFileSources || fileSourceFilter === 'session'
+  const showProjectFiles = showBothFileSources || fileSourceFilter === 'project'
 
+  const sessionFileRoots = React.useMemo(
+    () => sessionPath ? [{ path: sessionPath, scope: 'session' as const }] : [],
+    [sessionPath],
+  )
+  const projectFileRoots = React.useMemo(
+    () => workspaceFilesPath && !isProjectRootUnavailable
+      ? [{ path: workspaceFilesPath, scope: 'project' as const }]
+      : [],
+    [isProjectRootUnavailable, workspaceFilesPath],
+  )
   const visibleFileRoots = React.useMemo(() => [
-    ...(showProjectFiles && workspaceFilesPath && !isProjectRootUnavailable ? [{ path: workspaceFilesPath, scope: 'project' as const }] : []),
-    ...(showSessionFiles && sessionPath ? [{ path: sessionPath, scope: 'session' as const }] : []),
-  ], [showProjectFiles, workspaceFilesPath, isProjectRootUnavailable, showSessionFiles, sessionPath])
+    ...(showProjectFiles ? projectFileRoots : []),
+    ...(showSessionFiles ? sessionFileRoots : []),
+  ], [projectFileRoots, sessionFileRoots, showProjectFiles, showSessionFiles])
 
   // Files 将会话与项目文件放在同一视图；FileBrowser 自己处理对应根目录的自动定位。
   // RightSidePanel 完全由用户控制，不因 Agent 文件变更自动打开。
@@ -1013,6 +1025,41 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     return () => window.removeEventListener(CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT, handleCloseActiveWorkspaceTab)
   }, [activeTab, handleCloseWorkspaceTab, sessionId])
 
+  const renderFileSourceContent = (scope: 'session' | 'project'): React.ReactElement => {
+    const isSession = scope === 'session'
+    const hasAttachedItems = isSession ? hasSessionAttachedItems : hasWorkspaceAttachedItems
+    const roots = isSession ? sessionFileRoots : projectFileRoots
+
+    return (
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden" aria-label={isSession ? '会话文件' : '项目文件'}>
+        <h3 className="flex h-8 shrink-0 items-center px-3 text-[11px] font-medium text-muted-foreground">
+          {isSession ? '会话文件' : '项目文件'}
+        </h3>
+        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin pt-1">
+          {isSession && attachedFiles.length > 0 && (
+            <AttachedFilesSection scope="session" showSessionBadge={false} attachedFiles={attachedFiles} onDetach={handleDetachFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+          )}
+          {isSession && attachedDirs.length > 0 && (
+            <AttachedDirsSection scope="session" showSessionBadge={false} attachedDirs={attachedDirs} onDetach={handleDetachDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+          )}
+          {!isSession && wsAttachedFiles.length > 0 && (
+            <AttachedFilesSection scope="project" attachedFiles={wsAttachedFiles} onDetach={handleDetachWorkspaceFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+          )}
+          {!isSession && wsAttachedDirs.length > 0 && (
+            <AttachedDirsSection scope="project" attachedDirs={wsAttachedDirs} onDetach={handleDetachWorkspaceDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+          )}
+          {!isSession && isProjectRootUnavailable && <div className="mx-2 my-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">本地项目根目录不可用；当前会话文件仍可访问。</div>}
+          <FileBrowser roots={roots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+          {workspaceSlug && (isSession ? (
+            <FileDropZone workspaceSlug={workspaceSlug} sessionId={sessionId} target="session" onFilesUploaded={handleFilesUploaded} onFilesAttached={handleSessionFilesAttached} onAttachFolder={handleAttachSessionFolder} onFoldersDropped={handleSessionFoldersDropped} />
+          ) : !isProjectRootUnavailable ? (
+            <FileDropZone workspaceSlug={workspaceSlug} target="workspace" onFilesUploaded={handleFilesUploaded} onFilesAttached={handleWorkspaceFilesAttached} onAttachFolder={handleAttachWorkspaceFolder} onFoldersDropped={handleWorkspaceFoldersDropped} />
+          ) : null)}
+        </div>
+      </section>
+    )
+  }
+
   return (
     <div
       className={cn(
@@ -1138,134 +1185,82 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                     sessionPath={sessionPath}
                     sessionAttachedDirs={attachedDirs}
                     workspaceAttachedDirs={wsAttachedDirs}
-                    sourceFilter={fileSourceFilter}
-                    showSessionBadge={false}
+                    sourceFilter={showBothFileSources ? 'all' : fileSourceFilter}
+                    showSessionBadge={showBothFileSources}
                     placeholder="搜索文件..."
                     sessionId={sessionId}
                     onFilePreview={handleFilePreview}
                   >
-                    <div className="file-source-tabbar main-tabbar mt-1.5 flex h-7 border-b border-border/80" role="tablist" aria-label="文件来源">
-                      <button
-                        type="button"
-                        role="tab"
-                        className={cn(
-                          'relative flex-1 h-7 px-2 text-[11px] transition-colors select-none',
-                          fileSourceFilter === 'session'
-                            ? 'app-tab-active text-foreground'
-                            : 'app-tab-inactive text-muted-foreground hover:text-foreground',
-                        )}
-                        aria-selected={fileSourceFilter === 'session'}
-                        onClick={() => setFileSourceFilter('session')}
-                      >
-                        会话文件
-                      </button>
-                      <button
-                        type="button"
-                        role="tab"
-                        className={cn(
-                          'relative flex-1 h-7 px-2 text-[11px] transition-colors select-none',
-                          fileSourceFilter === 'project'
-                            ? 'app-tab-active text-foreground'
-                            : 'app-tab-inactive text-muted-foreground hover:text-foreground',
-                        )}
-                        aria-selected={fileSourceFilter === 'project'}
-                        onClick={() => setFileSourceFilter('project')}
-                      >
-                        项目文件
-                      </button>
-                    </div>
-                  </FileSearchBar>
-                  <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin pt-1">
-                    {/* 拖拽引用提示：引用块样式，左侧竖线 + 缩进，与下方文件列表内容左对齐 */}
-                    <div className="mb-1.5 ml-4 border-l-2 border-primary/40 pl-2 text-[11px] leading-4 text-foreground/75">
-                      支持拖拽文件或文件夹到输入框，实现引用
-                    </div>
-                    {showProjectFiles && wsAttachedFiles.length > 0 && (
-                      <AttachedFilesSection
-                        scope="project"
-                        attachedFiles={wsAttachedFiles}
-                        onDetach={handleDetachWorkspaceFile}
-                        onAddToChat={handleAddToChat}
-                        onFilePreview={handleFilePreview}
-                        allowedPaths={basePathsRef.current}
-                        sessionId={sessionId}
-                      />
-                    )}
-                    {showProjectFiles && wsAttachedDirs.length > 0 && (
-                      <AttachedDirsSection
-                        scope="project"
-                        attachedDirs={wsAttachedDirs}
-                        onDetach={handleDetachWorkspaceDirectory}
-                        refreshVersion={filesVersion}
-                        onAddToChat={handleAddToChat}
-                        onFilePreview={handleFilePreview}
-                        allowedPaths={basePathsRef.current}
-                        sessionId={sessionId}
-                      />
-                    )}
-                    {showSessionFiles && attachedFiles.length > 0 && (
-                      <AttachedFilesSection
-                        scope="session"
-                        showSessionBadge={false}
-                        attachedFiles={attachedFiles}
-                        onDetach={handleDetachFile}
-                        onAddToChat={handleAddToChat}
-                        onFilePreview={handleFilePreview}
-                        allowedPaths={basePathsRef.current}
-                        sessionId={sessionId}
-                      />
-                    )}
-                    {showSessionFiles && attachedDirs.length > 0 && (
-                      <AttachedDirsSection
-                        scope="session"
-                        showSessionBadge={false}
-                        attachedDirs={attachedDirs}
-                        onDetach={handleDetachDirectory}
-                        refreshVersion={filesVersion}
-                        onAddToChat={handleAddToChat}
-                        onFilePreview={handleFilePreview}
-                        allowedPaths={basePathsRef.current}
-                        sessionId={sessionId}
-                      />
-                    )}
-                    {showProjectFiles && isProjectRootUnavailable && (
-                      <div className="mx-2 my-2 px-3 py-2 text-xs text-destructive bg-destructive/10 rounded-md">
-                        本地项目根目录不可用；当前会话文件仍可访问。
+                    {!showBothFileSources && (
+                      <div className="file-source-tabbar main-tabbar mt-1.5 flex h-7 border-b border-border/80" role="tablist" aria-label="文件来源">
+                        <button
+                          type="button"
+                          role="tab"
+                          className={cn(
+                            'relative flex-1 h-7 px-2 text-[11px] transition-colors select-none',
+                            fileSourceFilter === 'session'
+                              ? 'app-tab-active text-foreground'
+                              : 'app-tab-inactive text-muted-foreground hover:text-foreground',
+                          )}
+                          aria-selected={fileSourceFilter === 'session'}
+                          onClick={() => setFileSourceFilter('session')}
+                        >
+                          会话文件
+                        </button>
+                        <button
+                          type="button"
+                          role="tab"
+                          className={cn(
+                            'relative flex-1 h-7 px-2 text-[11px] transition-colors select-none',
+                            fileSourceFilter === 'project'
+                              ? 'app-tab-active text-foreground'
+                              : 'app-tab-inactive text-muted-foreground hover:text-foreground',
+                          )}
+                          aria-selected={fileSourceFilter === 'project'}
+                          onClick={() => setFileSourceFilter('project')}
+                        >
+                          项目文件
+                        </button>
                       </div>
                     )}
-                    <FileBrowser
-                      roots={visibleFileRoots}
-                      access={fileAccess}
-                      projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath}
-                      showSessionBadge={false}
-                      hideToolbar
-                      embedded
-                      hideEmpty={hasVisibleSessionAttachedItems || hasVisibleWorkspaceAttachedItems}
-                      onAddToChat={handleAddToChat}
-                      onFilePreview={handleFilePreview}
-                    />
-                    {showSessionFiles && workspaceSlug && (
-                      <FileDropZone
-                        workspaceSlug={workspaceSlug}
-                        sessionId={sessionId}
-                        target="session"
-                        onFilesUploaded={handleFilesUploaded}
-                        onFilesAttached={handleSessionFilesAttached}
-                        onAttachFolder={handleAttachSessionFolder}
-                        onFoldersDropped={handleSessionFoldersDropped}
-                      />
-                    )}
-                    {showProjectFiles && !isProjectRootUnavailable && workspaceSlug && (
-                      <FileDropZone
-                        workspaceSlug={workspaceSlug}
-                        target="workspace"
-                        onFilesUploaded={handleFilesUploaded}
-                        onFilesAttached={handleWorkspaceFilesAttached}
-                        onAttachFolder={handleAttachWorkspaceFolder}
-                        onFoldersDropped={handleWorkspaceFoldersDropped}
-                      />
-                    )}
-                  </div>
+                  </FileSearchBar>
+                  {showBothFileSources ? (
+                    <div className="grid min-h-0 flex-1 grid-cols-2 divide-x divide-border/70 overflow-hidden pt-2">
+                      {renderFileSourceContent('session')}
+                      {renderFileSourceContent('project')}
+                    </div>
+                  ) : (
+                    <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin pt-1">
+                      {/* 拖拽引用提示：引用块样式，左侧竖线 + 缩进，与下方文件列表内容左对齐 */}
+                      <div className="mb-1.5 ml-4 border-l-2 border-primary/40 pl-2 text-[11px] leading-4 text-foreground/75">
+                        支持拖拽文件或文件夹到输入框，实现引用
+                      </div>
+                      {showProjectFiles && wsAttachedFiles.length > 0 && (
+                        <AttachedFilesSection scope="project" attachedFiles={wsAttachedFiles} onDetach={handleDetachWorkspaceFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+                      )}
+                      {showProjectFiles && wsAttachedDirs.length > 0 && (
+                        <AttachedDirsSection scope="project" attachedDirs={wsAttachedDirs} onDetach={handleDetachWorkspaceDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+                      )}
+                      {showSessionFiles && attachedFiles.length > 0 && (
+                        <AttachedFilesSection scope="session" showSessionBadge={false} attachedFiles={attachedFiles} onDetach={handleDetachFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+                      )}
+                      {showSessionFiles && attachedDirs.length > 0 && (
+                        <AttachedDirsSection scope="session" showSessionBadge={false} attachedDirs={attachedDirs} onDetach={handleDetachDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+                      )}
+                      {showProjectFiles && isProjectRootUnavailable && (
+                        <div className="mx-2 my-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                          本地项目根目录不可用；当前会话文件仍可访问。
+                        </div>
+                      )}
+                      <FileBrowser roots={visibleFileRoots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasVisibleSessionAttachedItems || hasVisibleWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+                      {showSessionFiles && workspaceSlug && (
+                        <FileDropZone workspaceSlug={workspaceSlug} sessionId={sessionId} target="session" onFilesUploaded={handleFilesUploaded} onFilesAttached={handleSessionFilesAttached} onAttachFolder={handleAttachSessionFolder} onFoldersDropped={handleSessionFoldersDropped} />
+                      )}
+                      {showProjectFiles && !isProjectRootUnavailable && workspaceSlug && (
+                        <FileDropZone workspaceSlug={workspaceSlug} target="workspace" onFilesUploaded={handleFilesUploaded} onFilesAttached={handleWorkspaceFilesAttached} onAttachFolder={handleAttachWorkspaceFolder} onFoldersDropped={handleWorkspaceFoldersDropped} />
+                      )}
+                    </div>
+                  )}
                 </>
               ) : (
                 <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>

--- a/apps/electron/src/renderer/components/agent/file-panel-layout.test.ts
+++ b/apps/electron/src/renderer/components/agent/file-panel-layout.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test'
+import { WIDE_FILE_PANEL_MIN_WIDTH, shouldShowBothFileSources } from './file-panel-layout'
+
+describe('右侧文件面板宽度布局', () => {
+  test('达到阈值时同时展示会话文件和项目文件', () => {
+    expect(shouldShowBothFileSources(WIDE_FILE_PANEL_MIN_WIDTH)).toBe(true)
+    expect(shouldShowBothFileSources(WIDE_FILE_PANEL_MIN_WIDTH + 1)).toBe(true)
+  })
+
+  test('低于阈值时保留单来源切换模式', () => {
+    expect(shouldShowBothFileSources(WIDE_FILE_PANEL_MIN_WIDTH - 1)).toBe(false)
+  })
+})

--- a/apps/electron/src/renderer/components/agent/file-panel-layout.ts
+++ b/apps/electron/src/renderer/components/agent/file-panel-layout.ts
@@ -1,0 +1,5 @@
+export const WIDE_FILE_PANEL_MIN_WIDTH = 760
+
+export function shouldShowBothFileSources(width: number): boolean {
+  return width >= WIDE_FILE_PANEL_MIN_WIDTH
+}

--- a/apps/electron/src/renderer/components/file-browser/FileSearchBar.test.ts
+++ b/apps/electron/src/renderer/components/file-browser/FileSearchBar.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+import type { FileIndexEntry } from '@proma/shared'
+import { hasMixedFileSources } from './file-search-sources'
+
+function result(source: FileIndexEntry['source']): FileIndexEntry {
+  return { name: 'report.md', path: 'report.md', type: 'file', source }
+}
+
+describe('文件搜索来源 badge', () => {
+  test('会话与项目结果同时存在时显示来源区分', () => {
+    expect(hasMixedFileSources([result('session'), result('workspace')])).toBe(true)
+  })
+
+  test('结果只有单一来源时不显示冗余 badge', () => {
+    expect(hasMixedFileSources([result('session'), result('session')])).toBe(false)
+    expect(hasMixedFileSources([result('workspace')])).toBe(false)
+    expect(hasMixedFileSources([])).toBe(false)
+  })
+})

--- a/apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx
@@ -13,6 +13,7 @@ import { FileTypeIcon } from './FileTypeIcon'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { fileBrowserAutoRevealAtom } from '@/atoms/agent-atoms'
 import type { FileIndexEntry } from '@proma/shared'
+import { hasMixedFileSources } from './file-search-sources'
 
 interface FileSearchBarProps {
   workspaceFilesPath: string | null
@@ -244,6 +245,8 @@ export function FileSearchBar({
     return children ? <div className="mx-2 flex-shrink-0">{children}</div> : null
   }
 
+  const shouldShowSessionBadge = showSessionBadge && hasMixedFileSources(results)
+
   return (
     <div ref={containerRef} className="relative mx-2 flex-shrink-0">
       {/* 搜索输入框 */}
@@ -278,7 +281,7 @@ export function FileSearchBar({
                 key={`${entry.source}:${entry.path}`}
                 entry={entry}
                 isSelected={index === selectedIndex}
-                showSessionBadge={showSessionBadge}
+                showSessionBadge={shouldShowSessionBadge}
                 onClick={handleClick}
                 onHover={() => setSelectedIndex(index)}
               />

--- a/apps/electron/src/renderer/components/file-browser/file-search-sources.ts
+++ b/apps/electron/src/renderer/components/file-browser/file-search-sources.ts
@@ -1,0 +1,12 @@
+import type { FileIndexEntry } from '@proma/shared'
+
+export function hasMixedFileSources(entries: readonly FileIndexEntry[]): boolean {
+  let hasSession = false
+  let hasWorkspace = false
+  for (const entry of entries) {
+    if (entry.source === 'session') hasSession = true
+    if (entry.source === 'workspace') hasWorkspace = true
+    if (hasSession && hasWorkspace) return true
+  }
+  return false
+}


### PR DESCRIPTION
## 概述
当 Agent 右侧文件面板展开到 760px 或更宽时，同时展示会话文件和项目文件，减少在两个来源之间来回切换的操作成本。窄栏继续保留原有的单来源 Tab 切换；宽栏搜索同时覆盖两个来源，并在搜索结果确实包含两个来源时为会话文件添加来源 badge，避免同名文件难以辨认。

本 PR 同时修复宽栏拖动期间可能重复触发目录读取 IPC 的问题，稳定两个 FileBrowser 的 roots 引用，避免每帧重复执行主进程目录枚举。

## 改动
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 增加 760px 宽栏阈值；宽栏并列渲染会话文件与项目文件；窄栏保留原有来源 Tab；使用稳定的 memoized roots，避免宽度拖动造成重复 `listDirectory` 请求。
- `apps/electron/src/renderer/components/agent/file-panel-layout.ts` — 提供宽栏布局阈值判断。
- `apps/electron/src/renderer/components/agent/file-panel-layout.test.ts` — 覆盖宽栏阈值边界。
- `apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx` — 宽栏搜索同时查询两个来源，并根据实际搜索结果决定是否显示会话文件 badge。
- `apps/electron/src/renderer/components/file-browser/file-search-sources.ts` — 提供双来源结果判断逻辑。
- `apps/electron/src/renderer/components/file-browser/FileSearchBar.test.ts` — 覆盖单来源与双来源搜索结果的 badge 判断。
- `apps/electron/package.json` — Electron patch 版本从 `0.17.70` 升至 `0.17.71`。

## 测试方法
1. 执行 `bun install --frozen-lockfile`。
2. 执行 `bun test ./apps/electron/src/renderer/components/agent/file-panel-layout.test.ts ./apps/electron/src/renderer/components/file-browser/FileSearchBar.test.ts`，4 个测试通过。
3. 执行 `bun run --cwd apps/electron typecheck`，通过。
4. 执行 `bun run --cwd apps/electron build:renderer`，构建通过。
5. 执行 `git diff upstream/main...HEAD --check`，通过。
6. 手动验证右栏达到 760px 后出现两个文件区、来源 Tab 活动条消失、双源搜索中的会话文件显示 badge，以及拖动宽度时文件列表不重复刷新。

## 备注
- 本分支基于最新 `ErlichLiu/Proma/main` `c63fb3e6` 创建并已完成 rebase。
- Renderer build 仍会输出仓库已有的 `sonner` 动态/静态导入提示和 chunk size 提示；本 PR 未新增这些警告。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
