### PR TITLE
fix(skills): 窄右栏改为单列布局【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -280,7 +280,7 @@ export function AgentSkillsView({
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className={cn('flex h-full flex-col overflow-hidden', embedded && 'skills-embedded-container')}>
       {/* 标题栏 + 工作区切换 */}
       {/* 不加 titlebar-drag-region：与 DropdownMenu 嵌套时 drag/no-drag 会让 Radix 拿不到
           pointerdown，下拉打不开。窗口拖拽由 AppShell 顶部 0–50px 的全局 drag 层兜底。
@@ -452,6 +452,7 @@ export function AgentSkillsView({
             <SkillsTab
               customSkills={customSkills}
               builtinSkills={builtinSkills}
+              embedded={embedded}
               total={data.skills.length}
               updateCount={updateCount}
               updatingSkill={data.updatingSkill}
@@ -539,6 +540,7 @@ export function AgentSkillsView({
 interface SkillsTabProps {
   customSkills: SkillMeta[]
   builtinSkills: SkillMeta[]
+  embedded: boolean
   total: number
   updateCount: number
   updatingSkill: string | null
@@ -551,6 +553,7 @@ interface SkillsTabProps {
 function SkillsTab({
   customSkills,
   builtinSkills,
+  embedded,
   total,
   updateCount,
   updatingSkill,
@@ -574,10 +577,10 @@ function SkillsTab({
         </div>
       )}
       {customSkills.length > 0 && (
-        <SkillSection title="我的 Skills" skills={customSkills} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onUpdate={onUpdate} />
+        <SkillSection title="我的 Skills" skills={customSkills} embedded={embedded} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onUpdate={onUpdate} />
       )}
       {builtinSkills.length > 0 && (
-        <SkillSection title="PROMA 内置" skills={builtinSkills} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onUpdate={onUpdate} />
+        <SkillSection title="PROMA 内置" skills={builtinSkills} embedded={embedded} isBuiltin={isBuiltin} updatingSkill={updatingSkill} onOpen={onOpen} onToggle={onToggle} onUpdate={onUpdate} />
       )}
     </div>
   )
@@ -586,6 +589,7 @@ function SkillsTab({
 interface SkillSectionProps {
   title: string
   skills: SkillMeta[]
+  embedded: boolean
   isBuiltin: (slug: string) => boolean
   updatingSkill: string | null
   onOpen: (slug: string) => void
@@ -593,7 +597,7 @@ interface SkillSectionProps {
   onUpdate: (slug: string) => void
 }
 
-function SkillSection({ title, skills, isBuiltin, updatingSkill, onOpen, onToggle, onUpdate }: SkillSectionProps): React.ReactElement {
+function SkillSection({ title, skills, embedded, isBuiltin, updatingSkill, onOpen, onToggle, onUpdate }: SkillSectionProps): React.ReactElement {
   const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set())
   const groups = React.useMemo(() => groupSkills(skills), [skills])
 
@@ -627,7 +631,7 @@ function SkillSection({ title, skills, isBuiltin, updatingSkill, onOpen, onToggl
                 <span className="text-[12px] tabular-nums text-foreground/35">{group.skills.length}</span>
               </button>
               {!collapsed && (
-                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                <div className={cn('grid gap-3', embedded ? 'skills-embedded-card-grid' : 'sm:grid-cols-2 lg:grid-cols-3')}>
                   {group.skills.map((skill) => (
                     <SkillCard
                       key={skill.slug}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2443,3 +2443,16 @@
 .ProseMirror-focused .ProseMirror-gapcursor {
   display: block;
 }
+
+/* 嵌入式 Skills 位于可拖拽的右侧工作区中，按容器实际宽度而非窗口宽度排版。 */
+.skills-embedded-container {
+  container-type: inline-size;
+}
+.skills-embedded-card-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+@container (min-width: 40rem) {
+  .skills-embedded-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## 概述
修复 Agent 会话右侧工作区的 Skills 卡片在面板被拖窄时仍按视口宽度维持双列、导致单张卡片过窄的问题。嵌入式 Skills 现在按自身容器宽度响应：内容宽度不足 640px 时单列，达到阈值后恢复双列。

## 改动
- `apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx` — 将 `embedded` 状态传入 Skills 分组卡片网格；仅嵌入式右侧视图启用容器响应布局，全屏能力中心保持原有视口断点。
- `apps/electron/src/renderer/styles/globals.css` — 新增 `inline-size` 容器查询：默认单列，容器达到 40rem（640px）时切为两列。
- `apps/electron/package.json` — 按项目版本约定将 `@proma/electron` 从 `0.18.2` 递增至 `0.18.3`。

## 测试方法
1. 在 Agent 会话中打开右侧 Skills 标签。
2. 将右侧面板拖窄到内容宽度低于 640px，确认每行仅显示一个 Skill 卡片。
3. 将右侧面板拖宽至内容宽度达到 640px，确认卡片恢复两列。
4. 切换 MCP 与全屏 Agent 技能页，确认原有布局不受影响。
5. 已执行 `bun run --filter='@proma/electron' typecheck`、`bun run --filter='@proma/electron' build:renderer`、`bun install --frozen-lockfile` 与 `git diff --check`。

## 备注
- 已完成 Local 准 PR 审核，未发现 blocker。
- 本次仅改变 CSS 网格列数，不引入 blur、动画、overlay 或额外合成层；GPU / Compositor 审查无可信回归。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
