### PR TITLE
fix(agent): preserve stream routes across run handoff

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -46,6 +46,7 @@ import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner
 import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
 import { AgentStreamForwarder } from './agent-stream-forwarder'
+import { AgentStreamRouteRegistry } from './agent-stream-route-registry'
 import { AgentQueueCoordinator } from './agent-queue-coordinator'
 import { isStaleActiveQueueError } from './agent-queue-routing'
 import { shouldStopBeforeAgentRun } from './agent-stop-policy'
@@ -67,12 +68,12 @@ import('./agent-collaboration-tools').then(({ registerCollaborationEventBus }) =
 }).catch(() => { /* collaboration 模块可能未加载 */ })
 
 /**
- * 会话 → webContents 映射
+ * 会话 → renderer 的流事件投递路由。
  *
- * EventBus IPC 转发中间件通过此映射找到目标 webContents。
- * runAgent 开始时注册，结束时清理。
+ * 每次 run 注册独立 owner；旧 run 只能清理自己仍拥有的 route，不能删除
+ * 队列接力或 renderer 重载后被新 run 接管的投递目标。
  */
-const sessionWebContents = new Map<string, WebContents>()
+const streamRoutes = new AgentStreamRouteRegistry<WebContents>()
 /** 每个 renderer 当前可见的 Agent 会话；仅该会话维持 20fps partial。 */
 const visibleAgentSessionByWebContents = new WeakMap<WebContents, string | null>()
 const streamForwarder = new AgentStreamForwarder()
@@ -86,29 +87,45 @@ const streamForwarder = new AgentStreamForwarder()
 const wcWithCleanupHook = new WeakSet<WebContents>()
 
 /**
- * 注册 sessionId → webContents 映射，并在 webContents 销毁时自动清理所有相关条目。
- *
- * 仅依赖 finally 块清理无法覆盖窗口关闭、渲染进程崩溃、headless 路径主窗口被替换等
- * webContents 提前销毁的场景——destroyed 事件兜底。
+ * 注册新的 stream route，并在 webContents 销毁时保留 owner 以等待 renderer 重绑或 run 收束。
  */
