### PR TITLE
feat(agent): add terminal output readback

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -85,6 +85,7 @@ import {
   interruptAgentTerminal,
   listAgentTerminals,
   openAgentTerminal,
+  readAgentTerminalOutput,
 } from '../terminal-service'
 import {
   automationCreateToolParameters,
@@ -1347,8 +1348,8 @@ function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDe
     sdk.defineTool({
       name: 'TerminalExecute',
       label: '在可见终端执行命令',
-      description: 'Run one command in a new visible Agent-owned terminal Tab. The user can see and interrupt it. Terminal output is not automatically returned to the Agent; only the command-start receipt is returned.',
-      promptSnippet: 'Execute one command only when it serves the user request. It is visibly run in the Agent workspace and may require permission approval.',
+      description: 'Run one command in a new visible Agent-owned terminal Tab. The user can see and interrupt it. Call TerminalRead with the returned terminal ID when you need to inspect its output; output is never pushed into this tool result.',
+      promptSnippet: 'Execute one command only when it serves the user request. It is visibly run in the Agent workspace and may require permission approval. If its result matters, call TerminalRead after it has produced output instead of assuming output is returned automatically.',
       parameters: Type.Object({
         command: Type.String({ description: 'Complete command to execute in the controlled shell. Do not prepend shell wrappers.' }),
         cwd: Type.Optional(Type.String({ description: 'Absolute or Agent-CWD-relative directory within the current authorized roots.' })),
@@ -1360,6 +1361,24 @@ function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDe
         if (!command) throw new Error('command 必填')
         const record = await executeAgentTerminal({ ...agentContext, ...terminalInput(args), command })
         return jsonToolResult({ terminal: record, commandStarted: true, outputSharedWithAgent: false })
+      },
+    }),
+    sdk.defineTool({
+      name: 'TerminalRead',
+      label: '读取 Agent 终端输出',
+      description: 'Read bounded buffered output from one current-session Agent-owned terminal. By default returns the latest 12,000 characters of normalized text. Use offset and limit to page earlier output; it can read output after the terminal exits until the terminal or session is closed.',
+      promptSnippet: 'After starting a visible terminal command, use TerminalRead whenever you need its result. Start with the default tail; use the returned nextOffset to page forward or a smaller offset to inspect earlier output. Do not assume terminal output is automatically returned.',
+      parameters: Type.Object({
+        terminalId: Type.String({ description: 'Terminal ID returned by TerminalOpen, TerminalExecute, or TerminalList.' }),
+        offset: Type.Optional(Type.Number({ description: 'Optional non-negative character offset in the terminal output stream. Omit to read the latest output.' })),
+        limit: Type.Optional(Type.Number({ description: 'Optional maximum characters to return, from 1 to 48000. Defaults to 12000.' })),
+      }),
+      async execute(_toolCallId, params) {
+        const args = params as Record<string, unknown>
+        const terminalId = typeof args.terminalId === 'string' ? args.terminalId : ''
+        const offset = typeof args.offset === 'number' ? args.offset : undefined
+        const limit = typeof args.limit === 'number' ? args.limit : undefined
+        return jsonToolResult(readAgentTerminalOutput(ctx.sessionId, terminalId, { offset, limit }))
       },
     }),
     sdk.defineTool({

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1294,8 +1294,8 @@ export class AgentOrchestrator {
           })
         }
 
-        // 终端元数据可在计划阶段检查，但创建、执行、打断或关闭 PTY 都属于可见的本地副作用。
-        if (toolName === 'TerminalList') return { behavior: 'allow' as const, updatedInput: input }
+        // 终端元数据与已缓冲的输出可在计划阶段只读检查；创建、执行、打断或关闭 PTY 都属于可见的本地副作用。
+        if (toolName === 'TerminalList' || toolName === 'TerminalRead') return { behavior: 'allow' as const, updatedInput: input }
         if (toolName.startsWith('Terminal') && currentMode === 'plan') {
           return { behavior: 'deny' as const, message: '计划模式下不能创建或操作本地终端，请在计划获批后执行。' }
         }

--- a/apps/electron/src/main/lib/terminal-output-buffer.ts
+++ b/apps/electron/src/main/lib/terminal-output-buffer.ts
@@ -1,9 +1,42 @@
 import type { TerminalOutputEvent } from '@proma/shared'
 
 export interface TerminalOutputBuffer {
+  /** 当前仍保留在内存中的原始 PTY 输出。 */
   output: string
+  /** 单终端最后接收的输出事件序号。 */
   sequence: number
+  /** output 在该终端完整输出流中的起始字符偏移。 */
+  startOffset: number
+  /** 完整输出流截至目前的字符偏移（exclusive）。 */
+  endOffset: number
 }
+
+export interface TerminalOutputReadOptions {
+  /** 从完整输出流的指定字符偏移开始读取；省略时读取末尾。 */
+  offset?: number
+  /** 最多返回的原始 PTY 字符数。 */
+  limit?: number
+}
+
+export interface TerminalOutputReadResult {
+  /** 供 Agent 阅读的、去除终端控制序列后的文本。 */
+  output: string
+  /** 当前内存缓冲仍可读取的完整输出流起始偏移。 */
+  availableStartOffset: number
+  /** 当前完整输出流的末尾偏移（exclusive）。 */
+  availableEndOffset: number
+  /** 本次读取的原始输出范围起点。 */
+  offset: number
+  /** 下一页应传入的 offset。 */
+  nextOffset: number
+  /** 缓冲区之前已有输出因容量限制不可用，或本次默认从末尾读取而省略了前文。 */
+  truncatedBefore: boolean
+  /** 当前缓冲区中还有未读取的后续输出。 */
+  truncatedAfter: boolean
+}
+
+const DEFAULT_READ_CHARS = 12_000
+const MAX_READ_CHARS = 48_000
 
 /** 保留可重放的末尾输出；序列号始终对应最后一批已接收数据。 */
 export function appendTerminalOutput(
@@ -12,8 +45,69 @@ export function appendTerminalOutput(
   maxChars: number,
 ): TerminalOutputBuffer {
   const output = `${buffer.output}${event.data}`
+  const retainedOutput = output.length > maxChars ? output.slice(output.length - maxChars) : output
+  const endOffset = buffer.endOffset + event.data.length
   return {
-    output: output.length > maxChars ? output.slice(output.length - maxChars) : output,
+    output: retainedOutput,
     sequence: event.sequence,
+    startOffset: endOffset - retainedOutput.length,
+    endOffset,
   }
+}
+
+/**
+ * 从有限的 PTY 回放缓冲中分页读取终端文本。
+ * offset 使用原始 PTY 流的字符偏移，因而即使缓冲滚动也能明确告知调用方可用范围。
+ */
+export function readTerminalOutput(
+  buffer: TerminalOutputBuffer,
+  options: TerminalOutputReadOptions = {},
+): TerminalOutputReadResult {
+  const limit = normalizeLimit(options.limit)
+  const requestedOffset = normalizeOffset(options.offset)
+  const defaultOffset = Math.max(buffer.startOffset, buffer.endOffset - limit)
+  const offset = clamp(requestedOffset ?? defaultOffset, buffer.startOffset, buffer.endOffset)
+  const nextOffset = Math.min(buffer.endOffset, offset + limit)
+  const rawOutput = buffer.output.slice(offset - buffer.startOffset, nextOffset - buffer.startOffset)
+
+  return {
+    output: normalizeTerminalText(rawOutput),
+    availableStartOffset: buffer.startOffset,
+    availableEndOffset: buffer.endOffset,
+    offset,
+    nextOffset,
+    truncatedBefore: buffer.startOffset > 0 || offset > buffer.startOffset,
+    truncatedAfter: nextOffset < buffer.endOffset,
+  }
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_READ_CHARS
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_READ_CHARS) {
+    throw new Error(`终端输出读取长度必须是 1 到 ${MAX_READ_CHARS} 之间的整数`)
+  }
+  return value
+}
+
+function normalizeOffset(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error('终端输出偏移必须是非负整数')
+  return value
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * PTY 输出含颜色、窗口标题、光标移动等控制序列，直接交给模型会降低可读性。
+ * 保留换行；孤立 \r 转为换行以让进度刷新仍有可检索文本。
+ */
+function normalizeTerminalText(output: string): string {
+  return output
+    .replace(/\u001B\][\s\S]*?(?:\u0007|\u001B\\)/g, '') // OSC（如窗口标题）
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, '') // CSI（颜色、光标、清屏等）
+    .replace(/\u001B[()][0-?]*[ -/]*[@-~]/g, '') // charset 切换
+    .replace(/\u0000/g, '')
+    .replace(/\r(?!\n)/g, '\n')
 }

--- a/apps/electron/src/main/lib/terminal-service.ts
+++ b/apps/electron/src/main/lib/terminal-service.ts
@@ -11,7 +11,13 @@ import {
   type TerminalState,
 } from '@proma/shared'
 import { getMainWindow } from './main-window-store'
-import { appendTerminalOutput, type TerminalOutputBuffer } from './terminal-output-buffer'
+import {
+  appendTerminalOutput,
+  readTerminalOutput,
+  type TerminalOutputBuffer,
+  type TerminalOutputReadOptions,
+  type TerminalOutputReadResult,
+} from './terminal-output-buffer'
 import { resolveAgentTerminalCwd } from './terminal-agent-policy'
 import { requireTerminalCwd, resolveTerminalCwd } from './terminal-cwd'
 import { terminalRuntimeClient } from './terminal-runtime-client'
@@ -44,11 +50,13 @@ function initialize(): void {
   })
   terminalRuntimeClient.onExit((event) => {
     terminals.delete(event.terminalId)
-    terminalOutputBuffers.delete(event.terminalId)
     const agentTerminal = agentTerminals.get(event.terminalId)
     if (agentTerminal) {
+      // Agent 可在命令退出后读取结果；缓冲会随显式关闭或会话回收一并释放。
       agentTerminal.status = 'exited'
       agentTerminal.exitCode = event.exitCode
+    } else {
+      terminalOutputBuffers.delete(event.terminalId)
     }
     getMainWindow()?.webContents.send(TERMINAL_IPC_CHANNELS.EXIT, event)
   })
