### PR TITLE
fix(agent): 支持用户关闭 Agent 当前浏览器标签【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -1040,8 +1040,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       id: getBrowserSidePanelTab(tab.tabId),
       label: tab.title || '新建标签页',
       icon: <Globe className="size-3.5" />,
-      // Agent 当前工作标签不能直接销毁，否则未指定 tabId 的后续浏览器工具会失去目标。
-      closable: tab.tabId !== browserState.agentTabId,
+      // 用户可关闭任何浏览器标签；关闭 Agent 工作标签后，后续未指定 tabId 的工具会提示新建或选择工作标签。
+      closable: true,
       activity: showBrowserActivity && activeBrowserTabId !== tab.tabId && browserState.activeTabId === tab.tabId,
     })) ?? []),
   ], [activeBrowserTabId, browserState, previewFiles, sessions, sessionId, showBrowserActivity, sideChatConversationId, sideDelegationSessionIds, sideTemporaryAgents, terminalTabs, workspaceComponentTabs])
@@ -1076,8 +1076,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     const delegationSessionId = getDelegationSessionIdFromSidePanelTab(tab)
     if (delegationSessionId) { handleCloseDelegationTab(delegationSessionId); return }
     const browserTabId = getBrowserTabIdFromSidePanelTab(tab)
-    if (browserTabId && browserTabId !== browserState?.agentTabId) void handleCloseBrowserTab(browserTabId)
-  }, [browserState?.agentTabId, handleCloseBrowserTab, handleCloseChatTab, handleCloseDelegationTab, handleCloseExplorationTab, handleClosePreviewTab, returnToPreviousTabAfterClose, sessionId, setTerminalTabsMap, setWorkspaceComponentTabs])
+    if (browserTabId) void handleCloseBrowserTab(browserTabId)
+  }, [handleCloseBrowserTab, handleCloseChatTab, handleCloseDelegationTab, handleCloseExplorationTab, handleClosePreviewTab, returnToPreviousTabAfterClose, sessionId, setTerminalTabsMap, setWorkspaceComponentTabs])
 
   React.useEffect(() => {
     const handleCloseActiveWorkspaceTab = (event: Event) => {


### PR DESCRIPTION
## 概述
允许用户在右侧工作区直接关闭 Agent 当前工作浏览器标签。此前该标签被 UI 强制设为不可关闭；主进程本来已具备关闭后的状态修复与后续操作引导能力。

## 改动
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 将所有浏览器标签标记为可关闭，并移除关闭回调对 `agentTabId` 的拦截，使当前 Agent 工作标签也能走既有 `closeAgentBrowserTab` 生命周期。

## 测试方法
1. 新建 Agent 工作浏览器标签，确认其标签栏显示关闭按钮。
2. 点击关闭，确认右侧工作区切换到可用的上一标签；若为最后一个浏览器标签，则浏览器会话关闭。
3. 关闭当前 Agent 工作标签后调用未指定 `tabId` 的浏览器工具，确认提示新建或选择工作标签。
4. 运行 `bun run --filter='@proma/electron' typecheck` 与 `bun run --filter='@proma/electron' build:renderer`。

## 备注
- 未修改 IPC 契约、存储格式或平台特定逻辑。
- 全量 `bun test` 中有 4 个既有 Electron 运行环境相关失败，失败栈不涉及本次变更文件。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)