### PR TITLE
feat: streamline worktree tab workflow

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -10,11 +10,14 @@
 import { Type } from 'typebox'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
 import type { AgentToolResult } from '@earendil-works/pi-agent-core'
+import { AGENT_IPC_CHANNELS, normalizePathForCompare } from '@proma/shared'
 import type {
   CreateAutomationInput,
   PromaPermissionMode,
   UpdateAutomationInput,
 } from '@proma/shared'
+import { realpathSync } from 'node:fs'
+import { resolve } from 'node:path'
 import {
   createAutomation,
   deleteAutomation,
@@ -28,7 +31,10 @@ import {
   broadcastChanged as broadcastAutomationsChanged,
   runAutomationNow,
 } from '../automation-scheduler'
-import { getAgentSessionMeta } from '../agent-session-manager'
+import { getAgentSessionMeta, updateAgentSessionMeta } from '../agent-session-manager'
+import { getMainWindow } from '../main-window-store'
+import { getMainRepoRoot, listWorktrees } from '../git-diff-service'
+import { getWorktreeRepos } from '../agent-workspace-manager'
 import { isBuiltinMcpUserEnabled } from '../builtin-mcp/settings'
 import { downloadInstaller, launchInstaller } from '../installer-downloader'
 import { fetchInstallerManifest, findInstallerSource } from '../installer-manifest'
@@ -1229,6 +1235,90 @@ function buildBrowserTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefiniti
   ] as ToolDefinition[]
 }
 
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(resolve(path))
+  } catch {
+    return resolve(path)
+  }
+}
+
+/**
+ * 仅允许绑定当前会话已授权仓库（或工作区已登记仓库）的 linked worktree。
+ * 这让 Agent 能在 `proma-worktree start` 后接管新目录，但不能借此扩大文件访问边界。
+ */
+async function selectAgentWorktree(ctx: PiBuiltinToolsContext, worktreePath: string) {
+  const requestedPath = resolve(ctx.agentCwd ?? process.cwd(), worktreePath)
+  const requestedKey = normalizePathForCompare(canonicalPath(requestedPath))
+  const selected = (await listWorktrees(requestedPath)).find((worktree) =>
+    !worktree.isMain && normalizePathForCompare(canonicalPath(worktree.path)) === requestedKey,
+  )
+  if (!selected) throw new Error('指定目录不是可用的 linked worktree')
+
+  const mainRepoRoot = await getMainRepoRoot(selected.path)
+  if (!mainRepoRoot) throw new Error('无法确认 worktree 的主仓库')
+  const targetMainRepo = normalizePathForCompare(canonicalPath(mainRepoRoot))
+  const authorizedRoots = [ctx.agentCwd, ...(ctx.allowedRoots ?? [])].filter((root): root is string => Boolean(root))
+  let authorized = false
+  for (const root of authorizedRoots) {
+    const rootMainRepo = await getMainRepoRoot(root)
+    if (rootMainRepo && normalizePathForCompare(canonicalPath(rootMainRepo)) === targetMainRepo) {
+      authorized = true
+      break
+    }
+  }
+  if (!authorized && ctx.workspaceSlug) {
+    const repos = await getWorktreeRepos(ctx.workspaceSlug)
+    for (const repo of repos) {
+      const repoMainRoot = await getMainRepoRoot(repo.repoPath)
+      if (repoMainRoot && normalizePathForCompare(canonicalPath(repoMainRoot)) === targetMainRepo) {
+        authorized = true
+        break
+      }
+    }
+  }
+  if (!authorized) throw new Error('该 worktree 不属于当前会话已授权或已登记的仓库')
+
+  const session = updateAgentSessionMeta(ctx.sessionId, {
+    activeWorktree: {
+      path: canonicalPath(selected.path),
+      mainRepoRoot: canonicalPath(mainRepoRoot),
+      branch: selected.branch,
+      selectedAt: Date.now(),
+    },
+  })
+  const mainWindow = getMainWindow()
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(AGENT_IPC_CHANNELS.ACTIVE_WORKTREE_UPDATED, session)
+  }
+  return session
+}
+
+function buildAgentWorktreeTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinition[] {
+  // 后台自动任务与子 Agent 不主动重定向交互会话的开发目录。
+  if (ctx.triggeredBy === 'automation' || ctx.triggeredBy === 'delegation' || ctx.triggeredBy === 'external') return []
+
+  return [sdk.defineTool({
+    name: 'SelectWorktree',
+    label: '选择 Agent Worktree',
+    description: 'Bind this Agent session to an existing linked Git worktree that belongs to an authorized or registered repository. Use immediately after creating or identifying the worktree, before editing its files. The binding updates the visible Changes tab now and makes the worktree the Agent cwd for subsequent runs.',
+    promptSnippet: 'After creating or locating a linked worktree for this task, select it before editing files so the session and Changes tab stay aligned.',
+    parameters: Type.Object({
+      worktreePath: Type.String({ description: 'Absolute path, or a path relative to the current Agent cwd, of the linked worktree to use.' }),
+    }),
+    async execute(_toolCallId, params) {
+      const value = (params as Record<string, unknown>).worktreePath
+      const worktreePath = typeof value === 'string' ? value.trim() : ''
+      if (!worktreePath) throw new Error('worktreePath 必填')
+      const session = await selectAgentWorktree(ctx, worktreePath)
+      return jsonToolResult({
+        activeWorktree: session.activeWorktree,
+        note: '已绑定到当前会话；本轮后续命令如未显式指定 cwd，请使用该目录。下一轮 Agent 将自动以此 Worktree 为 cwd。',
+      })
+    },
+  })] as ToolDefinition[]
+}
+
 function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinition[] {
   // 无用户在场的来源不能启动或驱动本地交互终端；这既没有可见性，也会扩大自动任务与外部 Bridge 的权限。
   if (ctx.triggeredBy === 'automation' || ctx.triggeredBy === 'delegation' || ctx.triggeredBy === 'external') return []
@@ -1388,6 +1478,13 @@ export async function buildPiBuiltinTools(
     tools.push(...buildWindowsShellInstallerTools(sdk, ctx))
   } catch (error) {
     console.error('[Pi 桥接] 注入 Windows Shell 安装工具失败:', error)
+  }
+
+  // Worktree 选择让 Agent 在创建或发现分支目录后主动绑定会话，不扩大既有授权范围。
+  try {
+    tools.push(...buildAgentWorktreeTools(sdk, ctx))
+  } catch (error) {
+    console.error('[Pi 桥接] 注入 Worktree 选择工具失败:', error)
   }
 
   // Agent 终端以可见 PTY 承接直接执行；无用户在场的自动任务/子 Agent 不会获得该能力。

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -770,6 +770,8 @@ export interface ElectronAPI {
 
   /** 订阅 Agent 标题自动更新事件 */
   onAgentTitleUpdated: (callback: (data: { sessionId: string; title: string }) => void) => () => void
+  /** 订阅 Agent 主动更新活动 Worktree 的事件 */
+  onAgentActiveWorktreeUpdated: (callback: (session: AgentSessionMeta) => void) => () => void
 
   // ===== Agent 权限系统 =====
 
@@ -2120,6 +2122,11 @@ const electronAPI: ElectronAPI = {
     const listener = (_: unknown, data: { sessionId: string; title: string }): void => callback(data)
     ipcRenderer.on(AGENT_IPC_CHANNELS.TITLE_UPDATED, listener)
     return () => { ipcRenderer.removeListener(AGENT_IPC_CHANNELS.TITLE_UPDATED, listener) }
+  },
+  onAgentActiveWorktreeUpdated: (callback: (session: AgentSessionMeta) => void) => {
+    const listener = (_: unknown, session: AgentSessionMeta): void => callback(session)
+    ipcRenderer.on(AGENT_IPC_CHANNELS.ACTIVE_WORKTREE_UPDATED, listener)
+    return () => { ipcRenderer.removeListener(AGENT_IPC_CHANNELS.ACTIVE_WORKTREE_UPDATED, listener) }
   },
 
   // Agent 权限系统

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -693,6 +693,8 @@ export function getPreviewIdFromSidePanelTab(tab: AgentSidePanelTab | 'preview')
 export interface AgentTerminalTab {
   terminalId: string
   title: string
+  /** 用户从 Worktree 入口打开时，终端固定在对应根目录。 */
+  cwd?: string
 }
 
 export const agentTerminalTabsAtom = atom<Map<string, AgentTerminalTab[]>>(new Map())

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -87,7 +87,7 @@ import { getPreviewFileId, previewFileMapAtom, previewFilesMapAtom, previewPanel
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
-import type { FileEntry, AgentPendingFile, AgentSessionMeta, SDKMessage } from '@proma/shared'
+import type { FileEntry, AgentPendingFile, AgentSessionMeta, SDKMessage, WorktreeInfo } from '@proma/shared'
 import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
 import { TerminalTabContent } from '@/components/tabs/TerminalTabContent'
@@ -861,15 +861,19 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     }
   }, [browserState, ensureBrowserOpen, onTabChange, publishBrowserState, sessionId])
 
