### PR TITLE
Fix unrelated file preview refreshes

### DIFF
--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -13,7 +13,6 @@
 
 import { watch, existsSync, statSync } from 'node:fs'
 import type { FSWatcher } from 'node:fs'
-import { stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import type { BrowserWindow } from 'electron'
 import { AGENT_IPC_CHANNELS } from '@proma/shared'
@@ -72,11 +71,10 @@ function notifyWorkspaceFilesChanged(changedPath?: string): void {
     const changedPaths = [...attachedChangedPaths]
     attachedChangedPaths.clear()
     attachedFilesTimer = null
-    void filterExistingFiles(changedPaths).then((filePaths) => {
-      if (mainWin && !mainWin.isDestroyed()) {
-        mainWin.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, filePaths)
-      }
-    })
+    if (mainWin && !mainWin.isDestroyed()) {
+      // 保留删除路径，使当前预览也能从旧缓存切换到“文件不存在”状态。
+      mainWin.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, changedPaths)
+    }
   }, DEBOUNCE_MS)
 }
 
@@ -87,18 +85,6 @@ function isExistingDirectory(dirPath: string): boolean {
   } catch {
     return false
   }
-}
-
-/** debounce 后异步筛选存在的普通文件，目录和已删除路径仍会触发空刷新事件。 */
-async function filterExistingFiles(paths: readonly string[]): Promise<string[]> {
-  const results = await Promise.all(paths.map(async (filePath) => {
-    try {
-      return (await stat(filePath)).isFile() ? filePath : null
-    } catch {
-      return null
-    }
-  }))
-  return results.filter((filePath): filePath is string => filePath !== null)
 }
 
 function findNearestExistingDirectory(dirPath: string): string | null {
@@ -259,19 +245,18 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
           capabilitiesTimer = null
         }, DEBOUNCE_MS)
       } else {
-        // 其他文件变化 → 通知文件浏览器刷新。删除或目录事件会发送空路径列表，
-        // 仍让 Git Diff 刷新，但不会把非文件路径记录到会话改动中。
+        // 其他文件变化 → 通知文件浏览器刷新。保留删除与目录路径，
+        // renderer 会在记录会话文件改动前确认路径仍是实际文件。
         if (filesTimer) clearTimeout(filesTimer)
         changedFilePaths.add(join(watchDir, normalizedFilename))
         filesTimer = setTimeout(() => {
           const paths = [...changedFilePaths]
           changedFilePaths.clear()
           filesTimer = null
-          void filterExistingFiles(paths).then((filePaths) => {
-            if (!win.isDestroyed()) {
-              win.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, filePaths)
-            }
-          })
+          if (!win.isDestroyed()) {
+            // 保留删除路径，供当前预览精确失效；文件列表自行重新读取目录。
+            win.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED, paths)
+          }
         }, DEBOUNCE_MS)
       }
     })

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -49,6 +49,9 @@ export function getPreviewContentRefreshKey(sessionId: string, file: Pick<Previe
  */
 export const previewContentRefreshVersionAtom = atom<Map<string, number>>(new Map())
 
+/** 纯预览最后一次实际解析到的绝对路径，用于精确匹配相对路径 watcher 事件。 */
+export const previewResolvedPathAtom = atom<Map<string, string>>(new Map())
+
 /** 每会话预览面板开关 */
 export const previewPanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -38,6 +38,17 @@ export function getPreviewFileId(file: PreviewFile): string {
   return [file.filePath, file.previewOnly ? 'preview' : 'diff', file.gitRoot ?? '', file.baseRef ?? ''].join('\u0000')
 }
 
+/** 同一会话中单个预览文件的内容刷新版本。 */
+export function getPreviewContentRefreshKey(sessionId: string, file: Pick<PreviewFile, 'filePath' | 'previewOnly' | 'gitRoot' | 'baseRef'>): string {
+  return `${sessionId}\u0000${getPreviewFileId(file)}`
+}
+
+/**
+ * 纯文件预览的内容刷新版本：按 session + 文件隔离。
+ * 不复用 Git diff 的会话级版本，避免无关文件改动重载当前预览。
+ */
+export const previewContentRefreshVersionAtom = atom<Map<string, number>>(new Map())
+
 /** 每会话预览面板开关 */
 export const previewPanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -92,6 +92,7 @@ import { BrowserPanel } from '@/components/browser/BrowserPanel'
 import {
   getPreviewFileId,
   previewContentRefreshVersionAtom,
+  previewResolvedPathAtom,
   previewFileMapAtom,
   previewFilesMapAtom,
   previewPanelOpenMapAtom,
@@ -456,6 +457,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const previewFilesMap = useAtomValue(previewFilesMapAtom)
   const setPreviewFilesMap = useSetAtom(previewFilesMapAtom)
   const setPreviewContentRefreshVersion = useSetAtom(previewContentRefreshVersionAtom)
+  const setPreviewResolvedPaths = useSetAtom(previewResolvedPathAtom)
   const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
   const previewFiles = previewFilesMap.get(sessionId) ?? []
@@ -908,13 +910,25 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       next.delete(key)
       return next
     })
