### PR TITLE
feat(preview): bundle OfficeCLI for high-fidelity Office previews

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
       - name: 安装依赖
         run: bun install --frozen-lockfile
 
+      # 准备当前 runner 架构的 OfficeCLI 资源
+      - name: 准备 OfficeCLI（macOS arm64）
+        run: bun run --filter='@proma/electron' prepare:officecli
+
       # macOS 代码签名准备
       - name: 导入 macOS 签名证书
         env:
@@ -113,6 +117,10 @@ jobs:
 
       - name: 安装依赖
         run: bun install --frozen-lockfile
+
+      # 准备当前 runner 架构的 OfficeCLI 资源
+      - name: 准备 OfficeCLI（macOS x64）
+        run: bun run --filter='@proma/electron' prepare:officecli
 
       # macOS 代码签名准备
       - name: 导入 macOS 签名证书
@@ -320,6 +328,10 @@ jobs:
 
       - name: 安装依赖
         run: bun install --frozen-lockfile
+
+      # 准备当前 runner 架构的 OfficeCLI 资源
+      - name: 准备 OfficeCLI（Windows x64）
+        run: bun run --filter='@proma/electron' prepare:officecli
 
       # 构建应用
       - name: 构建 Electron 应用

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ apps/electron/resources/bin/
 apps/electron/resources/agent-island/
 # Objective-C++ 编译的 macOS EventKit N-API addon（构建时生成，按宿主架构分发）
 apps/electron/resources/eventkit/
+# OfficeCLI 随构建脚本下载、校验并嵌入安装包，不提交大体积第三方二进制。
+apps/electron/resources/officecli/
 # bun build --compile 的临时中间产物
 *.bun-build
 

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -65,6 +65,11 @@ extraResources:
     to: bin
     filter:
       - "**/*"
+  # OfficeCLI Excel 高保真渲染器；由 prepare:officecli 下载、固定版本并校验 SHA-256。
+  - from: resources/officecli
+    to: officecli
+    filter:
+      - "**/*"
   # 默认 Skills 模板（首次启动时同步到 ~/.proma/default-skills/）
   - from: default-skills
     to: default-skills
@@ -103,6 +108,7 @@ mac:
   binaries:
     - resources/agent-island/macos-agent-island-helper
     - resources/eventkit/macos-eventkit.node
+    - resources/officecli/officecli
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: resources/entitlements.mac.plist

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -14,7 +14,7 @@
     "dev:split": "bash scripts/dev-split.sh",
     "dev:vite": "vite dev",
     "dev:kill": "bun run scripts/dev-kill.ts",
-    "dev:electron": "bun run dev:kill && bun run sync:runtime-deps:dev && bun run rebuild:node-pty && bun run build:native-helpers && bun run build:resources && bun run scripts/dev-bundle-readiness.ts --prepare && concurrently -k -n main,agent-runtime,terminal-runtime,preload,app -c yellow,red,blue,magenta,cyan \"bun run watch:main\" \"bun run watch:agent-runtime\" \"bun run watch:terminal-runtime\" \"bun run watch:preload\" \"bun run scripts/dev-bundle-readiness.ts --wait && bunx electronmon .\"",
+    "dev:electron": "bun run dev:kill && bun run sync:runtime-deps:dev && bun run rebuild:node-pty && bun run build:native-helpers && bun run prepare:officecli && bun run build:resources && bun run scripts/dev-bundle-readiness.ts --prepare && concurrently -k -n main,agent-runtime,terminal-runtime,preload,app -c yellow,red,blue,magenta,cyan \"bun run watch:main\" \"bun run watch:agent-runtime\" \"bun run watch:terminal-runtime\" \"bun run watch:preload\" \"bun run scripts/dev-bundle-readiness.ts --wait && bunx electronmon .\"",
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-agent-core --external:@earendil-works/pi-ai --external:sharp",
     "build:agent-runtime": "esbuild src/utility/agent-runtime.ts --bundle --platform=node --format=cjs --outfile=dist/agent-runtime.cjs --external:electron --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-agent-core --external:@earendil-works/pi-ai --external:sharp",
     "build:terminal-runtime": "esbuild src/utility/terminal-runtime.ts --bundle --platform=node --format=cjs --outfile=dist/terminal-runtime.cjs --external:electron --external:node-pty",
@@ -29,9 +29,10 @@
     "build:eventkit-native": "bun run scripts/build-eventkit-native.ts",
     "build:native-helpers": "bun run build:agent-island-native && bun run build:eventkit-native",
     "build:cli": "bun run scripts/build-cli.ts",
+    "prepare:officecli": "bun run scripts/prepare-officecli.ts",
     "sync:runtime-deps": "bun run scripts/sync-runtime-deps.ts",
     "sync:runtime-deps:dev": "bun run scripts/sync-runtime-deps.ts --no-clean",
-    "build": "bun run build:main && bun run build:agent-runtime && bun run build:terminal-runtime && bun run build:preload && bun run build:renderer && bun run build:cli && bun run build:native-helpers && bun run build:resources",
+    "build": "bun run prepare:officecli && bun run build:main && bun run build:agent-runtime && bun run build:terminal-runtime && bun run build:preload && bun run build:renderer && bun run build:cli && bun run build:native-helpers && bun run build:resources",
     "rebuild:node-pty": "electron-rebuild -f -w node-pty && bun run ensure:node-pty-helper",
     "ensure:node-pty-helper": "bun run scripts/ensure-node-pty-helper-executable.ts",
     "start": "bun run build && bunx electron .",