@@ -69,7 +77,7 @@ export async function createTerminal(
   // Record ownership before spawning so a concurrent session deletion can cancel it.
   terminalSessionOwners.set(input.terminalId, input.sessionId)
   // Initialize the replay buffer before the runtime can emit the first shell output.
-  terminalOutputBuffers.set(input.terminalId, { output: '', sequence: 0 })
+  terminalOutputBuffers.set(input.terminalId, { output: '', sequence: 0, startOffset: 0, endOffset: 0 })
   const creation = terminalRuntimeClient.create({
     ...input,
     cwd,
@@ -167,6 +175,18 @@ export function listAgentTerminals(sessionId: string): AgentTerminalRecord[] {
   return [...agentTerminals.values()].filter((record) => record.sessionId === sessionId)
 }
 
+/** 读取当前 Agent 会话拥有的终端输出；只暴露有限内存回放缓冲，不读取其他会话或系统终端。 */
+export function readAgentTerminalOutput(
+  sessionId: string,
+  terminalId: string,
+  options: TerminalOutputReadOptions = {},
+): { terminal: AgentTerminalRecord; read: TerminalOutputReadResult } {
+  const terminal = getOwnedAgentTerminal(sessionId, terminalId)
+  const buffer = terminalOutputBuffers.get(terminalId)
+  if (!buffer) throw new Error('终端输出已不可用')
+  return { terminal, read: readTerminalOutput(buffer, options) }
+}
+
 export async function interruptAgentTerminal(sessionId: string, terminalId: string): Promise<void> {
   const record = getOwnedAgentTerminal(sessionId, terminalId)
   if (record.status !== 'running') return
@@ -191,7 +211,7 @@ export function getTerminalSnapshot(terminalId: string): TerminalSnapshot {
   validateTerminalId(terminalId)
   const state = terminals.get(terminalId)
   if (!state) throw new Error('终端不存在')
-  const buffer = terminalOutputBuffers.get(terminalId) ?? { output: '', sequence: 0 }
+  const buffer = terminalOutputBuffers.get(terminalId) ?? { output: '', sequence: 0, startOffset: 0, endOffset: 0 }
   return { state, ...buffer }
 }
 
@@ -230,7 +250,7 @@ function getOwnedAgentTerminal(sessionId: string, terminalId: string): AgentTerm
 }
 
 function appendOutputBuffer(event: { terminalId: string; sequence: number; data: string }): void {
-  const current = terminalOutputBuffers.get(event.terminalId) ?? { output: '', sequence: 0 }
+  const current = terminalOutputBuffers.get(event.terminalId) ?? { output: '', sequence: 0, startOffset: 0, endOffset: 0 }
   terminalOutputBuffers.set(event.terminalId, appendTerminalOutput(current, event, MAX_REPLAY_CHARS))
 }
 


### PR DESCRIPTION
## Summary
- Add `TerminalRead` for bounded, paginated readback of the current session's visible Agent terminal output.
- Guide `TerminalExecute` callers to read output explicitly, while retaining bounded output after terminal exit until cleanup.
- Normalize terminal control sequences and expose pagination/truncation metadata; allow this read-only operation in plan mode.

## Validation
- `bun run typecheck`
- `bun run electron:build`
- Manual development run started with `bun run dev`

## Performance impact
- Low risk: no new output IPC or renderer update path. Text normalization and paging run only when the Agent explicitly calls `TerminalRead`; existing per-terminal replay buffer remains capped at 1 MB.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
