### PR TITLE
feat(agent): reuse visible terminals

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -1348,19 +1348,23 @@ function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDe
     sdk.defineTool({
       name: 'TerminalExecute',
       label: '在可见终端执行命令',
-      description: 'Run one command in a new visible Agent-owned terminal Tab. The user can see and interrupt it. Call TerminalRead with the returned terminal ID when you need to inspect its output; output is never pushed into this tool result.',
-      promptSnippet: 'Execute one command only when it serves the user request. It is visibly run in the Agent workspace and may require permission approval. If its result matters, call TerminalRead after it has produced output instead of assuming output is returned automatically.',
+      description: 'Run one command in a visible Agent-owned terminal Tab. Omit terminalId to open a new Tab, or provide the ID of a current-session running terminal to reuse it. The user can see and interrupt it. Call TerminalRead with the returned terminal ID when you need to inspect its output; output is never pushed into this tool result.',
+      promptSnippet: 'Use the visible terminal for user-attended commands that benefit from execution visibility. Before reusing a terminal, call TerminalList and reuse only a current-session terminal with a matching cwd whose previous command you observed finish; otherwise omit terminalId to open a new Tab. If the result matters, call TerminalRead after it has produced output instead of assuming output is returned automatically.',
       parameters: Type.Object({
         command: Type.String({ description: 'Complete command to execute in the controlled shell. Do not prepend shell wrappers.' }),
-        cwd: Type.Optional(Type.String({ description: 'Absolute or Agent-CWD-relative directory within the current authorized roots.' })),
-        title: Type.Optional(Type.String({ description: 'Short visible terminal title.' })),
+        terminalId: Type.Optional(Type.String({ description: 'Current-session running Agent terminal to reuse. First inspect candidates with TerminalList; do not reuse an interactive, long-running, or unverified-busy terminal.' })),
+        cwd: Type.Optional(Type.String({ description: 'Absolute or Agent-CWD-relative directory within the current authorized roots. Used only when opening a new terminal.' })),
+        title: Type.Optional(Type.String({ description: 'Short visible terminal title. Used only when opening a new terminal.' })),
       }),
       async execute(_toolCallId, params) {
         const args = params as Record<string, unknown>
         const command = typeof args.command === 'string' ? args.command.trim() : ''
         if (!command) throw new Error('command 必填')
-        const record = await executeAgentTerminal({ ...agentContext, ...terminalInput(args), command })
-        return jsonToolResult({ terminal: record, commandStarted: true, outputSharedWithAgent: false })
+        const terminalId = typeof args.terminalId === 'string' && args.terminalId.trim()
+          ? args.terminalId.trim()
+          : undefined
+        const record = await executeAgentTerminal({ ...agentContext, ...terminalInput(args), command, terminalId })
+        return jsonToolResult({ terminal: record, commandStarted: true, reused: Boolean(terminalId), outputSharedWithAgent: false })
       },
     }),
     sdk.defineTool({
@@ -1384,8 +1388,8 @@ function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDe
     sdk.defineTool({
       name: 'TerminalList',
       label: '列出 Agent 终端',
-      description: 'List terminals owned by the current Agent session, including cwd and running/exited state. It never exposes terminal output.',
-      promptSnippet: 'Inspect Agent-owned terminal metadata without reading terminal output.',
+      description: 'List terminals owned by the current Agent session, including cwd and running/exited state. Use this before deciding whether a visible terminal can be safely reused. It never exposes terminal output.',
+      promptSnippet: 'Inspect Agent-owned terminal metadata before deciding whether to reuse a visible terminal; do not read terminal output unless needed.',
       parameters: Type.Object({}),
       async execute() {
         return jsonToolResult({ terminals: listAgentTerminals(ctx.sessionId) })

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -112,6 +112,10 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 你是由 Pi Agent SDK 驱动的 Proma Agent，协助用户 ${userName}。优先中文，直接解决明确目标；低风险、可验证操作直接执行。涉及不可逆删除、外部发送/发布、付费或安全边界变化时先确认。`,
     `## Pi 运行时
 使用 Proma 提供的工具；Write 必须同时传入完整 \`path\` 与 \`content\`。附加目录可用其绝对路径访问。${modelRule}`,
+    `## 可见终端
+- 在用户在场的前台会话中，凡是用户值得关注执行过程的本地命令，优先使用内置 \`TerminalExecute\`，让用户可见、可中断：例如长时构建/测试、开发服务器、依赖安装、Git 或 Worktree 操作、数据迁移/清理、部署，以及用户明确要求观看的执行。只读文件检索或瞬时的低价值检查仍优先使用专用文件工具或 Bash，避免无意义地打扰用户。
+- 重要命令仍须遵守权限确认和安全规则；可见终端不替代确认。Automation、外部 Bridge 和协作子 Agent 没有可见终端时，不要假装可见。
+- 需要继续同一命令序列时，先用 \`TerminalList\` 查看本会话终端；仅当 cwd 一致、终端仍在运行，且你亲自观察到其上一条命令已结束时，才在 \`TerminalExecute\` 中传入 \`terminalId\` 复用。交互式、长驻或忙碌状态不明的终端一律新开，绝不向其中注入命令。需要命令结果时使用 \`TerminalRead\`。`,
     WORKFLOW_PROMPT,
     `## 任务、日程与自动化
 明确且用户认可的后续行动用 Todo；有明确开始时间的安排用日程；提醒必须有具体时点。创建 Todo 前必须调用 \`list_todos({ status: 'open', limit: 100 })\` 与 \`list_groups({ scope: 'todo' })\` 去重/复用；外部来源（\`nativeOrigin\`）的修改、完成或删除先说明副作用并确认。规划、承诺交付、询问近期安排或结束含行动项的对话时，按需读取 Todo/日程；已有事项只按事实更新或完成，取消不删除。持续或延迟的无人值守工作先读取 \`automation\` Skill；纯提醒不创建 Automation。具体参数和权限遵循工具说明。`,

--- a/apps/electron/src/main/lib/terminal-service.ts
+++ b/apps/electron/src/main/lib/terminal-service.ts
@@ -158,6 +158,8 @@ export async function openAgentTerminal(input: {
 export async function executeAgentTerminal(input: {
   sessionId: string
   command: string
+  /** 指定时复用当前 Agent 会话中仍在运行的可见 PTY；省略时创建新终端。 */
+  terminalId?: string
   cwd?: string
   title?: string
   agentCwd?: string
@@ -165,6 +167,15 @@ export async function executeAgentTerminal(input: {
 }): Promise<AgentTerminalRecord> {
   const command = input.command.trim()
   if (!command || command.length > 64 * 1024) throw new Error('终端命令为空或过长')
+
+  const requestedTerminalId = input.terminalId?.trim()
+  if (requestedTerminalId) {
+    const record = getOwnedAgentTerminal(input.sessionId, requestedTerminalId)
+    if (record.status !== 'running') throw new Error('终端已退出，不能复用')
+    await writeTerminal({ terminalId: record.terminalId, data: `${command}\r` })
+    return record
+  }
+
   const title = input.title?.trim() || `Agent · ${command.replace(/\s+/g, ' ').slice(0, 48)}`
   const record = await openAgentTerminal({ ...input, title })
   await writeTerminal({ terminalId: record.terminalId, data: `${command}\r` })


### PR DESCRIPTION
## Summary
- Let `TerminalExecute` reuse a running Agent-owned terminal when given its current-session `terminalId`.
- Guide foreground Agents to use visible terminals for user-attended, high-attention local commands and to reuse only verified-safe terminals.
- Keep automation, external bridges, and delegated Agents outside the visible-terminal path.

## Verification
- `bun run --filter='@proma/electron' build:main`
- Full Electron typecheck remains blocked by pre-existing `OfficePreviewResult` / `OfficePreviewKind` errors in `file-preview-service.ts` and `DiffTabContent.tsx`.

## Performance impact
- Low risk. Reuse avoids an additional PTY and right-side terminal Tab for eligible sequential commands; no new IPC listeners, timers, or streaming updates are introduced.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
