### PR TITLE
fix(agent): 同步子会话 Tab 状态提示【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -1054,8 +1054,10 @@ export const agentRunningSessionIdsAtom = atom<Set<string>>((get) => {
 /** 侧边栏会话指示点状态 */
 export type SessionIndicatorStatus = 'idle' | 'running' | 'blocked' | 'completed'
 
-/** 已完成但用户尚未查看的会话 ID 集合 */
+/** 顶层会话已完成但用户尚未查看的会话 ID 集合。 */
 export const unviewedCompletedSessionIdsAtom = atom<Set<string>>(new Set<string>())
+/** 委派子会话已完成但用户尚未查看的会话 ID 集合；不计入 Dock/Launcher 角标。 */
+export const unviewedCompletedDelegationSessionIdsAtom = atom<Set<string>>(new Set<string>())
 
 let lastIndicatorSignature = ''
 let lastIndicatorMap = new Map<string, SessionIndicatorStatus>()
@@ -1089,6 +1091,7 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
   const pendingAskUser = get(allPendingAskUserRequestsAtom)
   const pendingExitPlan = get(allPendingExitPlanRequestsAtom)
   const unviewedCompleted = get(unviewedCompletedSessionIdsAtom)
+  const unviewedCompletedDelegations = get(unviewedCompletedDelegationSessionIdsAtom)
 
   const map = new Map<string, SessionIndicatorStatus>()
 
@@ -1110,7 +1113,7 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
     }
   }
 
-  for (const id of unviewedCompleted) {
+  for (const id of [...unviewedCompleted, ...unviewedCompletedDelegations]) {
     if (!map.has(id)) {
       map.set(id, 'completed')
     }

--- a/apps/electron/src/renderer/atoms/delegated-completion-indicator.test.ts
+++ b/apps/electron/src/renderer/atoms/delegated-completion-indicator.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { createStore } from 'jotai'
+import {
+  agentSessionIndicatorMapAtom,
+  unviewedCompletedDelegationSessionIdsAtom,
+} from './agent-atoms'
+
+describe('委派子会话完成提示', () => {
+  test('只将未查看的委派完成态映射为绿色 completed 指示，不写入顶层未读集合', () => {
+    const store = createStore()
+    store.set(unviewedCompletedDelegationSessionIdsAtom, new Set(['delegated-child']))
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('delegated-child')).toBe('completed')
+  })
+
+  test('查看后移除委派完成标记，状态恢复 idle', () => {
+    const store = createStore()
+    store.set(unviewedCompletedDelegationSessionIdsAtom, new Set(['delegated-child']))
+    store.set(unviewedCompletedDelegationSessionIdsAtom, new Set())
+
+    expect(store.get(agentSessionIndicatorMapAtom).get('delegated-child')).toBeUndefined()
+  })
+})

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -32,6 +32,8 @@ import {
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   agentSessionsAtom,
+  agentSessionIndicatorMapAtom,
+  unviewedCompletedDelegationSessionIdsAtom,
   agentAttachedDirectoriesMapAtom,
   agentAttachedFilesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
@@ -96,6 +98,7 @@ import {
   recordRightPanelTabVisit,
   removeRightPanelTabFromHistory,
 } from '@/lib/right-panel-tab-history'
+import { getDelegatedChildSessionStatus } from '@/lib/agent-session-list'
 import { TerminalTabContent } from '@/components/tabs/TerminalTabContent'
 import { shouldShowBothFileSources } from './file-panel-layout'
 
@@ -350,6 +353,9 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const selectedWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const sessions = useAtomValue(agentSessionsAtom)
+  const sessionIndicatorMap = useAtomValue(agentSessionIndicatorMapAtom)
+  const unviewedCompletedDelegations = useAtomValue(unviewedCompletedDelegationSessionIdsAtom)
+  const setUnviewedCompletedDelegations = useSetAtom(unviewedCompletedDelegationSessionIdsAtom)
   const currentWorkspaceId = sessions.find((session) => session.id === sessionId)?.workspaceId ?? selectedWorkspaceId
   const currentWorkspace = workspaces.find((workspace) => workspace.id === currentWorkspaceId)
   const workspaceSlug = currentWorkspace?.slug ?? null
@@ -698,6 +704,16 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
         ? 'files'
         : activeTab
 
+  // 右栏正在展示子会话即表示用户已经查看，清除其临时绿色完成提示。
+  React.useEffect(() => {
+    if (!activeDelegationSessionId || !unviewedCompletedDelegations.has(activeDelegationSessionId)) return
+    setUnviewedCompletedDelegations((previous) => {
+      const next = new Set(previous)
+      next.delete(activeDelegationSessionId)
+      return next
+    })
+  }, [activeDelegationSessionId, setUnviewedCompletedDelegations, unviewedCompletedDelegations])
+
   // Agent 对当前项目记忆写入后，默认展开并激活完整编辑器这个独立工作区 Tab。
   // 记忆 watcher 按 workspace 缓存最新事件，必须排除本轮开始前的陈旧事件。
   // 用户正在查看 Skills 或项目记忆时，变更只在后台保留为可见的 Memory Tab，
@@ -895,12 +911,21 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
         })
       }
     }
