### PR TITLE
fix(agent): 修复 mention 引用边界与中文 MCP 兼容

### DIFF
--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -146,6 +146,7 @@ function createMentionSuggestion<T>(
               onSelect: (item: T) => {
                 const cmd = config.toCommand(item)
                 props.command({ ...cmd, mentionSuggestionChar: config.char })
+                props.editor.chain().insertContent(' ').run()
               },
             },
             editor: props.editor,
@@ -174,6 +175,7 @@ function createMentionSuggestion<T>(
             onSelect: (item: T) => {
               const cmd = config.toCommand(item)
               props.command({ ...cmd, mentionSuggestionChar: config.char })
+              props.editor.chain().insertContent(' ').run()
             },
           })
           positionPopup(popup, props.clientRect?.())

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -41,6 +41,7 @@ import { CodeBlock, MermaidBlock } from '@proma/ui'
 import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isImageFilePath, isRelativeFilePath } from './file-path-chip'
 import { buildAgentHistoryQuoteLabel, parseAgentHistoryQuoteMention } from '@/lib/quoted-selection'
+import { createMentionPattern } from '@/lib/mention-patterns'
 import { useAgentBrowserLink } from '@/components/browser/AgentBrowserLinkProvider'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
@@ -412,8 +413,9 @@ export function remarkMentions() {
   return (tree: MdastParent) => {
     walkMdastText(tree, (node, index, parent) => {
       const text = node.value
-      // 每次调用创建独立正则实例，避免 /g 状态在并发 remark pipeline 间互相干扰
-      const mentionPattern = /@file:(\S+)|\/skill:(\S+)|#mcp:(\S+)|&session:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(\S+))?|&quote:([A-Za-z0-9%_.!~*'()-]+)/g
+      // 每次调用创建独立正则实例，避免 /g 状态在并发 remark pipeline 间互相干扰。
+      // Mention 值已编码，遇到紧邻的 CJK 普通文本时应立即结束。
+      const mentionPattern = createMentionPattern()
       if (!mentionPattern.test(text)) return
       mentionPattern.lastIndex = 0
 

--- a/apps/electron/src/renderer/lib/agent-message-queue.test.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.test.ts
@@ -46,4 +46,20 @@ describe('queued message @file mention path decoding (Agent 侧真实路径)', (
       expect(fileRef.label).toBe('My report.pdf')
     }
   })
+
+  test('preserves text immediately after a file mention without whitespace', () => {
+    const text = '@file:Screenshot%202026-08-24%20at%2014.17.47.png还是做一个单独渲染的内容吧'
+    const result = parseQueuedMessageMentions(text)
+
+    expect(result.cleanedText).toBe('@file:Screenshot 2026-08-24 at 14.17.47.png还是做一个单独渲染的内容吧')
+    expect(getQueuedMessageDisplayParts(text)).toEqual([
+      {
+        type: 'reference',
+        referenceType: 'file',
+        id: 'Screenshot%202026-08-24%20at%2014.17.47.png',
+        label: 'Screenshot 2026-08-24 at 14.17.47.png',
+      },
+      { type: 'text', value: '还是做一个单独渲染的内容吧' },
+    ])
+  })
 })

--- a/apps/electron/src/renderer/lib/agent-message-queue.test.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.test.ts
@@ -62,4 +62,21 @@ describe('queued message @file mention path decoding (Agent 侧真实路径)', (
       { type: 'text', value: '还是做一个单独渲染的内容吧' },
     ])
   })
+
+  test('parses and renders a CJK MCP server name', () => {
+    const text = '#mcp:中文服务器 后续处理'
+    const result = parseQueuedMessageMentions(text)
+
+    expect(result.mentionedMcpServers).toEqual(['中文服务器'])
+    expect(result.cleanedText).toBe('后续处理')
+    expect(getQueuedMessageDisplayParts(text)).toEqual([
+      {
+        type: 'reference',
+        referenceType: 'mcp',
+        id: '中文服务器',
+        label: '中文服务器',
+      },
+      { type: 'text', value: ' 后续处理' },
+    ])
+  })
 })

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -5,6 +5,7 @@ import {
   expandAgentHistoryQuoteMentions,
   parseAgentHistoryQuoteMention,
 } from './quoted-selection'
