### PR TITLE
Fix Todo dialog not closing after creation

### DIFF
--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -482,6 +482,7 @@ function TodoWorkspace(): React.ReactElement {
       // 不自动打开详情；同时切换到新任务实际所属的视图，确保创建后立即可见。
       setSelectedId(null)
       setView(quickGroupId === '__none__' ? (dueAt ? 'today' : 'all') : `group:${quickGroupId}`)
+      setCreateOpen(false)
       setQuickTitle('')
       setQuickPriority('medium')
       setQuickDueAt(endOfToday())


### PR DESCRIPTION
## Summary

- 创建 Todo 成功后立即收起创建弹窗。

## Validation

- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`

## Performance

- 无明显性能影响：仅在单次创建请求成功后更新本地弹窗状态；不新增订阅、IPC、定时器或高频渲染路径。
- 未启动完整 Electron UI 进行手动交互验证，剩余风险仅限该成功回调的运行时路径。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)