### PR TITLE
fix(agent): isolate workspace component tabs

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.75",
+  "version": "0.18.0",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.test.ts
@@ -10,7 +10,10 @@ import {
   isRetryEventForCurrentStream,
   isWorkspaceComponentTab,
   sanitizeWorkspaceComponentTabs,
-  workspaceComponentTabsAtomFamily,
+  agentSessionComponentTabsAtomFamily,
+  agentDiffPanelTabAtom,
+  agentSidePanelOpenAtomFamily,
+  revealChangedWorkspaceComponentAtom,
   type AgentStreamState,
 } from './agent-atoms'
 
@@ -27,14 +30,26 @@ function createStreamState(overrides: Partial<AgentStreamState> = {}): AgentStre
 }
 
 describe('右侧工作区组件', () => {
-  test('工作区组件状态跨会话使用同一 workspace key，且不混入临时右栏状态', () => {
+  test('工作区组件 Tab 按 session 隔离，不会影响同一 workspace 的其他会话', () => {
     const store = createStore()
-    const atom = workspaceComponentTabsAtomFamily('workspace-a')
+    const sourceSessionTabs = agentSessionComponentTabsAtomFamily('session-a')
 
-    store.set(atom, ['todos', 'memory'])
+    store.set(sourceSessionTabs, ['skills', 'memory'])
 
-    expect(store.get(atom)).toEqual(['todos', 'memory'])
-    expect(store.get(workspaceComponentTabsAtomFamily('workspace-b'))).toEqual([])
+    expect(store.get(sourceSessionTabs)).toEqual(['skills', 'memory'])
+    expect(store.get(agentSessionComponentTabsAtomFamily('session-b'))).toEqual([])
+  })
+
+  test('Agent 变更只打开来源 session 的对应 Tab', () => {
+    const store = createStore()
+
+    store.set(revealChangedWorkspaceComponentAtom, { sessionId: 'source-session', component: 'memory' })
+
+    expect(store.get(agentSessionComponentTabsAtomFamily('source-session'))).toEqual(['memory'])
+    expect(store.get(agentSessionComponentTabsAtomFamily('other-session'))).toEqual([])
+    expect(store.get(agentSidePanelOpenAtomFamily('source-session'))).toBe(true)
+    expect(store.get(agentDiffPanelTabAtom).get('source-session')).toBe('memory')
+    expect(store.get(agentDiffPanelTabAtom).get('other-session')).toBeUndefined()
   })
 
   test('只接受已注册的项目级组件类型', () => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -732,24 +732,24 @@ export const currentSessionSidePanelOpenAtom = atom(
 )
 
 /**
- * 工作区组件的打开状态，按 workspaceId 持久化。这里故意只保存组件类型，
- * 具体的筛选、选中项等仍由各组件自己的状态管理，避免把短期 UI 草稿污染为项目数据。
+ * 项目级能力的右侧 Tab 打开状态按 Agent session 持久化。能力的数据仍归属于 workspace，
+ * 但同一 workspace 的后台会话不得改变彼此的右侧 Tab，避免抢走用户焦点。
  */
-export const workspaceComponentOpenMapAtom = atomWithStorage<Record<string, WorkspaceComponentTab[]>>(
-  'proma-workspace-component-tabs',
+export const agentSessionComponentOpenMapAtom = atomWithStorage<Record<string, WorkspaceComponentTab[]>>(
+  'proma-agent-session-component-tabs',
   {},
   undefined,
   { getOnInit: true },
 )
 
-export const workspaceComponentTabsAtomFamily = atomFamily((workspaceId: string) => atom(
-  (get) => get(workspaceComponentOpenMapAtom)[workspaceId] ?? [],
+export const agentSessionComponentTabsAtomFamily = atomFamily((sessionId: string) => atom(
+  (get) => get(agentSessionComponentOpenMapAtom)[sessionId] ?? [],
   (_get, set, update: WorkspaceComponentTab[] | ((previous: WorkspaceComponentTab[]) => WorkspaceComponentTab[])) => {
-    set(workspaceComponentOpenMapAtom, (previous) => {
-      const current = previous[workspaceId] ?? []
+    set(agentSessionComponentOpenMapAtom, (previous) => {
+      const current = previous[sessionId] ?? []
       const next = typeof update === 'function' ? update(current) : update
       if (next === current) return previous
-      return { ...previous, [workspaceId]: next }
+      return { ...previous, [sessionId]: next }
     })
   },
 ))
@@ -763,10 +763,7 @@ export const openWorkspaceComponentAtom = atom(
   (get, set, component: WorkspaceComponentTab) => {
     const sessionId = get(currentAgentSessionIdAtom)
     if (!sessionId) return
-    const workspaceId = get(agentSessionsAtom).find((session) => session.id === sessionId)?.workspaceId
-      ?? get(currentAgentWorkspaceIdAtom)
-    if (!workspaceId) return
-    set(workspaceComponentTabsAtomFamily(workspaceId), (previous) => (
+    set(agentSessionComponentTabsAtomFamily(sessionId), (previous) => (
       previous.includes(component) ? previous : [...previous, component]
     ))
     set(agentSidePanelOpenAtomFamily(sessionId), true)
@@ -780,19 +777,13 @@ export const openWorkspaceComponentAtom = atom(
 )
 
 /**
- * Agent 改动项目级数据时展示对应 Tab。若用户当前正在查看 Skills 或项目记忆，
- * 仅打开变更对应的 Tab，不改变用户显式选择的焦点。
+ * Agent 改动项目级数据时，仅在产生改动的 session 展示对应 Tab。
+ * 若该 session 正在查看 Skills 或项目记忆，保留用户显式选择的焦点。
  */
 export const revealChangedWorkspaceComponentAtom = atom(
   null,
-  (get, set, component: WorkspaceComponentTab) => {
-    const sessionId = get(currentAgentSessionIdAtom)
-    if (!sessionId) return
-    const workspaceId = get(agentSessionsAtom).find((session) => session.id === sessionId)?.workspaceId
-      ?? get(currentAgentWorkspaceIdAtom)
-    if (!workspaceId) return
-
-    set(workspaceComponentTabsAtomFamily(workspaceId), (previous) => (
+  (get, set, { sessionId, component }: { sessionId: string; component: WorkspaceComponentTab }) => {
+    set(agentSessionComponentTabsAtomFamily(sessionId), (previous) => (
       previous.includes(component) ? previous : [...previous, component]
     ))
 
@@ -811,16 +802,13 @@ export const revealChangedWorkspaceComponentAtom = atom(
   },
 )
 
-/** 关闭当前项目的一个组件；若它正被当前会话查看，回退到文件。 */
+/** 关闭当前 session 的一个组件；若它正被当前会话查看，回退到文件。 */
 export const closeWorkspaceComponentAtom = atom(
   null,
   (get, set, component: WorkspaceComponentTab) => {
     const sessionId = get(currentAgentSessionIdAtom)
     if (!sessionId) return
-    const workspaceId = get(agentSessionsAtom).find((session) => session.id === sessionId)?.workspaceId
-      ?? get(currentAgentWorkspaceIdAtom)
-    if (!workspaceId) return
-    set(workspaceComponentTabsAtomFamily(workspaceId), (previous) => previous.filter((item) => item !== component))
+    set(agentSessionComponentTabsAtomFamily(sessionId), (previous) => previous.filter((item) => item !== component))
     set(agentDiffPanelTabAtom, (previous) => {
       if (previous.get(sessionId) !== component) return previous
       const next = new Map(previous)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -40,12 +40,12 @@ import {
   agentDiffRefreshVersionAtom,
   agentNonGitFileChangesAtom,
   agentFileChangesCurrentRunAtom,
-  workspaceComponentTabsAtomFamily,
+  agentSessionComponentTabsAtomFamily,
+  agentSessionStreamingStateAtomFamily,
   isWorkspaceComponentTab,
   isUserPriorityWorkspaceComponentTab,
   sanitizeWorkspaceComponentTabs,
   getDelegationTabLabel,
-  agentSessionStreamingStateAtomFamily,
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
   agentSideTemporaryAgentMapAtom,
@@ -674,8 +674,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const activeExplorationBranch = activeExplorationSessionId
     ? sideTemporaryAgents.find((branch) => branch.sessionId === activeExplorationSessionId) ?? null
     : null
-  // Todo / 日程 / 能力 / 记忆是工作区组件，而不是会话附件；同一项目下切换会话仍保留打开状态。
-  const [workspaceComponentTabs, setWorkspaceComponentTabs] = useAtom(workspaceComponentTabsAtomFamily(currentWorkspaceId ?? ''))
+  // Todo / 日程 / 能力 / 记忆的数据仍归属于 workspace，但右侧 Tab 仅属于当前 session。
+  const [workspaceComponentTabs, setWorkspaceComponentTabs] = useAtom(agentSessionComponentTabsAtomFamily(sessionId))
   const automationFormOpen = useAtomValue(automationFormAtom).open
 
   React.useEffect(() => {
@@ -698,10 +698,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
         ? 'files'
         : activeTab
 
-  // Agent 对当前项目记忆写入后，默认展开并激活完整编辑器这个独立工作区 Tab。
-  // 记忆 watcher 按 workspace 缓存最新事件，必须排除本轮开始前的陈旧事件。
-  // 用户正在查看 Skills 或项目记忆时，变更只在后台保留为可见的 Memory Tab，
-  // 不抢焦点，也不重置其正在阅读或编辑的文件。
+  // memory 写入不能沿用通用组件激活：只有 watcher 捕获真实文件变更后才能生成受限 Diff。
+  // SidePanel 按 session 挂载，因此只会为正在运行的来源 session 路由这次 Diff；其他会话不受影响。
   React.useEffect(() => {
     const runStartedAt = agentStreamState?.startedAt
     if (!agentStreamState?.running || !runStartedAt || !latestMemoryChange || latestMemoryChange.changedAt < runStartedAt) return
@@ -710,6 +708,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     lastActivatedMemoryChangeRef.current = changeId
     setWorkspaceComponentTabs((previous) => previous.includes('memory') ? previous : [...previous, 'memory'])
 
+    // 用户正在阅读 Skills 或项目记忆时，只保留新变更，不抢焦点或覆盖其当前文件。
     if (isOpen && isUserPriorityWorkspaceComponentTab(effectiveActiveTab)) return
 
     setMemoryNavigationRequest({ workspaceSlug: workspaceSlug!, relativePath: latestMemoryChange.relativePath, mode: 'change' })

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -88,7 +88,7 @@ import { detectIsWindows } from '@/lib/platform'
 import { getSessionFileChangeKind, getOwnedSessionWatcherPaths, upsertSessionFileChange } from '@/lib/session-file-changes'
 import { removeQueuedMessage, createQueuedAgentStreamState } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
-import { getChangedWorkspaceComponentFromSdkMessage } from '@/lib/agent-component-activation'
+import { getChangedWorkspaceComponentFromSdkMessage, shouldRevealChangedWorkspaceComponentImmediately } from '@/lib/agent-component-activation'
 import { mergeActiveAgentSessionSnapshot } from '@/lib/agent-active-session-snapshot'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
@@ -1105,18 +1105,12 @@ export function useGlobalAgentListeners(): void {
 
         if (payload.kind === 'sdk_message') {
           const msgRecord = payload.message as Record<string, unknown>
-          // 仅在 Agent 发出变更工具调用时展示对应项目组件；同项目的当前会话可承接
-          // 后台/子会话变更，其他项目绝不抢走用户正在查看的工作区。
+          // 仅在 Agent 发出变更工具调用时展示对应项目组件；右侧 Tab 严格归属产生变更的 session，
+          // 同一 workspace 的其他活跃会话不得被后台变更抢走焦点。
           if (!msgRecord.isReplay) {
             const changedComponent = getChangedWorkspaceComponentFromSdkMessage(payload.message)
-            if (changedComponent) {
-              const activeSessionId = store.get(currentAgentSessionIdAtom)
-              const sessions = store.get(agentSessionsAtom)
-              const activeWorkspaceId = sessions.find((session) => session.id === activeSessionId)?.workspaceId
-              const sourceWorkspaceId = sessions.find((session) => session.id === sessionId)?.workspaceId
-              if (activeSessionId === sessionId || (activeWorkspaceId && activeWorkspaceId === sourceWorkspaceId)) {
-                store.set(revealChangedWorkspaceComponentAtom, changedComponent)
-              }
+            if (changedComponent && shouldRevealChangedWorkspaceComponentImmediately(changedComponent)) {
+              store.set(revealChangedWorkspaceComponentAtom, { sessionId, component: changedComponent })
             }
           }
 

--- a/apps/electron/src/renderer/lib/agent-component-activation.ts
+++ b/apps/electron/src/renderer/lib/agent-component-activation.ts
@@ -45,6 +45,7 @@ function getWorkspaceManagedFileComponent(path: string): WorkspaceComponentTab |
   // 只响应 Proma workspace 下的配置，避免用户项目中同名 skills/ 或 mcp.json 误触发。
   if (!normalized.includes('/agent-workspaces/')) return null
   if (normalized.includes('/skills/')) return 'skills'
+  if (normalized.includes('/memory/')) return 'memory'
   if (normalized.endsWith('/mcp.json')) return 'mcp'
   return null
 }
@@ -81,6 +82,13 @@ export function getChangedWorkspaceComponentForTool(
     return getWorkspaceManagedFileComponent(input.command)
   }
   return null
+}
+
+/**
+ * 记忆写入必须等待文件 watcher 生成真实的受限 Diff 后再打开；其他组件可在工具调用时立即展示。
+ */
+export function shouldRevealChangedWorkspaceComponentImmediately(component: WorkspaceComponentTab): boolean {
+  return component !== 'memory'
 }
 
 /** 从一条 SDK assistant 消息提取本轮第一个会改变项目组件数据的工具。 */


### PR DESCRIPTION
## Summary

- Scope right-workspace component tabs to the owning Agent session.
- Preserve memory-update navigation through the watcher-backed Diff view instead of opening the full project-memory browser.
- Keep an actively read Skills/Memory tab in place rather than stealing focus.

## Validation

- `bun test apps/electron/src/renderer/atoms/agent-atoms.test.ts`
- `bun run --filter=@proma/electron typecheck`

## Performance

- Low risk: reuses the existing debounced memory watcher and avoids the generic memory-tab activation render before a real file Diff is available.
- No new IPC subscriptions, timers, or per-token update paths.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