-function registerWebContents(sessionId: string, wc: WebContents): void {
-  // 同一 sessionId 切换 renderer 时，先丢弃捕获旧 wc.send 的等待 partial，避免投递到旧窗口。
-  const previousWebContents = sessionWebContents.get(sessionId)
-  if (previousWebContents && previousWebContents !== wc) streamForwarder.clear(sessionId)
-  // 旧 wc 的 destroyed 钩子仍由 WeakSet 持有，触发时会扫描 sessionWebContents 清理所有指向它的条目。
-  sessionWebContents.set(sessionId, wc)
+function attachWebContentsCleanup(wc: WebContents): void {
   if (wcWithCleanupHook.has(wc)) return
   wcWithCleanupHook.add(wc)
   wc.once('destroyed', () => {
-    // 单个 wc 可能映射到多个 sessionId（同窗口多 tab），需要清理所有指向它的条目
-    for (const [sid, mappedWc] of sessionWebContents) {
-      if (mappedWc === wc) {
-        sessionWebContents.delete(sid)
-        streamForwarder.clear(sid)
-      }
+    // 保留 route owner 到活跃 run 收束，允许新 renderer 重绑；取消旧 wc 捕获的 partial。
+    for (const sessionIdToClear of streamRoutes.markTargetDestroyed(wc)) {
+      streamForwarder.clear(sessionIdToClear)
     }
     visibleAgentSessionByWebContents.delete(wc)
   })
+}
+
+function registerWebContents(sessionId: string, wc: WebContents) {
+  const previousWebContents = streamRoutes.get(sessionId)?.target
+  if (previousWebContents && previousWebContents !== wc) streamForwarder.clear(sessionId)
+  const route = streamRoutes.bind(sessionId, wc)
+  attachWebContentsCleanup(wc)
+  return route
+}
+
+function getStreamRouteTargets(): Map<string, WebContents> {
+  const targets = new Map<string, WebContents>()
+  for (const snapshot of orchestrator.listActiveSessionSnapshots()) {
+    const target = streamRoutes.get(snapshot.sessionId)?.target
+    if (target) targets.set(snapshot.sessionId, target)
+  }
+  return targets
+}
+
+export function rebindActiveAgentStreams(webContents: WebContents): AgentActiveSessionSnapshot[] {
+  const snapshots = orchestrator.listActiveSessionSnapshots()
+  for (const snapshot of snapshots) {
+    streamForwarder.clear(snapshot.sessionId)
+    streamRoutes.rebind(snapshot.sessionId, webContents)
+  }
+  attachWebContentsCleanup(webContents)
+  return snapshots
 }
 
 function isMainRendererWindow(win: BrowserWindow): boolean {
@@ -128,7 +145,7 @@ function getMainRendererWebContents(): WebContents | null {
 
 const agentQueueCoordinator = new AgentQueueCoordinator({
   isActive: (sessionId) => orchestrator.isActive(sessionId),
-  getWebContents: (sessionId) => sessionWebContents.get(sessionId) ?? getMainRendererWebContents(),
+  getWebContents: (sessionId) => streamRoutes.get(sessionId)?.target ?? getMainRendererWebContents(),
   startRun: (input, webContents) => runAgent(input, webContents),
   sendStarted: (webContents, status) => {
     if (!webContents.isDestroyed()) webContents.send(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, status)
@@ -184,7 +201,7 @@ function getSessionMetaForRenderer(sessionId: string) {
 }
 
 eventBus.use((sessionId, payload, next) => {
-  const wc = sessionWebContents.get(sessionId)
+  const wc = streamRoutes.get(sessionId)?.target
   if (wc && !wc.isDestroyed()) {
     try {
       streamForwarder.forward(
@@ -204,6 +221,7 @@ eventBus.use((sessionId, payload, next) => {
 
 /** renderer 切换标签时更新流式优先级；切入会话立即 flush 等待中的后台快照。 */
 export function setVisibleAgentSession(webContents: WebContents, sessionId: string | null): void {
+  rebindActiveAgentStreams(webContents)
   const previousSessionId = visibleAgentSessionByWebContents.get(webContents)
   if (previousSessionId && previousSessionId !== sessionId) {
     // 切出后将已排队的前台帧按后台频率重排，避免继续以 20fps 发送。
@@ -229,8 +247,7 @@ export async function runAgent(
   input: AgentSendInput,
   webContents: WebContents,
 ): Promise<void> {
-  // 更新 webContents 映射（允许覆盖 — 由 orchestrator.activeSessions 处理真正的并发保护）
-  registerWebContents(input.sessionId, webContents)
+  const route = registerWebContents(input.sessionId, webContents)
   // deferred queue runs carry their queue id as an internal extension.
   const queueMessageId = (input as Partial<AgentDeferredQueueMessageInput>).queueMessageId
   // 开始新一轮执行时清除"完成未确认"标记
@@ -255,8 +272,9 @@ export async function runAgent(
   try {
     await orchestrator.sendMessage(input, {
       onError: (error) => {
-        if (!webContents.isDestroyed()) {
-          webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
+        const target = streamRoutes.getTargetIfOwner(input.sessionId, route.ownerId)
+        if (target) {
+          target.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
             sessionId: input.sessionId,
             error,
           })
@@ -264,8 +282,9 @@ export async function runAgent(
       },
       onComplete: (messages, opts) => {
         publishRunStopped(input.sessionId, opts?.stoppedByUser, opts?.startedAt)
-        if (!webContents.isDestroyed()) {
-          sendAgentStreamComplete(webContents, input, {
+        const target = streamRoutes.getTargetIfOwner(input.sessionId, route.ownerId)
+        if (target) {
+          sendAgentStreamComplete(target, input, {
             messages,
             stoppedByUser: opts?.stoppedByUser ?? false,
             startedAt: opts?.startedAt,
@@ -294,8 +313,9 @@ export async function runAgent(
           kind: 'proma_event',
           event: { type: 'title_updated', title },
         })
-        if (!webContents.isDestroyed()) {
-          webContents.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
+        const target = streamRoutes.getTargetIfOwner(input.sessionId, route.ownerId)
+        if (target) {
+          target.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
             sessionId: input.sessionId,
             title,
           })
@@ -305,22 +325,20 @@ export async function runAgent(
   } catch (err) {
     console.error('[Agent 服务] runAgent 未处理异常:', err)
     const errorMessage = err instanceof Error ? err.message : '未知错误'
-    if (!webContents.isDestroyed()) {
-      webContents.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
+    const target = streamRoutes.getTargetIfOwner(input.sessionId, route.ownerId)
+    if (target) {
+      target.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
         sessionId: input.sessionId,
         error: errorMessage,
       })
-      sendAgentStreamComplete(webContents, input, {
+      sendAgentStreamComplete(target, input, {
         messages: [],
         stoppedByUser: false,
       })
     }
     agentQueueCoordinator.onRunComplete(input.sessionId, queueMessageId, false, false)
   } finally {
-    // 仅在 orchestrator 已完成此会话时清理映射
-    // 避免被拒绝的请求误删仍在运行的会话映射
-    if (!orchestrator.isActive(input.sessionId)) {
-      sessionWebContents.delete(input.sessionId)
+    if (streamRoutes.removeIfOwner(input.sessionId, route.ownerId)) {
       streamForwarder.clear(input.sessionId)
     }
   }
@@ -345,7 +363,7 @@ export async function runAgentHeadless(
 ): Promise<void> {
   // 委派子会话优先回到父会话所在 renderer，外部无界面运行才回退任意主窗口。
   const wc = getHeadlessAgentRunTarget(
-    sessionWebContents,
+    getStreamRouteTargets(),
     callbacks.originSessionId,
     getMainRendererWebContents,
   )
@@ -359,17 +377,17 @@ export async function runAgentHeadless(
     ...(input.startedAt != null ? {} : { startedAt: Date.now() }),
   }
   const startedAt = runInput.startedAt!
-  if (wc) {
-    registerWebContents(runInput.sessionId, wc)
-  }
+  const route = wc ? registerWebContents(runInput.sessionId, wc) : undefined
 
   try {
     await orchestrator.sendMessage(runInput, {
       onError: (error) => {
         callbacks.onError(error)
-        // 同步到渲染进程
-        if (wc && !wc.isDestroyed()) {
-          wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
+        const target = route
+          ? streamRoutes.getTargetIfOwner(runInput.sessionId, route.ownerId)
+          : undefined
+        if (target) {
+          target.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
             sessionId: runInput.sessionId,
             error,
           })
@@ -378,9 +396,11 @@ export async function runAgentHeadless(
       onComplete: (messages, opts) => {
         callbacks.onComplete(messages)
         publishRunStopped(runInput.sessionId, opts?.stoppedByUser, opts?.startedAt)
-        // 同步到渲染进程
-        if (wc && !wc.isDestroyed()) {
-          sendAgentStreamComplete(wc, runInput, {
+        const target = route
+          ? streamRoutes.getTargetIfOwner(runInput.sessionId, route.ownerId)
+          : undefined
+        if (target) {
+          sendAgentStreamComplete(target, runInput, {
             messages,
             stoppedByUser: opts?.stoppedByUser ?? false,
             startedAt: opts?.startedAt,
@@ -404,9 +424,11 @@ export async function runAgentHeadless(
           kind: 'proma_event',
           event: { type: 'title_updated', title },
         })
-        // 同步到渲染进程
-        if (wc && !wc.isDestroyed()) {
-          wc.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
+        const target = route
+          ? streamRoutes.getTargetIfOwner(runInput.sessionId, route.ownerId)
+          : undefined
+        if (target) {
+          target.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
             sessionId: runInput.sessionId,
             title,
           })
@@ -434,9 +456,12 @@ export async function runAgentHeadless(
     const errorMessage = err instanceof Error ? err.message : '未知错误'
     callbacks.onError(errorMessage)
     callbacks.onComplete()
-    if (wc && !wc.isDestroyed()) {
-      wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, { sessionId: runInput.sessionId, error: errorMessage })
-      sendAgentStreamComplete(wc, runInput, {
+    const target = route
+      ? streamRoutes.getTargetIfOwner(runInput.sessionId, route.ownerId)
+      : undefined
+    if (target) {
+      target.send(AGENT_IPC_CHANNELS.STREAM_ERROR, { sessionId: runInput.sessionId, error: errorMessage })
+      sendAgentStreamComplete(target, runInput, {
         messages: [],
         stoppedByUser: false,
         startedAt,
@@ -444,8 +469,7 @@ export async function runAgentHeadless(
     }
     agentQueueCoordinator.onRunComplete(runInput.sessionId, undefined, false, false)
   } finally {
-    if (!orchestrator.isActive(runInput.sessionId)) {
-      sessionWebContents.delete(runInput.sessionId)
+    if (route && streamRoutes.removeIfOwner(runInput.sessionId, route.ownerId)) {
       streamForwarder.clear(runInput.sessionId)
     }
   }

--- a/apps/electron/src/main/lib/agent-stream-route-registry.ts
+++ b/apps/electron/src/main/lib/agent-stream-route-registry.ts
@@ -1,0 +1,63 @@
+export interface StreamRouteTarget {
+  isDestroyed(): boolean
+}
+
+export interface AgentStreamRoute<T extends StreamRouteTarget> {
+  target: T
+  ownerId: number
+}
+
+/**
+ * 管理 session → renderer 的流事件投递路由。
+ *
+ * 新 run 会取得新 owner；renderer 重载只替换既有 owner 的 target。这样旧 run
+ * 无法清理队列接力后的新 run route，而运行中的 renderer 重绑也不会脱离原 run 的
+ * finally 清理责任。
+ */
+export class AgentStreamRouteRegistry<T extends StreamRouteTarget> {
+  private readonly routes = new Map<string, AgentStreamRoute<T>>()
+  private nextOwnerId = 0
+
+  bind(sessionId: string, target: T): AgentStreamRoute<T> {
+    const route = { target, ownerId: ++this.nextOwnerId }
+    this.routes.set(sessionId, route)
+    return route
+  }
+
+  /** Renderer 重载：保留当前运行 owner，只替换可投递目标。 */
+  rebind(sessionId: string, target: T): AgentStreamRoute<T> {
+    const current = this.routes.get(sessionId)
+    const route = { target, ownerId: current?.ownerId ?? ++this.nextOwnerId }
+    this.routes.set(sessionId, route)
+    return route
+  }
+
+  /** 已销毁 target 不可投递，但 route 会保留到活跃 run 的 finally 或后续 rebind 收束。 */
+  get(sessionId: string): AgentStreamRoute<T> | undefined {
+    const route = this.routes.get(sessionId)
+    return route?.target.isDestroyed() ? undefined : route
+  }
+
+  /** 当前 route 仍属于指定 owner 时返回其目标。 */
+  getTargetIfOwner(sessionId: string, ownerId: number): T | undefined {
+    const route = this.routes.get(sessionId)
+    if (!route || route.ownerId !== ownerId || route.target.isDestroyed()) return undefined
+    return route.target
+  }
+
+  /** 当前路由的 owner 与目标一致时才移除；renderer 重绑不会改变 owner。 */
+  removeIfOwner(sessionId: string, ownerId: number): boolean {
+    const route = this.routes.get(sessionId)
+    if (!route || route.ownerId !== ownerId) return false
+    this.routes.delete(sessionId)
+    return true
+  }
+
+  markTargetDestroyed(target: T): string[] {
+    const affected: string[] = []
+    for (const [sessionId, route] of this.routes) {
+      if (route.target === target) affected.push(sessionId)
+    }
+    return affected
+  }
+}


### PR DESCRIPTION
## Summary

- 为每次 Agent run 引入带 owner 的 stream route registry，避免旧 run 的 finally 清理队列接替后的新 route。
- renderer 重载或切换可见会话时，重新绑定仍活跃的 Agent stream 到当前 renderer。
- 错误、完成、标题事件均按当前 run owner 路由，避免发往已销毁或已替换的 renderer。
- 保持 headless run 的外部回调语义：即使没有可投递的 renderer target，异常也会完成回调收束。
- 将 Electron 版本从 `0.18.3` 更新为 `0.18.4`。

## Root cause

同一 `sessionId` 的旧 run、新 run 和 renderer reload 共享原有 `sessionId -> WebContents` 映射。旧 run 的清理或旧 renderer 的 destroyed 回调可能删除新 run 的投递 route，导致 Agent 仍在后台运行、计时器继续增长，但 renderer 收不到消息和工具进度。

## Validation

- `bun test apps/electron/src/main/lib/agent-headless-run-target.test.ts`：通过（3 tests）。
- `bun run --filter @proma/electron build:main`：通过。
- `bun run --filter @proma/electron build:preload`：通过。
- `git diff --check`：通过。
- Electron 开发启动冒烟通过，IPC、Agent runtime 和主窗口初始化成功。
- 完整 typecheck 仍受 `origin/main` 已存在的 Office preview 类型错误阻断，未发现本次 stream route 修改新增的 typecheck 错误。

用户要求不在本 PR 保留新增 route registry 测试文件；这部分仍需后续补充完整的队列接替 / renderer reload 集成覆盖。

## Performance impact

低风险。改动位于主进程 route lookup / lifecycle 路径，不增加逐 token IPC，也不改变现有 partial batching（前台约 50ms、后台约 250ms）。renderer rebind 仅在会话可见状态上报/重载路径执行，按 active session 数量处理；没有扩大后台 renderer 状态复制。

尚未完成真实用户级队列接替和 renderer reload 持续输出验收，剩余风险已知并记录。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
