### PR TITLE
fix(agent): improve Windows project instruction resolution

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.74",
+  "version": "0.17.75",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-project-instruction-scope.ts
+++ b/apps/electron/src/main/lib/adapters/pi-project-instruction-scope.ts
@@ -1,8 +1,9 @@
-import { realpathSync } from 'node:fs'
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import {
+  normalizeProjectPathForComparison,
   resolveProjectInstructions,
+  canonicalizeProjectPath,
   type ProjectInstructionSource,
 } from '../project-instruction-resolver'
 import { buildLegacyProjectMigrationPrompt } from '../project-instruction-migration'
@@ -24,11 +25,15 @@ interface ScopeToolDecision {
 }
 
 function sourceKey(source: ProjectInstructionSource): string {
-  return `${source.path}\0${source.contentHash}`
+  return `${normalizeForComparison(source.path)}\0${source.contentHash}`
+}
+
+function normalizeForComparison(path: string): string {
+  return normalizeProjectPathForComparison(path)
 }
 
 function isWithinScope(candidate: string, scopeRoot: string): boolean {
-  const pathRelative = relative(scopeRoot, candidate)
+  const pathRelative = relative(normalizeForComparison(scopeRoot), normalizeForComparison(candidate))
   return pathRelative === '' || (!!pathRelative && !pathRelative.startsWith('..') && !isAbsolute(pathRelative))
 }
 
@@ -51,11 +56,7 @@ function resolveTargetDirectory(call: ScopedToolCall, cwd: string): string | und
   const scopePath = call.toolName === 'ls' || call.toolName === 'find' || call.toolName === 'grep'
     ? targetPath
     : dirname(targetPath)
