### PR TITLE
feat(reasoning): 支持自建 OpenAI 兼容模型配置推理档位 / support custom reasoning levels for self-hosted models

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.17.70",
+  "version": "0.17.71",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1335,6 +1335,14 @@ export function registerIpcHandlers(): void {
 
   // ===== 渠道管理相关 =====
 
+  /** 渠道增删改后向所有渲染窗口广播最新列表，保证多窗口配置同步。 */
+  const broadcastChannelsChanged = (): void => {
+    const channels = listChannels()
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send(CHANNEL_IPC_CHANNELS.CHANGED, channels)
+    }
+  }
+
   // 获取所有渠道（apiKey 保持加密态）
   ipcMain.handle(
     CHANNEL_IPC_CHANNELS.LIST,
@@ -1347,7 +1355,9 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     CHANNEL_IPC_CHANNELS.CREATE,
     async (_, input: ChannelCreateInput): Promise<Channel> => {
-      return createChannel(input)
+      const channel = createChannel(input)
+      broadcastChannelsChanged()
+      return channel
     }
   )
 
@@ -1355,7 +1365,9 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     CHANNEL_IPC_CHANNELS.UPDATE,
     async (_, id: string, input: ChannelUpdateInput): Promise<Channel> => {
-      return updateChannel(id, input)
+      const channel = updateChannel(id, input)
+      broadcastChannelsChanged()
+      return channel
     }
   )
 
@@ -1363,7 +1375,8 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     CHANNEL_IPC_CHANNELS.DELETE,
     async (_, id: string): Promise<void> => {
-      return deleteChannel(id)
+      deleteChannel(id)
+      broadcastChannelsChanged()
     }
   )
 