+import { MENTION_VALUE_PATTERN } from './mention-patterns'
 
 export type QueueDropPlacement = 'before' | 'after'
 
@@ -203,8 +204,14 @@ export function queuedTextToParagraphHtml(text: string): string {
     .join('')
 }
 
-const REF_PATTERN = /\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)\S+)?/g
-const DISPLAY_REFERENCE_PATTERN = /&quote:(?<quote>[A-Za-z0-9%_.!~*'()-]+)|@file:(?<file>\S+)|\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>\S+))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>\S+))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>\S+))?/g
+const REF_PATTERN = new RegExp(
+  String.raw`/skill:(?<skill>${MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?`,
+  'gu',
+)
+const DISPLAY_REFERENCE_PATTERN = new RegExp(
+  String.raw`&quote:(?<quote>[A-Za-z0-9%_.!~*'()-]+)|@file:(?<file>${MENTION_VALUE_PATTERN})|/skill:(?<skill>${MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>${MENTION_VALUE_PATTERN}))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>${MENTION_VALUE_PATTERN}))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>${MENTION_VALUE_PATTERN}))?`,
+  'gu',
+)
 
 function decodeReferenceLabel(value: string): string {
   try {
@@ -319,7 +326,7 @@ export function parseQueuedMessageMentions(text: string): ParsedQueuedMessageMen
       // @file: 路径在 htmlToMarkdown 序列化时已 encodeURIComponent（路径可能含空格），
       // 这里还原为真实路径，保证 Agent 侧读取的是可访问的完整路径；
       // 仅当含百分号编码时解码，避免破坏旧的未编码路径。
-      .replace(/@file:([^\s]+)/g, (full, encodedPath: string) =>
+      .replace(new RegExp(String.raw`@file:(${MENTION_VALUE_PATTERN})`, 'gu'), (full, encodedPath: string) =>
         /%[0-9A-Fa-f]{2}/.test(encodedPath)
           ? `@file:${decodeReferenceLabel(encodedPath)}`
           : full

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -5,7 +5,7 @@ import {
   expandAgentHistoryQuoteMentions,
   parseAgentHistoryQuoteMention,
 } from './quoted-selection'
-import { MENTION_VALUE_PATTERN } from './mention-patterns'
+import { ENCODED_MENTION_VALUE_PATTERN, PLAIN_MENTION_VALUE_PATTERN } from './mention-patterns'
 
 export type QueueDropPlacement = 'before' | 'after'
 
@@ -205,11 +205,11 @@ export function queuedTextToParagraphHtml(text: string): string {
 }
 
 const REF_PATTERN = new RegExp(
-  String.raw`/skill:(?<skill>${MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)${MENTION_VALUE_PATTERN})?`,
+  String.raw`/skill:(?<skill>${PLAIN_MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${PLAIN_MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)${ENCODED_MENTION_VALUE_PATTERN})?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)${ENCODED_MENTION_VALUE_PATTERN})?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)${ENCODED_MENTION_VALUE_PATTERN})?`,
   'gu',
 )
 const DISPLAY_REFERENCE_PATTERN = new RegExp(
-  String.raw`&quote:(?<quote>[A-Za-z0-9%_.!~*'()-]+)|@file:(?<file>${MENTION_VALUE_PATTERN})|/skill:(?<skill>${MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>${MENTION_VALUE_PATTERN}))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>${MENTION_VALUE_PATTERN}))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>${MENTION_VALUE_PATTERN}))?`,
+  String.raw`&quote:(?<quote>[A-Za-z0-9%_.!~*'()-]+)|@file:(?<file>${ENCODED_MENTION_VALUE_PATTERN})|/skill:(?<skill>${PLAIN_MENTION_VALUE_PATTERN})|#mcp:(?<mcp>${PLAIN_MENTION_VALUE_PATTERN})|&session:(?<session>[A-Za-z0-9-]+)(?:(?:~|::)(?<sessionLabel>${ENCODED_MENTION_VALUE_PATTERN}))?|&todo:(?<todo>[A-Za-z0-9-]+)(?:(?:~|::)(?<todoLabel>${ENCODED_MENTION_VALUE_PATTERN}))?|&calendar_event:(?<calendarEvent>[A-Za-z0-9-]+)(?:(?:~|::)(?<calendarEventLabel>${ENCODED_MENTION_VALUE_PATTERN}))?`,
   'gu',
 )
 
@@ -326,7 +326,7 @@ export function parseQueuedMessageMentions(text: string): ParsedQueuedMessageMen
       // @file: 路径在 htmlToMarkdown 序列化时已 encodeURIComponent（路径可能含空格），
       // 这里还原为真实路径，保证 Agent 侧读取的是可访问的完整路径；
       // 仅当含百分号编码时解码，避免破坏旧的未编码路径。
-      .replace(new RegExp(String.raw`@file:(${MENTION_VALUE_PATTERN})`, 'gu'), (full, encodedPath: string) =>
+      .replace(new RegExp(String.raw`@file:(${ENCODED_MENTION_VALUE_PATTERN})`, 'gu'), (full, encodedPath: string) =>
         /%[0-9A-Fa-f]{2}/.test(encodedPath)
           ? `@file:${decodeReferenceLabel(encodedPath)}`
           : full

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -188,6 +188,15 @@ describe('Agent mention serialization', () => {
     expect(markdown).toBe('@file:%2FUsers%2Fme%2FMy%20report.pdf')
   })
 
+  test('adds a separator when a mention is followed by adjacent English text', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown([
+      '<p>',
+      '<span data-type="mention" data-id="/Users/me/BPD与LD关系_综合研究报告.pdf" data-mention-suggestion-char="@">BPD与LD关系_综合研究报告.pdf</span>qwedqweq',
+      '</p>',
+    ].join('')))
+
+    expect(markdown).toBe(`@file:${encodeURIComponent('/Users/me/BPD与LD关系_综合研究报告.pdf')} qwedqweq`)
+  })
   test('serializes planning selections by reference type rather than the trigger character', () => {
     const markdown = withHtmlDocument(() => htmlToMarkdown([
       '<p>',

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -395,6 +395,11 @@ function serializeNamedMention(prefix: '&session' | '&todo' | '&calendar_event',
   return label ? `${prefix}:${id}::${encodeURIComponent(label)}` : `${prefix}:${id}`
 }
 
+function addMentionBoundary(serialized: string, element: HTMLElement): string {
+  const nextText = element.nextSibling?.textContent ?? ''
+  return nextText.length > 0 && !/^\s/u.test(nextText) ? `${serialized} ` : serialized
+}
+
 /** 将 TipTap 输出的 HTML 转换为 Markdown 格式 */
 export function htmlToMarkdown(
   html: string,
@@ -544,15 +549,20 @@ export function htmlToMarkdown(
         const referenceType = el.getAttribute('data-mention-reference-type')
         const agentHistoryQuote = el.getAttribute('data-mention-quote')
         if (dataType === 'mention') {
-          if (agentHistoryQuote) return `&quote:${agentHistoryQuote}`
-          if (referenceType === 'todo') return serializeNamedMention('&todo', dataId, dataLabel)
-          if (referenceType === 'calendar_event') return serializeNamedMention('&calendar_event', dataId, dataLabel)
-          if (suggestionChar === '/') return `/skill:${dataId}`
-          if (suggestionChar === '#') return `#mcp:${dataId}`
-          if (suggestionChar === '&') return serializeNamedMention('&session', dataId, dataLabel)
-          // 路径可能包含空格等字符，必须编码后再嵌入 @file: 协议，
-          // 否则展示层 @file:(\S+) 正则会在空格处截断（remarkMentions / MentionChip / 排队消息均内置解码）。
-          return `@file:${encodeURIComponent(dataId)}`
+          let serializedMention: string
+          if (agentHistoryQuote) serializedMention = `&quote:${agentHistoryQuote}`
+          else if (referenceType === 'todo') serializedMention = serializeNamedMention('&todo', dataId, dataLabel)
+          else if (referenceType === 'calendar_event') serializedMention = serializeNamedMention('&calendar_event', dataId, dataLabel)
+          else if (suggestionChar === '/') serializedMention = `/skill:${dataId}`
+          else if (suggestionChar === '#') serializedMention = `#mcp:${dataId}`
+          else if (suggestionChar === '&') serializedMention = serializeNamedMention('&session', dataId, dataLabel)
+          else {
+            // 路径可能包含空格等字符，必须编码后再嵌入 @file: 协议；
+            // 展示层和排队消息解析器会在显式空格或紧邻的 CJK 文本处结束 token；
+            // 序列化层会为未分隔的后续文本补充空格，避免 ASCII 后缀被吞进 chip。
+            serializedMention = `@file:${encodeURIComponent(dataId)}`
+          }
+          return addMentionBoundary(serializedMention, el)
         }
         return children
       }

--- a/apps/electron/src/renderer/lib/mention-patterns.test.ts
+++ b/apps/electron/src/renderer/lib/mention-patterns.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { createMentionPattern } from './mention-patterns'
+
+describe('mention token boundaries', () => {
+  test('stops a file chip before adjacent CJK text', () => {
+    const text = '@file:Screenshot%202026-08-24%20at%2014.17.47.png还是做一个单独渲染的内容吧'
+    const matches = Array.from(text.matchAll(createMentionPattern()))
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.[1]).toBe('Screenshot%202026-08-24%20at%2014.17.47.png')
+  })
+
+  test('keeps encoded named-reference labels intact before adjacent CJK text', () => {
+    const text = `&session:session-123::${encodeURIComponent('上下文整理')}继续查看`
+    const matches = Array.from(text.matchAll(createMentionPattern()))
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.[4]).toBe('session-123')
+    expect(matches[0]?.[5]).toBe(encodeURIComponent('上下文整理'))
+  })
+
+  test('still supports whitespace-delimited skill and MCP mentions', () => {
+    const text = '/skill:brainstorming #mcp:playwright 后续文本'
+    const matches = Array.from(text.matchAll(createMentionPattern()))
+
+    expect(matches.map((match) => match[0])).toEqual([
+      '/skill:brainstorming',
+      '#mcp:playwright',
+    ])
+  })
+})

--- a/apps/electron/src/renderer/lib/mention-patterns.test.ts
+++ b/apps/electron/src/renderer/lib/mention-patterns.test.ts
@@ -19,13 +19,14 @@ describe('mention token boundaries', () => {
     expect(matches[0]?.[5]).toBe(encodeURIComponent('上下文整理'))
   })
 
-  test('still supports whitespace-delimited skill and MCP mentions', () => {
-    const text = '/skill:brainstorming #mcp:playwright 后续文本'
+  test('supports whitespace-delimited raw Skill and MCP identifiers, including CJK MCP names', () => {
+    const text = '/skill:brainstorming #mcp:中文服务器 后续文本'
     const matches = Array.from(text.matchAll(createMentionPattern()))
 
     expect(matches.map((match) => match[0])).toEqual([
       '/skill:brainstorming',
-      '#mcp:playwright',
+      '#mcp:中文服务器',
     ])
+    expect(matches[1]?.[3]).toBe('中文服务器')
   })
 })

--- a/apps/electron/src/renderer/lib/mention-patterns.ts
+++ b/apps/electron/src/renderer/lib/mention-patterns.ts
@@ -1,0 +1,15 @@
+/**
+ * Mention values are serialized as non-whitespace tokens. CJK characters are
+ * excluded as well because generated mention values use percent encoding;
+ * this lets `@file:foo.md后续文字` end at the file name without requiring a
+ * separator in the user message.
+ */
+export const MENTION_VALUE_PATTERN = String.raw`[^\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}，。！？；：、（）【】《》“”‘’]+`
+
+/** Create a fresh instance because mention parsing uses a global regexp. */
+export function createMentionPattern(): RegExp {
+  return new RegExp(
+    String.raw`@file:(${MENTION_VALUE_PATTERN})|/skill:(${MENTION_VALUE_PATTERN})|#mcp:(${MENTION_VALUE_PATTERN})|&session:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&quote:([A-Za-z0-9%_.!~*'()-]+)`,
+    'gu',
+  )
+}

--- a/apps/electron/src/renderer/lib/mention-patterns.ts
+++ b/apps/electron/src/renderer/lib/mention-patterns.ts
@@ -1,15 +1,20 @@
 /**
- * Mention values are serialized as non-whitespace tokens. CJK characters are
- * excluded as well because generated mention values use percent encoding;
- * this lets `@file:foo.md后续文字` end at the file name without requiring a
- * separator in the user message.
+ * Encoded mention values are safe to end at adjacent CJK text because all
+ * generated paths and named-reference labels use encodeURIComponent.
  */
-export const MENTION_VALUE_PATTERN = String.raw`[^\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}，。！？；：、（）【】《》“”‘’]+`
+export const ENCODED_MENTION_VALUE_PATTERN = String.raw`[^\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}，。！？；：、（）【】《》“”‘’]+`
+
+/**
+ * MCP server names and Skill slugs are serialized as their raw IDs. These
+ * values may legitimately contain CJK characters, so their boundary is the
+ * explicit whitespace inserted by the mention suggestion and serializer.
+ */
+export const PLAIN_MENTION_VALUE_PATTERN = String.raw`\S+`
 
 /** Create a fresh instance because mention parsing uses a global regexp. */
 export function createMentionPattern(): RegExp {
   return new RegExp(
-    String.raw`@file:(${MENTION_VALUE_PATTERN})|/skill:(${MENTION_VALUE_PATTERN})|#mcp:(${MENTION_VALUE_PATTERN})|&session:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(${MENTION_VALUE_PATTERN}))?|&quote:([A-Za-z0-9%_.!~*'()-]+)`,
+    String.raw`@file:(${ENCODED_MENTION_VALUE_PATTERN})|/skill:(${PLAIN_MENTION_VALUE_PATTERN})|#mcp:(${PLAIN_MENTION_VALUE_PATTERN})|&session:([A-Za-z0-9-]+)(?:(?:~|::)(${ENCODED_MENTION_VALUE_PATTERN}))?|&todo:([A-Za-z0-9-]+)(?:(?:~|::)(${ENCODED_MENTION_VALUE_PATTERN}))?|&calendar_event:([A-Za-z0-9-]+)(?:(?:~|::)(${ENCODED_MENTION_VALUE_PATTERN}))?|&quote:([A-Za-z0-9%_.!~*'()-]+)`,
     'gu',
   )
 }


### PR DESCRIPTION
## 概述

修复 Agent 对话中 mention chip 与后续文本紧贴时的边界解析，并保持中文 MCP server 名称可被正确引用。

## 改动

- 为已编码值（文件路径、Session/Todo/日程标题）和原始 ID（Skill slug、MCP 名称）拆分边界规则。
- 继续在编码文件引用紧邻 CJK 文本时正确结束 chip。
- 保留 mention 选择和序列化时插入空格的行为，避免紧邻英文正文被吞并。
- 恢复中文 MCP server 名称在队列展示和发送 payload 中的解析。
- 增加中文 MCP 名称的正则、队列解析和 chip 展示回归测试。

## 验证

- `bun test ./apps/electron/src/renderer/lib/markdown-rich-text.test.ts ./apps/electron/src/renderer/lib/mention-patterns.test.ts ./apps/electron/src/renderer/lib/agent-message-queue.test.ts` — 35 passed
- `bun run --filter=@proma/electron typecheck` — passed
- `git diff --check` — passed

## 性能影响

无明显影响：仅对既有 mention 正则按协议类型分流；没有新增渲染、IPC、订阅或高频状态更新。

## 替代

替代并关闭 #1812：旧 PR 基于过期 main 且存在合并冲突；本 PR 已基于最新 `origin/main` 重放原修复并包含中文 MCP 兼容修复。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)