+    const delegationSessionId = getDelegationSessionIdFromSidePanelTab(tab)
+    if (delegationSessionId) {
+      setUnviewedCompletedDelegations((previous) => {
+        if (!previous.has(delegationSessionId)) return previous
+        const next = new Set(previous)
+        next.delete(delegationSessionId)
+        return next
+      })
+    }
     const browserTabId = getBrowserTabIdFromSidePanelTab(tab)
     onTabChange(tab)
     if (!browserTabId) return
     desiredBrowserTabIdRef.current = browserTabId
     flushBrowserTabSelection()
-  }, [flushBrowserTabSelection, onTabChange, previewFiles, sessionId, setPreviewFileMap])
+  }, [flushBrowserTabSelection, onTabChange, previewFiles, sessionId, setPreviewFileMap, setUnviewedCompletedDelegations])
 
   const handleOpenBrowserTab = React.useCallback(async () => {
     try {
@@ -1020,6 +1045,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
         label: getDelegationTabLabel(child.title),
         icon: <GitBranch className="size-3.5" />,
         closable: true,
+        // 与左侧子会话行共用状态解析：实时状态优先，重新运行后不受旧 delegationStatus 影响。
+        status: getDelegatedChildSessionStatus(child, sessionIndicatorMap),
       }] : []
     }),
     ...(browserState?.tabs.map((tab) => ({
@@ -1030,7 +1057,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       closable: tab.tabId !== browserState.agentTabId,
       activity: showBrowserActivity && activeBrowserTabId !== tab.tabId && browserState.activeTabId === tab.tabId,
     })) ?? []),
-  ], [activeBrowserTabId, browserState, previewFiles, sessions, sessionId, showBrowserActivity, sideChatConversationId, sideDelegationSessionIds, sideTemporaryAgents, terminalTabs, workspaceComponentTabs])
+  ], [activeBrowserTabId, browserState, previewFiles, sessionIndicatorMap, sessions, sessionId, showBrowserActivity, sideChatConversationId, sideDelegationSessionIds, sideTemporaryAgents, terminalTabs, workspaceComponentTabs])
   workspaceTabsRef.current = workspaceTabs
 
   const handleCloseWorkspaceTab = React.useCallback((tab: AgentSidePanelTab) => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -38,6 +38,7 @@ import {
   currentAgentSessionIdAtom,
   agentSessionIndicatorMapAtom,
   unviewedCompletedSessionIdsAtom,
+  unviewedCompletedDelegationSessionIdsAtom,
   agentChannelIdAtom,
   agentModelIdAtom,
   agentSessionChannelMapAtom,
@@ -768,6 +769,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const agentIndicatorMap = useAtomValue(agentSessionIndicatorMapAtom)
   const unviewedCompletedSessionIds = useAtomValue(unviewedCompletedSessionIdsAtom)
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
+  const setUnviewedCompletedDelegations = useSetAtom(unviewedCompletedDelegationSessionIdsAtom)
   const agentChannelId = useAtomValue(agentChannelIdAtom)
   const agentModelId = useAtomValue(agentModelIdAtom)
   const setSessionChannelMap = useSetAtom(agentSessionChannelMapAtom)
@@ -1786,6 +1788,13 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           next.delete(id)
           return next
         })
+        // 左侧树点击同样是查看子会话，必须清除其临时绿色完成提示。
+        setUnviewedCompletedDelegations((prev: Set<string>) => {
+          if (!prev.has(id)) return prev
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        })
         return
       }
     }
@@ -1799,7 +1808,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       next.delete(id)
       return next
     })