-  try {
-    return realpathSync(scopePath)
-  } catch {
-    return scopePath
-  }
+  return canonicalizeProjectPath(scopePath)
 }
 
 function formatSource(source: ProjectInstructionSource): string {
@@ -75,7 +76,7 @@ export class ProjectInstructionScopeController {
   private readonly pending = new Map<string, ProjectInstructionSource>()
 
   constructor(options: ProjectInstructionScopeOptions) {
-    this.projectRoot = realpathSync(options.projectRoot)
+    this.projectRoot = canonicalizeProjectPath(options.projectRoot)
     this.cwd = options.cwd
     for (const source of options.initialSources) {
       this.delivered.add(sourceKey(source))
@@ -118,15 +119,14 @@ export class ProjectInstructionScopeController {
     if (!isMutationTool(call.toolName)) return undefined
     const targetPath = typeof call.input.path === 'string' ? resolve(this.cwd, call.input.path) : undefined
     const canonicalTargetPath = targetPath
-      ? (() => {
-          try { return realpathSync(targetPath) } catch { return join(targetDirectory, basename(targetPath)) }
-        })()
+      ? canonicalizeProjectPath(targetPath)
       : undefined
-    const legacySource = manifest.sources.find((source) => source.kind === 'claude' && canonicalTargetPath && isWithinScope(canonicalTargetPath, dirname(source.path)))
+    if (!canonicalTargetPath) return undefined
+    const legacySource = manifest.sources.find((source) => source.kind === 'claude' && isWithinScope(canonicalTargetPath, dirname(source.path)))
     if (!legacySource) return undefined
 
-    const expectedAgentsPath = join(dirname(legacySource.path), 'AGENTS.md')
-    if (canonicalTargetPath === expectedAgentsPath) return undefined
+    const expectedAgentsPath = canonicalizeProjectPath(join(dirname(legacySource.path), 'AGENTS.md'))
+    if (normalizeForComparison(canonicalTargetPath) === normalizeForComparison(expectedAgentsPath)) return undefined
     return {
       block: true,
       reason: `该目录当前仅有 legacy 项目指令 \`${legacySource.relativePath}\`。请先结合当前目录实际情况创建同目录 \`AGENTS.md\`，保留原 CLAUDE.md，然后再修改其他项目文件。`,

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1432,7 +1432,7 @@ export class AgentOrchestrator {
         permissionMode: initialPermissionMode,
         collaborationAvailable,
         currentModelId: selectedModelId,
-        legacyProjectInstructions: projectInstructions?.sources,
+        projectInstructions,
         projectKnowledgeMaintenanceApproved,
         memoryGuidance,
         memoryRefreshOpportunity,

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -4,6 +4,7 @@
  */
 
 import type { PromaPermissionMode, SessionWorkbenchLayout } from '@proma/shared'
+import { lstatSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { getUserProfile } from './user-profile-service'
@@ -67,6 +68,16 @@ function buildWorkspacePaths(
     autoMemoryIndex: join(workspaceRoot, 'memory', 'MEMORY.md'),
     mcpConfig: join(workspaceRoot, 'mcp.json'),
     skillsDir: join(workspaceRoot, 'skills'),
+    workspaceAgentsExists: isRegularFile(join(workspaceRoot, 'AGENTS.md')),
+    projectAgentsExists: isRegularFile(join(projectRoot, 'AGENTS.md')),
+  }
+}
+
+function isRegularFile(path: string): boolean {
+  try {
+    return lstatSync(path).isFile()
+  } catch {
+    return false
   }
 }
 
@@ -104,7 +115,7 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
       ? `## 工作区与 Context
 - 项目根：\`${workspace.projectRoot}\`（${workspace.isLocalProject ? '用户本地原始文件' : 'Proma 托管项目文件'}）；cwd：\`${workspace.agentCwd}\`（${workspace.isProjectCwd ? '当前直接在项目根工作' : '会话工作台，不等同项目根'}）。
 - 会话工作台：\`${sessionContextDir}\`，用于本次任务、计划和交接；新会话直接使用 workbench 根，历史会话兼容 \`.context/\`。项目级 Context：\`${projectContextDir}\` 用于跨会话资料。用户指定位置优先；不要随意清理本地项目。
-- Proma 工作区规则：\`${workspace.agentsMd}\`；记忆索引：\`${workspace.autoMemoryIndex}\`；MCP：\`${workspace.mcpConfig}\`；Skills：\`${workspace.skillsDir}\`。只使用 Proma 工作区的 MCP/Skills 配置。
+- Proma 工作区规则：\`${workspace.agentsMd}\`${workspace.workspaceAgentsExists ? '（已加载）' : '（当前未建立；这是候选路径，不要读取）'}；记忆索引：\`${workspace.autoMemoryIndex}\`；MCP：\`${workspace.mcpConfig}\`；Skills：\`${workspace.skillsDir}\`。只使用 Proma 工作区的 MCP/Skills 配置。
 - 需要原文或更多细节时，再按当前任务读取两级 Context、记忆索引或 Skill 元数据；禁止无差别全量扫描。`
       : undefined,
     buildLegacyProjectMigrationRequirement({ sources: ctx.legacyProjectInstructions ?? [] }),
@@ -113,8 +124,8 @@ Proma 将项目地图与用户协作记忆分开维护：前者让 Agent 少做�
 
 | 层级 | 位置 | 维护方式 | 内容边界 |
 | --- | --- | --- | --- |
-| 项目地图 | \`${workspace?.projectAgentsMd ?? '项目根/AGENTS.md'}\` | ${agentsMaintenanceMode} | 架构、目录、命令、验证、项目边界与关键文档索引 |
-| Proma 工作区规则 | \`${workspace?.agentsMd ?? 'AGENTS.md'}\` | ${agentsMaintenanceMode} | Proma 执行环境、工作区流程、项目入口指针；不复制项目地图 |
+| 项目地图 | \`${workspace?.projectAgentsMd ?? '项目根/AGENTS.md'}\` | ${agentsMaintenanceMode}${workspace && !workspace.projectAgentsExists ? '；当前未建立' : ''} | 架构、目录、命令、验证、项目边界与关键文档索引 |
+| Proma 工作区规则 | \`${workspace?.agentsMd ?? 'AGENTS.md'}\` | ${agentsMaintenanceMode}${workspace && !workspace.workspaceAgentsExists ? '；当前未建立' : ''} | Proma 执行环境、工作区流程、项目入口指针；不复制项目地图 |
 | 协作记忆 | \`${workspace?.autoMemoryDir ?? 'memory'}\` | 已验证的最小增量可直接写入并在完成后说明；删除/大段覆盖、冲突、不确定推断或敏感信息先确认 | 用户画像、协作偏好、纠错、经验与会影响未来判断的决策理由；\`MEMORY.md\` 只作主题索引 |
 | Skills | \`${workspace?.skillsDir ?? 'skills'}\` | 仅在匹配任务或用户请求时读取/维护 | 可复用流程与 SOP，不存普通事实 |
 | 会话工作台 | \`${sessionContextDir}\` | 当前会话可读写 | todo、plan、handoff、临时笔记和中间产物，不自动升级为长期知识 |

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -12,7 +12,7 @@ import { getAgentWorkspaceBySlug, getProjectFilesPath, getWorkspaceMcpConfig, ty
 import { getConfigDirName } from './config-paths'
 import { buildGitAttributionPromptSection, isGitAttributionEnabled } from './agent-git-attribution'
 import { getSettings } from './settings-service'
-import type { ProjectInstructionSource } from './project-instruction-resolver'
+import { hasRootProjectAgentsInstruction, type ProjectInstructionManifest } from './project-instruction-resolver'
 import { buildLegacyProjectMigrationPrompt as buildLegacyProjectMigrationRequirement } from './project-instruction-migration'
 import type { BrowserUserContextSnapshot } from './browser-controller'
 
@@ -31,7 +31,7 @@ interface SystemPromptContext {
   permissionMode: PromaPermissionMode
   collaborationAvailable?: boolean
   currentModelId?: string
-  legacyProjectInstructions?: ProjectInstructionSource[]
+  projectInstructions?: ProjectInstructionManifest
   /** Only explicit guided consent enables Agent-initiated AGENTS.md maintenance. */
   projectKnowledgeMaintenanceApproved?: boolean
   /** 每次前台运行按 Markdown 文件实际覆盖度计算；不产生第二套记忆状态。 */
@@ -45,6 +45,7 @@ function buildWorkspacePaths(
   sessionId: string,
   agentCwd?: string,
   sessionWorkbenchLayout: SessionWorkbenchLayout = 'legacy-context',
+  projectAgentsExists = false,
 ) {
   const configDirName = getConfigDirName()
   const workspaceRoot = join(homedir(), configDirName, 'agent-workspaces', workspaceSlug)
@@ -69,7 +70,7 @@ function buildWorkspacePaths(
     mcpConfig: join(workspaceRoot, 'mcp.json'),
     skillsDir: join(workspaceRoot, 'skills'),
     workspaceAgentsExists: isRegularFile(join(workspaceRoot, 'AGENTS.md')),
-    projectAgentsExists: isRegularFile(join(projectRoot, 'AGENTS.md')),
+    projectAgentsExists,
   }
 }
 
@@ -85,7 +86,13 @@ function isRegularFile(path: string): boolean {
 export function buildSystemPrompt(ctx: SystemPromptContext): string {
   const userName = getUserProfile().userName || '用户'
   const workspace = ctx.workspaceSlug
-    ? buildWorkspacePaths(ctx.workspaceSlug, ctx.sessionId, ctx.agentCwd, ctx.sessionWorkbenchLayout)
+    ? buildWorkspacePaths(
+        ctx.workspaceSlug,
+        ctx.sessionId,
+        ctx.agentCwd,
+        ctx.sessionWorkbenchLayout,
+        hasRootProjectAgentsInstruction(ctx.projectInstructions),
+      )
     : undefined
   const sessionContextDir = workspace?.sessionContextDir ?? '.context'
   const projectContextDir = workspace?.workspaceContextDir ?? '.context'
@@ -118,7 +125,7 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - Proma 工作区规则：\`${workspace.agentsMd}\`${workspace.workspaceAgentsExists ? '（已加载）' : '（当前未建立；这是候选路径，不要读取）'}；记忆索引：\`${workspace.autoMemoryIndex}\`；MCP：\`${workspace.mcpConfig}\`；Skills：\`${workspace.skillsDir}\`。只使用 Proma 工作区的 MCP/Skills 配置。
 - 需要原文或更多细节时，再按当前任务读取两级 Context、记忆索引或 Skill 元数据；禁止无差别全量扫描。`
       : undefined,
-    buildLegacyProjectMigrationRequirement({ sources: ctx.legacyProjectInstructions ?? [] }),
+    buildLegacyProjectMigrationRequirement({ sources: ctx.projectInstructions?.sources ?? [] }),
     `## 知识维护与访问边界
 Proma 将项目地图与用户协作记忆分开维护：前者让 Agent 少做重复探索，后者让 Agent 更好地服务用户。不得把它们混为同一个档案。
 

--- a/apps/electron/src/main/lib/project-instruction-resolver.test.ts
+++ b/apps/electron/src/main/lib/project-instruction-resolver.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { hasRootProjectAgentsInstruction, resolveProjectInstructions } from './project-instruction-resolver'
+
+const temporaryProjects: string[] = []
+
+function createProject(): string {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'proma-project-instructions-'))
+  temporaryProjects.push(projectRoot)
+  return projectRoot
+}
+
+afterEach(() => {
+  for (const projectRoot of temporaryProjects.splice(0)) {
+    rmSync(projectRoot, { recursive: true, force: true })
+  }
+})
+
+describe('项目根 AGENTS 指令状态', () => {
+  test('Given Linux 大小写不同的 AGENTS.MD When 解析项目指令 Then 标记项目地图已建立', () => {
+    const projectRoot = createProject()
+    writeFileSync(join(projectRoot, 'AGENTS.MD'), '# Project instructions')
+
+    const manifest = resolveProjectInstructions({ projectRoot })
+
+    expect(manifest.sources).toHaveLength(1)
+    expect(manifest.sources[0]).toMatchObject({ kind: 'agents', scopeRoot: '.' })
+    expect(hasRootProjectAgentsInstruction(manifest)).toBe(true)
+  })
+
+  test('Given 项目内 AGENTS.md 符号链接 When 解析项目指令 Then 标记项目地图已建立', () => {
+    const projectRoot = createProject()
+    const instructionsDirectory = join(projectRoot, 'instructions')
+    mkdirSync(instructionsDirectory)
+    writeFileSync(join(instructionsDirectory, 'project.md'), '# Project instructions')
+    symlinkSync(join('instructions', 'project.md'), join(projectRoot, 'AGENTS.md'))
+
+    const manifest = resolveProjectInstructions({ projectRoot })
+
+    expect(manifest.sources).toHaveLength(1)
+    expect(manifest.sources[0]).toMatchObject({ kind: 'agents', relativePath: 'AGENTS.md', scopeRoot: '.' })
+    expect(hasRootProjectAgentsInstruction(manifest)).toBe(true)
+  })
+
+  test('Given 仅有 legacy CLAUDE.md When 解析项目指令 Then 项目地图仍标记未建立', () => {
+    const projectRoot = createProject()
+    writeFileSync(join(projectRoot, 'CLAUDE.md'), '# Legacy instructions')
+
+    const manifest = resolveProjectInstructions({ projectRoot })
+
+    expect(hasRootProjectAgentsInstruction(manifest)).toBe(false)
+  })
+
+  test('Given 未创建的目标文件位于项目根内 When 解析项目指令 Then 仍保留根指令状态', () => {
+    const projectRoot = createProject()
+    writeFileSync(join(projectRoot, 'AGENTS.md'), '# Project instructions')
+
+    const manifest = resolveProjectInstructions({
+      projectRoot,
+      targetPath: join(projectRoot, 'new-directory', 'new-file.ts'),
+    })
+
+    expect(hasRootProjectAgentsInstruction(manifest)).toBe(true)
+  })
+})

--- a/apps/electron/src/main/lib/project-instruction-resolver.ts
+++ b/apps/electron/src/main/lib/project-instruction-resolver.ts
@@ -38,6 +38,11 @@ export interface ProjectInstructionManifest {
   totalBytes: number
 }
 
+/** Whether the selected project root contributed an active AGENTS instruction. */
+export function hasRootProjectAgentsInstruction(manifest: ProjectInstructionManifest | undefined): boolean {
+  return manifest?.sources.some((source) => source.kind === 'agents' && source.scopeRoot === '.') ?? false
+}
+
 export interface ResolveProjectInstructionsOptions {
   /** The user-authorized project root. Proma never walks above it. */
   projectRoot: string

--- a/apps/electron/src/main/lib/project-instruction-resolver.ts
+++ b/apps/electron/src/main/lib/project-instruction-resolver.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path'
 
 const INSTRUCTION_FILE_CANDIDATES = [
   { name: 'AGENTS.md', kind: 'agents' },
@@ -48,8 +48,42 @@ export interface ResolveProjectInstructionsOptions {
   targetPath?: string
 }
 
+/**
+ * Normalize an absolute path for comparisons without changing the display
+ * path stored in diagnostics. Windows paths are case-insensitive, and native
+ * realpath keeps drive/junction handling consistent with the host filesystem.
+ */
+export function canonicalizeProjectPath(path: string): string {
+  const absolutePath = resolve(path)
+  const missingSegments: string[] = []
+  let current = absolutePath
+
+  while (true) {
+    try {
+      const canonical = realpathSync.native(current)
+      return missingSegments.reduceRight((parent, segment) => join(parent, segment), canonical)
+    } catch {
+      const parent = dirname(current)
+      if (parent === current) return absolutePath
+      missingSegments.push(basename(current))
+      current = parent
+    }
+  }
+}
+
+function comparisonPath(path: string): string {
+  const normalized = normalize(canonicalizeProjectPath(path))
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+export function normalizeProjectPathForComparison(path: string): string {
+  return comparisonPath(path)
+}
+
 function isWithinRoot(root: string, candidate: string): boolean {
-  const rel = relative(root, candidate)
+  const normalizedRoot = comparisonPath(root)
+  const normalizedCandidate = comparisonPath(candidate)
+  const rel = relative(normalizedRoot, normalizedCandidate)
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
 }
 
@@ -67,7 +101,7 @@ function instructionDirectories(projectRoot: string, targetPath: string): string
 
   const directories = [projectRoot]
   let current = projectRoot
-  const segments = relative(projectRoot, targetDirectory).split(/[\\/]/).filter(Boolean)
+  const segments = relative(comparisonPath(projectRoot), comparisonPath(targetDirectory)).split(/[\\/]/).filter(Boolean)
   for (const segment of segments) {
     current = join(current, segment)
     directories.push(current)
@@ -90,11 +124,13 @@ export function resolveProjectInstructions(options: ResolveProjectInstructionsOp
   if (!isWithinRoot(requestedRoot, requestedTarget)) {
     throw new Error('项目指令目标路径必须位于已授权的项目根目录内')
   }
-  // macOS may expose the same directory through /var and /private/var. Keep
-  // the requested target's relative path, but resolve it under the canonical
-  // root so the root-boundary check stays stable across those aliases.
-  const projectRoot = realpathSync(requestedRoot)
-  const targetPath = resolve(projectRoot, relative(requestedRoot, requestedTarget))
+  // Resolve the existing root and preserve missing target suffixes. This keeps
+  // new-file writes and Windows junction/case aliases in the same scope.
+  const projectRoot = canonicalizeProjectPath(requestedRoot)
+  const targetPath = canonicalizeProjectPath(join(
+    projectRoot,
+    relative(comparisonPath(requestedRoot), comparisonPath(requestedTarget)),
+  ))
 
   const sources: ProjectInstructionSource[] = []
   const diagnostics: ProjectInstructionDiagnostic[] = []


### PR DESCRIPTION
## Summary
- Treat missing workspace/project `AGENTS.md` files as an explicit uninitialized state instead of prompting the Agent to read nonexistent paths.
- Canonicalize existing and missing-tail paths for Windows case-insensitive comparisons, junctions, and new-file targets.
- Reuse canonical instruction source keys across scoped tool activation to reduce repeated activation prompts.
- Derive the project-map status from the resolved instruction manifest, keeping `AGENTS.MD` and project-internal symlink sources consistent with the instructions actually loaded.
- Bump `@proma/electron` from `0.17.73` to `0.17.75`.

## Verification
- `bun test apps/electron/src/main/lib/project-instruction-resolver.test.ts` passed (4 tests).
- `bun run --filter='@proma/electron' typecheck` passed.
- No renderer, IPC, listener, timer, or high-frequency update path changed; runtime performance validation is not applicable to this startup-time instruction-state calculation.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
