### PR TITLE
feat(changes): open terminals from directories

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -1067,6 +1067,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     handleOpenTerminal(worktree.path, `终端 · ${worktree.branch}`)
   }, [handleOpenTerminal])
 
+  const handleOpenDirectoryTerminal = React.useCallback((directoryPath: string, directoryName: string) => {
+    handleOpenTerminal(directoryPath, `终端 · ${directoryName}`)
+  }, [handleOpenTerminal])
+
   const handleCloseBrowserTab = React.useCallback(async (browserTabId: string) => {
     try {
       const state = await window.electronAPI.closeAgentBrowserTab({ sessionId, tabId: browserTabId })
@@ -1231,16 +1235,16 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             <AttachedFilesSection scope="session" showSessionBadge={false} attachedFiles={attachedFiles} onDetach={handleDetachFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
           )}
           {isSession && attachedDirs.length > 0 && (
-            <AttachedDirsSection scope="session" showSessionBadge={false} attachedDirs={attachedDirs} onDetach={handleDetachDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+            <AttachedDirsSection scope="session" showSessionBadge={false} attachedDirs={attachedDirs} onDetach={handleDetachDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} onOpenDirectoryTerminal={handleOpenDirectoryTerminal} allowedPaths={basePathsRef.current} sessionId={sessionId} />
           )}
           {!isSession && wsAttachedFiles.length > 0 && (
             <AttachedFilesSection scope="project" attachedFiles={wsAttachedFiles} onDetach={handleDetachWorkspaceFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
           )}
           {!isSession && wsAttachedDirs.length > 0 && (
-            <AttachedDirsSection scope="project" attachedDirs={wsAttachedDirs} onDetach={handleDetachWorkspaceDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+            <AttachedDirsSection scope="project" attachedDirs={wsAttachedDirs} onDetach={handleDetachWorkspaceDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} onOpenDirectoryTerminal={handleOpenDirectoryTerminal} allowedPaths={basePathsRef.current} sessionId={sessionId} />
           )}
           {!isSession && isProjectRootUnavailable && <div className="mx-2 my-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">本地项目根目录不可用；当前会话文件仍可访问。</div>}
-          <FileBrowser roots={roots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+          <FileBrowser roots={roots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} onOpenDirectoryTerminal={handleOpenDirectoryTerminal} />
           {workspaceSlug && (isSession ? (
             <FileDropZone workspaceSlug={workspaceSlug} sessionId={sessionId} target="session" onFilesUploaded={handleFilesUploaded} onFilesAttached={handleSessionFilesAttached} onAttachFolder={handleAttachSessionFolder} onFoldersDropped={handleSessionFoldersDropped} />
           ) : !isProjectRootUnavailable ? (
@@ -1358,6 +1362,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                 workspaceSlug={workspaceSlug || undefined}
                 worktreeRepoPaths={worktreeRepoPathsMemo}
                 onOpenWorktreeTerminal={handleOpenWorktreeTerminal}
+                onOpenDirectoryTerminal={handleOpenDirectoryTerminal}
                 nonGitFileChanges={nonGitFileChanges}
                 currentFileChangeRunId={fileChangesCurrentRunId}
                 onPlainFileClick={handleFilePreview}
@@ -1432,20 +1437,20 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         <AttachedFilesSection scope="project" attachedFiles={wsAttachedFiles} onDetach={handleDetachWorkspaceFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
                       )}
                       {showProjectFiles && wsAttachedDirs.length > 0 && (
-                        <AttachedDirsSection scope="project" attachedDirs={wsAttachedDirs} onDetach={handleDetachWorkspaceDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+                        <AttachedDirsSection scope="project" attachedDirs={wsAttachedDirs} onDetach={handleDetachWorkspaceDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} onOpenDirectoryTerminal={handleOpenDirectoryTerminal} allowedPaths={basePathsRef.current} sessionId={sessionId} />
                       )}
                       {showSessionFiles && attachedFiles.length > 0 && (
                         <AttachedFilesSection scope="session" showSessionBadge={false} attachedFiles={attachedFiles} onDetach={handleDetachFile} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
                       )}
                       {showSessionFiles && attachedDirs.length > 0 && (
-                        <AttachedDirsSection scope="session" showSessionBadge={false} attachedDirs={attachedDirs} onDetach={handleDetachDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} allowedPaths={basePathsRef.current} sessionId={sessionId} />
+                        <AttachedDirsSection scope="session" showSessionBadge={false} attachedDirs={attachedDirs} onDetach={handleDetachDirectory} refreshVersion={filesVersion} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} onOpenDirectoryTerminal={handleOpenDirectoryTerminal} allowedPaths={basePathsRef.current} sessionId={sessionId} />
                       )}
                       {showProjectFiles && isProjectRootUnavailable && (
                         <div className="mx-2 my-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
                           本地项目根目录不可用；当前会话文件仍可访问。
                         </div>
                       )}
-                      <FileBrowser roots={visibleFileRoots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasVisibleSessionAttachedItems || hasVisibleWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+                      <FileBrowser roots={visibleFileRoots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasVisibleSessionAttachedItems || hasVisibleWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} onOpenDirectoryTerminal={handleOpenDirectoryTerminal} />
                       {showSessionFiles && workspaceSlug && (
                         <FileDropZone workspaceSlug={workspaceSlug} sessionId={sessionId} target="session" onFilesUploaded={handleFilesUploaded} onFilesAttached={handleSessionFilesAttached} onAttachFolder={handleAttachSessionFolder} onFoldersDropped={handleSessionFoldersDropped} />
                       )}
@@ -1592,13 +1597,15 @@ interface AttachedDirsSectionProps {
   refreshVersion: number
   onAddToChat?: (entry: FileEntry) => void
   onFilePreview?: (filePath: string) => void
+  /** 在右侧工作区中以指定目录为 cwd 打开终端。 */
+  onOpenDirectoryTerminal?: (directoryPath: string, directoryName: string) => void
   /** 所有允许访问的路径（传给 IPC 做路径校验） */
   allowedPaths?: string[]
   sessionId: string
 }
 
 /** 附加目录区域：统一管理所有子项的选中状态 */
-function AttachedDirsSection({ title, scope = 'project', showSessionBadge = true, attachedDirs, onDetach, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId }: AttachedDirsSectionProps): React.ReactElement {
+function AttachedDirsSection({ title, scope = 'project', showSessionBadge = true, attachedDirs, onDetach, refreshVersion, onAddToChat, onFilePreview, onOpenDirectoryTerminal, allowedPaths, sessionId }: AttachedDirsSectionProps): React.ReactElement {
   const [selectedPaths, setSelectedPaths] = React.useState<Set<string>>(new Set())
 
   // ===== 接入搜索点击触发的 reveal：附加目录文件搜到后，需要展开/选中目标 =====
@@ -1660,6 +1667,7 @@ function AttachedDirsSection({ title, scope = 'project', showSessionBadge = true
             refreshVersion={refreshVersion}
             onAddToChat={onAddToChat}
             onFilePreview={onFilePreview}
+            onOpenDirectoryTerminal={onOpenDirectoryTerminal}
             allowedPaths={allowedPaths}
             sessionId={sessionId}
             scope={scope}
@@ -1683,6 +1691,7 @@ interface AttachedDirTreeProps {
   refreshVersion: number
   onAddToChat?: (entry: FileEntry) => void
   onFilePreview?: (filePath: string) => void
+  onOpenDirectoryTerminal?: (directoryPath: string, directoryName: string) => void
   allowedPaths?: string[]
   sessionId: string
   scope: 'project' | 'session'
@@ -1693,7 +1702,7 @@ interface AttachedDirTreeProps {
   revealTs?: number
 }
 
-function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId, scope, showSessionBadge, revealTarget = null, revealTs = 0 }: AttachedDirTreeProps): React.ReactElement {
+function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, onOpenDirectoryTerminal, allowedPaths, sessionId, scope, showSessionBadge, revealTarget = null, revealTs = 0 }: AttachedDirTreeProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
@@ -1797,6 +1806,25 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
         {showSessionBadge && scope === 'session' && (
           <span className="relative z-10 flex-shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">会话文件</span>
         )}
+        {onOpenDirectoryTerminal && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={`在 ${dirName} 打开终端`}
+                title={`在 ${dirName} 打开终端`}
+                className="relative z-10 flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-[background-color,color,opacity,transform] hover:bg-accent/70 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 active:scale-[0.96]"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onOpenDirectoryTerminal(dirPath, dirName)
+                }}
+              >
+                <SquareTerminal className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">在右侧标签中打开终端</TooltipContent>
+          </Tooltip>
+        )}
         <Button
           type="button"
           variant="ghost"
@@ -1823,7 +1851,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
             </div>
           )}
           {children.map((child) => (
-            <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
+            <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} onOpenDirectoryTerminal={onOpenDirectoryTerminal} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
           ))}
         </div>
       )}
@@ -1839,6 +1867,7 @@ interface AttachedDirItemProps {
   refreshVersion: number
   onAddToChat?: (entry: FileEntry) => void
   onFilePreview?: (filePath: string) => void
+  onOpenDirectoryTerminal?: (directoryPath: string, directoryName: string) => void
   allowedPaths?: string[]
   sessionId: string
   scope: 'project' | 'session'
@@ -1850,7 +1879,7 @@ interface AttachedDirItemProps {
   revealAncestors?: Set<string>
 }
 
-function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId, scope, revealTarget = null, revealTs = 0, revealAncestors }: AttachedDirItemProps): React.ReactElement {
+function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, onOpenDirectoryTerminal, allowedPaths, sessionId, scope, revealTarget = null, revealTs = 0, revealAncestors }: AttachedDirItemProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
@@ -2068,6 +2097,26 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
           <span className="relative z-10 truncate text-xs flex-1">{currentName}</span>
         )}
 
+        {entry.isDirectory && onOpenDirectoryTerminal && !isRenaming && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={`在 ${currentName} 打开终端`}
+                title={`在 ${currentName} 打开终端`}
+                className="relative z-10 flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-[background-color,color,opacity,transform] hover:bg-accent/70 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 active:scale-[0.96]"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onOpenDirectoryTerminal(currentPath, currentName)
+                }}
+              >
+                <SquareTerminal className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">在右侧标签中打开终端</TooltipContent>
+          </Tooltip>
+        )}
+
         {/* 右侧操作按钮占位 */}
         <div
           className="relative z-10 flex-shrink-0 mr-1"
