### PR TITLE
fix(renderer): 缩小右侧面板最小宽度【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -28,14 +28,14 @@ import { getWindowTitlebarContentInsetClass } from '@/lib/window-titlebar-layout
 import { cn } from '@/lib/utils'
 import { Toaster } from '@/components/ui/sonner'
 
-const MIN_RIGHT_PANEL_WIDTH = 360
+const MIN_RIGHT_PANEL_WIDTH = 280
 // 日程、定时任务、能力、记忆、探索、协作、终端及浏览/预览统一采用可读的工作区宽度。
-const MIN_EXPANDED_WORKSPACE_PANEL_WIDTH = 480
+const MIN_EXPANDED_WORKSPACE_PANEL_WIDTH = 400
 // Todo 选中任务后同时展示导航、列表与详情三栏，需要比其他工作区组件更宽的可读空间。
 const MIN_TODO_PANEL_WIDTH = 720
 const RIGHT_PANEL_MAX_VIEWPORT_RATIO = 3 / 5
 const EXPANDED_WORKSPACE_DEFAULT_VIEWPORT_RATIO = 2 / 5
-// 窄窗口时优先保留主会话的最小可读宽度；扩展工作区的 480px 仅在空间足够时强制。
+// 窄窗口时优先保留主会话的最小可读宽度；扩展工作区的 400px 仅在空间足够时强制。
 const MIN_MAIN_AREA_WIDTH = 320
 const COLLAPSED_LEFT_SIDEBAR_WIDTH = 60
 const CLASSIC_LEFT_SIDEBAR_LEADING_PADDING = 8
@@ -79,7 +79,7 @@ function clampRightPanelWidth(
   leftSidebarOccupiedWidth = 0,
 ): number {
   const maximumWidth = getRightPanelMaxWidth(viewportWidth, leftSidebarOccupiedWidth)
-  // 480px 是 Agent 会话的理想下限；在窄窗口中放宽它，而不是把中间会话挤到不可用。
+  // 最小宽度只是理想下限；在窄窗口中放宽它，而不是把中间会话挤到不可用。
   const effectiveMinimumWidth = Math.min(minimumWidth, maximumWidth)
   return Math.max(effectiveMinimumWidth, Math.min(maximumWidth, width))
 }


### PR DESCRIPTION
## 概述

Proma 右侧面板当前的最小宽度在小屏设备上占用空间偏多，用户即使主动拖拽也无法继续收窄。本 PR 调低普通右侧面板和扩展工作区的宽度下限，在不改变默认宽度、最大宽度与主会话可读空间保护逻辑的前提下，让小屏布局更灵活。

## 改动

- `apps/electron/src/renderer/components/app-shell/AppShell.tsx`
  - 将普通右侧面板最小宽度从 `360px` 调整为 `280px`。
  - 将浏览器、预览、终端、协作等扩展工作区的最小宽度从 `480px` 调整为 `400px`。
  - 保持 Todo 三栏工作区的 `720px` 最小宽度不变，避免破坏三栏可读性。
  - 同步更新相关注释；保留原有 viewport 动态钳制、主会话 `320px` 最小可读宽度及按 Session 持久化逻辑。

## 测试方法

1. 启动 Proma 并打开一个 Agent 会话及右侧面板。
2. 拖动普通右侧面板左侧边缘，确认最窄可调整到约 `280px`。
3. 打开浏览器、预览或终端等扩展工作区，确认最窄可调整到约 `400px`。
4. 切换右侧 Tab、切换 Session 或重启应用，确认已设置宽度能够正常保持与恢复。
5. 缩小应用窗口，确认主会话仍优先保留最小可读空间且布局没有横向溢出。
6. 打开 Todo 三栏视图，确认其 `720px` 宽度下限未受影响。

## 验证

- `git diff --check origin/main...HEAD` 通过。
- `bun run typecheck` 通过，包括 `@proma/shared`、`@proma/session-core`、`@proma/core`、`@proma/cli`、`@proma/ui`、`@proma/electron`。
- 已完成 Local 准 PR 审核，未发现阻塞缺陷或 GPU/Compositor 回归风险。

## 备注

- 本 PR 只调整拖拽下限，不改变新会话默认右侧面板宽度 `460px`。
- 未新增 CSS 效果、动画、React 订阅或 IPC 行为。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
