### PR TITLE
fix(terminal): fall back from missing working directory

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.71",
+  "version": "0.17.72",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.72",
+  "version": "0.17.73",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/terminal-cwd.test.ts
+++ b/apps/electron/src/main/lib/terminal-cwd.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { resolveTerminalCwd } from './terminal-cwd'
+import { requireTerminalCwd, resolveTerminalCwd } from './terminal-cwd'
 
 test('resolveTerminalCwd preserves an existing directory', () => {
   const root = mkdtempSync(join(tmpdir(), 'proma-terminal-cwd-'))
@@ -20,9 +20,23 @@ test('resolveTerminalCwd falls back when the requested path is missing or a file
   const file = join(root, 'file')
 
   try {
+    mkdirSync(fallback)
     writeFileSync(file, '', 'utf-8')
     expect(resolveTerminalCwd(join(root, 'missing'), fallback)).toBe(fallback)
     expect(resolveTerminalCwd(file, fallback)).toBe(fallback)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('requireTerminalCwd rejects missing and non-directory Agent cwd values', () => {
+  const root = mkdtempSync(join(tmpdir(), 'proma-terminal-cwd-'))
+  const file = join(root, 'file')
+
+  try {
+    writeFileSync(file, '', 'utf-8')
+    expect(() => requireTerminalCwd(join(root, 'missing'))).toThrow('终端工作目录不存在或不是目录')
+    expect(() => requireTerminalCwd(file)).toThrow('终端工作目录不存在或不是目录')
   } finally {
     rmSync(root, { recursive: true, force: true })
   }

--- a/apps/electron/src/main/lib/terminal-cwd.test.ts
+++ b/apps/electron/src/main/lib/terminal-cwd.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveTerminalCwd } from './terminal-cwd'
+
+test('resolveTerminalCwd preserves an existing directory', () => {
+  const root = mkdtempSync(join(tmpdir(), 'proma-terminal-cwd-'))
+
+  try {
+    expect(resolveTerminalCwd(root, 'fallback')).toBe(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveTerminalCwd falls back when the requested path is missing or a file', () => {
+  const root = mkdtempSync(join(tmpdir(), 'proma-terminal-cwd-'))
+  const fallback = join(root, 'fallback')
+  const file = join(root, 'file')
+
+  try {
+    writeFileSync(file, '', 'utf-8')
+    expect(resolveTerminalCwd(join(root, 'missing'), fallback)).toBe(fallback)
+    expect(resolveTerminalCwd(file, fallback)).toBe(fallback)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/apps/electron/src/main/lib/terminal-cwd.ts
+++ b/apps/electron/src/main/lib/terminal-cwd.ts
@@ -1,0 +1,20 @@
+import { existsSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+
+/**
+ * 普通终端可由用户在目录被移除后再次打开。此时保留可用的终端体验，
+ * 而不是将失效的历史 cwd 传给 PTY。Agent 终端仍在 terminal-agent-policy 中
+ * 执行单独的授权范围校验。
+ */
+export function resolveTerminalCwd(cwd: string | undefined, fallback = homedir()): string {
+  return isDirectory(cwd) ? cwd : fallback
+}
+
+function isDirectory(path: string | undefined): path is string {
+  if (!path || !existsSync(path)) return false
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}

--- a/apps/electron/src/main/lib/terminal-cwd.ts
+++ b/apps/electron/src/main/lib/terminal-cwd.ts
@@ -1,13 +1,20 @@
 import { existsSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 
+const INVALID_CWD_ERROR = '终端工作目录不存在或不是目录'
+
 /**
  * 普通终端可由用户在目录被移除后再次打开。此时保留可用的终端体验，
- * 而不是将失效的历史 cwd 传给 PTY。Agent 终端仍在 terminal-agent-policy 中
- * 执行单独的授权范围校验。
+ * 而不是将失效的历史 cwd 传给 PTY。
  */
 export function resolveTerminalCwd(cwd: string | undefined, fallback = homedir()): string {
   return isDirectory(cwd) ? cwd : fallback
+}
+
+/** Agent 终端必须始终在已授权且有效的目录中启动。 */
+export function requireTerminalCwd(cwd: string | undefined): string {
+  if (!isDirectory(cwd)) throw new Error(INVALID_CWD_ERROR)
+  return cwd
 }
 
 function isDirectory(path: string | undefined): path is string {

--- a/apps/electron/src/main/lib/terminal-runtime-client.ts
+++ b/apps/electron/src/main/lib/terminal-runtime-client.ts
@@ -20,6 +20,10 @@ type PendingCreate = {
   reject: (reason: Error) => void
 }
 
+type RuntimeTerminalCreateInput = TerminalCreateInput & {
+  strictCwd?: boolean
+}
+
 type RuntimeMessage =
   | { type: 'terminal.ready'; pid: number }
   | { type: 'terminal.created'; state: TerminalState }
@@ -51,7 +55,7 @@ export class TerminalRuntimeClient {
     return () => this.exitListeners.delete(listener)
   }
 
-  async create(input: TerminalCreateInput): Promise<TerminalState> {
+  async create(input: TerminalCreateInput, options: { strictCwd?: boolean } = {}): Promise<TerminalState> {
     await this.start()
     const pending = this.pendingCreates.get(input.terminalId)
     if (pending) return pending.promise
@@ -63,7 +67,10 @@ export class TerminalRuntimeClient {
       rejectCreate = reject
     })
     this.pendingCreates.set(input.terminalId, { promise, resolve: resolveCreate, reject: rejectCreate })
-    this.port?.postMessage({ type: 'terminal.create', input })
+    const runtimeInput: RuntimeTerminalCreateInput = options.strictCwd
+      ? { ...input, strictCwd: true }
+      : input
+    this.port?.postMessage({ type: 'terminal.create', input: runtimeInput })
     return promise
   }
 

--- a/apps/electron/src/main/lib/terminal-service.ts
+++ b/apps/electron/src/main/lib/terminal-service.ts
@@ -13,7 +13,7 @@ import {
 import { getMainWindow } from './main-window-store'
 import { appendTerminalOutput, type TerminalOutputBuffer } from './terminal-output-buffer'
 import { resolveAgentTerminalCwd } from './terminal-agent-policy'
-import { resolveTerminalCwd } from './terminal-cwd'
+import { requireTerminalCwd, resolveTerminalCwd } from './terminal-cwd'
 import { terminalRuntimeClient } from './terminal-runtime-client'
 
 const terminals = new Map<string, TerminalState>()
@@ -54,14 +54,17 @@ function initialize(): void {
   })
 }
 
-export async function createTerminal(input: TerminalCreateInput): Promise<TerminalState> {
+export async function createTerminal(
+  input: TerminalCreateInput,
+  options: { strictCwd?: boolean } = {},
+): Promise<TerminalState> {
   initialize()
   validateTerminalId(input.terminalId)
   const existing = terminals.get(input.terminalId)
   if (existing) return existing
   const pending = pendingTerminals.get(input.terminalId)
   if (pending) return pending
-  const cwd = resolveTerminalCwd(input.cwd)
+  const cwd = options.strictCwd ? requireTerminalCwd(input.cwd) : resolveTerminalCwd(input.cwd)
 
   // Record ownership before spawning so a concurrent session deletion can cancel it.
   terminalSessionOwners.set(input.terminalId, input.sessionId)
@@ -72,7 +75,7 @@ export async function createTerminal(input: TerminalCreateInput): Promise<Termin
     cwd,
     cols: normalizeDimension(input.cols),
     rows: normalizeDimension(input.rows),
-  }).then((state) => {
+  }, options).then((state) => {
     if (cancelledPendingTerminalIds.delete(state.terminalId)) {
       terminalRuntimeClient.kill(state.terminalId)
       throw new Error('终端已在创建完成前关闭')
@@ -133,7 +136,7 @@ export async function openAgentTerminal(input: {
   const cwd = resolveAgentTerminalCwd(input)
   const terminalId = randomUUID()
   const title = input.title?.trim().slice(0, 80) || 'Agent 终端'
-  await createTerminal({ terminalId, sessionId: input.sessionId, cwd, cols: 80, rows: 24 })
+  await createTerminal({ terminalId, sessionId: input.sessionId, cwd, cols: 80, rows: 24 }, { strictCwd: true })
   const record: AgentTerminalRecord = { sessionId: input.sessionId, terminalId, title, cwd, status: 'running' }
   agentTerminals.set(terminalId, record)
   notifyAgentTerminalOpen(record)

--- a/apps/electron/src/main/lib/terminal-service.ts
+++ b/apps/electron/src/main/lib/terminal-service.ts
@@ -1,6 +1,4 @@
-import { existsSync, statSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { homedir } from 'node:os'
 import {
   TERMINAL_IPC_CHANNELS,
   type AgentTerminalCloseEvent,
@@ -15,6 +13,7 @@ import {
 import { getMainWindow } from './main-window-store'
 import { appendTerminalOutput, type TerminalOutputBuffer } from './terminal-output-buffer'
 import { resolveAgentTerminalCwd } from './terminal-agent-policy'
+import { resolveTerminalCwd } from './terminal-cwd'
 import { terminalRuntimeClient } from './terminal-runtime-client'
 
 const terminals = new Map<string, TerminalState>()
@@ -62,9 +61,7 @@ export async function createTerminal(input: TerminalCreateInput): Promise<Termin
   if (existing) return existing
   const pending = pendingTerminals.get(input.terminalId)
   if (pending) return pending
-  if (input.cwd && (!existsSync(input.cwd) || !statSync(input.cwd).isDirectory())) {
-    throw new Error('终端工作目录不存在或不是目录')
-  }
+  const cwd = resolveTerminalCwd(input.cwd)
 
   // Record ownership before spawning so a concurrent session deletion can cancel it.
   terminalSessionOwners.set(input.terminalId, input.sessionId)
@@ -72,7 +69,7 @@ export async function createTerminal(input: TerminalCreateInput): Promise<Termin
   terminalOutputBuffers.set(input.terminalId, { output: '', sequence: 0 })
   const creation = terminalRuntimeClient.create({
     ...input,
-    cwd: input.cwd || homedir(),
+    cwd,
     cols: normalizeDimension(input.cols),
     rows: normalizeDimension(input.rows),
   }).then((state) => {

--- a/apps/electron/src/utility/terminal-runtime.ts
+++ b/apps/electron/src/utility/terminal-runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { spawn, type IPty } from 'node-pty'
@@ -26,8 +26,12 @@ type ParentPortLike = {
   start?: () => void
 }
 
+type RuntimeTerminalCreateInput = TerminalCreateInput & {
+  strictCwd?: boolean
+}
+
 type RuntimeRequest =
-  | { type: 'terminal.create'; input: TerminalCreateInput }
+  | { type: 'terminal.create'; input: RuntimeTerminalCreateInput }
   | { type: 'terminal.input'; input: TerminalInput }
   | { type: 'terminal.resize'; input: TerminalResizeInput }
   | { type: 'terminal.kill'; terminalId: string }
@@ -105,7 +109,7 @@ function handleRequest(raw: unknown): void {
   }
 }
 
-function createTerminal(input: TerminalCreateInput): void {
+function createTerminal(input: RuntimeTerminalCreateInput): void {
   const existing = terminals.get(input.terminalId)
   if (existing) {
     runtimePort?.postMessage({ type: 'terminal.created', state: existing.state })
@@ -114,17 +118,18 @@ function createTerminal(input: TerminalCreateInput): void {
   const profile = isTerminalProfile(input.profile) ? input.profile : 'default'
   const shell = resolveShell(profile)
   try {
+    const cwd = getSafeCwd(input.cwd, input.strictCwd === true)
     const pty = spawn(shell.file, shell.args, {
       name: 'xterm-256color',
       cols: normalizeDimension(input.cols),
       rows: normalizeDimension(input.rows),
-      cwd: getSafeCwd(input.cwd),
+      cwd,
       env: { ...process.env, TERM: 'xterm-256color' },
     })
     const state: TerminalState = {
       terminalId: input.terminalId,
       title: shell.title,
-      cwd: getSafeCwd(input.cwd),
+      cwd,
       profile,
       pid: pty.pid,
     }
@@ -223,8 +228,19 @@ function destroyTerminal(terminalId: string): void {
   }
 }
 
-function getSafeCwd(cwd: string | undefined): string {
-  return cwd && existsSync(cwd) ? cwd : homedir()
+function getSafeCwd(cwd: string | undefined, strict: boolean): string {
+  if (isDirectory(cwd)) return cwd
+  if (strict) throw new Error('终端工作目录不存在或不是目录')
+  return homedir()
+}
+
+function isDirectory(path: string | undefined): path is string {
+  if (!path || !existsSync(path)) return false
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
 }
 
 function normalizeDimension(value: number): number {


### PR DESCRIPTION
## Summary

- Fall back to the user home directory when a manually opened terminal receives a missing or non-directory cwd.
- Preserve the existing strict authorization checks for Agent-owned terminals.
- Add focused coverage for existing, missing, and file cwd inputs.

## Validation

- `bun test ./apps/electron/src/main/lib/terminal-cwd.test.ts`
- `bun run typecheck`
- `bun run build:terminal-runtime`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)