### PR TITLE
fix(settings): 修复返回按钮 hover 布局跳动【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -330,7 +330,7 @@ export function SettingsPanel({
             >
               <ArrowLeft size={16} />
               <span>返回</span>
-              <span className="ml-auto hidden group-hover:inline-flex">
+              <span aria-hidden="true" className="ml-auto inline-flex opacity-0 transition-opacity group-hover:opacity-100">
                 <ShortcutKeycaps accelerator="Esc" />
               </span>
             </button>


### PR DESCRIPTION
## 概述
修复设置面板左侧“返回”按钮在鼠标悬停时显示 Esc 键帽导致文字横向位移的问题。Esc 键帽始终保留布局空间，仅通过透明度渐显，按钮内容保持静止。

## 改动
- `apps/electron/src/renderer/components/settings/SettingsPanel.tsx` — 将 Esc 提示从 `display` 切换改为保留布局空间的透明度过渡；添加 `aria-hidden="true"`，使默认隐藏的纯视觉提示不改变按钮的辅助技术名称。

## 测试方法
1. 打开设置面板并观察底部“返回”按钮。
2. 鼠标悬停与移出该按钮，确认 Esc 键帽渐显和隐藏。
3. 确认箭头及“返回”文字在整个 hover 过程中位置不变。
4. 点击“返回”或按 Esc，确认仍可关闭设置面板。

## 备注
- 已完成 Local 准 PR 审核与 `git diff --check`。
- 此改动未引入新的 GPU 合成层、模糊效果或高频状态更新。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