@@ -2167,7 +2216,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
             </div>
           )}
           {children.map((child) => (
-            <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
+            <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} onOpenDirectoryTerminal={onOpenDirectoryTerminal} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
           ))}
         </div>
       )}

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react'
-import { Box, ChevronRight, FolderSearch, Search, Undo2, X } from 'lucide-react'
+import { Box, ChevronRight, FolderSearch, Search, SquareTerminal, Undo2, X } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -63,6 +63,8 @@ interface DiffChangesListProps {
   worktreeRepoPaths?: string[]
   /** 在指定 Worktree 根目录创建右侧终端 */
   onOpenWorktreeTerminal?: (worktree: WorktreeInfo) => void
+  /** 在右侧工作区中以 Git 目录为 cwd 打开终端。 */
+  onOpenDirectoryTerminal?: (directoryPath: string, directoryName: string) => void
   /** 本会话在非 Git 目录中成功写入的文件 */
   nonGitFileChanges?: SessionFileChange[]
   /** 当前 Agent run ID，用于将文件变更划分为本轮和更早 */
@@ -83,6 +85,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   workspaceSlug,
   worktreeRepoPaths,
   onOpenWorktreeTerminal,
+  onOpenDirectoryTerminal,
   nonGitFileChanges = [],
   currentFileChangeRunId,
   onPlainFileClick,
@@ -335,8 +338,8 @@ export const DiffChangesList = React.memo(function DiffChangesList({
           {fileGroups.map((group) => {
             return (
               <div key={group.gitRoot} className="py-1">
-                <div className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
-                  <span className="truncate">{group.dirName}</span>
+                <div className="group flex items-center gap-1.5 px-3 py-1.5 text-[14px] font-medium text-muted-foreground">
+                  <span className="min-w-0 flex-1 truncate">{group.dirName}</span>
                   {group.sources.map((source) => {
                     const config = DIFF_CHANGE_SOURCE_CONFIG[source]
                     return (
@@ -345,6 +348,22 @@ export const DiffChangesList = React.memo(function DiffChangesList({
                       </span>
                     )
                   })}
+                  {onOpenDirectoryTerminal && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={`在 ${group.dirName} 打开终端`}
+                          title={`在 ${group.dirName} 打开终端`}
+                          className="inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-[background-color,color,opacity,transform] hover:bg-accent/70 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 active:scale-[0.96]"
+                          onClick={() => onOpenDirectoryTerminal(group.gitRoot, group.dirName)}
+                        >
+                          <SquareTerminal className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left">在右侧标签中打开终端</TooltipContent>
+                    </Tooltip>
+                  )}
                 </div>
                 {group.tree.map((node) => (
                   <GitFileTreeNode
@@ -363,6 +382,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
                       onFileClick(file.filePath, file.status === 'untracked', file.gitRoot)
                     }}
                     onRevert={(file) => handleRevert(file.filePath, file.gitRoot)}
+                    onOpenDirectoryTerminal={onOpenDirectoryTerminal}
                   />
                 ))}
               </div>
@@ -387,6 +407,7 @@ function GitFileTreeNode({
   onToggle,
   onFileClick,
   onRevert,
+  onOpenDirectoryTerminal,
 }: {
   node: DiffFileTreeNode<GitFileEntry>
   depth: number
@@ -399,6 +420,7 @@ function GitFileTreeNode({
   onToggle: (path: string) => void
   onFileClick: (file: GitFileEntry, absPath: string) => void
   onRevert: (file: GitFileEntry) => void
+  onOpenDirectoryTerminal?: (directoryPath: string, directoryName: string) => void
 }): React.ReactElement {
   if (node.kind === 'file') {
     const file = node.entry
@@ -418,16 +440,18 @@ function GitFileTreeNode({
 
   const stateKey = `${gitRoot}:${node.path}`
   const isCollapsed = !forceExpanded && collapsedDirs.has(stateKey)
+  const directoryPath = `${gitRoot}/${node.path}`.replace(/\/+/g, '/')
   const rowPaddingLeft = 8 + depth * 16
   const guideLeft = 23 + depth * 16
 
   return (
     <div className="relative">
+      <div className="group mx-2 flex h-8 items-center gap-1.5 rounded-md pr-2 text-[13px] font-medium text-foreground/75 transition-colors hover:bg-accent/50">
       <button
         type="button"
         aria-expanded={!isCollapsed}
         title={node.name}
-        className="mx-2 flex h-8 items-center gap-1.5 rounded-md pr-2 text-left text-[13px] font-medium text-foreground/75 transition-colors hover:bg-accent/50"
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
         style={{ paddingLeft: rowPaddingLeft }}
         onClick={() => onToggle(stateKey)}
       >
@@ -436,6 +460,23 @@ function GitFileTreeNode({
         />
         <span className="min-w-0 flex-1 truncate">{node.name}</span>
       </button>
+      {onOpenDirectoryTerminal && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={`在 ${node.name} 打开终端`}
+              title={`在 ${node.name} 打开终端`}
+              className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-[background-color,color,opacity,transform] hover:bg-accent/70 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 active:scale-[0.96]"
+              onClick={() => onOpenDirectoryTerminal(directoryPath, node.name)}
+            >
+              <SquareTerminal className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">在右侧标签中打开终端</TooltipContent>
+        </Tooltip>
+      )}
+      </div>
       {!isCollapsed && (
         <div className="relative">
           <span
@@ -457,6 +498,7 @@ function GitFileTreeNode({
               onToggle={onToggle}
               onFileClick={onFileClick}
               onRevert={onRevert}
+              onOpenDirectoryTerminal={onOpenDirectoryTerminal}
             />
           ))}
         </div>
@@ -602,7 +644,7 @@ function FileRow({
       role="button"
       tabIndex={0}
       className={cn(
-        'group/file relative mx-2 flex h-8 items-center rounded-md pr-2 text-[14px] transition-colors',
+        'group/file relative mx-2 flex h-8 items-center rounded-md pr-2 text-[12px] transition-colors',
         isSelected
           ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-primary/5',
@@ -633,7 +675,7 @@ function FileRow({
       </Tooltip>
 
       {hasLineChanges && (
-        <span className="ml-auto flex shrink-0 items-center gap-1.5 text-[13px] tabular-nums transition-opacity group-hover/file:opacity-0">
+        <span className="ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums transition-opacity group-hover/file:opacity-0">
           {file.additions > 0 && (
             <span style={{ color: 'rgb(34 197 94)' }}>+{file.additions}</span>
           )}
@@ -684,7 +726,7 @@ function GitStatusMarker({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className={cn('w-4 shrink-0 text-right text-[12px] font-medium tabular-nums', className, color)}>{label}</span>
+        <span className={cn('w-4 shrink-0 text-right text-[11px] font-medium tabular-nums', className, color)}>{label}</span>
       </TooltipTrigger>
       <TooltipContent side="bottom">{description}</TooltipContent>
     </Tooltip>

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -121,6 +121,8 @@ interface FileBrowserProps {
   onAddToChat?: (entry: FileEntry) => void
   /** 单击文件时在内联预览面板中显示（替代外部窗口预览） */
   onFilePreview?: (filePath: string) => void
+  /** 在右侧工作区中以指定目录为 cwd 打开终端。 */
+  onOpenDirectoryTerminal?: (directoryPath: string, directoryName: string) => void
 }
 
 function sortEntries(entries: ScopedFileEntry[]): ScopedFileEntry[] {
@@ -138,7 +140,7 @@ function getFileBrowserStateKey(sessionId: string | null, roots: readonly FileBr
   return `${sessionId ?? 'standalone'}\u0002${rootKey}`
 }
 
-export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty, access, projectRootPath, showSessionBadge = true, onAddToChat, onFilePreview }: FileBrowserProps): React.ReactElement {
+export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty, access, projectRootPath, showSessionBadge = true, onAddToChat, onFilePreview, onOpenDirectoryTerminal }: FileBrowserProps): React.ReactElement {
   const browserRoots = React.useMemo<FileBrowserRoot[]>(() => {
     if (roots && roots.length > 0) return roots.filter((root) => Boolean(root.path))
     return rootPath ? [{ path: rootPath, scope: 'project' }] : []
@@ -407,6 +409,7 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
           onSelect={handleSelect}
           onShowInFolder={handleShowInFolder}
           onOpenInTerminal={handleOpenInTerminal}
+          onOpenDirectoryTerminal={onOpenDirectoryTerminal}
           onStartRename={handleStartRename}
           onCancelRename={handleCancelRename}
           onRename={handleRename}
@@ -517,6 +520,7 @@ interface FileTreeItemProps {
   onSelect: (entry: FileEntry, event: React.MouseEvent) => void
   onShowInFolder: (entry: FileEntry) => void
   onOpenInTerminal: (entry: FileEntry) => void
+  onOpenDirectoryTerminal?: (directoryPath: string, directoryName: string) => void
   onStartRename: (entry: FileEntry) => void
   onCancelRename: () => void
   onRename: (filePath: string, newName: string) => Promise<string | null>
@@ -547,6 +551,7 @@ function FileTreeItem({
   onSelect,
   onShowInFolder,
   onOpenInTerminal,
+  onOpenDirectoryTerminal,
   onStartRename,
   onCancelRename,
   onRename,
@@ -887,6 +892,26 @@ function FileTreeItem({
           </>
         )}
 
+        {entry.isDirectory && onOpenDirectoryTerminal && !isRenaming && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={`在 ${entry.name} 打开终端`}
+                title={`在 ${entry.name} 打开终端`}
+                className="relative z-10 flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-[background-color,color,opacity,transform] hover:bg-accent/70 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 active:scale-[0.96]"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onOpenDirectoryTerminal(entry.path, entry.name)
+                }}
+              >
+                <Terminal className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">在右侧标签中打开终端</TooltipContent>
+          </Tooltip>
+        )}
+
         {/* 右侧操作按钮占位（始终占位，避免行宽跳动） */}
         <div
           className="relative z-10 flex-shrink-0 mr-1"
@@ -1045,6 +1070,7 @@ function FileTreeItem({
               onSelect={onSelect}
               onShowInFolder={onShowInFolder}
               onOpenInTerminal={onOpenInTerminal}
+              onOpenDirectoryTerminal={onOpenDirectoryTerminal}
               onStartRename={onStartRename}
               onCancelRename={onCancelRename}
               onRename={onRename}


### PR DESCRIPTION
## Summary
- Add direct right-panel terminal entries for regular and attached directories.
- Open each terminal with the selected directory as its working directory.
- Refine Changes typography to prioritize repository roots over file rows.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`

## Performance
Low risk: the action only creates a terminal after an explicit click; it adds no polling, IPC listeners, or background updates.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)