-  const handleOpenTerminal = React.useCallback(() => {
+  const handleOpenTerminal = React.useCallback((cwd?: string, title = '终端') => {
     const terminalId = crypto.randomUUID()
     setTerminalTabsMap((previous) => {
       const next = new Map(previous)
-      next.set(sessionId, [...(next.get(sessionId) ?? []), { terminalId, title: '终端' }])
+      next.set(sessionId, [...(next.get(sessionId) ?? []), { terminalId, title, cwd }])
       return next
     })
     onTabChange(getTerminalSidePanelTab(terminalId))
   }, [onTabChange, sessionId, setTerminalTabsMap])
+
+  const handleOpenWorktreeTerminal = React.useCallback((worktree: WorktreeInfo) => {
+    handleOpenTerminal(worktree.path, `终端 · ${worktree.branch}`)
+  }, [handleOpenTerminal])
 
   const handleCloseBrowserTab = React.useCallback(async (browserTabId: string) => {
     try {
@@ -1122,6 +1126,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                 onFileClick={handleDiffFileClick}
                 workspaceSlug={workspaceSlug || undefined}
                 worktreeRepoPaths={worktreeRepoPathsMemo}
+                onOpenWorktreeTerminal={handleOpenWorktreeTerminal}
                 nonGitFileChanges={nonGitFileChanges}
                 currentFileChangeRunId={fileChangesCurrentRunId}
                 onPlainFileClick={handleFilePreview}
@@ -1992,7 +1997,7 @@ function SidePanelTerminalTabs({
   sessionId,
   cwd,
 }: {
-  terminals: Array<{ terminalId: string; title: string }>
+  terminals: Array<{ terminalId: string; title: string; cwd?: string }>
   activeTerminalId: string | null
   sessionId: string
   cwd?: string
@@ -2005,7 +2010,7 @@ function SidePanelTerminalTabs({
           className={cn('absolute inset-0', terminal.terminalId === activeTerminalId ? 'block' : 'hidden')}
           aria-hidden={terminal.terminalId !== activeTerminalId}
         >
-          <TerminalTabContent terminalId={terminal.terminalId} sessionId={sessionId} cwd={cwd} terminateOnUnmount={false} />
+          <TerminalTabContent terminalId={terminal.terminalId} sessionId={sessionId} cwd={terminal.cwd ?? cwd} terminateOnUnmount={false} />
         </div>
       ))}
     </div>

--- a/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
@@ -58,7 +58,7 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
         const current = previous.get(event.sessionId) ?? []
         if (current.some((terminal) => terminal.terminalId === event.terminalId)) return previous
         const next = new Map(previous)
-        next.set(event.sessionId, [...current, { terminalId: event.terminalId, title: event.title }])
+        next.set(event.sessionId, [...current, { terminalId: event.terminalId, title: event.title, cwd: event.cwd }])
         return next
       })
       if (event.sessionId !== currentSessionId) return

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -61,6 +61,8 @@ interface DiffChangesListProps {
   workspaceSlug?: string
   /** 用于自动发现 worktree 的仓库候选路径 */
   worktreeRepoPaths?: string[]
+  /** 在指定 Worktree 根目录创建右侧终端 */
+  onOpenWorktreeTerminal?: (worktree: WorktreeInfo) => void
   /** 本会话在非 Git 目录中成功写入的文件 */
   nonGitFileChanges?: SessionFileChange[]
   /** 当前 Agent run ID，用于将文件变更划分为本轮和更早 */
@@ -80,6 +82,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   extraPaths,
   workspaceSlug,
   worktreeRepoPaths,
+  onOpenWorktreeTerminal,
   nonGitFileChanges = [],
   currentFileChangeRunId,
   onPlainFileClick,
@@ -270,6 +273,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
           repoPaths={worktreeRepoPaths}
           selectedPath={selectedWorktreePath}
           onSelect={handleWorktreeSelect}
+          onOpenTerminal={onOpenWorktreeTerminal}
         />
       )}
 

--- a/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import { GitBranch, ChevronDown, RefreshCw } from 'lucide-react'
+import { ChevronDown, GitBranch, RotateCw, SquareTerminal } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { WorktreeInfo, WorkspaceWorktreeRepo } from '@proma/shared'
 import { normalizePathForCompare } from '@proma/shared'
 
@@ -10,6 +11,7 @@ interface WorktreeSelectorProps {
   repoPaths?: string[]
   selectedPath: string | null
   onSelect: (worktree: WorktreeInfo | null) => void
+  onOpenTerminal?: (worktree: WorktreeInfo) => void
 }
 
 interface RepoWorktrees {
@@ -31,13 +33,18 @@ export function WorktreeSelector({
   repoPaths,
   selectedPath,
   onSelect,
+  onOpenTerminal,
 }: WorktreeSelectorProps): React.ReactElement {
   const [repoWorktrees, setRepoWorktrees] = React.useState<RepoWorktrees[]>([])
   const [isOpen, setIsOpen] = React.useState(false)
-  const [isLoading, setIsLoading] = React.useState(false)
+  // 初次挂载即保留工具栏高度，避免切回「改动」Tab 后选择器异步出现而推挤文件列表。
+  const [isLoading, setIsLoading] = React.useState(true)
   const dropdownRef = React.useRef<HTMLDivElement>(null)
+  /** 丢弃较早请求的迟到响应，避免手动刷新后回滚到旧 Worktree 列表。 */
+  const fetchSequenceRef = React.useRef(0)
 
   const fetchWorktrees = React.useCallback(async () => {
+    const requestId = ++fetchSequenceRef.current
     setIsLoading(true)
     try {
       const repoMap = new Map<string, WorkspaceWorktreeRepo>()
@@ -63,7 +70,7 @@ export function WorktreeSelector({
 
       const repos = Array.from(repoMap.values())
       if (repos.length === 0) {
-        setRepoWorktrees([])
+        if (requestId === fetchSequenceRef.current) setRepoWorktrees([])
         return
       }
 
@@ -76,14 +83,14 @@ export function WorktreeSelector({
             results.push({ repo, worktrees: nonMain })
           }
         } catch {
-          // skip repos that fail
+          // 跳过当前会话无权读取或已失效的仓库。
         }
       }
-      setRepoWorktrees(results)
+      if (requestId === fetchSequenceRef.current) setRepoWorktrees(results)
     } catch {
-      setRepoWorktrees([])
+      if (requestId === fetchSequenceRef.current) setRepoWorktrees([])
     } finally {
-      setIsLoading(false)
+      if (requestId === fetchSequenceRef.current) setIsLoading(false)
     }
   }, [workspaceSlug, repoPaths, sessionId])
 
@@ -92,8 +99,8 @@ export function WorktreeSelector({
   }, [fetchWorktrees])
 
   React.useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false)
       }
     }
@@ -104,80 +111,142 @@ export function WorktreeSelector({
   }, [isOpen])
 
   const allWorktrees = repoWorktrees.flatMap((rw) => rw.worktrees)
-  const selectedWorktree = allWorktrees.find((wt) => wt.path === selectedPath)
-  const displayLabel = selectedWorktree ? selectedWorktree.branch : 'Worktrees'
+  const selectedWorktree = allWorktrees.find((wt) => normalizePathKey(wt.path) === normalizePathKey(selectedPath ?? ''))
   const hasMultipleRepos = repoWorktrees.length > 1
 
-  if (allWorktrees.length === 0) return <></>
+  if (allWorktrees.length === 0 && !isLoading) return <></>
 
   return (
-    <div ref={dropdownRef} className="relative px-3 py-1.5 border-b border-border/50">
+    <div ref={dropdownRef} className="relative shrink-0 border-b border-border/60 bg-content-area px-2 py-2">
       <div className="flex items-center gap-1.5">
+        {allWorktrees.length === 0 ? (
+          <div className="flex h-9 min-w-0 flex-1 items-center gap-2 rounded-lg bg-muted/45 px-2.5" aria-busy="true">
+            <div className="size-3.5 shrink-0 rounded bg-muted-foreground/15 animate-pulse" />
+            <div className="min-w-0 flex-1 space-y-1">
+              <div className="h-2.5 w-28 rounded bg-muted-foreground/15 animate-pulse" />
+              <div className="h-2 w-16 rounded bg-muted-foreground/10 animate-pulse" />
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsOpen((open) => !open)}
+            className={cn(
+              'flex h-9 min-w-0 flex-1 items-center gap-2 rounded-lg bg-muted/45 px-2.5 py-1.5 text-left transition-[background-color,color] hover:bg-muted/75',
+              selectedWorktree ? 'text-foreground' : 'text-muted-foreground',
+            )}
+            aria-expanded={isOpen}
+          >
+            <GitBranch className="size-3.5 shrink-0 text-primary" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-xs font-medium leading-4">
+                {selectedWorktree?.branch ?? '选择开发 Worktree'}
+              </span>
+              <span className="block truncate text-[10px] leading-3 text-muted-foreground">
+                {selectedWorktree ? getPathBasename(selectedWorktree.path) : '会话改动'}
+              </span>
+            </span>
+            <ChevronDown className={cn('size-3.5 shrink-0 text-muted-foreground transition-transform', isOpen && 'rotate-180')} />
+          </button>
+        )}
+        {allWorktrees.length === 0 && selectedPath && onOpenTerminal && (
+          <span className="inline-flex size-9 shrink-0 items-center justify-center text-muted-foreground/30" aria-hidden="true">
+            <SquareTerminal className="size-4 animate-pulse" />
+          </span>
+        )}
+        {selectedWorktree && onOpenTerminal && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => onOpenTerminal(selectedWorktree)}
+                className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-[background-color,color,transform] hover:bg-muted hover:text-foreground active:scale-[0.96]"
+                aria-label={`在 ${selectedWorktree.branch} 打开终端`}
+              >
+                <SquareTerminal className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">在右侧标签中打开终端</TooltipContent>
+          </Tooltip>
+        )}
         <button
-          onClick={() => setIsOpen(!isOpen)}
-          className={cn(
-            'flex items-center gap-1.5 px-2 py-1 rounded-md text-xs',
-            'hover:bg-accent/50 transition-colors',
-            'text-muted-foreground hover:text-foreground',
-            selectedWorktree && 'text-foreground font-medium',
-          )}
+          type="button"
+          onClick={() => void fetchWorktrees()}
+          className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-[background-color,color,transform] hover:bg-muted hover:text-foreground active:scale-[0.96]"
+          title="刷新 Worktree 列表"
+          aria-label="刷新 Worktree 列表"
         >
-          <GitBranch className="w-3.5 h-3.5 shrink-0" />
-          <span className="truncate max-w-[160px]">{displayLabel}</span>
-          <ChevronDown className={cn('w-3 h-3 shrink-0 transition-transform', isOpen && 'rotate-180')} />
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            fetchWorktrees()
-          }}
-          className="p-1 rounded hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors"
-          title="刷新 worktree 列表"
-        >
-          <RefreshCw className={cn('w-3 h-3', isLoading && 'animate-spin')} />
+          <RotateCw className={cn('size-3.5', isLoading && 'animate-spin')} />
         </button>
       </div>
 
       {isOpen && (
-        <div className="absolute left-2 right-2 top-full mt-0.5 z-50 bg-popover border border-border rounded-md shadow-md py-1 max-h-[240px] overflow-y-auto">
+        <div className="absolute inset-x-2 top-full z-50 mt-1 overflow-hidden rounded-xl border border-border bg-popover p-1 shadow-lg" aria-label="开发 Worktree">
           <button
+            type="button"
             onClick={() => {
               onSelect(null)
               setIsOpen(false)
             }}
             className={cn(
-              'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors',
-              !selectedPath && 'bg-accent/30 font-medium',
+              'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent/60',
+              !selectedPath && 'bg-accent/45 font-medium',
             )}
           >
-            会话改动
+            <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block leading-4">会话改动</span>
+              <span className="block truncate text-[10px] leading-3 text-muted-foreground">显示此会话直接产生的改动</span>
+            </span>
           </button>
-          {repoWorktrees.map((rw) => (
-            <React.Fragment key={rw.repo.repoPath}>
-              {hasMultipleRepos && (
-                <div className="px-3 pt-2 pb-0.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
-                  {rw.repo.name}
-                </div>
-              )}
-              {rw.worktrees.map((wt) => (
-                <button
-                  key={wt.path}
-                  onClick={() => {
-                    onSelect(wt)
-                    setIsOpen(false)
-                  }}
-                  className={cn(
-                    'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors flex items-center gap-2',
-                    selectedPath === wt.path && 'bg-accent/30 font-medium',
-                  )}
-                >
-                  <GitBranch className="w-3 h-3 shrink-0 text-muted-foreground" />
-                  <span className="truncate">{wt.branch}</span>
-                  <span className="text-muted-foreground ml-auto shrink-0">{wt.head}</span>
-                </button>
-              ))}
-            </React.Fragment>
-          ))}
+          <div className="my-1 h-px bg-border/70" />
+          <div className="max-h-56 overflow-y-auto">
+            {repoWorktrees.map((rw) => (
+              <React.Fragment key={rw.repo.repoPath}>
+                {hasMultipleRepos && (
+                  <div className="px-2.5 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
+                    {rw.repo.name}
+                  </div>
+                )}
+                {rw.worktrees.map((wt) => {
+                  const selected = normalizePathKey(wt.path) === normalizePathKey(selectedPath ?? '')
+                  return (
+                    <div
+                      key={wt.path}
+                      className={cn('group flex items-center gap-1 rounded-lg', selected && 'bg-accent/45')}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onSelect(wt)
+                          setIsOpen(false)
+                        }}
+                        className="flex min-w-0 flex-1 items-center gap-2 px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent/60"
+                      >
+                        <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-medium leading-4">{wt.branch}</span>
+                          <span className="block truncate text-[10px] leading-3 text-muted-foreground">{wt.path}</span>
+                        </span>
+                        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">{wt.head}</span>
+                      </button>
+                      {onOpenTerminal && (
+                        <button
+                          type="button"
+                          onClick={() => onOpenTerminal(wt)}
+                          className="mr-1 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-[background-color,color,opacity,transform] hover:bg-background/80 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 active:scale-[0.96]"
+                          title={`在 ${wt.branch} 打开终端`}
+                          aria-label={`在 ${wt.branch} 打开终端`}
+                        >
+                          <SquareTerminal className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  )
+                })}
+              </React.Fragment>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -47,6 +47,7 @@ import {
   agentSessionPathMapAtom,
   agentDiffRefreshVersionAtom,
   agentDiffPanelTabAtom,
+  agentSelectedWorktreeAtom,
   agentNonGitFileChangesAtom,
   agentFileChangesCurrentRunAtom,
   agentSidePanelOpenAtomFamily,
@@ -877,6 +878,18 @@ export function useGlobalAgentListeners(): void {
       ) return
 
       autoActivatedChangeTurns.set(sessionId, runId)
+      // 本轮由已绑定 Worktree 的 Agent 触发时，同步改动面板的临时选择。
+      // 否则 atom 中曾缓存的 null 会覆盖会话元数据，导致自动打开 Tab 后仍展示会话改动。
+      const activeWorktreePath = store.get(agentSessionsAtom)
+        .find((session) => session.id === sessionId)?.activeWorktree?.path
+      if (activeWorktreePath) {
+        store.set(agentSelectedWorktreeAtom, (previous) => {
+          if (previous.get(sessionId) === activeWorktreePath) return previous
+          const next = new Map(previous)
+          next.set(sessionId, activeWorktreePath)
+          return next
+        })
+      }
       store.set(agentSidePanelOpenAtomFamily(sessionId), true)
       store.set(agentDiffPanelTabAtom, (prev) => {
         const map = new Map(prev)
@@ -1743,6 +1756,16 @@ export function useGlobalAgentListeners(): void {
         .catch(console.error)
     })
 
+    const cleanupActiveWorktreeUpdated = window.electronAPI.onAgentActiveWorktreeUpdated((session) => {
+      store.set(agentSessionsAtom, (previous) => upsertAgentSession(previous, session))
+      store.set(agentSelectedWorktreeAtom, (previous) => {
+        const next = new Map(previous)
+        if (session.activeWorktree?.path) next.set(session.id, session.activeWorktree.path)
+        else next.delete(session.id)
+        return next
+      })
+    })
+
     // ===== 5. Windows Agent Island 提示音委托 =====
     const cleanupPlaySound = window.electronAPI.onWindowsAgentIslandPlaySound(({ type }) => {
       const sounds = store.get(notificationSoundsAtom)
@@ -1859,6 +1882,7 @@ export function useGlobalAgentListeners(): void {
       cleanupComplete()
       cleanupError()
       cleanupTitleUpdated()
+      cleanupActiveWorktreeUpdated()
       cleanupPlaySound()
       cleanupWatchedFileChanges()
       cleanupQueuedMessageStatus()

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1671,6 +1671,8 @@ export const AGENT_IPC_CHANNELS = {
   UPDATE_SESSION_MODEL: 'agent:update-session-model',
   /** 选择或清除当前会话的活动 worktree */
   SET_ACTIVE_WORKTREE: 'agent:set-active-worktree',
+  /** 主进程通知 Renderer：Agent 主动切换了会话的活动 worktree */
+  ACTIVE_WORKTREE_UPDATED: 'agent:active-worktree-updated',
   /** 删除会话 */
   DELETE_SESSION: 'agent:delete-session',
   /** 迁移 Chat 对话记录到 Agent 会话 */


### PR DESCRIPTION
## Summary
- Keep the Worktree selector stable while the Changes tab loads, and add direct Worktree terminal entry points.
- Automatically align the Changes tab with the session-bound Worktree.
- Let a user-triggered Agent bind an authorized linked Worktree for subsequent runs.

## Validation
- `bun run typecheck`
- `git diff --check`

## Performance impact
Low risk: this adds only one session-scoped state update when a Worktree is selected or a change panel is auto-activated. The selector keeps a fixed-height loading skeleton to avoid layout shifts; it adds no polling, streaming updates, or new high-frequency IPC.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)