+    setPreviewFileMap((previous) => {
+      const next = new Map(previous)
+      next.set(sessionId, fallback)
+      return next
+    })
+    setPreviewResolvedPaths((previous) => {
+      const key = `${sessionId}\u0000${previewId}`
+      if (!previous.has(key)) return previous
+      const next = new Map(previous)
+      next.delete(key)
+      return next
+    })
     setPreviewOpenMap((previous) => {
       const next = new Map(previous)
       next.set(sessionId, fallback !== null)
       return next
     })
     if (getPreviewIdFromSidePanelTab(activeTab) === previewId) returnToPreviousTabAfterClose(getPreviewSidePanelTab(previewId))
-  }, [activeTab, previewFiles, returnToPreviousTabAfterClose, sessionId, setPreviewContentRefreshVersion, setPreviewFilesMap, setPreviewOpenMap])
+  }, [activeTab, previewFiles, returnToPreviousTabAfterClose, sessionId, setPreviewContentRefreshVersion, setPreviewFileMap, setPreviewFilesMap, setPreviewOpenMap, setPreviewResolvedPaths])
 
   const handleCloseChatTab = React.useCallback(() => {
     setSideChatMap((prev) => {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -89,7 +89,13 @@ import {
   browserStateMapAtom,
 } from '@/atoms/browser-atoms'
 import { BrowserPanel } from '@/components/browser/BrowserPanel'
-import { getPreviewFileId, previewFileMapAtom, previewFilesMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
+import {
+  getPreviewFileId,
+  previewContentRefreshVersionAtom,
+  previewFileMapAtom,
+  previewFilesMapAtom,
+  previewPanelOpenMapAtom,
+} from '@/atoms/preview-atoms'
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import type { FileEntry, AgentPendingFile, AgentSessionMeta, SDKMessage, WorktreeInfo } from '@proma/shared'
@@ -449,6 +455,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const setPreviewFileMap = useSetAtom(previewFileMapAtom)
   const previewFilesMap = useAtomValue(previewFilesMapAtom)
   const setPreviewFilesMap = useSetAtom(previewFilesMapAtom)
+  const setPreviewContentRefreshVersion = useSetAtom(previewContentRefreshVersionAtom)
   const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
   const previewFiles = previewFilesMap.get(sessionId) ?? []
@@ -894,13 +901,20 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       return next
     })
     const fallback = remaining.at(-1) ?? null
+    setPreviewContentRefreshVersion((previous) => {
+      const key = `${sessionId}\u0000${previewId}`
+      if (!previous.has(key)) return previous
+      const next = new Map(previous)
+      next.delete(key)
+      return next
+    })
     setPreviewOpenMap((previous) => {
       const next = new Map(previous)
       next.set(sessionId, fallback !== null)
       return next
     })
     if (getPreviewIdFromSidePanelTab(activeTab) === previewId) returnToPreviousTabAfterClose(getPreviewSidePanelTab(previewId))
-  }, [activeTab, previewFiles, returnToPreviousTabAfterClose, sessionId, setPreviewFilesMap, setPreviewOpenMap])
+  }, [activeTab, previewFiles, returnToPreviousTabAfterClose, sessionId, setPreviewContentRefreshVersion, setPreviewFilesMap, setPreviewOpenMap])
 
   const handleCloseChatTab = React.useCallback(() => {
     setSideChatMap((prev) => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -73,7 +73,12 @@ import {
   automationGroupOrderAtom,
 } from '@/atoms/agent-atoms'
 import type { SessionIndicatorStatus, WorkspaceComponentTab } from '@/atoms/agent-atoms'
-import { previewPanelOpenMapAtom, previewFileMapAtom, previewFilesMapAtom } from '@/atoms/preview-atoms'
+import {
+  previewPanelOpenMapAtom,
+  previewFileMapAtom,
+  previewFilesMapAtom,
+  previewContentRefreshVersionAtom,
+} from '@/atoms/preview-atoms'
 import { clearPreviewCacheForSession } from '@/components/diff/DiffTabContent'
 import {
   tabsAtom,
@@ -855,6 +860,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setPreviewPanelOpen = useSetAtom(previewPanelOpenMapAtom)
   const setPreviewFile = useSetAtom(previewFileMapAtom)
   const setPreviewFiles = useSetAtom(previewFilesMapAtom)
+  const setPreviewContentRefreshVersion = useSetAtom(previewContentRefreshVersionAtom)
   const setAgentSideChatMap = useSetAtom(agentSideChatMapAtom)
   const setDiffPanelTab = useSetAtom(agentDiffPanelTabAtom)
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
@@ -885,6 +891,14 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setPreviewPanelOpen(deleteKey)
     setPreviewFile(deleteKey)
     setPreviewFiles(deleteKey)
+    setPreviewContentRefreshVersion((prev) => {
+      const prefix = `${id}\u0000`
+      const keys = [...prev.keys()].filter((key) => key.startsWith(prefix))
+      if (keys.length === 0) return prev
+      const next = new Map(prev)
+      for (const key of keys) next.delete(key)
+      return next
+    })
     setAgentSideChatMap((prev) => {
       let changed = false
       const map = new Map(prev)
@@ -959,7 +973,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     sessionExistsAtom.remove(id)
 
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setPreviewFiles, setPreviewContentRefreshVersion, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -78,6 +78,7 @@ import {
   previewFileMapAtom,
   previewFilesMapAtom,
   previewContentRefreshVersionAtom,
+  previewResolvedPathAtom,
 } from '@/atoms/preview-atoms'
 import { clearPreviewCacheForSession } from '@/components/diff/DiffTabContent'
 import {
@@ -861,6 +862,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setPreviewFile = useSetAtom(previewFileMapAtom)
   const setPreviewFiles = useSetAtom(previewFilesMapAtom)
   const setPreviewContentRefreshVersion = useSetAtom(previewContentRefreshVersionAtom)
+  const setPreviewResolvedPaths = useSetAtom(previewResolvedPathAtom)
   const setAgentSideChatMap = useSetAtom(agentSideChatMapAtom)
   const setDiffPanelTab = useSetAtom(agentDiffPanelTabAtom)
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
@@ -891,14 +893,16 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setPreviewPanelOpen(deleteKey)
     setPreviewFile(deleteKey)
     setPreviewFiles(deleteKey)
-    setPreviewContentRefreshVersion((prev) => {
+    const deletePreviewSessionEntries = <T,>(prev: Map<string, T>): Map<string, T> => {
       const prefix = `${id}\u0000`
       const keys = [...prev.keys()].filter((key) => key.startsWith(prefix))
       if (keys.length === 0) return prev
       const next = new Map(prev)
       for (const key of keys) next.delete(key)
       return next
-    })
+    }
+    setPreviewContentRefreshVersion(deletePreviewSessionEntries)
+    setPreviewResolvedPaths(deletePreviewSessionEntries)
     setAgentSideChatMap((prev) => {
       let changed = false
       const map = new Map(prev)
@@ -973,7 +977,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     sessionExistsAtom.remove(id)
 
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setPreviewFiles, setPreviewContentRefreshVersion, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setPreviewFiles, setPreviewContentRefreshVersion, setPreviewResolvedPaths, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { ChevronRight, Code2, Copy, Check, Eye, FolderOpen, List, Pencil, RotateCw, Save, WrapText, X } from 'lucide-react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
 import { toast } from 'sonner'
@@ -23,7 +23,12 @@ import {
   getExplorationSidePanelTab,
 } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
-import { previewCodeWrapAtom, quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import {
+  getPreviewContentRefreshKey,
+  previewCodeWrapAtom,
+  previewContentRefreshVersionAtom,
+  quotedSelectionMapAtom,
+} from '@/atoms/preview-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
 import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { useShortcut } from '@/hooks/useShortcut'
@@ -81,8 +86,8 @@ const FILE_FIND_SHORTCUT_OPTIONS = { exclusive: true }
  * 简易 LRU 缓存：保留最近访问的 N 个 entries。
  * key 设计：
  * - diff 模式：`${sessionId}:diff:${filePath}@v${refreshVersion}:${scope}`
- * - preview 模式：`${sessionId}:preview:${filePath}@v${refreshVersion}:${scope}`
- * refreshVersion 变化时（agent 写文件、git 突变）key 自然变化，
+ * - preview 模式：`${sessionId}:preview:${filePath}@v${previewContentVersion}:${scope}`
+ * Diff 使用会话级版本；纯预览使用文件级版本，只在当前文件实际变化时失效。
  * 老 entry 不会被命中，最终被 LRU 淘汰；无需主动失效。
  */
 type CacheEntry = {
@@ -363,10 +368,21 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [findOpen, setFindOpen] = React.useState(false)
   const [loading, setLoading] = React.useState(true)
   const [copied, setCopied] = React.useState(false)
-  const refreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
   const setRefreshVersionMap = useSetAtom(agentDiffRefreshVersionAtom)
-  const refreshVersion = refreshVersionMap.get(sessionId) ?? 0
-  const previewContentVersion = previewOnly ? refreshVersion : 0
+  const setPreviewContentRefreshVersionMap = useSetAtom(previewContentRefreshVersionAtom)
+  const previewContentRefreshKey = React.useMemo(
+    () => getPreviewContentRefreshKey(sessionId, { filePath, previewOnly, gitRoot, baseRef }),
+    [baseRef, filePath, gitRoot, previewOnly, sessionId],
+  )
+  // 预览不能订阅会话级 diff 版本：Agent 写入任意其他文件时该版本会变化。
+  // 用派生 atom 只订阅当前模式实际使用的版本，避免无关写入触发整个 Markdown 预览重渲染。
+  const contentRefreshVersionAtom = React.useMemo(() => atom((get) => {
+    if (previewOnly) return get(previewContentRefreshVersionAtom).get(previewContentRefreshKey) ?? 0
+    return get(agentDiffRefreshVersionAtom).get(sessionId) ?? 0
+  }), [previewContentRefreshKey, previewOnly, sessionId])
+  const contentRefreshVersion = useAtomValue(contentRefreshVersionAtom)
+  const refreshVersion = previewOnly ? 0 : contentRefreshVersion
+  const previewContentVersion = previewOnly ? contentRefreshVersion : 0
   const theme = useAtomValue(resolvedThemeAtom)
   const [codeWrap, setCodeWrap] = useAtom(previewCodeWrapAtom)
   const [tocOpen, setTocOpen] = useAtom(markdownTocOpenAtom)
@@ -782,7 +798,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   }, [updateMarkdownEditorViewState])
 
   // 主加载 effect：上下文变化（filePath/dirPath/gitRoot/previewOnly）时触发；
-  // 纯预览模式也跟随 refreshVersion 失效，保证同一文件二次写入后重新读盘。
+  // 纯预览仅在该文件收到 watcher 事件、焦点校验变化或手动刷新时重新读盘。
   // 命中缓存时跳过 loading 闪烁直接渲染；未命中走 IPC 拉取
   React.useEffect(() => {
     let cancelled = false
@@ -1259,10 +1275,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         lastOldContentRef.current = ''
         setOldContent('')
         setNewContent(draft)
-        cacheSet(getContentCacheKey('preview', refreshVersion + 1), { oldContent: '', newContent: draft })
-        setRefreshVersionMap((prev) => {
+        const nextPreviewContentVersion = previewContentVersion + 1
+        cacheSet(getContentCacheKey('preview', nextPreviewContentVersion), { oldContent: '', newContent: draft })
+        setPreviewContentRefreshVersionMap((prev) => {
           const m = new Map(prev)
-          m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
+          m.set(previewContentRefreshKey, nextPreviewContentVersion)
           return m
         })
         setAutosaveStatus('saved')
@@ -1275,7 +1292,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
 
     return enqueueMarkdownEditorSave(targetSessionId, editorCacheKey, run)
-  }, [componentMountedRef, getContentCacheKey, markdownEditorCacheKey, ownerGeneration, persistMarkdownEditorViewState, refreshVersion, sessionId, setRefreshVersionMap])
+  }, [componentMountedRef, getContentCacheKey, markdownEditorCacheKey, ownerGeneration, persistMarkdownEditorViewState, previewContentRefreshKey, previewContentVersion, setPreviewContentRefreshVersionMap, sessionId])
 
 
   const saveMarkdownEdit = React.useCallback(async () => {
@@ -1320,12 +1337,21 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   }, [isEditableText, markdownSourceMode, persistMarkdownEditorViewState, readOnly])
 
   const handleManualRefresh = React.useCallback(() => {
+    if (previewOnly) {
+      setPreviewContentRefreshVersionMap((prev) => {
+        const m = new Map(prev)
+        m.set(previewContentRefreshKey, (prev.get(previewContentRefreshKey) ?? 0) + 1)
+        return m
+      })
+      return
+    }
+
     setRefreshVersionMap((prev) => {
       const m = new Map(prev)
       m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
       return m
     })
-  }, [sessionId, setRefreshVersionMap])
+  }, [previewContentRefreshKey, previewOnly, sessionId, setPreviewContentRefreshVersionMap, setRefreshVersionMap])
 
   const handleAddSelectionToAgent = React.useCallback(() => {
     if (!previewSelection) return

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -27,6 +27,7 @@ import {
   getPreviewContentRefreshKey,
   previewCodeWrapAtom,
   previewContentRefreshVersionAtom,
+  previewResolvedPathAtom,
   quotedSelectionMapAtom,
 } from '@/atoms/preview-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
@@ -370,6 +371,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [copied, setCopied] = React.useState(false)
   const setRefreshVersionMap = useSetAtom(agentDiffRefreshVersionAtom)
   const setPreviewContentRefreshVersionMap = useSetAtom(previewContentRefreshVersionAtom)
+  const setPreviewResolvedPaths = useSetAtom(previewResolvedPathAtom)
   const previewContentRefreshKey = React.useMemo(
     () => getPreviewContentRefreshKey(sessionId, { filePath, previewOnly, gitRoot, baseRef }),
     [baseRef, filePath, gitRoot, previewOnly, sessionId],
@@ -916,6 +918,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             }
             const result = await window.electronAPI.resolveAndReadFile(filePath, fileAccess)
             if (cancelled) return
+            if (result?.resolvedPath) {
+              setPreviewResolvedPaths((previous) => {
+                if (previous.get(previewContentRefreshKey) === result.resolvedPath) return previous
+                const next = new Map(previous)
+                next.set(previewContentRefreshKey, result.resolvedPath)
+                return next
+              })
+            }
             if (result?.isBinary || result?.isTooLarge) {
               const reason = result.isTooLarge
                 ? '此文本文件超过 5 MB，无法安全进行内联预览，请使用默认应用打开。'
@@ -968,7 +978,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     load()
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, fileAccess, isPdf, isOfficePreview, isLegacyOffice, isImage, isHtml, sessionId, ext, getContentCacheKey])
+  }, [filePath, dirPath, gitRoot, previewOnly, previewContentRefreshKey, previewContentVersion, fileAccess, isPdf, isOfficePreview, isLegacyOffice, isImage, isHtml, sessionId, ext, getContentCacheKey, setPreviewResolvedPaths])
 
   // refreshVersion 触发的静默刷新：仅 diff 模式、内容有变化时才更新 state
   const prevRefreshRef = React.useRef(-1)

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -871,6 +871,16 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
 
     async function load() {
+      const recordResolvedPreviewPath = (resolvedPath: string | undefined): void => {
+        if (!previewOnly || !resolvedPath) return
+        setPreviewResolvedPaths((previous) => {
+          if (previous.get(previewContentRefreshKey) === resolvedPath) return previous
+          const next = new Map(previous)
+          next.set(previewContentRefreshKey, resolvedPath)
+          return next
+        })
+      }
+
       try {
         let content = cached?.newContent ?? ''
         let old = cached?.oldContent ?? ''
@@ -879,6 +889,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         if (!cached) {
           // 即使从「改动」列表点开，XLSX/PPTX 也应保留原有的 Office 内联预览。
           if (isOfficePreview) {
+            if (previewOnly) {
+              const resolvedPreview = await window.electronAPI.resolveAndReadFile(filePath, fileAccess)
+              if (cancelled) return
+              recordResolvedPreviewPath(resolvedPreview?.resolvedPath)
+            }
             const result = await window.electronAPI.officeToHtml(filePath, fileAccess)
             if (cancelled) return
             const html = DOMPurify.sanitize(result?.html ?? '')
@@ -891,6 +906,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             return
           }
           if (previewOnly) {
+            // 所有纯预览类型先记录主进程实际解析到的路径。相对路径的多个候选根
+            // 中只有这个路径能使 watcher 刷新当前正在展示的文件。
+            const resolvedPreview = await window.electronAPI.resolveAndReadFile(filePath, fileAccess)
+            if (cancelled) return
+            recordResolvedPreviewPath(resolvedPreview?.resolvedPath)
+
             if (isPdf) {
               const result = await window.electronAPI.preparePdfPreview(filePath, fileAccess)
               if (cancelled) return
@@ -916,16 +937,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             if (isLegacyOffice) {
               return
             }
-            const result = await window.electronAPI.resolveAndReadFile(filePath, fileAccess)
-            if (cancelled) return
-            if (result?.resolvedPath) {
-              setPreviewResolvedPaths((previous) => {
-                if (previous.get(previewContentRefreshKey) === result.resolvedPath) return previous
-                const next = new Map(previous)
-                next.set(previewContentRefreshKey, result.resolvedPath)
-                return next
-              })
-            }
+            const result = resolvedPreview
             if (result?.isBinary || result?.isTooLarge) {
               const reason = result.isTooLarge
                 ? '此文本文件超过 5 MB，无法安全进行内联预览，请使用默认应用打开。'

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -13,7 +13,7 @@ interface PreviewPanelProps {
   onClose: () => void
 }
 
-export function PreviewPanel({ sessionId, file, onClose }: PreviewPanelProps): React.ReactElement {
+function PreviewPanelContent({ sessionId, file, onClose }: PreviewPanelProps): React.ReactElement {
   const sessionPath = useAtomValue(agentSessionPathMapAtom).get(sessionId) ?? ''
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-content-area titlebar-no-drag">
@@ -38,3 +38,10 @@ export function PreviewPanel({ sessionId, file, onClose }: PreviewPanelProps): R
     </div>
   )
 }
+
+/** Pure file previews only re-render when their own file descriptor changes. */
+export const PreviewPanel = React.memo(PreviewPanelContent, (previous, next) => {
+  if (previous.sessionId !== next.sessionId || previous.file !== next.file) return false
+  // previewOnly never calls onEmptyDiff, so its parent callback must not defeat render isolation.
+  return previous.file.previewOnly || previous.onClose === next.onClose
+})

--- a/apps/electron/src/renderer/components/diff/preview-open-path.ts
+++ b/apps/electron/src/renderer/components/diff/preview-open-path.ts
@@ -1,5 +1,6 @@
 import type { FileAccessOptions } from '@proma/shared'
 import type { PreviewFile } from '@/atoms/preview-atoms'
+import { arePathsEqual } from '@/lib/session-file-changes'
 
 export function isAbsoluteFilePath(filePath: string): boolean {
   return filePath.startsWith('/') || filePath.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(filePath)
@@ -32,6 +33,31 @@ export function getPreviewCandidateBasePaths(
   ...contextPaths: Array<string | null | undefined>
 ): string[] {
   return uniqueTruthyPaths([...(basePaths ?? []), ...contextPaths])
+}
+
+/** Returns every absolute candidate represented by a preview file descriptor. */
+export function getPreviewFileCandidatePaths(file: PreviewFile, sessionPath?: string): string[] {
+  if (isAbsoluteFilePath(file.filePath)) return [file.filePath]
+
+  return getPreviewCandidateBasePaths(
+    file.basePaths,
+    file.gitRoot,
+    file.dirPath,
+    sessionPath,
+  ).map((basePath) => joinFilePath(basePath, file.filePath))
+}
+
+/** Whether a workspace watcher event modifies the file represented by this preview. */
+export function doesWorkspaceChangeAffectPreview(
+  file: PreviewFile,
+  changedPaths: readonly string[],
+  sessionPath?: string,
+  caseInsensitive = false,
+): boolean {
+  const candidatePaths = getPreviewFileCandidatePaths(file, sessionPath)
+  return candidatePaths.some((candidatePath) => (
+    changedPaths.some((changedPath) => arePathsEqual(candidatePath, changedPath, caseInsensitive))
+  ))
 }
 
 /**

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -68,7 +68,13 @@ import { tabsAtom, activeTabIdAtom, activeSessionIdAtom, openTab, updateTabTitle
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
-import { previewFileMapAtom } from '@/atoms/preview-atoms'
+import {
+  getPreviewContentRefreshKey,
+  previewContentRefreshVersionAtom,
+  previewFileMapAtom,
+  previewFilesMapAtom,
+  type PreviewFile,
+} from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
 import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, AgentAssistantDelta, AgentAssistantDeltaPayload, SDKAssistantMessage, SDKMessage, SDKUserMessage, SDKSystemMessage, PromaEvent, AgentSessionMeta, ProviderType, SDKContentBlock, SDKUserContentBlock } from '@proma/shared'
@@ -86,6 +92,7 @@ import {
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { detectIsWindows } from '@/lib/platform'
 import { getSessionFileChangeKind, getOwnedSessionWatcherPaths, upsertSessionFileChange } from '@/lib/session-file-changes'
+import { doesWorkspaceChangeAffectPreview } from '@/components/diff/preview-open-path'
 import { removeQueuedMessage, createQueuedAgentStreamState } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
 import { getChangedWorkspaceComponentFromSdkMessage, shouldRevealChangedWorkspaceComponentImmediately } from '@/lib/agent-component-activation'
@@ -860,8 +867,41 @@ export function useGlobalAgentListeners(): void {
     // startedAt 后仍需保留一个短生命周期的终态标记，避免迟到快照复活旧 run。
     const latestTerminalRunStartedAt = new Map<string, number>()
 
+    const bumpPreviewContentRefresh = (sessionId: string, file: PreviewFile): void => {
+      const key = getPreviewContentRefreshKey(sessionId, file)
+      store.set(previewContentRefreshVersionAtom, (previous) => {
+        const next = new Map(previous)
+        next.set(key, (previous.get(key) ?? 0) + 1)
+        return next
+      })
+    }
+
+    const refreshAffectedPreviews = (filePaths: readonly string[]): void => {
+      if (filePaths.length === 0) return
+      const previewsBySession = store.get(previewFilesMapAtom)
+      const sessionPaths = store.get(agentSessionPathMapAtom)
+      const affectedKeys = new Set<string>()
+
+      for (const [sessionId, previews] of previewsBySession) {
+        const sessionPath = sessionPaths.get(sessionId)
+        for (const preview of previews) {
+          if (!preview.previewOnly || !doesWorkspaceChangeAffectPreview(preview, filePaths, sessionPath, isWindows)) continue
+          affectedKeys.add(getPreviewContentRefreshKey(sessionId, preview))
+        }
+      }
+      if (affectedKeys.length === 0) return
+
+      // 单次 watcher 事件最多更新一次 atom，避免多个已打开预览导致连续渲染。
+      store.set(previewContentRefreshVersionAtom, (previous) => {
+        const next = new Map(previous)
+        for (const key of affectedKeys) next.set(key, (previous.get(key) ?? 0) + 1)
+        return next
+      })
+    }
+
     const cleanupWatchedFileChanges = window.electronAPI.onWorkspaceFilesChanged((changedPaths) => {
       const filePaths = (changedPaths ?? []).filter(isAbsolutePath)
+      refreshAffectedPreviews(filePaths)
       if (filePaths.length === 0) return
 
       void (async () => {
@@ -1750,7 +1790,6 @@ export function useGlobalAgentListeners(): void {
     const HASH_MAX = 100
     let focusCheckSeq = 0
     const bumpDiffRefresh = (sessionId: string) => {
-      // 外部修改的精确路径无法从 focus 事件可靠取得，保守地失效全部缓存。
       void window.electronAPI.invalidateGitDiffCache().finally(() => {
         store.set(agentDiffRefreshVersionAtom, (prev) => {
           const m = new Map(prev)
@@ -1797,6 +1836,7 @@ export function useGlobalAgentListeners(): void {
         if (prevHash === undefined || prevHash !== hash) {
           // 首次建立 hash 基准时也刷新一次，避免用户离开窗口后首次外部修改被吞掉。
           bumpDiffRefresh(activeSessionId)
+          bumpPreviewContentRefresh(activeSessionId, previewFile)
         }
         fileContentHashMap.set(hashKey, hash)
 
@@ -1809,6 +1849,7 @@ export function useGlobalAgentListeners(): void {
         // 读取失败时删除旧 hash，并触发一次刷新让预览进入真实失败/空状态。
         fileContentHashMap.delete(hashKey)
         bumpDiffRefresh(activeSessionId)
+        bumpPreviewContentRefresh(activeSessionId, previewFile)
       }
     }
     window.addEventListener('focus', onWindowFocus)

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -71,6 +71,7 @@ import { channelsAtom } from '@/atoms/chat-atoms'
 import {
   getPreviewContentRefreshKey,
   previewContentRefreshVersionAtom,
+  previewResolvedPathAtom,
   previewFileMapAtom,
   previewFilesMapAtom,
   type PreviewFile,
@@ -105,7 +106,7 @@ const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Upda
 const GIT_MUTATING_SUBCOMMANDS = /\bgit\s+(commit|checkout|reset|restore|stash|clean|add|rm|mv|pull|merge|rebase|cherry-pick|revert|switch|am|apply)\b/
 
 function isAbsolutePath(path: string): boolean {
-  return path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)
+  return path.startsWith('/') || path.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(path)
 }
 
 function getParentDir(path: string): string {
@@ -880,13 +881,18 @@ export function useGlobalAgentListeners(): void {
       if (filePaths.length === 0) return
       const previewsBySession = store.get(previewFilesMapAtom)
       const sessionPaths = store.get(agentSessionPathMapAtom)
+      const resolvedPaths = store.get(previewResolvedPathAtom)
       const affectedKeys = new Set<string>()
 
       for (const [sessionId, previews] of previewsBySession) {
         const sessionPath = sessionPaths.get(sessionId)
         for (const preview of previews) {
-          if (!preview.previewOnly || !doesWorkspaceChangeAffectPreview(preview, filePaths, sessionPath, isWindows)) continue
-          affectedKeys.add(getPreviewContentRefreshKey(sessionId, preview))
+          if (!preview.previewOnly) continue
+          const key = getPreviewContentRefreshKey(sessionId, preview)
+          const resolvedPath = resolvedPaths.get(key)
+          const fileForMatch = resolvedPath ? { ...preview, filePath: resolvedPath } : preview
+          if (!doesWorkspaceChangeAffectPreview(fileForMatch, filePaths, sessionPath, isWindows)) continue
+          affectedKeys.add(key)
         }
       }
       if (affectedKeys.length === 0) return
@@ -940,6 +946,9 @@ export function useGlobalAgentListeners(): void {
           const runId = store.get(agentFileChangesCurrentRunAtom).get(sessionId)
             ?? String(streamingStates.get(sessionId)?.startedAt ?? Date.now())
           for (const changedPath of uniquelyMatchingPaths) {
+            // watcher 现在也会携带删除/目录路径；这些不应进入会话的文件改动记录。
+            const existingFile = await window.electronAPI.resolveAndReadFile(changedPath, { sessionId, unrestricted: true })
+            if (!existingFile) continue
             const previewFile = await buildWrittenFilePreviewInfo(sessionId, changedPath)
             if (previewFile.previewOnly) {
               store.set(agentNonGitFileChangesAtom, (prev) => {


### PR DESCRIPTION
## Summary
- Scope pure file-preview invalidation to the changed preview path.
- Keep diff refreshes session-scoped without re-rendering unrelated Markdown previews.
- Preserve manual refresh, focused-window checks, and cleanup when previews or sessions close.

## Validation
- `git diff --check`
- Bun syntax bundles for the changed renderer entry points
- Full typecheck could not run because local `node_modules/@proma/shared` points to an unrelated stale worktree.

## Performance
- Workspace watcher events now only advance versions for matching open previews.
- The preview renderer subscribes to its file-level version rather than the high-frequency session-level diff version.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)