-  }, [agentSessions, openSession, setActiveView, setUnviewedCompleted, store])
+  }, [agentSessions, openSession, setActiveView, setUnviewedCompleted, setUnviewedCompletedDelegations, store])
 
   const clearQuickSwitchHints = React.useCallback((): void => {
     for (const row of quickSwitchHintRowsRef.current) {

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -18,7 +18,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
-import type { AgentSidePanelTab, WorkspaceComponentTab } from '@/atoms/agent-atoms'
+import type { AgentSidePanelTab, SessionIndicatorStatus, WorkspaceComponentTab } from '@/atoms/agent-atoms'
+
+const TAB_STATUS_ICON_CLASS: Partial<Record<SessionIndicatorStatus, string>> = {
+  running: 'text-blue-500 animate-pulse',
+  blocked: 'text-orange-500',
+  completed: 'text-green-500',
+}
 
 export interface WorkspacePanelTab {
   id: AgentSidePanelTab
@@ -26,6 +32,8 @@ export interface WorkspacePanelTab {
   icon: React.ReactNode
   closable?: boolean
   activity?: boolean
+  /** 会话状态色；委派子会话与左侧会话列表共用同一状态源。 */
+  status?: SessionIndicatorStatus
 }
 
 interface DiffPanelTabBarProps {
@@ -132,7 +140,14 @@ export function DiffPanelTabBar({
                   {tab.activity || (isChangesTab && unseenChanges && !selected) ? (
                     <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-label="有未查看更新" />
                   ) : (
-                    <span className={cn('shrink-0', selected ? 'text-foreground' : 'text-muted-foreground/80')}>{tab.icon}</span>
+                    <span
+                      className={cn(
+                        'shrink-0',
+                        TAB_STATUS_ICON_CLASS[tab.status ?? 'idle'] ?? (selected ? 'text-foreground' : 'text-muted-foreground/80'),
+                      )}
+                    >
+                      {tab.icon}
+                    </span>
                   )}
                   <span className="truncate">{tab.label}</span>
                 </button>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -44,6 +44,7 @@ import {
   workspaceAttachedDirectoriesMapAtom,
   workspaceAttachedFilesMapAtom,
   unviewedCompletedSessionIdsAtom,
+  unviewedCompletedDelegationSessionIdsAtom,
   agentSessionPathMapAtom,
   agentDiffRefreshVersionAtom,
   agentDiffPanelTabAtom,
@@ -701,6 +702,12 @@ export function useGlobalAgentListeners(): void {
           next.delete(event.sessionId)
           return next
         })
+        store.set(unviewedCompletedDelegationSessionIdsAtom, (prev) => {
+          if (!prev.has(event.sessionId)) return prev
+          const next = new Set(prev)
+          next.delete(event.sessionId)
+          return next
+        })
         store.set(agentStreamingStatesAtom, (prev) => {
           const map = new Map(prev)
           map.set(event.sessionId, activation.streamState)
@@ -1023,6 +1030,12 @@ export function useGlobalAgentListeners(): void {
             next.delete(sessionId)
             return next
           })
+          store.set(unviewedCompletedDelegationSessionIdsAtom, (prev) => {
+            if (!prev.has(sessionId)) return prev
+            const next = new Set(prev)
+            next.delete(sessionId)
+            return next
+          })
         }
 
         // 自动任务会话被用户接管（毕业）：向用户提示，后续定时运行将新建独立会话
@@ -1209,6 +1222,12 @@ export function useGlobalAgentListeners(): void {
             const prevState = store.get(agentSessionStreamingStateAtomFamily(sessionId))
             if (!prevState || !prevState.running) {
               store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
+                if (!prev.has(sessionId)) return prev
+                const next = new Set(prev)
+                next.delete(sessionId)
+                return next
+              })
+              store.set(unviewedCompletedDelegationSessionIdsAtom, (prev: Set<string>) => {
                 if (!prev.has(sessionId)) return prev
                 const next = new Set(prev)
                 next.delete(sessionId)
@@ -1567,7 +1586,14 @@ export function useGlobalAgentListeners(): void {
           session: completionSession,
           documentHasFocus: document.hasFocus(),
         })
-        if (completionMarkers.markUnviewedCompleted && !backgroundTasksPending) {
+        if (completionSession?.sourceDelegationId && !backgroundTasksPending) {
+          // 子会话也需要短暂的绿色完成提示，但不属于用户级 Dock/通知未读。
+          store.set(unviewedCompletedDelegationSessionIdsAtom, (prev: Set<string>) => {
+            const next = new Set(prev)
+            next.add(data.sessionId)
+            return next
+          })
+        } else if (completionMarkers.markUnviewedCompleted && !backgroundTasksPending) {
           store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
             const next = new Set(prev)
             next.add(data.sessionId)

--- a/apps/electron/src/renderer/lib/agent-session-list.test.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import type { AgentSessionMeta } from '@proma/shared'
+import { getDelegatedChildSessionStatus } from './agent-session-list'
+
+function delegatedChild(delegationStatus?: AgentSessionMeta['delegationStatus']): AgentSessionMeta {
+  return {
+    id: 'child-session',
+    title: '子会话',
+    parentSessionId: 'parent-session',
+    sourceDelegationId: 'delegation-1',
+    delegationStatus,
+    createdAt: 0,
+    updatedAt: 0,
+  }
+}
+
+describe('getDelegatedChildSessionStatus', () => {
+  test('only displays a completed marker while the completion is unviewed', () => {
+    const child = delegatedChild('completed')
+    expect(getDelegatedChildSessionStatus(child, new Map([[child.id, 'completed']]))).toBe('completed')
+    expect(getDelegatedChildSessionStatus(child, new Map())).toBe('idle')
+  })
+
+  test('gives the live status precedence when a completed delegation is rerun or blocked', () => {
+    const child = delegatedChild('completed')
+    expect(getDelegatedChildSessionStatus(child, new Map([[child.id, 'running']]))).toBe('running')
+    expect(getDelegatedChildSessionStatus(child, new Map([[child.id, 'blocked']]))).toBe('blocked')
+  })
+
+  test('leaves failed, cancelled, and interrupted delegations unaccented', () => {
+    for (const delegationStatus of ['failed', 'cancelled', 'interrupted'] as const) {
+      expect(getDelegatedChildSessionStatus(delegatedChild(delegationStatus), new Map())).toBe('idle')
+    }
+  })
+})

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -197,7 +197,9 @@ export function isAgentSessionVisibleInTrees(
 
 /**
  * Resolve a delegated child's current sidebar status. A live status takes
- * precedence over the persisted delegation status after the child is rerun.
+ * precedence over persisted state after the child is rerun. Completion is
+ * intentionally supplied only by the ephemeral "unviewed" indicator map,
+ * so historical delegated sessions never retain a permanent green marker.
  */
 export function getDelegatedChildSessionStatus(
   session: AgentSessionMeta,


### PR DESCRIPTION
## 概述
为右侧栏的协作子会话 Tab 增加与左侧会话树一致的运行、阻塞与完成状态色；将完成态改为「刚完成且尚未查看」的临时提示，避免历史已完成子会话永久显示绿色。

## 改动
- `apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx` — 为工作区 Tab 定义可选会话状态并渲染蓝色运行、橙色阻塞、绿色完成图标。
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 委派 Tab 复用左栏状态解析；在右栏打开或点击子会话时清除其临时完成提示。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 从左侧树打开子会话时也清除临时完成提示，避免绿点残留。
- `apps/electron/src/renderer/atoms/agent-atoms.ts` — 将委派子会话未查看完成状态独立存储，并仅用于状态图标，不计入 Dock/Launcher 未读角标。
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` — 在子会话完成时写入临时标记，在重新运行或激活时清除旧标记。
- `apps/electron/src/renderer/lib/agent-session-list.ts` — 不再从持久化 `delegationStatus: completed` 推导绿色状态，历史完成子会话保持普通状态。
- `apps/electron/src/renderer/atoms/delegated-completion-indicator.test.ts`、`apps/electron/src/renderer/lib/agent-session-list.test.ts` — 覆盖临时完成态、查看后清除、重跑/阻塞优先级及失败态。

## 测试方法
1. `bun test apps/electron/src/renderer/atoms/delegated-completion-indicator.test.ts apps/electron/src/renderer/lib/agent-session-list.test.ts`
2. `bun run --filter='@proma/electron' typecheck`
3. `bun run --filter='@proma/electron' build:renderer`
4. 手动验证：子会话运行时蓝色、权限或提问阻塞时橙色、后台成功完成时绿色；从左栏或右栏打开后绿色消失，重新运行覆盖为蓝色。

## 备注
- 已基于最新 `main`（`9fd61ae3`）重新创建分支并解决右侧 Tab 访问历史相关变更的合并冲突。
- `build:renderer` 仅保留仓库既有的 chunk size 警告。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