--- a/apps/electron/scripts/dist.ts
+++ b/apps/electron/scripts/dist.ts
@@ -156,6 +156,15 @@ function parseArgs(): DistOptions {
 function main(): void {
   const opts = parseArgs()
   const arch = process.arch // arm64 或 x64
+  const hostPlatform: DistOptions['platform'] = process.platform === 'darwin'
+    ? 'mac'
+    : process.platform === 'win32'
+      ? 'win'
+      : 'linux'
+  if (opts.platform !== hostPlatform) {
+    console.error(`[dist] 当前可视化打包脚本只能在目标平台 Runner 上运行：目标 ${opts.platform}，当前 ${hostPlatform}`)
+    process.exit(1)
+  }
   const results: StepResult[] = []
 
   // 打印配置信息
@@ -167,10 +176,19 @@ function main(): void {
   console.log(`  ${color.bold}详细日志${color.reset}: ${opts.verbose ? '开启' : '关闭'}`)
   printSeparator()
 
-  const totalSteps = 7
+  const totalSteps = 8
   let step = 0
 
-  // ── 步骤 1: 构建主进程 ──
+  // ── 步骤 1: 准备与当前目标平台/架构匹配的 OfficeCLI ──
+  step++
+  printStepStart(step, totalSteps, '准备 OfficeCLI 资源')
+  results.push(
+    runStep('准备 OfficeCLI 资源', 'bun', ['run', 'prepare:officecli'], { verbose: opts.verbose })
+  )
+  printStepResult(results[results.length - 1])
+  if (!results[results.length - 1].success) return printSummary(results)
+
+  // ── 步骤 2: 构建主进程 ──
   step++
   printStepStart(step, totalSteps, '构建主进程 (esbuild)')
   results.push(
@@ -179,7 +197,7 @@ function main(): void {
   printStepResult(results[results.length - 1])
   if (!results[results.length - 1].success) return printSummary(results)
 
-  // ── 步骤 2: 构建 Preload ──
+  // ── 步骤 3: 构建 Preload ──
   step++
   printStepStart(step, totalSteps, '构建 Preload (esbuild)')
   results.push(
@@ -188,7 +206,7 @@ function main(): void {
   printStepResult(results[results.length - 1])
   if (!results[results.length - 1].success) return printSummary(results)
 
-  // ── 步骤 3: 构建渲染进程 ──
+  // ── 步骤 4: 构建渲染进程 ──
   step++
   printStepStart(step, totalSteps, '构建渲染进程 (Vite)')
   results.push(
@@ -197,7 +215,7 @@ function main(): void {
   printStepResult(results[results.length - 1])
   if (!results[results.length - 1].success) return printSummary(results)
 
-  // ── 步骤 4: 编译 proma CLI 二进制 ──
+  // ── 步骤 5: 编译 proma CLI 二进制 ──
   step++
   printStepStart(step, totalSteps, '编译 proma CLI (bun --compile)')
   results.push(
@@ -206,7 +224,7 @@ function main(): void {
   printStepResult(results[results.length - 1])
   if (!results[results.length - 1].success) return printSummary(results)
 
-  // ── 步骤 5: 编译 macOS 原生 helpers ──
+  // ── 步骤 6: 编译 macOS 原生 helpers ──
   step++
   printStepStart(step, totalSteps, '编译 macOS 原生 Helpers')
   results.push(
@@ -215,7 +233,7 @@ function main(): void {
   printStepResult(results[results.length - 1])
   if (!results[results.length - 1].success) return printSummary(results)
 
-  // ── 步骤 6: 复制资源文件 ──
+  // ── 步骤 7: 复制资源文件 ──
   step++
   printStepStart(step, totalSteps, '复制资源文件')
   results.push(
@@ -223,7 +241,7 @@ function main(): void {
   )
   printStepResult(results[results.length - 1])
 
-  // ── 步骤 7: electron-builder 打包 ──
+  // ── 步骤 8: electron-builder 打包 ──
   step++
   printStepStart(step, totalSteps, 'Electron Builder 打包')
 

--- a/apps/electron/scripts/prepare-officecli.ts
+++ b/apps/electron/scripts/prepare-officecli.ts
@@ -2,8 +2,9 @@
 /**
  * 准备随 Proma 安装包分发的 OfficeCLI 二进制。
  *
- * 每次 Electron build / dev 启动前按当前宿主平台与架构从 OfficeCLI 官方 GitHub
+ * 每次 Electron build / dev 启动前按当前构建目标的平台与架构从 OfficeCLI 官方 GitHub
  * Release 取得固定版本，流式校验文件大小及 SHA-256，再原子写入 resources/officecli/。
+ * 对交叉架构打包，可通过 OFFICECLI_PLATFORM / OFFICECLI_ARCH 指定安装包目标；默认使用宿主。
  * 该目录被 gitignore，避免将大体积第三方二进制提交进源码仓库。
  */
 
@@ -16,7 +17,9 @@ const OFFICECLI_VERSION = 'v1.0.145'
 const RELEASE_BASE_URL = `https://github.com/iOfficeAI/OfficeCLI/releases/download/${OFFICECLI_VERSION}`
 const MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024
 const OUTPUT_DIR = join(resolve(import.meta.dir, '..'), 'resources', 'officecli')
-const outputName = process.platform === 'win32' ? 'officecli.exe' : 'officecli'
+const targetPlatform = process.env.OFFICECLI_PLATFORM || process.platform
+const targetArch = process.env.OFFICECLI_ARCH || process.arch
+const outputName = targetPlatform === 'win32' ? 'officecli.exe' : 'officecli'
 
 interface Asset {
   url: string
@@ -129,21 +132,25 @@ async function downloadAndVerify(asset: Asset, destination: string): Promise<voi
   if (actual.toLowerCase() !== asset.sha256) fail(`SHA-256 校验失败：预期 ${asset.sha256}，实际 ${actual}`)
 }
 
-const key = `${process.platform}-${process.arch}`
+const key = `${targetPlatform}-${targetArch}`
 const asset = assets[key]
-if (!asset) fail(`当前构建平台不受支持：${key}`)
+if (!asset) fail(`当前构建目标不受支持：${key}`)
 const outputPath = join(OUTPUT_DIR, outputName)
+
+if (targetPlatform !== process.platform) {
+  fail(`OfficeCLI 资源必须在目标平台 Runner 上准备：目标 ${targetPlatform}，当前 ${process.platform}`)
+}
 
 await mkdir(OUTPUT_DIR, { recursive: true })
 if (await verifyExisting(outputPath, asset)) {
-  if (process.platform !== 'win32') await chmod(outputPath, 0o755)
+  if (targetPlatform !== 'win32') await chmod(outputPath, 0o755)
   console.log(`[prepare:officecli] 已验证 ${OFFICECLI_VERSION}（${key}）`)
 } else {
   const temporaryPath = `${outputPath}.download-${process.pid}-${Date.now()}`
   try {
     console.log(`[prepare:officecli] 下载并校验 ${OFFICECLI_VERSION}（${key}）`)
     await downloadAndVerify(asset, temporaryPath)
-    if (process.platform !== 'win32') await chmod(temporaryPath, 0o755)
+    if (targetPlatform !== 'win32') await chmod(temporaryPath, 0o755)
     await rename(temporaryPath, outputPath)
   } catch (error) {
     await rm(temporaryPath, { force: true }).catch(() => {})

--- a/apps/electron/scripts/prepare-officecli.ts
+++ b/apps/electron/scripts/prepare-officecli.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env bun
+/**
+ * 准备随 Proma 安装包分发的 OfficeCLI 二进制。
+ *
+ * 每次 Electron build / dev 启动前按当前宿主平台与架构从 OfficeCLI 官方 GitHub
+ * Release 取得固定版本，流式校验文件大小及 SHA-256，再原子写入 resources/officecli/。
+ * 该目录被 gitignore，避免将大体积第三方二进制提交进源码仓库。
+ */
+
+import { createHash } from 'node:crypto'
+import { chmod, mkdir, open, rename, rm } from 'node:fs/promises'
+import { existsSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const OFFICECLI_VERSION = 'v1.0.145'
+const RELEASE_BASE_URL = `https://github.com/iOfficeAI/OfficeCLI/releases/download/${OFFICECLI_VERSION}`
+const MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024
+const OUTPUT_DIR = join(resolve(import.meta.dir, '..'), 'resources', 'officecli')
+const outputName = process.platform === 'win32' ? 'officecli.exe' : 'officecli'
+
+interface Asset {
+  url: string
+  sha256: string
+  sizeBytes: number
+}
+
+const assets: Record<string, Asset> = {
+  'darwin-arm64': {
+    url: `${RELEASE_BASE_URL}/officecli-mac-arm64`,
+    sha256: 'd66763a563bc844c3cc67036ebc7c4a9caa9319b9592814d9acd3706da231fc1',
+    sizeBytes: 33_764_912,
+  },
+  'darwin-x64': {
+    url: `${RELEASE_BASE_URL}/officecli-mac-x64`,
+    sha256: 'd7dc7013f7bf0af6345ae16a7913e6cf041947460d7f2fa3e024f0b27073d0a2',
+    sizeBytes: 34_708_640,
+  },
+  'linux-arm64': {
+    url: `${RELEASE_BASE_URL}/officecli-linux-arm64`,
+    sha256: 'd38233bb7df4f0f5fb40313de1f00c0f0e575dc96b4164742709711ceec148c5',
+    sizeBytes: 34_737_671,
+  },
+  'linux-x64': {
+    url: `${RELEASE_BASE_URL}/officecli-linux-x64`,
+    sha256: '449f0e6a1298e3c6d7da792d26ab53d04ba77bd990f299b51123c7aef383d2ce',
+    sizeBytes: 35_319_717,
+  },
+  'win32-arm64': {
+    url: `${RELEASE_BASE_URL}/officecli-win-arm64.exe`,
+    sha256: '9ab800745ef06f4d30b8fd41729c516a4b28c86a24a32af8764d12a6a5226d57',
+    sizeBytes: 33_824_692,
+  },
+  'win32-x64': {
+    url: `${RELEASE_BASE_URL}/officecli-win-x64.exe`,
+    sha256: '760696b262f3d6bd2cd174577220d54541b6e1e04ec58dee051f1897395638b8',
+    sizeBytes: 33_386_408,
+  },
+}
+
+function fail(message: string): never {
+  console.error(`[prepare:officecli] ${message}`)
+  process.exit(1)
+}
+
+function isAllowedDownloadUrl(url: URL): boolean {
+  return url.protocol === 'https:' && (
+    url.hostname === 'github.com'
+    || url.hostname === 'objects.githubusercontent.com'
+    || url.hostname === 'release-assets.githubusercontent.com'
+    || url.hostname === 'github-releases.githubusercontent.com'
+    || url.hostname.endsWith('.githubusercontent.com')
+  )
+}
+
+async function fetchOfficialAsset(url: string): Promise<Response> {
+  let target = new URL(url)
+  for (let redirectsLeft = 5; redirectsLeft >= 0; redirectsLeft--) {
+    if (!isAllowedDownloadUrl(target)) fail(`下载地址不受信任：${target.hostname}`)
+    const response = await fetch(target, { redirect: 'manual' })
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location')
+      if (!location || redirectsLeft === 0) fail('下载重定向无效或次数过多')
+      target = new URL(location, target)
+      continue
+    }
+    if (!response.ok) fail(`下载失败：HTTP ${response.status}`)
+    return response
+  }
+  fail('下载重定向次数过多')
+}
+
+async function verifyExisting(filePath: string, asset: Asset): Promise<boolean> {
+  try {
+    if (!existsSync(filePath) || statSync(filePath).size !== asset.sizeBytes) return false
+    const hash = new Bun.CryptoHasher('sha256')
+    hash.update(await Bun.file(filePath).arrayBuffer())
+    return hash.digest('hex').toLowerCase() === asset.sha256
+  } catch {
+    return false
+  }
+}
+
+async function downloadAndVerify(asset: Asset, destination: string): Promise<void> {
+  const response = await fetchOfficialAsset(asset.url)
+  if (!response.body) fail('下载响应为空')
+  const declaredLength = Number(response.headers.get('content-length') ?? 0)
+  if (declaredLength > MAX_DOWNLOAD_SIZE) fail('下载文件超过安全大小上限')
+
+  const file = await open(destination, 'w', 0o700)
+  const hash = createHash('sha256')
+  let downloaded = 0
+  try {
+    const reader = response.body.getReader()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value) continue
+      downloaded += value.byteLength
+      if (downloaded > MAX_DOWNLOAD_SIZE) fail('下载文件超过安全大小上限')
+      hash.update(value)
+      await file.write(value)
+    }
+  } finally {
+    await file.close()
+  }
+
+  if (downloaded !== asset.sizeBytes) fail(`下载文件大小不匹配：预期 ${asset.sizeBytes}，实际 ${downloaded}`)
+  const actual = hash.digest('hex')
+  if (actual.toLowerCase() !== asset.sha256) fail(`SHA-256 校验失败：预期 ${asset.sha256}，实际 ${actual}`)
+}
+
+const key = `${process.platform}-${process.arch}`
+const asset = assets[key]
+if (!asset) fail(`当前构建平台不受支持：${key}`)
+const outputPath = join(OUTPUT_DIR, outputName)
+
+await mkdir(OUTPUT_DIR, { recursive: true })
+if (await verifyExisting(outputPath, asset)) {
+  if (process.platform !== 'win32') await chmod(outputPath, 0o755)
+  console.log(`[prepare:officecli] 已验证 ${OFFICECLI_VERSION}（${key}）`)
+} else {
+  const temporaryPath = `${outputPath}.download-${process.pid}-${Date.now()}`
+  try {
+    console.log(`[prepare:officecli] 下载并校验 ${OFFICECLI_VERSION}（${key}）`)
+    await downloadAndVerify(asset, temporaryPath)
+    if (process.platform !== 'win32') await chmod(temporaryPath, 0o755)
+    await rename(temporaryPath, outputPath)
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => {})
+    throw error
+  }
+}

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3694,22 +3694,7 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // DOCX 转 HTML（内联预览使用 mammoth）
-  ipcMain.handle(
-    'file:docx-to-html',
-    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<{ resolvedPath: string; html: string } | null> => {
-      const { convertDocxToHtml, resolveFilePath } = await import('./lib/file-preview-service')
-      const options = normalizeFileAccessOptions(access)
-      const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
-      if (!resolved) {
-        return null
-      }
-      const result = await convertDocxToHtml(resolved)
-      return result
-    }
-  )
-
-  // XLSX/PPTX 转 HTML（内联预览使用 OOXML 解析）
+  // Office 文件转高保真 HTML（内联预览；失败时由服务层降级到内置解析器）
   ipcMain.handle(
     'file:office-to-html',
     async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<import('@proma/shared').OfficePreviewResult | null> => {

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -8,11 +8,14 @@
 import { basename, join, dirname, extname, resolve, posix as pathPosix } from 'node:path'
 import { readFileSync, readdirSync, statSync, mkdirSync, existsSync, writeFileSync, unlinkSync } from 'node:fs'
 import { tmpdir, homedir } from 'node:os'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import { createRequire } from 'node:module'
 import { createHash } from 'node:crypto'
 import AdmZip from 'adm-zip'
 import { DOMParser } from '@xmldom/xmldom'
 import type { FilePreviewReadResult, OfficePreviewResult } from '@proma/shared'
+import { getBundledOfficeCliPath } from './officecli-manager'
 
 const require = createRequire(__filename)
 const PDFJS_PACKAGE = 'pdfjs-dist'
@@ -25,6 +28,11 @@ const MAX_XLSX_SHEETS = 8
 const MAX_XLSX_ROWS = 200
 const MAX_XLSX_COLUMNS = 40
 const MAX_PPTX_SLIDES = 80
+const OFFICECLI_RENDER_TIMEOUT_MS = 15_000
+const OFFICECLI_TEXT_RENDER_TIMEOUT_MS = 5_000
+const OFFICECLI_MAX_HTML_SIZE = 20 * 1024 * 1024
+const PREVIEW_TEMP_FILE_TTL_MS = 60 * 60 * 1000
+const execFileAsync = promisify(execFile)
 
 // ─── 临时文件 ───
 
@@ -44,6 +52,21 @@ function writeTempHtml(html: string): string {
     writeFileSync(tmpFile, html, 'utf-8')
   }
   return tmpFile
+}
+
+function createOfficeCliOutputPath(sourcePath: string): string {
+  const fileHash = createHash('sha256')
+    .update(`${sourcePath}\0${Date.now()}\0${Math.random()}`)
+    .digest('hex')
+    .slice(0, 24)
+  return join(getPreviewTmpDir(), `officecli-${fileHash}.html`)
+}
+
+function removeTempFileLater(path: string): void {
+  const cleanup = setTimeout(() => {
+    try { unlinkSync(path) } catch { /* 已由启动清理或其他路径删除 */ }
+  }, PREVIEW_TEMP_FILE_TTL_MS)
+  cleanup.unref()
 }
 
 /** 清理所有临时预览文件 */
@@ -728,6 +751,93 @@ function renderOfficeTextFallback(filePath: string, text: string, kind: OfficePr
   return `<div class="office-preview office-preview-${kind}"><div class="office-preview-title">${title}</div>${body}</div>`
 }
 
+function getOfficeCliCandidates(): string[] {
+  return [getBundledOfficeCliPath()]
+}
+
+function isExecutableFile(path: string): boolean {
+  try {
+    const stats = statSync(path)
+    if (!stats.isFile()) return false
+    if (process.platform === 'win32') return true
+    return (stats.mode & 0o111) !== 0
+  } catch {
+    return false
+  }
+}
+
+function restrictOfficeCliHtml(html: string): string {
+  const contentSecurityPolicy = "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'"
+  const policyTag = `<meta http-equiv="Content-Security-Policy" content="${contentSecurityPolicy}">`
+  return html.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}${policyTag}`)
+}
+
+async function registerOfficeCliOutputFile(path: string): Promise<string> {
+  const { registerPromaFilePath } = await import('./local-file-protocol')
+  return registerPromaFilePath(path)
+}
+
+export async function renderOfficeWithOfficeCli(
+  resolvedPath: string,
+  registerFilePath: (path: string) => string | Promise<string> = registerOfficeCliOutputFile,
+  officeCliCandidates = getOfficeCliCandidates(),
+  expectedExtensions: ReadonlySet<string> = new Set(['.docx', '.xlsx', '.pptx']),
+): Promise<{ htmlUrl: string; text: string } | null> {
+  if (!expectedExtensions.has(extname(resolvedPath).toLowerCase())) return null
+
+  const outputPath = createOfficeCliOutputPath(resolvedPath)
+  let lastError: unknown
+  for (const candidate of officeCliCandidates) {
+    if (!isExecutableFile(candidate)) continue
+    try {
+      await execFileAsync(candidate, ['view', resolvedPath, 'html', '-o', outputPath], {
+        timeout: OFFICECLI_RENDER_TIMEOUT_MS,
+        windowsHide: true,
+        env: { ...process.env, OFFICECLI_SKIP_UPDATE: '1', OFFICECLI_NO_AUTO_INSTALL: '1', OFFICECLI_NO_AUTO_RESIDENT: '1' },
+        maxBuffer: 1024 * 1024,
+      })
+      const outputStat = statSync(outputPath)
+      if (outputStat.size <= 0 || outputStat.size > OFFICECLI_MAX_HTML_SIZE) {
+        throw new Error(`OfficeCLI HTML 输出大小异常: ${outputStat.size}`)
+      }
+      const html = restrictOfficeCliHtml(readFileSync(outputPath, 'utf-8'))
+      if (!html.includes('<html') || !html.includes('</html>')) throw new Error('OfficeCLI HTML 输出不完整')
+      writeFileSync(outputPath, html, 'utf-8')
+      const htmlUrl = await registerFilePath(outputPath)
+      let text = ''
+      try {
+        const result = await execFileAsync(candidate, ['view', resolvedPath, 'text', '--max-lines', '10000'], {
+          timeout: OFFICECLI_TEXT_RENDER_TIMEOUT_MS,
+          windowsHide: true,
+          env: { ...process.env, OFFICECLI_SKIP_UPDATE: '1', OFFICECLI_NO_AUTO_INSTALL: '1', OFFICECLI_NO_AUTO_RESIDENT: '1' },
+          maxBuffer: 2 * 1024 * 1024,
+        })
+        text = result.stdout.trim()
+      } catch (textError) {
+        console.warn('[file-preview] OfficeCLI 文本提取失败，预览仍可用:', textError instanceof Error ? textError.message : textError)
+      }
+      removeTempFileLater(outputPath)
+      return { htmlUrl, text }
+    } catch (error) {
+      lastError = error
+      try { unlinkSync(outputPath) } catch { /* 输出可能尚未生成 */ }
+    }
+  }
+
+  if (lastError) {
+    console.warn('[file-preview] OfficeCLI 文档渲染不可用，回退内置解析器:', lastError instanceof Error ? lastError.message : lastError)
+  }
+  return null
+}
+
+export async function renderXlsxWithOfficeCli(
+  resolvedPath: string,
+  registerFilePath: (path: string) => string | Promise<string> = registerOfficeCliOutputFile,
+  officeCliCandidates = getOfficeCliCandidates(),
+): Promise<{ htmlUrl: string; text: string } | null> {
+  return renderOfficeWithOfficeCli(resolvedPath, registerFilePath, officeCliCandidates, new Set(['.xlsx']))
+}
+
 /** 将 XLSX/PPTX 转成可内联展示的 HTML 预览 */
 export async function convertOfficeToHtml(filePath: string, basePaths?: string[]): Promise<OfficePreviewResult | null> {
   const safePath = resolveTargetPath(filePath, basePaths)
@@ -738,8 +848,29 @@ export async function convertOfficeToHtml(filePath: string, basePaths?: string[]
     if (st.size > MAX_FILE_SIZE) return null
 
     const ext = extname(safePath).toLowerCase()
-    if (ext === '.xlsx') return convertXlsxToHtml(filePath, safePath)
-    if (ext === '.pptx') return convertPptxToHtml(filePath, safePath)
+    if (ext === '.xlsx' || ext === '.docx' || ext === '.pptx') {
+      const officeCliResult = await renderOfficeWithOfficeCli(safePath)
+      if (officeCliResult) {
+        const kind: OfficePreviewResult['kind'] = ext === '.xlsx'
+          ? 'spreadsheet'
+          : ext === '.docx'
+            ? 'document'
+            : 'presentation'
+        return {
+          resolvedPath: safePath,
+          kind,
+          html: '',
+          htmlUrl: officeCliResult.htmlUrl,
+          text: officeCliResult.text,
+          renderer: 'officecli',
+        }
+      }
+      if (ext === '.xlsx') return convertXlsxToHtml(filePath, safePath)
+      if (ext === '.pptx') return convertPptxToHtml(filePath, safePath)
+      const mammoth = await import('mammoth')
+      const result = await mammoth.convertToHtml({ path: safePath })
+      return { resolvedPath: safePath, kind: 'document', html: result.value, text: result.value.replace(/<[^>]+>/g, ' ') }
+    }
     return null
   } catch (err) {
     console.error('[file-preview] convertOfficeToHtml structured preview failed:', err)
@@ -747,7 +878,11 @@ export async function convertOfficeToHtml(filePath: string, basePaths?: string[]
       const officeParser = await import('officeparser')
       const text = await officeParser.parseOfficeAsync(safePath)
       const ext = extname(safePath).toLowerCase()
-      const kind: OfficePreviewResult['kind'] = ext === '.pptx' ? 'presentation' : 'spreadsheet'
+      const kind: OfficePreviewResult['kind'] = ext === '.pptx'
+        ? 'presentation'
+        : ext === '.docx'
+          ? 'document'
+          : 'spreadsheet'
       return {
         resolvedPath: safePath,
         kind,

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -724,21 +724,6 @@ export async function preparePdfPreview(filePath: string, basePaths?: string[]):
 }
 
 /** 将 DOCX 文件转换为 HTML（供内联预览使用） */
-export async function convertDocxToHtml(filePath: string, basePaths?: string[]): Promise<{ resolvedPath: string; html: string } | null> {
-  const safePath = resolveTargetPath(filePath, basePaths)
-  if (!existsSync(safePath)) return null
-  try {
-    const st = statSync(safePath)
-    if (st.size > MAX_FILE_SIZE) return null
-    const mammoth = await import('mammoth')
-    const result = await mammoth.convertToHtml({ path: safePath })
-    return { resolvedPath: safePath, html: result.value }
-  } catch (err) {
-    console.error('[file-preview] convertDocxToHtml failed:', err)
-    return null
-  }
-}
-
 function renderOfficeTextFallback(filePath: string, text: string, kind: OfficePreviewResult['kind']): string {
   const title = escapeHtml(basename(filePath))
   const paragraphs = text
@@ -767,9 +752,12 @@ function isExecutableFile(path: string): boolean {
 }
 
 function restrictOfficeCliHtml(html: string): string {
-  const contentSecurityPolicy = "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'"
+  const contentSecurityPolicy = "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; media-src data: blob:"
   const policyTag = `<meta http-equiv="Content-Security-Policy" content="${contentSecurityPolicy}">`
-  return html.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}${policyTag}`)
+  if (/<head(?:\s[^>]*)?>/i.test(html)) {
+    return html.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}${policyTag}`)
+  }
+  return html.replace(/<html(?:\s[^>]*)?>/i, (htmlTag) => `${htmlTag}<head>${policyTag}</head>`)
 }
 
 async function registerOfficeCliOutputFile(path: string): Promise<string> {

--- a/apps/electron/src/main/lib/officecli-manager.ts
+++ b/apps/electron/src/main/lib/officecli-manager.ts
@@ -1,0 +1,19 @@
+/**
+ * OfficeCLI 内嵌资源路径
+ *
+ * OfficeCLI 由构建脚本下载、校验并交给 electron-builder 随应用分发；运行时不读取
+ * 用户 PATH，也不提供下载/安装设置。若资源因构建或签名问题不可用，调用方回退到
+ * Proma 原有的内置 OOXML 解析器。
+ */
+
+import { join } from 'node:path'
+
+const OFFICECLI_COMMAND = process.platform === 'win32' ? 'officecli.exe' : 'officecli'
+
+export function getBundledOfficeCliPath(): string {
+  const { app } = require('electron') as { app: { isPackaged: boolean } }
+  const resourcesDir = app.isPackaged
+    ? process.resourcesPath
+    : join(__dirname, 'resources')
+  return join(resourcesDir, 'officecli', OFFICECLI_COMMAND)
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -926,10 +926,7 @@ export interface ElectronAPI {
   /** 读取文件为 base64（带路径校验，供内联图片预览等） */
   readBinaryBase64: (filePath: string, access?: import('@proma/shared').FileAccessOptions, maxSize?: number) => Promise<string | null>
 
-  /** DOCX 转 HTML（内联预览） */
-  docxToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<{ resolvedPath: string; html: string } | null>
-
-  /** XLSX/PPTX 转 HTML（内联预览） */
+  /** Office 文件转高保真 HTML（内联预览） */
   officeToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<import('@proma/shared').OfficePreviewResult | null>
 
   /** 截图导出：将 HTML 渲染为 PNG 并复制到剪贴板或保存文件 */
@@ -2346,10 +2343,6 @@ const electronAPI: ElectronAPI = {
 
   readBinaryBase64: (filePath: string, access?: import('@proma/shared').FileAccessOptions, maxSize?: number) => {
     return ipcRenderer.invoke('file:read-binary-base64', filePath, access, maxSize) as Promise<string | null>
-  },
-
-  docxToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
-    return ipcRenderer.invoke('file:docx-to-html', filePath, access) as Promise<{ resolvedPath: string; html: string } | null>
   },
 
   officeToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -59,8 +59,7 @@ const MD_EXTS = new Set(['.md', '.markdown'])
 const HTML_EXTS = new Set(['.html', '.htm'])
 const PLAIN_TEXT_EDIT_EXTS = new Set(['.txt', '.text', '.log'])
 const PDF_EXTS = new Set(['.pdf'])
-const DOCX_EXTS = new Set(['.docx'])
-const OFFICE_PREVIEW_EXTS = new Set(['.xlsx', '.pptx'])
+const OFFICE_PREVIEW_EXTS = new Set(['.docx', '.xlsx', '.pptx'])
 const LEGACY_OFFICE_EXTS = new Set(['.doc', '.xls', '.ppt'])
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.ico'])
 
@@ -95,6 +94,7 @@ type CacheEntry = {
   imagePath?: string
   docxHtml?: string
   officeHtml?: string
+  officeHtmlUrl?: string
   officeText?: string
   /** HTML 预览的目录级 token URL，允许加载同目录相对资源 */
   htmlPreviewUrl?: string
@@ -281,8 +281,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const isPlainTextEditable = previewOnly && PLAIN_TEXT_EDIT_EXTS.has(ext)
   const isEditableText = isMarkdown || isPlainTextEditable
   const isPdf = previewOnly && PDF_EXTS.has(ext)
-  const isDocx = previewOnly && DOCX_EXTS.has(ext)
-  // XLSX/PPTX 没有可读的文本 diff；无论从文件区还是改动区打开都走 Office 预览。
+  // DOCX/XLSX/PPTX 没有可读的文本 diff；无论从文件区还是改动区打开都走 Office 预览。
   const isOfficePreview = OFFICE_PREVIEW_EXTS.has(ext)
   const isLegacyOffice = previewOnly && LEGACY_OFFICE_EXTS.has(ext)
   const isImage = previewOnly && IMAGE_EXTS.has(ext)
@@ -346,6 +345,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [previewScrollRestoreVersion, setPreviewScrollRestoreVersion] = React.useState(0)
   const [docxHtml, setDocxHtml] = React.useState('')
   const [officeHtml, setOfficeHtml] = React.useState('')
+  const [officeHtmlUrl, setOfficeHtmlUrl] = React.useState('')
   const [officeText, setOfficeText] = React.useState('')
   // HTML 默认展示运行后的页面；用户可随时切换回源码高亮预览。
   const [htmlPreviewUrl, setHtmlPreviewUrl] = React.useState('')
@@ -380,7 +380,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     (!isHtml || htmlSourceMode) &&
     !isPdf &&
     !isImage &&
-    !isDocx &&
     !isOfficePreview &&
     !isLegacyOffice &&
     newContent.length > 0 &&
@@ -409,11 +408,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     oldLength: oldContent.length,
     docxLength: docxHtml.length,
     officeLength: officeHtml.length,
+    officeHtmlUrl,
     htmlPreviewUrl,
     htmlSourceMode,
     markdownEditing: activeMarkdownEditing,
     markdownSourceMode: activeMarkdownEditing && markdownSourceMode,
-  }), [docxHtml.length, filePath, loading, activeMarkdownEditing, markdownSourceMode, newContent.length, officeHtml.length, htmlPreviewUrl, htmlSourceMode, oldContent.length, previewOnly, viewMode])
+  }), [docxHtml.length, filePath, loading, activeMarkdownEditing, markdownSourceMode, newContent.length, officeHtml.length, officeHtmlUrl, htmlPreviewUrl, htmlSourceMode, oldContent.length, previewOnly, viewMode])
 
   // 目录提取只需在「文件本身或其内容」变化时重建，避免 loading/编辑态切换造成的抖动
   const tocContentKey = React.useMemo(
@@ -648,6 +648,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     setNewContent('')
     setDocxHtml('')
     setOfficeHtml('')
+    setOfficeHtmlUrl('')
     setOfficeText('')
     setHtmlPreviewUrl('')
     setHtmlSourceMode(false)
@@ -812,6 +813,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       setNewContent(cached.newContent)
       setDocxHtml(cached.docxHtml ?? '')
       setOfficeHtml(cached.officeHtml ?? '')
+      setOfficeHtmlUrl(cached.officeHtmlUrl ?? '')
       setOfficeText(cached.officeText ?? '')
       setHtmlPreviewUrl(cached.htmlPreviewUrl ?? '')
       setUnsupportedPreviewReason(cached.unsupportedPreviewReason ?? '')
@@ -835,6 +837,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         setNewContent('')
         setDocxHtml('')
         setOfficeHtml('')
+        setOfficeHtmlUrl('')
         setOfficeText('')
         setHtmlPreviewUrl('')
         setUnsupportedPreviewReason('')
@@ -867,10 +870,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             const result = await window.electronAPI.officeToHtml(filePath, fileAccess)
             if (cancelled) return
             const html = DOMPurify.sanitize(result?.html ?? '')
+            const htmlUrl = result?.htmlUrl ?? ''
             const text = result?.text ?? ''
             setOfficeHtml(html)
+            setOfficeHtmlUrl(htmlUrl)
             setOfficeText(text)
-            cacheSet(cacheKey, { oldContent: '', newContent: '', officeHtml: html, officeText: text })
+            cacheSet(cacheKey, { oldContent: '', newContent: '', officeHtml: html, officeHtmlUrl: htmlUrl, officeText: text })
             return
           }
           if (previewOnly) {
@@ -894,14 +899,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                 setImageDataUrl('')
                 cacheSet(cacheKey, { oldContent: '', newContent: '', imagePath: '', imageDataUrl: '' })
               }
-              return
-            }
-            if (isDocx) {
-              const result = await window.electronAPI.docxToHtml(filePath, fileAccess)
-              if (cancelled) return
-              const html = DOMPurify.sanitize(result?.html ?? '')
-              setDocxHtml(html)
-              cacheSet(cacheKey, { oldContent: '', newContent: '', docxHtml: html })
               return
             }
             if (isLegacyOffice) {
@@ -961,7 +958,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     load()
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, isHtml, sessionId, ext, getContentCacheKey])
+  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, fileAccess, isPdf, isOfficePreview, isLegacyOffice, isImage, isHtml, sessionId, ext, getContentCacheKey])
 
   // refreshVersion 触发的静默刷新：仅 diff 模式、内容有变化时才更新 state
   const prevRefreshRef = React.useRef(-1)
@@ -1021,10 +1018,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       message = `暂不支持 ${ext.toUpperCase().slice(1)} 格式内联预览`
     } else if (isPdf && !pdfSrc) {
       message = 'PDF 文件过大，无法在此预览'
-    } else if (isDocx && !docxHtml) {
-      message = '无法加载 DOCX 预览'
-    } else if (isOfficePreview && !officeHtml) {
-      message = `无法加载 ${ext === '.pptx' ? 'PPTX' : 'Excel'} 预览`
+    } else if (isOfficePreview && !officeHtml && !officeHtmlUrl) {
+      message = `无法加载 ${ext === '.pptx' ? 'PPTX' : ext === '.docx' ? 'DOCX' : 'Excel'} 预览`
     } else if (isImage && !imageDataUrl) {
       message = '图片文件过大，无法在此预览'
     }
@@ -1032,7 +1027,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       toastedPreviewFailRef.current = key
       toast.warning(message)
     }
-  }, [previewOnly, isOfficePreview, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, isDocx, docxHtml, officeHtml, isImage, imageDataUrl])
+  }, [previewOnly, isOfficePreview, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, docxHtml, officeHtml, officeHtmlUrl, isImage, imageDataUrl])
 
   // scrollPosition persistent: module-level Map scoped by session, file path, and resolution context
   // content changes (refreshVersion bump) → delete stored position;
@@ -1714,7 +1709,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             <TooltipContent side="right">展开目录</TooltipContent>
           </Tooltip>
         )}
-        <div ref={scrollContainerRef} onScroll={handleScroll} className="h-full flex-1 min-w-0 overflow-auto scrollbar-thin relative">
+        <div
+          ref={scrollContainerRef}
+          onScroll={handleScroll}
+          className={cn(
+            'h-full flex-1 min-w-0 scrollbar-thin relative',
+            isOfficePreview ? 'overflow-hidden' : 'overflow-auto',
+          )}
+        >
           {loading ? (
             <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">加载中...</div>
           ) : (previewOnly || isOfficePreview) ? (
@@ -1805,15 +1807,16 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                 </div>
               </div>
               ) : null
-            ) : isDocx ? (
-              docxHtml ? (
-                <div
-                  className="prose prose-sm dark:prose-invert max-w-none px-4 py-3"
-                  dangerouslySetInnerHTML={{ __html: docxHtml }}
-                />
-              ) : null
             ) : isOfficePreview ? (
-              officeHtml ? (
+              officeHtmlUrl ? (
+                <iframe
+                  src={officeHtmlUrl}
+                  className="office-preview-iframe"
+                  title={`${filePath.split('/').pop() || 'Office'} 高保真预览`}
+                  sandbox="allow-scripts"
+                  referrerPolicy="no-referrer"
+                />
+              ) : officeHtml ? (
                 <div
                   className="office-preview-host"
                   dangerouslySetInnerHTML={{ __html: officeHtml }}

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -92,7 +92,6 @@ type CacheEntry = {
   pdfSrc?: string
   imageDataUrl?: string
   imagePath?: string
-  docxHtml?: string
   officeHtml?: string
   officeHtmlUrl?: string
   officeText?: string
@@ -343,7 +342,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const pendingPreviewScrollRestoreRef = React.useRef<MarkdownScrollPosition | null>(null)
   const preserveScrollOnNextRefreshRef = React.useRef(false)
   const [previewScrollRestoreVersion, setPreviewScrollRestoreVersion] = React.useState(0)
-  const [docxHtml, setDocxHtml] = React.useState('')
   const [officeHtml, setOfficeHtml] = React.useState('')
   const [officeHtmlUrl, setOfficeHtmlUrl] = React.useState('')
   const [officeText, setOfficeText] = React.useState('')
@@ -406,14 +404,13 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     loading,
     newLength: newContent.length,
     oldLength: oldContent.length,
-    docxLength: docxHtml.length,
     officeLength: officeHtml.length,
     officeHtmlUrl,
     htmlPreviewUrl,
     htmlSourceMode,
     markdownEditing: activeMarkdownEditing,
     markdownSourceMode: activeMarkdownEditing && markdownSourceMode,
-  }), [docxHtml.length, filePath, loading, activeMarkdownEditing, markdownSourceMode, newContent.length, officeHtml.length, officeHtmlUrl, htmlPreviewUrl, htmlSourceMode, oldContent.length, previewOnly, viewMode])
+  }), [filePath, loading, activeMarkdownEditing, markdownSourceMode, newContent.length, officeHtml.length, officeHtmlUrl, htmlPreviewUrl, htmlSourceMode, oldContent.length, previewOnly, viewMode])
 
   // 目录提取只需在「文件本身或其内容」变化时重建，避免 loading/编辑态切换造成的抖动
   const tocContentKey = React.useMemo(
@@ -646,7 +643,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
     setOldContent('')
     setNewContent('')
-    setDocxHtml('')
     setOfficeHtml('')
     setOfficeHtmlUrl('')
     setOfficeText('')
@@ -811,7 +807,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       lastOldContentRef.current = cached.oldContent
       setOldContent(cached.oldContent)
       setNewContent(cached.newContent)
-      setDocxHtml(cached.docxHtml ?? '')
       setOfficeHtml(cached.officeHtml ?? '')
       setOfficeHtmlUrl(cached.officeHtmlUrl ?? '')
       setOfficeText(cached.officeText ?? '')
@@ -835,7 +830,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       if (!preserveMarkdownEditor) {
         setOldContent('')
         setNewContent('')
-        setDocxHtml('')
         setOfficeHtml('')
         setOfficeHtmlUrl('')
         setOfficeText('')
@@ -1027,7 +1021,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       toastedPreviewFailRef.current = key
       toast.warning(message)
     }
-  }, [previewOnly, isOfficePreview, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, docxHtml, officeHtml, officeHtmlUrl, isImage, imageDataUrl])
+  }, [previewOnly, isOfficePreview, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, officeHtml, officeHtmlUrl, isImage, imageDataUrl])
 
   // scrollPosition persistent: module-level Map scoped by session, file path, and resolution context
   // content changes (refreshVersion bump) → delete stored position;

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1613,13 +1613,11 @@
 
 .office-preview-iframe {
   display: block;
-  width: 125%;
-  height: 125%;
+  width: 100%;
+  height: 100%;
   min-height: 0;
   border: 0;
   background: #f0f0f0;
-  transform: scale(0.8);
-  transform-origin: top left;
 }
 
 .office-preview {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1611,6 +1611,17 @@
   font-size: 12px;
 }
 
+.office-preview-iframe {
+  display: block;
+  width: 125%;
+  height: 125%;
+  min-height: 0;
+  border: 0;
+  background: #f0f0f0;
+  transform: scale(0.8);
+  transform-origin: top left;
+}
+
 .office-preview {
   display: flex;
   flex-direction: column;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "electron:build": "bun run --filter='@proma/electron' build",
     "electron:start": "bun run --filter='@proma/electron' start",
     "dist:mac": "bun run --filter='@proma/electron' dist:mac",
+  "dist:win": "bun run --filter='@proma/electron' dist:win",
+  "dist:linux": "bun run --filter='@proma/electron' dist:linux",
     "build": "bun run --filter='*' build",
     "typecheck": "bun run --filter='*' typecheck",
     "test": "bun test"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -232,13 +232,18 @@ export interface ResolvedFileUrl {
 }
 
 /** Office 文件内联预览类型 */
-export type OfficePreviewKind = 'spreadsheet' | 'presentation'
+export type OfficePreviewKind = 'document' | 'spreadsheet' | 'presentation'
 
 /** Office 文件内联预览结果 */
 export interface OfficePreviewResult {
   resolvedPath: string
   kind: OfficePreviewKind
+  /** 内置解析器生成、可直接嵌入的净化后 HTML。 */
   html: string
+  /** 高保真渲染器生成的受令牌保护独立 HTML 文档地址。 */
+  htmlUrl?: string
+  /** 实际产出该预览的渲染器；未指定时表示内置解析器。 */
+  renderer?: 'builtin' | 'officecli'
   text: string
 }
 


### PR DESCRIPTION
## 概述

- 将 OfficeCLI `v1.0.145` 固定为 Proma 开发版与安装包内嵌依赖；构建阶段按目标平台/架构下载、限制重定向、校验 SHA-256 后原子写入资源目录。
- DOCX、XLSX、PPTX 优先经 `officecli view <file> html` 生成高保真静态 HTML；原有 Mammoth/OOXML 转换仍作为 OfficeCLI 缺失、失败、超时或异常输出时的降级路径。
- OfficeCLI HTML 保留 token 保护的 `proma-file://` URL、严格 CSP 与 sandbox iframe 隔离；预览外层采用 fit 裁切，不再出现额外的双层上下左右滚动。
- 不探测用户系统安装、环境变量或 PATH；不实现 watch 常驻服务。

## 性能与运行时影响

- 每次渲染只在显式打开/刷新预览时启动一次短生命周期子进程；无轮询、常驻进程、额外 IPC listener 或持续 Renderer 状态更新。
- HTML 在隔离 iframe 中加载，避免将大文档 DOM 合并到 Proma Renderer；输出设有大小上限和超时保护。
- 已用代表性 XLSX 与 DOCX 文件人工验证渲染；PPTX 复用同一通用渲染路径。剩余风险：不同平台的 OfficeCLI 二进制在 CI/正式签名环境需随发布流水线进一步覆盖。

## 验证

- `bun run typecheck`
- `bun run electron:build`
- `cd apps/electron && bun run pack`（macOS arm64；本机无 Developer ID，符合预期地跳过签名）
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
