### PR TITLE
feat(windows): unify top titlebar controls

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.71",
+  "version": "0.17.72",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.73",
+  "version": "0.17.74",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -8,7 +8,8 @@ import { TooltipProvider } from './components/ui/tooltip'
 import { ShortcutGuideDialog } from './components/shortcuts/ShortcutGuideDialog'
 import { FaqDialog } from './components/shortcuts/FaqDialog'
 import { WindowControls } from './components/WindowControls'
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from './lib/platform'
+import { detectIsWindows } from './lib/platform'
+import { getWindowTitlebarContentInsetClass } from './lib/window-titlebar-layout'
 import { cn } from './lib/utils'
 import { PlanningReminderRail } from './components/planning/PlanningReminderRail'
 import { conversationsAtom } from './atoms/chat-atoms'
@@ -108,15 +109,7 @@ export default function App(): React.ReactElement {
   if (showOnboarding) {
     return (
       <TooltipProvider delayDuration={200} disableHoverableContent>
-        <div className="relative h-screen w-screen overflow-hidden">
-          {/* Onboarding 绕过 AppShell 时仍需提供隐藏标题栏窗口的拖拽区，并避开 Windows 控制按钮。 */}
-          <div
-            aria-hidden="true"
-            className={cn(
-              'titlebar-drag-region fixed left-0 top-0 z-50 h-[50px]',
-              isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0',
-            )}
-          />
+        <div className={cn('relative h-screen w-screen overflow-hidden', getWindowTitlebarContentInsetClass(isWindows))}>
           <WindowControls />
           <OnboardingView
             initialStep={isReplayingOnboarding ? 'guide' : 'welcome'}

--- a/apps/electron/src/renderer/components/WindowControls.tsx
+++ b/apps/electron/src/renderer/components/WindowControls.tsx
@@ -1,13 +1,9 @@
-/**
- * WindowControls - Windows 自定义窗口控制按钮（最小化/最大化/关闭）
- * 仅 Windows 平台渲染，替换 Electron 原生 titleBarOverlay 按钮。
- */
-
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import { detectIsWindows } from '@/lib/platform'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { cn } from '@/lib/utils'
+import { getWindowTitlebarDragInsetClass } from '@/lib/window-titlebar-layout'
 
 export function WindowControls(): React.ReactElement | null {
   const isWindows = React.useMemo(() => detectIsWindows(), [])
@@ -15,15 +11,11 @@ export function WindowControls(): React.ReactElement | null {
   const isClassic = interfaceVariant === 'classic'
   const [isMaximized, setIsMaximized] = React.useState(false)
 
-  // 初始化最大化状态并监听窗口 resize 事件
   React.useEffect(() => {
     if (!isWindows) return
     window.electronAPI.windowIsMaximized().then(setIsMaximized)
     const unsub = window.electronAPI.onWindowResize(() => {
       window.electronAPI.windowIsMaximized().then((next) => {
-        // 只在状态实际变化时 setState，避免每次 resize 都触发重渲染——
-        // Windows 上每次重渲染都会让 Chromium 重算可拖拽区域，期间存在数十 ms 的 stale 窗口，
-        // 用户在此窗口内点击按钮会被 OS 误判为标题栏点击。
         setIsMaximized((prev) => (prev === next ? prev : next))
       })
     })
@@ -34,51 +26,51 @@ export function WindowControls(): React.ReactElement | null {
 
   return (
     <div className={cn(
-      "window-controls fixed z-[100] flex select-none",
-      isClassic ? "right-[16px] top-[12px]" : "right-[8px] top-[5px]"
+      'window-titlebar fixed inset-x-0 top-0 z-[100] flex h-8 select-none',
+      isClassic && 'window-titlebar-classic',
     )}>
-      {/* 最小化 */}
-      <button
-        type="button"
-        className="window-control-btn"
-        aria-label="最小化"
-        onClick={() => window.electronAPI.windowMinimize()}
-      >
-        <svg width="12" height="12" viewBox="0 0 12 12">
-          <rect x="1" y="5.5" width="10" height="1" fill="currentColor" />
-        </svg>
-      </button>
-
-      {/* 最大化/还原 */}
-      <button
-        type="button"
-        className="window-control-btn"
-        aria-label={isMaximized ? '还原' : '最大化'}
-        onClick={() => window.electronAPI.windowMaximize()}
-      >
-        {isMaximized ? (
+      <div aria-hidden="true" className={cn('titlebar-drag-region absolute inset-y-0 left-0', getWindowTitlebarDragInsetClass(isWindows))} />
+      <div className="window-controls relative ml-auto flex">
+        <button
+          type="button"
+          className="window-control-btn"
+          aria-label="最小化"
+          onClick={() => window.electronAPI.windowMinimize()}
+        >
           <svg width="12" height="12" viewBox="0 0 12 12">
-            <rect x="3" y="0.5" width="8" height="8" rx="0.5" fill="none" stroke="currentColor" strokeWidth="1" />
-            <rect x="1" y="3.5" width="8" height="8" rx="0.5" fill="currentColor" stroke="currentColor" strokeWidth="1" />
+            <rect x="1" y="5.5" width="10" height="1" fill="currentColor" />
           </svg>
-        ) : (
-          <svg width="12" height="12" viewBox="0 0 12 12">
-            <rect x="1.5" y="1.5" width="9" height="9" rx="1" fill="none" stroke="currentColor" strokeWidth="1" />
-          </svg>
-        )}
-      </button>
+        </button>
 
-      {/* 关闭 */}
-      <button
-        type="button"
-        className="window-control-btn window-control-close"
-        aria-label="关闭"
-        onClick={() => window.electronAPI.windowClose()}
-      >
-        <svg width="12" height="12" viewBox="0 0 12 12">
-          <path d="M1.5 1.5l9 9M10.5 1.5l-9 9" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-        </svg>
-      </button>
+        <button
+          type="button"
+          className="window-control-btn"
+          aria-label={isMaximized ? '还原' : '最大化'}
+          onClick={() => window.electronAPI.windowMaximize()}
+        >
+          {isMaximized ? (
+            <svg width="12" height="12" viewBox="0 0 12 12">
+              <rect x="3" y="0.5" width="8" height="8" rx="0.5" fill="none" stroke="currentColor" strokeWidth="1" />
+              <rect x="1" y="3.5" width="8" height="8" rx="0.5" fill="currentColor" stroke="currentColor" strokeWidth="1" />
+            </svg>
+          ) : (
+            <svg width="12" height="12" viewBox="0 0 12 12">
+              <rect x="1.5" y="1.5" width="9" height="9" rx="1" fill="none" stroke="currentColor" strokeWidth="1" />
+            </svg>
+          )}
+        </button>
+
+        <button
+          type="button"
+          className="window-control-btn window-control-close"
+          aria-label="关闭"
+          onClick={() => window.electronAPI.windowClose()}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12">
+            <path d="M1.5 1.5l9 9M10.5 1.5l-9 9" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        </button>
+      </div>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryWindowApp.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryWindowApp.tsx
@@ -7,7 +7,8 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { WindowControls } from '@/components/WindowControls'
 import { MessageResponse } from '@/components/ai-elements/message'
-import { WINDOW_CONTROLS_INSET_RIGHT, WINDOW_CONTROLS_PADDING_RIGHT, detectIsMac, detectIsWindows } from '@/lib/platform'
+import { detectIsMac, detectIsWindows } from '@/lib/platform'
+import { getWindowTitlebarContentInsetClass } from '@/lib/window-titlebar-layout'
 import { cn } from '@/lib/utils'
 
 function flattenFiles(nodes: SkillFileNode[]): SkillFileNode[] {
@@ -214,16 +215,12 @@ export function WorkspaceMemoryWindowApp(): React.ReactElement {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      <div className="flex h-screen min-h-0 flex-col overflow-hidden bg-content-area antialiased">
+      <div className={cn('flex h-screen min-h-0 flex-col overflow-hidden bg-content-area antialiased', getWindowTitlebarContentInsetClass(isWindows))}>
         <WindowControls />
         <header className={cn(
-          'relative flex h-12 shrink-0 items-center border-b border-border/70',
-          isMac ? 'pl-[88px] pr-5' : isWindows ? `pl-5 ${WINDOW_CONTROLS_PADDING_RIGHT}` : 'px-5',
+          'relative flex h-12 shrink-0 items-center border-b border-border/70 titlebar-no-drag',
+          isMac ? 'pl-[88px] pr-5' : 'px-5',
         )}>
-          {/* 拖拽层：容器本身不再直接 app-region: drag。
-              Windows 上用 WINDOW_CONTROLS_INSET_RIGHT 让出右上角按钮区域，
-              避免 drag hitmask 与 WindowControls 按钮重叠导致最小化/最大化/关闭不生效。 */}
-          <div aria-hidden="true" className={cn('titlebar-drag-region pointer-events-none absolute inset-y-0 left-0', isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0')} />
           <div>
             <h1 className="text-sm font-semibold text-foreground">工作区记忆</h1>
             <p className="text-[11px] text-muted-foreground">{workspaceSlug} · memory/</p>

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -10,7 +10,6 @@ import { Check, ChevronDown, PanelRight, Pencil, Split, X } from 'lucide-react'
 import { agentSessionsAtom, agentSideTemporaryAgentMapAtom, agentDiffPanelTabAtom, currentSessionSidePanelOpenAtom, getExplorationSidePanelTab } from '@/atoms/agent-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { replaceAgentSessionInFreshnessOrder } from '@/lib/agent-session-list'
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import {
   DropdownMenu,
@@ -25,7 +24,6 @@ interface AgentHeaderProps {
 }
 
 export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement | null {
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
   const sessions = useAtomValue(agentSessionsAtom)
   const session = sessions.find((s) => s.id === sessionId) ?? null
   const setAgentSessions = useSetAtom(agentSessionsAtom)
@@ -100,8 +98,8 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
 
   return (
     <div className="relative z-[51] flex items-center gap-2 px-3 h-[48px]">
-      {/* 拖拽层覆盖整行（Windows 避开右上角 WindowControls ~126px），编辑/标题按钮内部已自带 titlebar-no-drag。 */}
-      <div className={cn("absolute inset-0 titlebar-drag-region pointer-events-none", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
+      {/* 页面标题栏仍可拖动；系统控制按钮由窗口顶部的统一标题栏承载。 */}
+      <div className="absolute inset-0 titlebar-drag-region pointer-events-none" />
       {editing ? (
         <div className="flex items-center gap-1.5 flex-1 min-w-0 titlebar-no-drag">
           <input

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -88,7 +88,6 @@ import { BrowserPanel } from '@/components/browser/BrowserPanel'
 import { getPreviewFileId, previewFileMapAtom, previewFilesMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { useOpenPreview } from '@/components/diff/preview-opener'
-import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile, AgentSessionMeta, SDKMessage, WorktreeInfo } from '@proma/shared'
 import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
@@ -255,8 +254,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const showBothFileSources = shouldShowBothFileSources(width)
   // 侧面板状态按 sessionId 持久化，切换会话不会互相覆盖。
   const [isOpen, setIsOpen] = useAtom(currentSessionSidePanelOpenAtom)
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
-
   // Tab 系统
   const previewFileMap = useAtomValue(previewFileMapAtom)
   const setPreviewFileMap = useSetAtom(previewFileMapAtom)
@@ -1087,7 +1084,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       <div
         className={cn(
           'w-full h-full flex flex-col titlebar-no-drag',
-          isWindows ? 'pt-[34px]' : 'pt-0',
           shouldAnimate && 'transition-opacity duration-300',
           isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
         )}
@@ -1109,7 +1105,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
               <ExplorationBringBackAction parentSessionId={sessionId} branch={activeExplorationBranch} sessions={sessions} />
             ) : undefined}
             onClose={() => setIsOpen(false)}
-            isWindows={isWindows}
           />
 
           <SidePanelTerminalTabs

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -23,7 +23,8 @@ import { interfaceVariantAtom } from '@/atoms/theme'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { WindowControls } from '@/components/WindowControls'
 import { SettingsPanel } from '@/components/settings/SettingsPanel'
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
+import { detectIsWindows } from '@/lib/platform'
+import { getWindowTitlebarContentInsetClass } from '@/lib/window-titlebar-layout'
 import { cn } from '@/lib/utils'
 import { Toaster } from '@/components/ui/sonner'
 
@@ -284,22 +285,10 @@ export function AppShell(): React.ReactElement {
 
   return (
     <>
-      {/* 可拖动标题栏区域，用于窗口拖动。
-          Windows 上必须避开右上角的 WindowControls 区域（buttons ~118px + 8px buffer = 126px），
-          否则 drag-region 与按钮区的 hitmask 重叠会让 OS 把单击当成标题栏点击，
-          表现为"按钮要双击才响应"。 */}
-      <div
-        className={cn(
-          'titlebar-drag-region fixed top-0 left-0 h-[50px] z-50',
-          isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0'
-        )}
-      />
-
-      {/* Windows 自定义窗口控制按钮（最小化/最大化/关闭） */}
       <WindowControls />
 
       <div className="shell-bg relative h-screen w-screen overflow-hidden bg-gradient-to-br from-zinc-50 to-zinc-100 dark:from-zinc-950 dark:to-zinc-900">
-        <div className={cn('flex h-full w-full', settingsOpen && 'hidden')} aria-hidden={settingsOpen}>
+        <div className={cn('flex h-full w-full', getWindowTitlebarContentInsetClass(isWindows), settingsOpen && 'hidden')} aria-hidden={settingsOpen}>
             {/* 左侧边栏：可折叠，可拖拽调整宽度 */}
             <div className={cn(isClassic ? 'p-2 pr-0' : '', 'relative z-[60] crt-sidebar')}>
               <LeftSidebar width={clampedLeftSidebarWidth} noTransition={isDraggingLeftSidebar} />

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -15,7 +15,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { BROWSER_RISK_DISCLAIMER_VERSION } from '@/types/settings'
-import { detectIsWindows, getWindowControlsPaddingClass } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import { browserPendingNavigationMapAtom } from '@/atoms/browser-atoms'
 import { BrowserSlot } from './BrowserSlot'
@@ -118,10 +117,9 @@ export function BrowserPanel({ sessionId, tabId, state, isAddTabMenuOpen = false
   // 依赖 controller.activeTabId 的历史操作，导航则始终显式携带当前 tabId。
   const isControllerTabActive = state?.activeTabId === tabId
   const isBackgroundRun = state?.executionSource === 'automation' || state?.executionSource === 'delegation'
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
   return (
     <div className="flex h-full min-w-0 flex-col overflow-hidden border-l border-border/80 bg-content-area titlebar-no-drag">
-      <div className={cn('flex items-center h-[42px] gap-1 px-2 border-b border-border/40 bg-muted/20', getWindowControlsPaddingClass(isWindows))}>
+      <div className="flex items-center h-[42px] gap-1 px-2 border-b border-border/40 bg-muted/20">
         <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !isControllerTabActive || !state?.canGoBack} onClick={() => void window.electronAPI.goBackAgentBrowser?.(sessionId)}><ChevronLeft className="size-5" /></Button></TooltipTrigger><TooltipContent>后退</TooltipContent></Tooltip>
         <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !isControllerTabActive || !state?.canGoForward} onClick={() => void window.electronAPI.goForwardAgentBrowser?.(sessionId)}><ChevronRight className="size-5" /></Button></TooltipTrigger><TooltipContent>前进</TooltipContent></Tooltip>
         <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-8 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" disabled={riskBlocked || !isControllerTabActive} onClick={() => void window.electronAPI.reloadAgentBrowser?.(sessionId)}><RotateCw className="size-[18px]" /></Button></TooltipTrigger><TooltipContent>刷新</TooltipContent></Tooltip>

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -13,7 +13,6 @@ import type { ConversationMeta } from '@proma/shared'
 import { SystemPromptSelector } from './SystemPromptSelector'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
 interface ChatHeaderProps {
@@ -21,7 +20,6 @@ interface ChatHeaderProps {
 }
 
 export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElement | null {
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
   const setConversations = useSetAtom(conversationsAtom)
   const [parallelMode, setParallelMode] = useConversationParallelMode()
   const [editing, setEditing] = React.useState(false)
@@ -68,9 +66,8 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
 
   return (
     <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px]">
-      {/* 拖拽层仅覆盖左侧区域，Windows 上避开右上角 WindowControls（~126px）。
-          否则 header 的 drag-region 会与按钮重叠，导致 OS hitmask 把单击当成标题栏点击。 */}
-      <div className={cn("absolute inset-0 titlebar-drag-region pointer-events-none", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
+      {/* 系统控制按钮由窗口顶部的统一标题栏承载。 */}
+      <div className="absolute inset-0 titlebar-drag-region pointer-events-none" />
       {editing ? (
         <div className="flex items-center gap-1.5 flex-1 min-w-0 titlebar-no-drag">
           <input

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -8,7 +8,6 @@ import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { Blocks, Brain, CalendarDays, Clock, FolderOpen, Globe, ListTodo, MessageCircle, PanelRight, Plus, Repeat2, ServerCog, SquareTerminal, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { getScrollLeftToRevealTab } from '@/lib/tab-visibility'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import {
@@ -44,7 +43,6 @@ interface DiffPanelTabBarProps {
   /** 仅当前右侧 Tab 需要的紧凑动作，渲染于标签列表之后，不影响内容区布局。 */
   activeTabAction?: React.ReactNode
   onClose?: () => void
-  isWindows?: boolean
 }
 
 export function DiffPanelTabBar({
@@ -60,7 +58,6 @@ export function DiffPanelTabBar({
   onOpenChat,
   activeTabAction,
   onClose,
-  isWindows = false,
 }: DiffPanelTabBarProps): React.ReactElement {
   const unseenMap = useAtomValue(agentDiffUnseenChangesAtom)
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
@@ -105,7 +102,7 @@ export function DiffPanelTabBar({
 
   return (
     <div className="relative flex h-10 shrink-0 items-center border-b border-border/50 bg-content-area">
-      <div className={cn('pointer-events-none absolute inset-0 titlebar-drag-region', isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
+      <div className="pointer-events-none absolute inset-0 titlebar-drag-region" />
       <div className="relative flex min-w-0 flex-1 items-center titlebar-no-drag">
         <div ref={tabListRef} className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto overscroll-x-contain px-2 py-1 scrollbar-none" role="tablist" aria-label="右侧工作区">
           {tabs.map((tab) => {

--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -29,7 +29,6 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog'
 import { TodoDatePicker } from '@/components/ui/todo-date-picker'
 import { ShortcutKeycaps } from '@/components/shortcuts/ShortcutKeycaps'
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { getTodoWorkspaceLayoutMode, type TodoWorkspaceLayoutMode } from '@/components/planning/todo-layout'
 
 const TABS: Array<{ id: PlanningTab; label: string }> = [
@@ -62,7 +61,6 @@ export function PlanningView({
   // planningTabAtom 的初始值为 Todo；右侧组件由 componentTab 锁定，避免组件 Tab 与内部导航失焦。
   const [tab, setTab] = useAtom(planningTabAtom)
   const visibleTab = embedded && componentTab ? componentTab : tab
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
   const automations = useAtomValue(automationsAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
   const requestTodoCreate = useSetAtom(planningTodoCreateRequestAtom)
@@ -92,7 +90,7 @@ export function PlanningView({
   return (
     <div className="flex h-full flex-col overflow-hidden bg-content-area">
       <header className={cn('relative flex w-full items-center justify-between titlebar-no-drag', embedded ? 'px-4 py-3' : 'px-6 pb-5 pt-8 sm:px-8 xl:px-10')}>
-        <div className={cn('absolute inset-y-0 left-0 z-0 titlebar-drag-region', isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0')} />
+        <div className="absolute inset-y-0 left-0 z-0 titlebar-drag-region right-0" />
         <div className="relative z-[1]">
           <h1 className={cn('font-semibold tracking-tight text-wrap-balance', embedded ? 'text-lg' : 'text-2xl')}>{visibleTab === 'todos' ? 'Todo' : visibleTab === 'calendar' ? '日程' : '定时任务'}</h1>
           <p className={cn('text-muted-foreground', embedded ? 'mt-0.5 text-xs' : 'mt-1 text-sm')}>{visibleTab === 'todos' ? '今天要完成什么？' : visibleTab === 'calendar' ? '安排你的时间' : '持续运行的自动任务'}</p>

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -8,7 +8,6 @@
 import * as React from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { cn } from "@/lib/utils";
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from "@/lib/platform";
 import {
   Settings,
   Radio,
@@ -181,8 +180,6 @@ export function SettingsPanel({
   const [mainTabs, setMainTabs] = useAtom(tabsAtom);
   const setMainActiveTabId = useSetAtom(activeTabIdAtom);
   const openSession = useOpenSession()
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
-
   /** 统一的退出拦截对话框状态 */
   type PendingAction =
     | { type: 'tab'; tabId: SettingsTab }
@@ -298,17 +295,8 @@ export function SettingsPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-content-area text-foreground">
-      {/* 顶部可拖动标题栏区域。背景层保持全宽；drag 层在 Windows 上必须避开右上角的
-          WindowControls 按钮区域（WINDOW_CONTROLS_INSET_RIGHT），否则 OS hitmask 会把
-          按钮点击误判为标题栏点击，导致最小化/最大化/关闭按钮无响应（与 AppShell/TabBar 一致）。 */}
       <div className="relative h-[35px] flex-shrink-0 bg-[hsl(var(--sidebar-surface))]">
-        <div
-          aria-hidden="true"
-          className={cn(
-            'titlebar-drag-region pointer-events-none absolute left-0 top-0 h-full',
-            isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0',
-          )}
-        />
+        <div aria-hidden="true" className="titlebar-drag-region pointer-events-none absolute inset-0" />
       </div>
 
       {/* 主体：左导航 + 右内容 */}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -39,7 +39,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { TabBarItem } from './TabBarItem'
 import { getTabBarActionLayout } from './tab-bar-action-layout'
 import { useCloseTab } from '@/hooks/useCloseTab'
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import { shortcutGuideOpenAtom } from '@/atoms/shortcut-guide'
 import { faqDialogOpenAtom } from '@/atoms/faq-dialog'
@@ -231,7 +230,6 @@ function TabBarInner({
   const enterTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const leaveTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const fadeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
 
   // 文件面板按会话独立保存；Agent 会话及其归属的预览 Tab 都可切换面板；
   // 仅 Agent 会话 Tab 在面板关闭时展示右上角"打开"按钮。
@@ -254,7 +252,7 @@ function TabBarInner({
   const setBrowserStateMap = useSetAtom(browserStateMapAtom)
   const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const hasMinimizedBrowser = Boolean(activeAgentSession && browserStateMap.has(activeAgentSession.id) && browserMinimizedMap.get(activeAgentSession.id) === true)
-  const actionLayout = getTabBarActionLayout(isWindows, showOpenPanelButton, showBrowserButton)
+  const actionLayout = getTabBarActionLayout(showOpenPanelButton, showBrowserButton)
 
   const togglePanel = React.useCallback(() => {
     if (!isAgentContextTab(activeTab)) return
@@ -412,11 +410,10 @@ function TabBarInner({
 
   return (
     <div ref={barRef} className="main-tabbar flex items-end h-[34px] tabbar-bg relative">
-      {/* 顶部 TabBar 的空白区域必须保持可拖拽，尤其是 macOS/Windows 自定义标题栏。
-          注意：不要把 titlebar-no-drag 加到下面的整条 flex 容器上，否则标签右侧空白会再次失去拖拽能力。
-          Windows 上背景拖拽层避开右上角 WindowControls 区域（126px），防止 hitmask 重叠。
+      {/* 顶部 TabBar 的空白区域保持可拖拽；系统控制按钮由窗口顶部的统一标题栏承载。
+          不要把 titlebar-no-drag 加到下面的整条 flex 容器上，否则标签右侧空白会失去拖拽能力。
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
-      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
+      <div className="pointer-events-none absolute inset-0 titlebar-drag-region" />
 
       {/* Tear-off 提示遮罩：拖出 TabBar 区域时，让 TabBar 下方出现一条高亮分割线 */}
       {tearingOff && (

--- a/apps/electron/src/renderer/components/tabs/tab-bar-action-layout.ts
+++ b/apps/electron/src/renderer/components/tabs/tab-bar-action-layout.ts
@@ -4,30 +4,15 @@ export interface TabBarActionLayout {
   panelPositionClassName: string
 }
 
-/**
- * 保持 Tab 栏右侧操作区与窗口控制按钮分离，同时为标签滚动区留出空间。
- */
-export function getTabBarActionLayout(isWindows: boolean, hasPanelButton: boolean, hasBrowserButton = false): TabBarActionLayout {
-  if (!isWindows) {
-    return {
-      scrollPaddingClassName: hasPanelButton
-        ? (hasBrowserButton ? 'pr-28' : 'pr-20')
-        : (hasBrowserButton ? 'pr-20' : 'pr-10'),
-      shortcutPositionClassName: hasPanelButton
-        ? 'inset-y-0 items-end pb-[3px] z-10 right-9'
-        : 'inset-y-0 items-end pb-[3px] z-10 right-1',
-      panelPositionClassName: 'inset-y-0 right-1 items-end pb-[3px] z-10',
-    }
-  }
-
+/** 保持 Tab 栏右侧操作区与标签滚动区分离。窗口控制按钮位于全局顶部标题栏。 */
+export function getTabBarActionLayout(hasPanelButton: boolean, hasBrowserButton = false): TabBarActionLayout {
   return {
-    // 126px WindowControls + 60px 快捷操作区；文件面板按钮额外占用 28px 与 4px 间隔。
     scrollPaddingClassName: hasPanelButton
-      ? (hasBrowserButton ? 'pr-[246px]' : 'pr-[218px]')
-      : (hasBrowserButton ? 'pr-[218px]' : 'pr-[190px]'),
+      ? (hasBrowserButton ? 'pr-28' : 'pr-20')
+      : (hasBrowserButton ? 'pr-20' : 'pr-10'),
     shortcutPositionClassName: hasPanelButton
-      ? 'inset-y-0 items-end pb-[3px] z-10 right-[158px]'
-      : 'inset-y-0 items-end pb-[3px] z-10 right-[130px]',
-    panelPositionClassName: 'inset-y-0 right-[126px] items-end pb-[3px] z-10',
+      ? 'inset-y-0 items-end pb-[3px] z-10 right-9'
+      : 'inset-y-0 items-end pb-[3px] z-10 right-1',
+    panelPositionClassName: 'inset-y-0 right-1 items-end pb-[3px] z-10',
   }
 }

--- a/apps/electron/src/renderer/lib/platform.ts
+++ b/apps/electron/src/renderer/lib/platform.ts
@@ -1,15 +1,3 @@
-/**
- * Windows 自定义 WindowControls 按钮区域总宽度（3 buttons × ~42px）。
- * 拖拽层和内容区需避让此宽度，防止 OS hitmask 冲突。
- */
-export const WINDOW_CONTROLS_WIDTH_PX = 126
-export const WINDOW_CONTROLS_INSET_RIGHT = 'right-[126px]'
-export const WINDOW_CONTROLS_PADDING_RIGHT = 'pr-[126px]'
-
-export function getWindowControlsPaddingClass(isWindows: boolean): string {
-  return isWindows ? WINDOW_CONTROLS_PADDING_RIGHT : ''
-}
-
 export function detectIsWindows(): boolean {
   const platform =
     typeof navigator !== 'undefined' &&

--- a/apps/electron/src/renderer/lib/window-titlebar-layout.ts
+++ b/apps/electron/src/renderer/lib/window-titlebar-layout.ts
@@ -1,0 +1,10 @@
+export const WINDOW_TITLEBAR_HEIGHT_PX = 32
+export const WINDOW_TITLEBAR_CONTROLS_WIDTH_PX = 138
+
+export function getWindowTitlebarContentInsetClass(isWindows: boolean): string {
+  return isWindows ? 'pt-8' : ''
+}
+
+export function getWindowTitlebarDragInsetClass(isWindows: boolean): string {
+  return isWindows ? 'right-[138px]' : 'right-0'
+}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -576,8 +576,7 @@
 
 /* Windows 顶部标题栏与系统控制按钮。拖拽区和按钮组分属独立矩形，避免高 DPI 下的 hitmask 重叠。 */
 .window-titlebar {
-  background-color: hsl(var(--background) / 0.9);
-  backdrop-filter: blur(12px);
+  background-color: hsl(var(--background));
 }
 
 .window-titlebar-classic {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -574,29 +574,29 @@
   border-right: 7px solid currentColor;
 }
 
-/* Windows 自定义窗口控制按钮
- *
- * 可点击性关键点（解决 Windows 用户点击失效 / 需要双击的 bug）：
- * 1. 容器本身就是 no-drag 矩形，不靠"在 drag 区里挖三个小洞"——避免 Chromium hitmask
- *    在小矩形 + 高 DPI 缩放下的像素对齐误差。
- * 2. AppShell 的 drag-region 在 Windows 上不再延伸到按钮区域（见 AppShell.tsx 的 right-[126px]），
- *    drag 与 no-drag 区域彻底解耦，OS hitmask 不会再误判。
- * 3. 按钮尺寸与位置使用整数 px，避免 125%/150%/175% DPI 下四舍五入收缩。
- */
+/* Windows 顶部标题栏与系统控制按钮。拖拽区和按钮组分属独立矩形，避免高 DPI 下的 hitmask 重叠。 */
+.window-titlebar {
+  background-color: hsl(var(--background) / 0.9);
+  backdrop-filter: blur(12px);
+}
+
+.window-titlebar-classic {
+  background-color: hsl(var(--sidebar-surface));
+}
+
 .window-controls {
   -webkit-app-region: no-drag;
   app-region: no-drag;
-  height: 28px;
-  gap: 1px;
+  height: 32px;
 }
 
 .window-control-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 28px;
-  border-radius: 4px;
+  width: 46px;
+  height: 32px;
+  border-radius: 0;
   color: hsl(var(--muted-foreground));
   background: transparent;
   border: none;


### PR DESCRIPTION
## Summary

- Move Windows minimize, maximize, and close controls into a persistent full-width top titlebar.
- Reserve the titlebar height across the main shell, onboarding, and workspace-memory window.
- Remove obsolete content-level control insets so headers and tab actions use their full width.
- Remove the titlebar bottom divider for a continuous visual surface.
- Bump `@proma/electron` to `0.17.72`.

## Validation

- `bun run --cwd apps/electron typecheck`
- `bun run --cwd apps/electron build:renderer`
- Manual Electron dev smoke test on Windows

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)