@@ -3030,7 +3043,9 @@ export function registerIpcHandlers(): void {
       if (!channelId || !modelId) return undefined
       const channel = getChannelById(channelId)
       if (!channel) return undefined
-      return resolvePiReasoningCapability(channel.provider, modelId)
+      // 查找当前模型的频道级推理声明，连同 provider/modelId 一起传入能力解析
+      const channelReasoning = channel.models.find((model) => model.id === modelId)?.reasoning
+      return resolvePiReasoningCapability(channel.provider, modelId, channelReasoning)
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -112,6 +112,8 @@ export interface PiAgentQueryOptions extends AgentQueryInput {
   /** OAuth credential coordination key; equals the selected Proma channel id. */
   channelId?: string
   channelName?: string
+  /** 频道模型级推理档位声明，供 Pi 运行时注册自建模型时编译为 reasoning_effort 能力。 */
+  modelReasoning?: import('@proma/shared').ChannelModelReasoningConfig
   maxTurns?: number
   permissionMode: PromaPermissionMode
   canUseTool?: (

--- a/apps/electron/src/main/lib/adapters/pi-model-registry-reasoning.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry-reasoning.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+import { compilePiChannelReasoningCapabilities, resolvePiReasoningCapability } from './pi-model-registry'
+
+describe('自建模型推理能力', () => {
+  const reasoning = {
+    levels: ['off', 'low', 'medium', 'high'] as const,
+    defaultLevel: 'high' as const,
+    thinkingLevelMap: { off: 'none' },
+  }
+
+  test('OpenAI 兼容模型注册 reasoning_effort 与档位映射', () => {
+    expect(compilePiChannelReasoningCapabilities('openai-completions', {
+      ...reasoning,
+      levels: [...reasoning.levels],
+    })).toEqual({
+      compat: { supportsReasoningEffort: true, supportsStrictMode: false },
+      thinkingLevelMap: { off: 'none' },
+    })
+  })
+
+  test('频道声明为目录外模型提供会话级滑杆能力', async () => {
+    await expect(resolvePiReasoningCapability('openai', 'qwen3.8-27b-q8', {
+      ...reasoning,
+      levels: [...reasoning.levels],
+    })).resolves.toEqual({
+      source: 'channel',
+      levels: ['off', 'low', 'medium', 'high'],
+      defaultLevel: 'high',
+    })
+  })
+
+  test('Anthropic transport 不应用 OpenAI 推理声明', () => {
+    expect(compilePiChannelReasoningCapabilities('anthropic-messages', {
+      ...reasoning,
+      levels: [...reasoning.levels],
+    })).toBeUndefined()
+  })
+
+  test('内置模型的已验证 profile 优先于频道声明', async () => {
+    await expect(resolvePiReasoningCapability('openai', 'gpt-5.5', {
+      levels: ['off', 'high'],
+      defaultLevel: 'high',
+    })).resolves.toEqual({
+      source: 'profile',
+      levels: ['off', 'low', 'medium', 'high', 'xhigh'],
+      defaultLevel: 'high',
+    })
+  })
+})

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -12,9 +12,11 @@ import {
   extractZhipuCodingTeamApiToken,
   inferContextWindow,
   inferCodexAlignedGPT5ContextWindow,
+  resolveChannelReasoningCapability,
   resolveReasoningCapability,
   resolveReasoningProfile,
   type CodexOAuthCredentials,
+  type ChannelModelReasoningConfig,
   type XaiOAuthCredentials,
   type ReasoningCapability,
   type ReasoningTransport,
@@ -123,6 +125,33 @@ function compilePiReasoningCapabilities(
         },
         thinkingLevelMap,
       }
+  }
+}
+
+/** 将频道模型声明编译为通用 OpenAI reasoning_effort 能力。 */
+export function compilePiChannelReasoningCapabilities(
+  api: Api,
+  config: ChannelModelReasoningConfig | undefined,
+): Pick<PiModelDefaults, 'compat' | 'thinkingLevelMap'> | undefined {
+  if (api !== 'openai-completions' && api !== 'openai-responses') return undefined
+  const capability = resolveChannelReasoningCapability(config)
+  if (!capability || !config) return undefined
+
+  const thinkingLevelMap: Partial<Record<(typeof capability.levels)[number], string | null>> = {}
+  for (const level of capability.levels) {
+    const mapped = config.thinkingLevelMap?.[level]
+    if (typeof mapped === 'string' || mapped === null) thinkingLevelMap[level] = mapped
+  }
+
+  return {
+    compat: {
+      supportsReasoningEffort: true,
+      // Ollama/llama.cpp 等兼容端点可能无法把复杂工具 schema 编译为 grammar。
+      supportsStrictMode: false,
+    },
+    ...(Object.keys(thinkingLevelMap).length > 0 && {
+      thinkingLevelMap: thinkingLevelMap as PiCatalogModel['thinkingLevelMap'],
+    }),
   }
 }
 
@@ -567,6 +596,7 @@ export async function resolvePiVisionRelayRoute(
 export async function resolvePiReasoningCapability(
   provider: ProviderType,
   modelId: string | undefined,
+  channelReasoning?: ChannelModelReasoningConfig,
 ): Promise<ReasoningCapability | undefined> {
   const resolvedModelId = stripLegacyAgentSdkContextSuffix(modelId)
   const catalogModel = resolvedModelId
@@ -578,8 +608,18 @@ export async function resolvePiReasoningCapability(
       ? 'openai-responses'
       : toReasoningTransport(resolvePiApi(provider, catalogModel?.api)),
   })
+  const profileCapability = resolveReasoningCapability({ profile })
+  // 内置 profile 优先：白名单模型行为不变
+  if (profileCapability) return profileCapability
+
+  const api = resolvePiApi(provider, catalogModel?.api)
+  // profile 未命中时回退到频道级推理声明（仅 OpenAI 兼容 transport）
+  if (api === 'openai-completions' || api === 'openai-responses') {
+    const channelCapability = resolveChannelReasoningCapability(channelReasoning)
+    if (channelCapability) return channelCapability
+  }
+
   return resolveReasoningCapability({
-    profile,
     catalog: catalogModel && {
       reasoning: catalogModel.reasoning,
       thinkingLevelMap: catalogModel.thinkingLevelMap,
@@ -592,6 +632,10 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const codexAlignedCapabilities = getCodexAlignedGPT5Capabilities(input.model)
   const api = resolvePiApi(input.provider, catalogModel?.api)
   const providerSpecificCapabilities = compilePiReasoningCapabilities(api, input.model)
+  // 内置 profile 能力优先；未命中时编译频道级推理声明作为 fallback
+  const channelSpecificCapabilities = providerSpecificCapabilities
+    ? undefined
+    : compilePiChannelReasoningCapabilities(api, input.modelReasoning)
   const glmModelId = input.model?.toLowerCase()
   const isVolcengineGlm5x = (input.provider === 'doubao' || input.provider === 'doubao-api' || input.provider === 'ark-coding-plan')
     && (glmModelId === 'glm-5.2' || glmModelId === 'glm-5.3')
@@ -601,12 +645,13 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const shouldForceAdaptiveThinking = shouldForcePiAdaptiveThinking(api, catalogModel)
   return {
     api,
-    reasoning: catalogModel?.reasoning ?? true,
+    reasoning: channelSpecificCapabilities ? true : (catalogModel?.reasoning ?? true),
     thinkingLevelMap: providerSpecificCapabilities?.thinkingLevelMap
+      ?? channelSpecificCapabilities?.thinkingLevelMap
       ?? catalogModel?.thinkingLevelMap,
     compat: shouldForceAdaptiveThinking
-      ? { ...providerSpecificCapabilities?.compat, forceAdaptiveThinking: true }
-      : providerSpecificCapabilities?.compat,
+      ? { ...providerSpecificCapabilities?.compat, ...channelSpecificCapabilities?.compat, forceAdaptiveThinking: true }
+      : (providerSpecificCapabilities?.compat ?? channelSpecificCapabilities?.compat),
     input: catalogModel ? [...catalogModel.input] : ['text', 'image'],
     cost: catalogModel ? { ...catalogModel.cost } : { ...ZERO_MODEL_COST },
     // Codex 对齐策略优先；其他模型仍保留 catalog 与 shared inference 中更大的已验证能力。

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1378,7 +1378,9 @@ export class AgentOrchestrator {
       const maxTurns = appSettings.agentMaxTurns && appSettings.agentMaxTurns > 0
         ? appSettings.agentMaxTurns
         : undefined
-      const piReasoningCapability = await resolvePiReasoningCapability(channel.provider, selectedModelId)
+      // 查找当前模型的频道级推理声明，传入能力解析以支持自建模型推理档位
+      const modelReasoning = channel.models.find((model) => model.id === selectedModelId)?.reasoning
+      const piReasoningCapability = await resolvePiReasoningCapability(channel.provider, selectedModelId, modelReasoning)
       const piThinkingLevel = resolvePiThinkingLevel(appSettings, sessionMeta, channel.provider, selectedModelId, piReasoningCapability)
       const projectInstructions = workspaceSlug
         ? (() => {
@@ -1505,6 +1507,8 @@ export class AgentOrchestrator {
         provider: channel.provider,
         channelId,
         channelName: channel.name,
+        // 将频道推理声明透传给 Pi 运行时，供模型注册时编译为 reasoning_effort 能力
+        ...(modelReasoning && { modelReasoning }),
         proxyUrl,
         runtimeEnv,
         ...(maxTurns != null && { maxTurns }),

--- a/apps/electron/src/main/lib/agent-thinking-level.test.ts
+++ b/apps/electron/src/main/lib/agent-thinking-level.test.ts
@@ -11,6 +11,18 @@ describe('Pi thinking level resolver', () => {
     )).toBe('off')
   })
 
+  test('Given two sessions on one custom model When each selects a level Then resolves independently', () => {
+    const capability = {
+      source: 'channel' as const,
+      levels: ['low', 'high'] as const,
+      defaultLevel: 'high' as const,
+    }
+    const settings = { agentThinking: { type: 'adaptive' as const }, agentEffort: 'high' as const }
+
+    expect(resolvePiThinkingLevel(settings, { reasoningLevel: 'low' }, 'openai', 'custom-model', capability)).toBe('low')
+    expect(resolvePiThinkingLevel(settings, { reasoningLevel: 'high' }, 'openai', 'custom-model', capability)).toBe('high')
+  })
+
   test.each(['openai', 'openai-responses', 'custom'] as const)(
     'Given third-party %s GPT-5.6 When session has max override Then uses it',
     (provider) => {

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -14,7 +14,7 @@
 
 import { randomUUID } from 'node:crypto'
 import type { WebContents } from 'electron'
-import { CHAT_IPC_CHANNELS } from '@proma/shared'
+import { CHAT_IPC_CHANNELS, resolveChannelReasoningEffort } from '@proma/shared'
 import type { ChatSendInput, ChatMessage, GenerateTitleInput, FileAttachment, ChatToolActivity } from '@proma/shared'
 import {
   getAdapter,
@@ -197,7 +197,7 @@ export async function sendMessage(
   const {
     conversationId, userMessage, channelId,
     modelId, systemMessage, contextLength, contextDividers, attachments,
-    thinkingEnabled, enabledToolIds,
+    thinkingEnabled, reasoningLevel, enabledToolIds,
   } = input
 
   // 1. 查找渠道
@@ -210,6 +210,9 @@ export async function sendMessage(
     })
     return
   }
+  // 查找当前模型的频道级推理声明，将会话档位映射为线上 reasoning_effort 字符串
+  const modelReasoning = channel.models.find((model) => model.id === modelId)?.reasoning
+  const reasoningEffort = resolveChannelReasoningEffort(modelReasoning, reasoningLevel)
 
   // Subscription OAuth uses Pi provider-specific transports, which Chat mode does
   // not currently implement. Keep this guard for historical conversations that
@@ -332,6 +335,7 @@ export async function sendMessage(
         attachments,
         readImageAttachments: getImageAttachmentData,
         thinkingEnabled,
+        reasoningEffort,
         tools,
         continuationMessages: continuationMessages.length > 0 ? continuationMessages : undefined,
       })
@@ -408,6 +412,7 @@ export async function sendMessage(
         attachments,
         readImageAttachments: getImageAttachmentData,
         thinkingEnabled,
+        reasoningEffort,
         // 不传 tools，强制模型生成文本回复而非继续调用工具
         continuationMessages,
       })

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -288,6 +288,9 @@ export interface ElectronAPI {
   /** 获取所有渠道列表（apiKey 保持加密态） */
   listChannels: () => Promise<Channel[]>
 
+  /** 订阅来自其他窗口的渠道配置变化。 */
+  onChannelsChanged: (callback: (channels: Channel[]) => void) => () => void
+
   /** 创建渠道（apiKey 为明文，主进程加密） */
   createChannel: (input: ChannelCreateInput) => Promise<Channel>
 
@@ -1435,6 +1438,12 @@ const electronAPI: ElectronAPI = {
   // 渠道管理
   listChannels: () => {
     return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.LIST)
+  },
+
+  onChannelsChanged: (callback: (channels: Channel[]) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, channels: Channel[]): void => callback(channels)
+    ipcRenderer.on(CHANNEL_IPC_CHANNELS.CHANGED, listener)
+    return () => ipcRenderer.removeListener(CHANNEL_IPC_CHANNELS.CHANGED, listener)
   },
 
   createChannel: (input: ChannelCreateInput) => {

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -7,7 +7,7 @@
 
 import { atom } from 'jotai'
 import { atomFamily, atomWithStorage } from 'jotai/utils'
-import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
+import type { AgentThinkingLevel, ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
 
 /** 全局渠道列表缓存（启动时加载一次，设置变更时刷新） */
 export const channelsAtom = atom<Channel[]>([])
@@ -286,6 +286,9 @@ export const conversationContextLengthAtom = atom<Map<string, ContextLengthValue
 
 /** 每个对话的思考模式 */
 export const conversationThinkingEnabledAtom = atom<Map<string, boolean>>(new Map())
+
+/** 每个对话选择的模型推理档位。 */
+export const conversationReasoningLevelAtom = atom<Map<string, AgentThinkingLevel>>(new Map())
 
 /** 每个对话的并排模式 */
 export const conversationParallelModeAtom = atom<Map<string, boolean>>(new Map())

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -59,6 +59,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
+import { createReasoningCapabilityKey, resolveConversationReasoningCapability } from '@/lib/channel-model-reasoning'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { registerShortcut } from '@/lib/shortcut-registry'
 import { supportsChannelPlanQuota } from '@/lib/channel-plan-quota'
@@ -302,7 +303,8 @@ function normalizeOpenAIThinkingLevel(
   level: AgentThinkingLevel | undefined,
   levels: readonly OpenAIThinkingLevel[],
 ): OpenAIThinkingLevel {
-  if (level === 'minimal') return 'low'
+  // minimal 档位仅在模型声明支持时保留，否则降级为 low（兼容 GPT-5 标准档位）
+  if (level === 'minimal' && !levels.includes('minimal')) return 'low'
   // max 会话设置在切到非 GPT-5.6 时由主进程降级为 xhigh；UI 同步展示有效档位。
   if (level === 'max' && !levels.includes('max')) return 'xhigh'
   return levels.includes(level as OpenAIThinkingLevel) ? level as OpenAIThinkingLevel : 'off'
@@ -311,6 +313,8 @@ function normalizeOpenAIThinkingLevel(
 interface CodexThinkingConfig {
   thinkingLevel: AgentThinkingLevel
   levels: readonly OpenAIThinkingLevel[]
+  /** 开启思考时的默认档位，用于点击开关时恢复初始档位。 */
+  defaultLevel: AgentThinkingLevel
   onThinkingLevelChange: (level: AgentThinkingLevel) => void
 }
 
@@ -318,6 +322,43 @@ interface AgentThinkingPopoverProps {
   agentThinking: import('@proma/shared').ThinkingConfig | undefined
   onToggle: () => void
   codexConfig?: CodexThinkingConfig
+}
+
+/** Agent 输入栏的推理档位下拉选择器，按当前能力声明渲染可选档位。 */
+interface AgentReasoningLevelSelectProps {
+  thinkingLevel: AgentThinkingLevel
+  levels: readonly AgentThinkingLevel[]
+  enabled: boolean
+  onThinkingLevelChange: (level: AgentThinkingLevel) => void
+}
+
+function AgentReasoningLevelSelect({
+  thinkingLevel,
+  levels,
+  enabled,
+  onThinkingLevelChange,
+}: AgentReasoningLevelSelectProps): React.ReactElement {
+  const normalizedLevel = normalizeOpenAIThinkingLevel(thinkingLevel, levels)
+  return (
+    <Select
+      value={normalizedLevel}
+      onValueChange={(level) => onThinkingLevelChange(level as AgentThinkingLevel)}
+      disabled={!enabled}
+    >
+      <SelectTrigger
+        className="h-8 w-auto min-w-[52px] border-0 bg-transparent px-2 text-xs font-medium text-foreground/70 shadow-none hover:bg-muted/50 hover:text-foreground focus:ring-0 disabled:opacity-40"
+        aria-label="推理档位"
+        title={enabled ? '选择当前会话的推理档位' : '开启思考后可选择推理档位'}
+      >
+        <SelectValue>{OPENAI_THINKING_LABELS[normalizedLevel]}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align="center">
+        {levels.filter((level) => level !== 'off').map((level) => (
+          <SelectItem key={level} value={level}>{OPENAI_THINKING_LABELS[level]}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
 }
 
 function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThinkingPopoverProps): React.ReactElement {
@@ -352,7 +393,7 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
   const handleButtonClick = (): void => {
     if (codexConfig) {
       if (!supportsThinkingToggle) return
-      codexConfig.onThinkingLevelChange(isEnabled ? 'off' : 'high')
+      codexConfig.onThinkingLevelChange(isEnabled ? 'off' : codexConfig.defaultLevel)
       return
     }
     onToggle()
@@ -737,10 +778,11 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
     ? stableChannel.id
     : null
   const planQuotaChannelUpdatedAt = planQuotaChannelId ? stableChannel?.updatedAt : undefined
-  const agentChannelProvider = React.useMemo(
-    () => globalChannels.find((c) => c.id === agentChannelId)?.provider,
+  const agentChannel = React.useMemo(
+    () => globalChannels.find((channel) => channel.id === agentChannelId),
     [globalChannels, agentChannelId],
   )
+  const agentChannelProvider = agentChannel?.provider
   const isCodexFastModeAvailable = hasSessionMeta
     && agentChannelProvider === 'openai-codex'
     && isCodexFastModeSupportedModel(agentModelId ?? undefined)
@@ -751,7 +793,15 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
       transport: inferReasoningTransport(agentChannelProvider),
     })
     : undefined
-  const reasoningCapabilityKey = `${agentChannelId ?? ''}:${agentModelId ?? ''}`
+  // 查找当前模型的频道级推理声明，用于 capability 缓存键与三级优先级解析
+  const modelReasoningConfig = agentChannel?.models.find((model) => model.id === agentModelId)?.reasoning
+  // 缓存键包含 channelId/modelId/频道更新时间/推理配置，任一变化时触发重新解析
+  const reasoningCapabilityKey = createReasoningCapabilityKey({
+    channelId: agentChannelId,
+    modelId: agentModelId,
+    channelUpdatedAt: agentChannel?.updatedAt,
+    reasoning: modelReasoningConfig,
+  })
   const [piReasoningCapability, setPiReasoningCapability] = React.useState<{
     key: string
     capability: ReasoningCapability | undefined
@@ -776,9 +826,15 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
     return () => { cancelled = true }
   }, [agentChannelId, agentModelId, hasSessionMeta, reasoningCapabilityKey])
 
-  const effectiveReasoningCapability = piReasoningCapability.key === reasoningCapabilityKey
-    ? piReasoningCapability.capability ?? resolveReasoningCapability({ profile: reasoningProfile })
-    : resolveReasoningCapability({ profile: reasoningProfile })
+  // 三级优先级解析推理能力：内置 profile > 频道声明 > IPC 远端目录
+  const profileReasoningCapability = resolveReasoningCapability({ profile: reasoningProfile })
+  const effectiveReasoningCapability = resolveConversationReasoningCapability({
+    profile: profileReasoningCapability,
+    channelReasoning: modelReasoningConfig,
+    remote: piReasoningCapability.key === reasoningCapabilityKey
+      ? piReasoningCapability.capability
+      : undefined,
+  })
   const isSessionThinkingAvailable = Boolean(effectiveReasoningCapability)
   const openAIThinkingLevels = effectiveReasoningCapability?.levels ?? OPENAI_STANDARD_THINKING_LEVELS
   const fallbackOpenAIThinkingLevel: AgentThinkingLevel = agentEffort === 'max'
@@ -789,6 +845,9 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
     ? normalizeReasoningLevel(reasoningProfile, persistedReasoningLevel ?? fallbackOpenAIThinkingLevel)
     : normalizeReasoningCapabilityLevel(effectiveReasoningCapability, persistedReasoningLevel ?? fallbackOpenAIThinkingLevel)
   const openAIThinkingLevel = normalizedReasoningLevel ?? (persistedReasoningLevel ?? fallbackOpenAIThinkingLevel)
+  // UI 展示档位：将实际档位规范化到可选列表内；档位选择器在思考关闭时禁用
+  const displayedReasoningLevel = normalizeOpenAIThinkingLevel(openAIThinkingLevel, openAIThinkingLevels)
+  const reasoningLevelSelectionEnabled = !openAIThinkingLevels.includes('off') || displayedReasoningLevel !== 'off'
 
   // Pi runtime supports all protocols, so any enabled channel with an enabled model is available.
   const hasAvailableModel = React.useMemo(
@@ -2815,11 +2874,25 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
           codexConfig={isSessionThinkingAvailable ? {
             thinkingLevel: openAIThinkingLevel,
             levels: openAIThinkingLevels,
+            // 开启思考时恢复的默认档位，取自能力声明的 defaultLevel
+            defaultLevel: effectiveReasoningCapability?.defaultLevel ?? 'high',
             onThinkingLevelChange: (level) => { void updateReasoningLevel(level) },
           } : undefined}
         />
       ),
     },
+    // 推理档位选择器：仅在有推理能力时显示，与思考开关联动
+    ...(isSessionThinkingAvailable ? [{
+      key: 'reasoning-level',
+      node: (
+        <AgentReasoningLevelSelect
+          thinkingLevel={displayedReasoningLevel}
+          levels={openAIThinkingLevels}
+          enabled={reasoningLevelSelectionEnabled}
+          onThinkingLevelChange={(level) => { void updateReasoningLevel(level) }}
+        />
+      ),
+    }] : []),
     { key: 'speech', node: <SpeechButton className={inputToolbarButtonClass} voiceInputId={agentVoiceInputId} /> },
     {
       key: 'attach-content',
@@ -2862,6 +2935,8 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
     isSessionThinkingAvailable,
     openAIThinkingLevel,
     openAIThinkingLevels,
+    displayedReasoningLevel,
+    reasoningLevelSelectionEnabled,
     updateReasoningLevel,
     backgroundWaiting,
     sessionId,

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -29,6 +29,7 @@ import {
   conversationModelsAtom,
   conversationContextLengthAtom,
   conversationThinkingEnabledAtom,
+  conversationReasoningLevelAtom,
   conversationParallelModeAtom,
   agentSideChatMapAtom,
 } from '@/atoms/chat-atoms'
@@ -853,6 +854,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setConvModels = useSetAtom(conversationModelsAtom)
   const setConvContextLength = useSetAtom(conversationContextLengthAtom)
   const setConvThinking = useSetAtom(conversationThinkingEnabledAtom)
+  const setConvReasoningLevel = useSetAtom(conversationReasoningLevelAtom)
   const setConvParallel = useSetAtom(conversationParallelModeAtom)
   const setConvPromptId = useSetAtom(conversationPromptIdAtom)
   const setPreviewPanelOpen = useSetAtom(previewPanelOpenMapAtom)
@@ -883,6 +885,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setConvModels(deleteKey)
     setConvContextLength(deleteKey)
     setConvThinking(deleteKey)
+    setConvReasoningLevel(deleteKey)
     setConvParallel(deleteKey)
     setConvPromptId(deleteKey)
     setPreviewPanelOpen(deleteKey)
@@ -962,7 +965,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     sessionExistsAtom.remove(id)
 
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvReasoningLevel, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -32,6 +32,7 @@ import {
   inputToolbarSendButtonClass,
 } from '@/components/ai-elements/input-toolbar-styles'
 import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Tooltip,
   TooltipContent,
@@ -42,16 +43,19 @@ import {
   conversationDraftsAtom,
   conversationDraftSyncVersionsAtom,
   conversationDraftSyncVersionAtomFamily,
+  channelsAtom,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
   useConversationModel,
   useConversationThinkingEnabled,
+  useConversationReasoningLevel,
 } from '@/hooks/useConversationSettings'
 import { cn } from '@/lib/utils'
 import { fileToBase64, formatFileNames } from '@/lib/file-utils'
-import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
+import { MAX_ATTACHMENT_SIZE, normalizeReasoningCapabilityLevel, resolveChannelReasoningCapability } from '@proma/shared'
+import type { AgentThinkingLevel } from '@proma/shared'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
 import { toast } from 'sonner'
 
@@ -70,6 +74,16 @@ interface ChatInputProps {
   onStop: () => void
   /** 清除上下文回调 */
   onClearContext?: () => void
+}
+
+const REASONING_LEVEL_LABELS: Record<AgentThinkingLevel, string> = {
+  off: '关闭',
+  minimal: '最小',
+  low: '低',
+  medium: '中',
+  high: '高',
+  xhigh: '极高',
+  max: '最大',
 }
 
 export function ChatInput({ conversationId, streaming, pendingAttachments, onSetPendingAttachments, onSend, onStop, onClearContext }: ChatInputProps): React.ReactElement {
@@ -105,6 +119,31 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
 
   const [selectedModel] = useConversationModel()
   const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
+  const [reasoningLevel, setReasoningLevel] = useConversationReasoningLevel()
+  const channels = useAtomValue(channelsAtom)
+  const reasoningCapability = React.useMemo(() => {
+    if (!selectedModel) return undefined
+    const config = channels
+      .find((channel) => channel.id === selectedModel.channelId)
+      ?.models.find((model) => model.id === selectedModel.modelId)
+      ?.reasoning
+    return resolveChannelReasoningCapability(config)
+  }, [channels, selectedModel])
+  const availableReasoningLevels: AgentThinkingLevel[] = reasoningCapability?.levels.filter((level) => level !== 'off') ?? []
+  const effectiveReasoningLevel = normalizeReasoningCapabilityLevel(
+    reasoningCapability,
+    reasoningLevel ?? reasoningCapability?.defaultLevel,
+  )
+  // displayedReasoningLevel 是实际生效的档位（用于请求发送）。
+  // selectDisplayValue 是 Select 当前展示值：当生效档位不在可选列表中（如 defaultLevel 为 off，
+  // 或用户尚未选择且默认值被过滤掉）时回退为 undefined，使 SelectValue 显示「推理强度」占位文字。
+  const displayedReasoningLevel = effectiveReasoningLevel === 'off'
+    ? reasoningCapability?.defaultLevel
+    : effectiveReasoningLevel
+  const selectDisplayValue = displayedReasoningLevel
+    && availableReasoningLevels.includes(displayedReasoningLevel)
+    ? displayedReasoningLevel
+    : undefined
   const setPendingAttachments = onSetPendingAttachments
   const [isDragOver, setIsDragOver] = React.useState(false)
   const chatVoiceInputId = React.useId()
@@ -349,7 +388,13 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
                 inputToolbarButtonClass,
                 thinkingEnabled && inputToolbarActiveButtonClass
               )}
-              onClick={() => setThinkingEnabled(!thinkingEnabled)}
+              onClick={() => {
+                const next = !thinkingEnabled
+                setThinkingEnabled(next)
+                if (next && reasoningCapability) {
+                  setReasoningLevel(displayedReasoningLevel ?? reasoningCapability.defaultLevel)
+                }
+              }}
             >
               <Brain className="size-5" />
             </Button>
@@ -360,6 +405,29 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
         </Tooltip>
       ),
     },
+    ...(reasoningCapability && availableReasoningLevels.length > 0 ? [{
+      key: 'reasoning-level',
+      node: (
+        <Select
+          value={selectDisplayValue}
+          onValueChange={(level) => setReasoningLevel(level as AgentThinkingLevel)}
+          disabled={!thinkingEnabled}
+        >
+          <SelectTrigger
+            className="h-8 w-auto min-w-[52px] border-0 bg-transparent px-2 text-xs font-medium text-foreground/70 shadow-none hover:bg-muted/50 hover:text-foreground focus:ring-0 disabled:opacity-40"
+            aria-label="推理档位"
+            title={thinkingEnabled ? '选择当前对话的推理档位' : '开启思考后可选择推理档位'}
+          >
+            <SelectValue placeholder="推理强度" />
+          </SelectTrigger>
+          <SelectContent align="center">
+            {availableReasoningLevels.map((level) => (
+              <SelectItem key={level} value={level}>{REASONING_LEVEL_LABELS[level]}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ),
+    }] : []),
     {
       key: 'attach',
       node: (
@@ -385,7 +453,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     { key: 'tools', node: <ToolSelectorPopover /> },
     { key: 'context', node: <ContextSettingsPopover /> },
     { key: 'clear', node: <ClearContextButton onClick={onClearContext} /> },
-  ], [handleOpenFileDialog, thinkingEnabled, setThinkingEnabled, onClearContext, chatVoiceInputId])
+  ], [availableReasoningLevels, chatVoiceInputId, selectDisplayValue, handleOpenFileDialog, onClearContext, reasoningCapability, setReasoningLevel, setThinkingEnabled, thinkingEnabled])
 
   const trailingNode = streaming ? (
     <Tooltip>

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -29,6 +29,7 @@ import {
   chatMessageRefreshAtom,
   pendingAgentRecommendationAtom,
   conversationModelsAtom,
+  channelsAtom,
   chatPendingMessageAtom,
   INITIAL_MESSAGE_LIMIT,
 } from '@/atoms/chat-atoms'
@@ -42,6 +43,7 @@ import {
   useConversationModel,
   useConversationContextLength,
   useConversationThinkingEnabled,
+  useConversationReasoningLevel,
   useConversationPromptId,
 } from '@/hooks/useConversationSettings'
 import { registerPendingTitle } from '@/hooks/useGlobalChatListeners'
@@ -49,11 +51,13 @@ import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { cn } from '@/lib/utils'
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import type {
+  AgentThinkingLevel,
   ChatMessage,
   ChatSendInput,
   FileAttachment,
   AttachmentSaveInput,
 } from '@proma/shared'
+import { resolveConversationRequestReasoningLevel } from '@/lib/channel-model-reasoning'
 
 interface ChatViewProps {
   conversationId: string
@@ -91,10 +95,12 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   const [selectedModel, setSelectedModel] = useConversationModel()
   const [contextLength] = useConversationContextLength()
   const [thinkingEnabled] = useConversationThinkingEnabled()
+  const [reasoningLevel] = useConversationReasoningLevel()
   const [conversationPromptId] = useConversationPromptId()
 
   // ===== 全局 atoms（Map 结构，按 conversationId 读取） =====
   const conversations = useAtomValue(conversationsAtom)
+  const channels = useAtomValue(channelsAtom)
   const setConversations = useSetAtom(conversationsAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
   const streamingStates = useAtomValue(streamingStatesAtom)
@@ -336,6 +342,17 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       return next
     })
 
+    // 从频道配置查找当前模型的推理声明，按会话档位与思考开关解析请求档位
+    const modelReasoning = channels
+      .find((channel) => channel.id === selectedModel.channelId)
+      ?.models.find((model) => model.id === selectedModel.modelId)
+      ?.reasoning
+    const requestReasoningLevel: AgentThinkingLevel | undefined = resolveConversationRequestReasoningLevel({
+      config: modelReasoning,
+      selectedLevel: reasoningLevel,
+      enabled: thinkingEnabled,
+    })
+
     const input: ChatSendInput = {
       conversationId,
       userMessage: finalContent,
@@ -346,6 +363,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       contextDividers: options?.contextDividersOverride ?? contextDividers,
       attachments: savedAttachments.length > 0 ? savedAttachments : undefined,
       thinkingEnabled: thinkingEnabled || undefined,
+      reasoningLevel: requestReasoningLevel,
       systemMessage: resolveSystemMessage(conversationPromptId, promptConfig, userProfile.userName),
       enabledToolIds: activeToolIds.length > 0 ? activeToolIds : undefined,
     }
@@ -385,6 +403,8 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     contextLength,
     contextDividers,
     thinkingEnabled,
+    reasoningLevel,
+    channels,
     conversationPromptId,
     promptConfig,
     userProfile.userName,

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -22,13 +22,23 @@ import {
   Zap,
   Download,
   Search,
+  Settings2,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useSetAtom } from 'jotai'
 import { channelFormDirtyAtom } from '@/atoms/settings-tab'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   PROVIDER_DEFAULT_URLS,
   PROVIDER_LABELS,
@@ -42,11 +52,19 @@ import type {
   ChannelCreateInput,
   ChannelModel,
   ChannelTestResult,
+  AgentThinkingLevel,
   CodexOAuthDeviceCode,
   FetchModelsResult,
   ProviderType,
   XaiOAuthDeviceCode,
 } from '@proma/shared'
+import {
+  addChannelReasoningLevel,
+  CHANNEL_REASONING_LEVELS,
+  createChannelReasoningConfig,
+  removeChannelReasoningLevel,
+  updateChannelReasoningEffort,
+} from '@/lib/channel-model-reasoning'
 import {
   normalizeBaseUrl,
   resolveAnthropicMessagesUrl,
@@ -123,6 +141,27 @@ const ANTHROPIC_PROTOCOL_PROVIDERS: ReadonlySet<ProviderType> = new Set<Provider
   'qwen-anthropic',
   'qwen-token-plan',
 ])
+
+const CHANNEL_REASONING_PROVIDERS: ReadonlySet<ProviderType> = new Set<ProviderType>([
+  'openai',
+  'openai-responses',
+  'opencode-go-openai',
+  'zhipu',
+  'doubao',
+  'doubao-api',
+  'qwen',
+  'custom',
+])
+
+const CHANNEL_REASONING_LEVEL_LABELS: Record<AgentThinkingLevel, string> = {
+  off: '关闭',
+  minimal: '最小',
+  low: '低',
+  medium: '中',
+  high: '高',
+  xhigh: '极高',
+  max: '最大',
+}
 
 /**
  * 生成 API 端点预览 URL
@@ -221,6 +260,8 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
 
   // 模型搜索过滤
   const [modelFilter, setModelFilter] = React.useState('')
+  const [expandedReasoningModelId, setExpandedReasoningModelId] = React.useState<string | null>(null)
+  const [reasoningLevelToAdd, setReasoningLevelToAdd] = React.useState<AgentThinkingLevel | ''>('')
 
   // UI 状态
   const [saving, setSaving] = React.useState(false)
@@ -238,6 +279,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
   const [xaiDeviceCode, setXaiDeviceCode] = React.useState<XaiOAuthDeviceCode | null>(null)
 
   const setChannelFormDirty = useSetAtom(channelFormDirtyAtom)
+  const setGlobalChannels = useSetAtom(channelsAtom)
   const codexLoggingInRef = React.useRef(false)
   const xaiLoggingInRef = React.useRef(false)
 
@@ -329,12 +371,16 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         models: currentModels,
         enabled: currentEnabled,
       })
+      // 同步更新全局渠道缓存，使 ChatInput 等依赖 channelsAtom 的组件立即反映推理配置变化
+      setGlobalChannels((current) => current.map((item) => (
+        item.id === savedChannel.id ? savedChannel : item
+      )))
       toast.success('已保存', { id: 'auto-save-success' })
     } catch (error) {
       console.error('[模型配置表单] auto-save 失败:', error)
       toast.error('自动保存失败，请检查后手动重试', { id: 'auto-save-error' })
     }
-  }, [isEdit, channel])
+  }, [isEdit, channel, setGlobalChannels])
 
   /** 触发防抖 auto-save */
   const scheduleAutoSave = React.useCallback((
@@ -509,6 +555,58 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
     )
   }
 
+  // ===== 频道模型推理档位编辑 handler =====
+
+  const handleToggleModelReasoning = (modelId: string, checked: boolean): void => {
+    setModels((prev) => prev.map((model) => (
+      model.id === modelId
+        ? {
+            ...model,
+            reasoning: checked
+              ? createChannelReasoningConfig()
+              : undefined,
+          }
+        : model
+    )))
+  }
+
+  const handleAddModelReasoningLevel = (modelId: string, level: AgentThinkingLevel): void => {
+    setModels((prev) => prev.map((model) => (
+      model.id === modelId && model.reasoning
+        ? { ...model, reasoning: addChannelReasoningLevel(model.reasoning, level) }
+        : model
+    )))
+    setReasoningLevelToAdd('')
+  }
+
+  const handleRemoveModelReasoningLevel = (modelId: string, level: AgentThinkingLevel): void => {
+    setModels((prev) => prev.map((model) => (
+      model.id === modelId && model.reasoning
+        ? { ...model, reasoning: removeChannelReasoningLevel(model.reasoning, level) }
+        : model
+    )))
+  }
+
+  const handleModelReasoningDefaultChange = (modelId: string, level: AgentThinkingLevel): void => {
+    setModels((prev) => prev.map((model) => (
+      model.id === modelId && model.reasoning?.levels.includes(level)
+        ? { ...model, reasoning: { ...model.reasoning, defaultLevel: level } }
+        : model
+    )))
+  }
+
+  const handleModelReasoningEffortChange = (
+    modelId: string,
+    level: AgentThinkingLevel,
+    effort: string,
+  ): void => {
+    setModels((prev) => prev.map((model) => (
+      model.id === modelId && model.reasoning
+        ? { ...model, reasoning: updateChannelReasoningEffort(model.reasoning, level, effort) }
+        : model
+    )))
+  }
+
   const handleCancelCodexLogin = (): void => {
     codexLoggingInRef.current = false
     void window.electronAPI.codexOAuthCancel()
@@ -676,7 +774,10 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
           // 与登录自动拉取路径（handleCodexLogin）保持一致，避免新模型（如 gpt-5.6 系列）
           // 默认未启用而沉到「可用模型」折叠区，被误认为"拉不到"。
           if (isSubscriptionProvider) return { ...m, enabled: true }
-          return old ? { ...m, enabled: old.enabled } : { ...m, enabled: false }
+          return old
+            // 保留已有模型的启用状态与推理声明，避免重新拉取列表后丢失用户配置
+            ? { ...m, enabled: old.enabled, ...(old.reasoning && { reasoning: old.reasoning }) }
+            : { ...m, enabled: false }
         })
         return [...manualKept, ...merged]
       })
@@ -1143,28 +1244,147 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
             </div>
           ) : (
             <div className="divide-y divide-border/50">
-              {enabledModels.map((model) => (
-                <div
-                  key={model.id}
-                  className="flex items-center gap-2 px-4 py-2.5 group"
-                >
-                  <CheckCircle2 size={14} className="text-emerald-500 flex-shrink-0" />
-                  <span className="text-sm text-foreground flex-1">
-                    {model.name}
-                    {model.name !== model.id && (
-                      <span className="text-muted-foreground ml-1">({model.id})</span>
+              {enabledModels.map((model) => {
+                const reasoningExpanded = expandedReasoningModelId === model.id
+                return (
+                  <div key={model.id}>
+                    <div className="flex items-center gap-2 px-4 py-2.5 group">
+                      <CheckCircle2 size={14} className="text-emerald-500 flex-shrink-0" />
+                      <span className="text-sm text-foreground flex-1 min-w-0 break-all">
+                        {model.name}
+                        {model.name !== model.id && (
+                          <span className="text-muted-foreground ml-1">({model.id})</span>
+                        )}
+                      </span>
+                      {CHANNEL_REASONING_PROVIDERS.has(provider) && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setExpandedReasoningModelId(reasoningExpanded ? null : model.id)
+                            setReasoningLevelToAdd('')
+                          }}
+                          className={cn(
+                            'p-1 transition-colors',
+                            reasoningExpanded || model.reasoning
+                              ? 'text-primary'
+                              : 'text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100',
+                          )}
+                          title="推理强度设置"
+                          aria-label={`${model.name} 推理强度设置`}
+                          aria-expanded={reasoningExpanded}
+                        >
+                          <Settings2 size={14} />
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => handleToggleModel(model.id)}
+                        className="p-0.5 text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
+                        title="取消启用"
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                    {reasoningExpanded && (
+                      <div className="space-y-3 border-t border-border/40 bg-muted/20 px-4 py-3">
+                        <div className="flex items-center gap-3">
+                          <div className="flex-1 min-w-0">
+                            <div className="text-sm text-foreground">自定义推理档位</div>
+                            <div className="text-xs text-muted-foreground">为此模型声明会话可选档位</div>
+                          </div>
+                          <Switch
+                            checked={Boolean(model.reasoning)}
+                            onCheckedChange={(checked) => handleToggleModelReasoning(model.id, checked)}
+                            aria-label={`${model.name} 自定义推理档位`}
+                          />
+                        </div>
+                        {model.reasoning && (
+                          <div className="space-y-2.5">
+                            {model.reasoning.levels.length > 0 && (
+                              <div className="flex items-center gap-3">
+                                <span className="w-20 shrink-0 text-xs text-muted-foreground">默认档位</span>
+                                <Select
+                                  value={model.reasoning.defaultLevel}
+                                  onValueChange={(value) => handleModelReasoningDefaultChange(
+                                    model.id,
+                                    value as AgentThinkingLevel,
+                                  )}
+                                >
+                                  <SelectTrigger className="h-8 flex-1">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {model.reasoning.levels.map((level) => (
+                                      <SelectItem key={level} value={level}>
+                                        {CHANNEL_REASONING_LEVEL_LABELS[level]} ({level})
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                            )}
+                            {model.reasoning.levels.map((level) => (
+                              <div key={level} className="flex items-center gap-2">
+                                <span className="w-20 shrink-0 text-xs text-foreground">
+                                  {CHANNEL_REASONING_LEVEL_LABELS[level]}
+                                </span>
+                                <Input
+                                  value={model.reasoning?.thinkingLevelMap?.[level] ?? ''}
+                                  onChange={(event) => handleModelReasoningEffortChange(
+                                    model.id,
+                                    level,
+                                    event.target.value,
+                                  )}
+                                  placeholder={level === 'off' ? '如 none；留空则不发送' : `留空则发送 ${level}`}
+                                  className="h-8 flex-1 text-xs"
+                                  aria-label={`${CHANNEL_REASONING_LEVEL_LABELS[level]}档位发送值`}
+                                />
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                                  onClick={() => handleRemoveModelReasoningLevel(model.id, level)}
+                                  aria-label={`删除${CHANNEL_REASONING_LEVEL_LABELS[level]}档位`}
+                                >
+                                  <X size={14} />
+                                </Button>
+                              </div>
+                            ))}
+                            {model.reasoning.levels.length === 0 && (
+                              <div className="py-2 text-center text-xs text-muted-foreground">
+                                尚未添加档位
+                              </div>
+                            )}
+                            {model.reasoning.levels.length < CHANNEL_REASONING_LEVELS.length && (
+                              <Select
+                                value={reasoningLevelToAdd}
+                                onValueChange={(value) => handleAddModelReasoningLevel(
+                                  model.id,
+                                  value as AgentThinkingLevel,
+                                )}
+                              >
+                                <SelectTrigger className="h-8 w-full border-dashed text-xs">
+                                  <SelectValue placeholder="添加推理档位" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {CHANNEL_REASONING_LEVELS
+                                    .filter((level) => !model.reasoning?.levels.includes(level))
+                                    .map((level) => (
+                                      <SelectItem key={level} value={level}>
+                                        {CHANNEL_REASONING_LEVEL_LABELS[level]} ({level})
+                                      </SelectItem>
+                                    ))}
+                                </SelectContent>
+                              </Select>
+                            )}
+                          </div>
+                        )}
+                      </div>
                     )}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => handleToggleModel(model.id)}
-                    className="p-0.5 text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
-                    title="取消启用"
-                  >
-                    <X size={14} />
-                  </button>
-                </div>
-              ))}
+                  </div>
+                )
+              })}
             </div>
           )}
         </SettingsCard>

--- a/apps/electron/src/renderer/hooks/useConversationSettings.ts
+++ b/apps/electron/src/renderer/hooks/useConversationSettings.ts
@@ -15,9 +15,11 @@ import {
   conversationModelsAtom,
   conversationContextLengthAtom,
   conversationThinkingEnabledAtom,
+  conversationReasoningLevelAtom,
   conversationParallelModeAtom,
 } from '@/atoms/chat-atoms'
 import type { SelectedModel, ContextLengthValue } from '@/atoms/chat-atoms'
+import type { AgentThinkingLevel } from '@proma/shared'
 import {
   selectedPromptIdAtom,
   conversationPromptIdAtom,
@@ -105,6 +107,14 @@ export function useConversationThinkingEnabled(): [boolean, (v: boolean) => void
   const value = useMapValue(conversationThinkingEnabledAtom, conversationId, defaultEnabled)
   const setter = useMapSetter(conversationThinkingEnabledAtom, conversationId)
   return [value, setter]
+}
+
+/** 每个对话独立的模型推理档位。 */
+export function useConversationReasoningLevel(): [AgentThinkingLevel | undefined, (v: AgentThinkingLevel) => void] {
+  const conversationId = useConversationId()
+  const values = useAtomValue(conversationReasoningLevelAtom)
+  const setter = useMapSetter(conversationReasoningLevelAtom, conversationId)
+  return [values.get(conversationId), setter]
 }
 
 /** 每个对话独立的并排模式 */

--- a/apps/electron/src/renderer/lib/channel-model-reasoning.test.ts
+++ b/apps/electron/src/renderer/lib/channel-model-reasoning.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  addChannelReasoningLevel,
+  createReasoningCapabilityKey,
+  createChannelReasoningConfig,
+  removeChannelReasoningLevel,
+  resolveConversationReasoningCapability,
+  resolveConversationRequestReasoningLevel,
+  updateChannelReasoningEffort,
+} from './channel-model-reasoning'
+
+describe('频道模型自定义推理档位', () => {
+  test('开启配置时不预置任何推理档位', () => {
+    expect(createChannelReasoningConfig()).toEqual({
+      levels: [],
+      defaultLevel: 'high',
+      thinkingLevelMap: {},
+    })
+  })
+
+  test('添加首个档位时将它设为默认档位', () => {
+    expect(addChannelReasoningLevel(createChannelReasoningConfig(), 'minimal')).toMatchObject({
+      levels: ['minimal'],
+      defaultLevel: 'minimal',
+    })
+  })
+
+  test('删除默认档位时选择剩余首档并移除对应线上映射', () => {
+    expect(removeChannelReasoningLevel({
+      levels: ['low', 'high'],
+      defaultLevel: 'low',
+      thinkingLevelMap: { low: 'light', high: 'deep' },
+    }, 'low')).toEqual({
+      levels: ['high'],
+      defaultLevel: 'high',
+      thinkingLevelMap: { high: 'deep' },
+    })
+  })
+
+  test('允许为每个档位设置和清除自定义线上 effort', () => {
+    const configured = updateChannelReasoningEffort({
+      levels: ['off'],
+      defaultLevel: 'off',
+      thinkingLevelMap: {},
+    }, 'off', 'none')
+    expect(configured.thinkingLevelMap).toEqual({ off: 'none' })
+    expect(updateChannelReasoningEffort(configured, 'off', '  ').thinkingLevelMap).toEqual({})
+  })
+
+  test('同一模型的推理配置变化时生成不同 capability 缓存键', () => {
+    const base = { channelId: 'channel-a', modelId: 'custom-model', channelUpdatedAt: 1 }
+    expect(createReasoningCapabilityKey({
+      ...base,
+      reasoning: { levels: ['low'], defaultLevel: 'low' },
+    })).not.toBe(createReasoningCapabilityKey({
+      ...base,
+      reasoning: { levels: ['low', 'high'], defaultLevel: 'high' },
+    }))
+  })
+
+  test('IPC 尚未返回能力时直接使用频道模型声明', () => {
+    expect(resolveConversationReasoningCapability({
+      channelReasoning: { levels: ['low', 'high'], defaultLevel: 'high' },
+    })).toEqual({
+      source: 'channel',
+      levels: ['low', 'high'],
+      defaultLevel: 'high',
+    })
+  })
+
+  test('内置 profile 仍优先于频道声明和远端目录', () => {
+    expect(resolveConversationReasoningCapability({
+      profile: { source: 'profile', levels: ['off', 'high'], defaultLevel: 'high' },
+      channelReasoning: { levels: ['low'], defaultLevel: 'low' },
+      remote: { source: 'pi-catalog', levels: ['medium'], defaultLevel: 'medium' },
+    })?.source).toBe('profile')
+  })
+
+  test('Chat 开启思考时使用当前会话档位，缺省使用模型默认档位', () => {
+    const config = { levels: ['off', 'low', 'high'] as const, defaultLevel: 'high' as const }
+    expect(resolveConversationRequestReasoningLevel({ config: { ...config, levels: [...config.levels] }, selectedLevel: 'low', enabled: true })).toBe('low')
+    expect(resolveConversationRequestReasoningLevel({ config: { ...config, levels: [...config.levels] }, enabled: true })).toBe('high')
+  })
+
+  test('Chat 关闭思考时仅在模型声明 off 时发送关闭档位', () => {
+    expect(resolveConversationRequestReasoningLevel({
+      config: { levels: ['off', 'high'], defaultLevel: 'high' },
+      enabled: false,
+    })).toBe('off')
+    expect(resolveConversationRequestReasoningLevel({
+      config: { levels: ['low', 'high'], defaultLevel: 'high' },
+      enabled: false,
+    })).toBeUndefined()
+  })
+})

--- a/apps/electron/src/renderer/lib/channel-model-reasoning.ts
+++ b/apps/electron/src/renderer/lib/channel-model-reasoning.ts
@@ -1,0 +1,107 @@
+import { normalizeReasoningCapabilityLevel, resolveChannelReasoningCapability } from '@proma/shared'
+import type { AgentThinkingLevel, ChannelModelReasoningConfig, ReasoningCapability } from '@proma/shared'
+
+export const CHANNEL_REASONING_LEVELS = [
+  'off',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const satisfies readonly AgentThinkingLevel[]
+
+/** 生成推理能力缓存键，任一维度变化即触发重新解析。 */
+export function createReasoningCapabilityKey(input: {
+  channelId: string | null
+  modelId: string | null
+  channelUpdatedAt?: number
+  reasoning?: ChannelModelReasoningConfig
+}): string {
+  return [
+    input.channelId ?? '',
+    input.modelId ?? '',
+    input.channelUpdatedAt ?? '',
+    JSON.stringify(input.reasoning ?? null),
+  ].join(':')
+}
+
+/** 三级优先级解析会话推理能力：内置 profile > 频道声明 > IPC 远端目录。 */
+export function resolveConversationReasoningCapability(input: {
+  profile?: ReasoningCapability
+  channelReasoning?: ChannelModelReasoningConfig
+  remote?: ReasoningCapability
+}): ReasoningCapability | undefined {
+  return input.profile
+    ?? resolveChannelReasoningCapability(input.channelReasoning)
+    ?? input.remote
+}
+
+/** 创建空白推理配置：不预置档位，默认档位 high。 */
+export function createChannelReasoningConfig(): ChannelModelReasoningConfig {
+  return {
+    levels: [],
+    defaultLevel: 'high',
+    thinkingLevelMap: {},
+  }
+}
+
+/** 添加推理档位，首个档位自动设为默认。 */
+export function addChannelReasoningLevel(
+  config: ChannelModelReasoningConfig,
+  level: AgentThinkingLevel,
+): ChannelModelReasoningConfig {
+  if (config.levels.includes(level)) return config
+  return {
+    ...config,
+    levels: [...config.levels, level],
+    defaultLevel: config.levels.length === 0 ? level : config.defaultLevel,
+  }
+}
+
+/** 删除推理档位，若删除的是默认档位则回退到剩余首档。 */
+export function removeChannelReasoningLevel(
+  config: ChannelModelReasoningConfig,
+  level: AgentThinkingLevel,
+): ChannelModelReasoningConfig {
+  const levels = config.levels.filter((item) => item !== level)
+  const thinkingLevelMap = { ...config.thinkingLevelMap }
+  delete thinkingLevelMap[level]
+  return {
+    ...config,
+    levels,
+    defaultLevel: config.defaultLevel === level ? (levels[0] ?? 'high') : config.defaultLevel,
+    thinkingLevelMap,
+  }
+}
+
+/** 设置或清除某档位的线上 effort 映射，空字符串表示删除映射。 */
+export function updateChannelReasoningEffort(
+  config: ChannelModelReasoningConfig,
+  level: AgentThinkingLevel,
+  effort: string,
+): ChannelModelReasoningConfig {
+  const thinkingLevelMap = { ...config.thinkingLevelMap }
+  const normalizedEffort = effort.trim()
+  if (normalizedEffort) {
+    thinkingLevelMap[level] = normalizedEffort
+  } else {
+    delete thinkingLevelMap[level]
+  }
+  return { ...config, thinkingLevelMap }
+}
+
+/** 解析 Chat 发送时的请求档位：思考开启时用会话档位或默认档位，关闭时仅发送 off。 */
+export function resolveConversationRequestReasoningLevel(input: {
+  config?: ChannelModelReasoningConfig
+  selectedLevel?: AgentThinkingLevel
+  enabled: boolean
+}): AgentThinkingLevel | undefined {
+  const capability = resolveChannelReasoningCapability(input.config)
+  if (!capability) return undefined
+  if (!input.enabled) return capability.levels.includes('off') ? 'off' : undefined
+  return normalizeReasoningCapabilityLevel(
+    capability,
+    input.selectedLevel ?? capability.defaultLevel,
+  )
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -199,6 +199,12 @@ function AgentSettingsInitializer(): null {
   // 初次加载标记 — 应用启动或切换工作区时不显示 toast
   const suppressToastRef = useRef(true)
 
+  // 订阅渠道变更广播：其他窗口增删改渠道时同步更新全局缓存
+  useEffect(() => window.electronAPI.onChannelsChanged((channels) => {
+    setChannels(channels)
+    setChannelsLoaded(true)
+  }), [setChannels, setChannelsLoaded])
+
   useEffect(() => {
     // 并行加载渠道列表和设置，确保两者都就绪后再验证渠道有效性
     Promise.all([

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.17.68",
+      "version": "0.17.71",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.84.2",
         "@earendil-works/pi-ai": "0.84.2",
@@ -157,7 +157,7 @@
     },
     "packages/core": {
       "name": "@proma/core",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@proma/shared": "workspace:*",
         "highlight.js": "^11.11.1",
@@ -184,7 +184,7 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "devDependencies": {
         "typescript": "^5.0.0",
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/core",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "license": "AGPL-3.0-only",
   "description": "proma core types,storage and core logic with agents",
   "type": "module",

--- a/packages/core/src/providers/openai-adapter.test.ts
+++ b/packages/core/src/providers/openai-adapter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import { OpenAIAdapter } from './openai-adapter.ts'
+
+describe('OpenAIAdapter', () => {
+  test('Given 自建模型推理档位 When buildStreamRequest Then 编码 reasoning_effort', () => {
+    const request = new OpenAIAdapter().buildStreamRequest({
+      baseUrl: 'http://localhost:8001/v1',
+      apiKey: 'test',
+      modelId: 'qwen3.8-27b-q8',
+      history: [],
+      userMessage: '你好',
+      readImageAttachments: () => [],
+      reasoningEffort: 'low',
+    })
+
+    expect(JSON.parse(request.body)).toMatchObject({ reasoning_effort: 'low' })
+  })
+})

--- a/packages/core/src/providers/openai-adapter.ts
+++ b/packages/core/src/providers/openai-adapter.ts
@@ -202,6 +202,11 @@ export class OpenAIAdapter implements ProviderAdapter {
       stream: true,
     }
 
+    // 自建模型推理强度：按频道配置映射后的 effort 字符串写入请求体
+    if (typeof input.reasoningEffort === 'string') {
+      bodyObj.reasoning_effort = input.reasoningEffort
+    }
+
     // 工具定义
     if (input.tools && input.tools.length > 0) {
       bodyObj.tools = toOpenAITools(input.tools)

--- a/packages/core/src/providers/openai-responses-adapter.test.ts
+++ b/packages/core/src/providers/openai-responses-adapter.test.ts
@@ -48,6 +48,20 @@ describe('OpenAIResponsesAdapter', () => {
     ])
   })
 
+  test('Given 自建模型推理档位 When buildStreamRequest Then 编码 reasoning effort', () => {
+    const request = adapter.buildStreamRequest({
+      baseUrl: 'http://localhost:8001/v1',
+      apiKey: 'test',
+      modelId: 'qwen3.8-27b-q8',
+      history: [],
+      userMessage: '你好',
+      readImageAttachments: () => [],
+      reasoningEffort: 'high',
+    })
+
+    expect(JSON.parse(request.body)).toMatchObject({ reasoning: { effort: 'high' } })
+  })
+
   test('Given Responses 文本 delta When parseSSELine Then 输出 chunk', () => {
     expect(adapter.parseSSELine(JSON.stringify({ type: 'response.output_text.delta', delta: 'hi' }))).toEqual([
       { type: 'chunk', delta: 'hi' },

--- a/packages/core/src/providers/openai-responses-adapter.ts
+++ b/packages/core/src/providers/openai-responses-adapter.ts
@@ -248,6 +248,11 @@ export class OpenAIResponsesAdapter implements ProviderAdapter {
       stream: true,
     }
 
+    // 自建模型推理强度：Responses API 使用嵌套 reasoning.effort 字段
+    if (typeof input.reasoningEffort === 'string') {
+      bodyObj.reasoning = { effort: input.reasoningEffort }
+    }
+
     if (input.tools && input.tools.length > 0) {
       bodyObj.tools = toResponsesTools(input.tools)
     }

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -220,6 +220,8 @@ export interface StreamRequestInput {
   readImageAttachments: ImageAttachmentReader
   /** 是否启用思考模式（各适配器根据供应商 API 自行转换） */
   thinkingEnabled?: boolean
+  /** 已按频道模型配置映射的线上推理强度；null 表示不发送。 */
+  reasoningEffort?: string | null
   /** 工具定义列表（可选，启用 function calling） */
   tools?: ToolDefinition[]
   /** 工具续接消息（tool use 循环中，前一轮的 tool_use + tool_result） */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -5,6 +5,8 @@
  * API Key 使用 Electron safeStorage 加密后存储在本地配置文件中。
  */
 
+import type { AgentThinkingLevel } from './agent'
+
 /**
  * 支持的 AI 供应商类型
  */
@@ -265,6 +267,15 @@ export function isXaiCredentialExpired(credentials: XaiOAuthCredentials, skewMs 
 /**
  * 渠道中的模型配置
  */
+export interface ChannelModelReasoningConfig {
+  /** UI 可选档位；顺序即滑杆展示顺序。 */
+  levels: AgentThinkingLevel[]
+  /** 新会话默认档位，必须包含在 levels 中。 */
+  defaultLevel: AgentThinkingLevel
+  /** 档位到 OpenAI reasoning_effort 的可选映射；null 表示不发送。 */
+  thinkingLevelMap?: Partial<Record<AgentThinkingLevel, string | null>>
+}
+
 export interface ChannelModel {
   /** 模型唯一标识（如 claude-sonnet-4-5-20250929） */
   id: string
@@ -274,6 +285,8 @@ export interface ChannelModel {
   enabled: boolean
   /** 来源标记：手动添加的模型在拉取供应商列表时保留，不会被覆盖清除 */
   source?: 'manual' | 'fetched'
+  /** 自建 OpenAI 兼容模型的推理档位声明。 */
+  reasoning?: ChannelModelReasoningConfig
 }
 
 /**
@@ -470,6 +483,8 @@ export interface ChannelPlanQuotaResult {
 export const CHANNEL_IPC_CHANNELS = {
   /** 获取所有渠道列表 */
   LIST: 'channel:list',
+  /** 渠道配置变化后向所有渲染窗口广播最新列表 */
+  CHANGED: 'channel:changed',
   /** 创建渠道 */
   CREATE: 'channel:create',
   /** 更新渠道 */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ProviderType } from './channel'
+import type { AgentThinkingLevel } from './agent'
 
 // ===== 附件相关 =====
 
@@ -222,6 +223,8 @@ export interface ChatSendInput {
   attachments?: FileAttachment[]
   /** 是否启用思考模式 */
   thinkingEnabled?: boolean
+  /** 当前对话选择的模型推理档位。 */
+  reasoningLevel?: AgentThinkingLevel
   /** 本次请求启用的工具 ID 列表（由前端工具选择器决定） */
   enabledToolIds?: string[]
 }

--- a/packages/shared/src/types/reasoning-profile.test.ts
+++ b/packages/shared/src/types/reasoning-profile.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveChannelReasoningCapability, resolveChannelReasoningEffort } from './reasoning-profile'
+
+describe('频道模型推理能力声明', () => {
+  test('给定有效档位时，返回供会话滑杆使用的频道能力', () => {
+    expect(resolveChannelReasoningCapability({
+      levels: ['off', 'low', 'medium', 'high'],
+      defaultLevel: 'high',
+      thinkingLevelMap: { off: 'none' },
+    })).toEqual({
+      source: 'channel',
+      levels: ['off', 'low', 'medium', 'high'],
+      defaultLevel: 'high',
+    })
+  })
+
+  test('默认档位不在可选档位中时，忽略无效声明', () => {
+    expect(resolveChannelReasoningCapability({
+      levels: ['off', 'low'],
+      defaultLevel: 'high',
+    })).toBeUndefined()
+  })
+
+  test('将会话档位解析为频道声明的线上 effort', () => {
+    const config = {
+      levels: ['off', 'low', 'high'] as const,
+      defaultLevel: 'high' as const,
+      thinkingLevelMap: { off: 'none', low: 'light', high: null },
+    }
+    expect(resolveChannelReasoningEffort({ ...config, levels: [...config.levels] }, 'off')).toBe('none')
+    expect(resolveChannelReasoningEffort({ ...config, levels: [...config.levels] }, 'low')).toBe('light')
+    expect(resolveChannelReasoningEffort({ ...config, levels: [...config.levels] }, 'high')).toBeNull()
+  })
+
+  test('未配置映射时原样发送档位名称', () => {
+    expect(resolveChannelReasoningEffort({ levels: ['medium'], defaultLevel: 'medium' }, 'medium')).toBe('medium')
+  })
+})

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -1,4 +1,5 @@
 import type { ProviderType } from './channel'
+import type { ChannelModelReasoningConfig } from './channel'
 import type { AgentThinkingLevel } from './agent'
 
 /** Proma 可识别的 reasoning 请求协议族。 */
@@ -70,7 +71,7 @@ export interface PiCatalogReasoningMetadata {
  * 不携带 protocol encoding；Pi catalog 继续负责把所选 level 编码为实际请求字段。
  */
 export interface ReasoningCapability {
-  source: 'profile' | 'pi-catalog'
+  source: 'profile' | 'pi-catalog' | 'channel'
   levels: readonly AgentThinkingLevel[]
   defaultLevel: AgentThinkingLevel
 }
@@ -342,6 +343,37 @@ export function resolveReasoningProfile(input: ResolveReasoningProfileInput): Re
 }
 
 const PI_EXTENDED_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const satisfies readonly AgentThinkingLevel[]
+
+/**
+ * 将频道模型推理声明解析为会话滑杆使用的 capability。
+ * 校验档位合法性与默认档位归属，无效声明返回 undefined（行为不变）。
+ */
+export function resolveChannelReasoningCapability(
+  config: ChannelModelReasoningConfig | undefined,
+): ReasoningCapability | undefined {
+  if (!config || !Array.isArray(config.levels)) return undefined
+
+  const validLevels = new Set<AgentThinkingLevel>(PI_EXTENDED_THINKING_LEVELS)
+  const levels = [...new Set(config.levels)].filter((level) => validLevels.has(level))
+  if (levels.length === 0 || !levels.includes(config.defaultLevel)) return undefined
+
+  return { source: 'channel', levels, defaultLevel: config.defaultLevel }
+}
+
+/**
+ * 将会话档位映射为线上 reasoning_effort 字符串。
+ * thinkingLevelMap 中 null 表示不发送，未配置映射时原样发送档位名称。
+ */
+export function resolveChannelReasoningEffort(
+  config: ChannelModelReasoningConfig | undefined,
+  level: AgentThinkingLevel | undefined,
+): string | null | undefined {
+  const capability = resolveChannelReasoningCapability(config)
+  if (!capability || !config || !level || !capability.levels.includes(level)) return undefined
+  const mapped = config.thinkingLevelMap?.[level]
+  if (mapped === null) return null
+  return typeof mapped === 'string' && mapped.trim() ? mapped.trim() : level
+}
 
 function getPiCatalogThinkingLevels(catalog: PiCatalogReasoningMetadata): AgentThinkingLevel[] {
   if (!catalog.reasoning) return []


### PR DESCRIPTION

为目录外的自建 OpenAI 兼容模型（Ollama、vLLM 等）提供频道级推理档位
声明能力，解决此类模型此前只能依赖全局思考开关、无法按会话调整
reasoning_effort 的问题。

- 新增 ChannelModelReasoningConfig（levels/defaultLevel/thinkingLevelMap）， 允许在频道设置中为每个模型声明可选档位与线上 effort 映射
- resolvePiReasoningCapability 在内置 profile 未命中时回退到频道声明 （profile 优先级高于频道声明，白名单模型行为不变）
- compilePiChannelReasoningCapabilities 将频道声明编译为 supportsReasoningEffort + supportsStrictMode:false，避免 Ollama 等端点 无法编译 strict tool grammar
- Chat 与 Agent 双路径支持：ChatInput/AgentView 新增推理档位 Select， ChatView 发送时计算 requestReasoningLevel，chat-service 映射为 reasoning_effort 字符串
- 新增 channel:changed IPC 广播，保证多窗口频道配置同步
- ChannelForm 增加频道级推理档位编辑 UI（开关/增删档位/默认档位/ 每档发送值映射），模型拉取合并时保留 reasoning 字段
- 修复 Chat 推理档位 Select 在未选择时显示空白的问题

版本：electron 0.17.71、shared 0.1.64、core 0.2.18

---

Add per-channel reasoning effort declarations so self-hosted OpenAI-compatible models (Ollama, vLLM, etc.) can expose configurable reasoning levels instead of relying solely on the global thinking toggle.

- ChannelModelReasoningConfig: levels, defaultLevel, thinkingLevelMap for declaring per-model reasoning levels and effort mapping
- resolvePiReasoningCapability falls back to channel declarations when built-in profiles miss (profiles take priority, whitelist behavior unchanged)
- compilePiChannelReasoningCapabilities compiles channel declarations into supportsReasoningEffort compat with supportsStrictMode disabled for local endpoints that cannot compile strict tool grammar
- Per-session reasoning level Select in both Chat and Agent inputs; ChatView computes requestReasoningLevel, chat-service maps it to reasoning_effort string
- channel:changed IPC broadcast for multi-window config sync
- Channel-level reasoning editor UI in ChannelForm (toggle/add-remove levels/default level/per-level effort mapping); reasoning field preserved across model list re-fetch
- Fix empty placeholder in Chat reasoning level Select

Bump: electron 0.17.71, shared 0.1.64, core 0.2.18