### PR TITLE
feat: open project folders in embedded terminal

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -1644,7 +1644,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                     本地项目根目录不可用；当前会话文件仍可访问。
                   </div>
                 )}
-                <FileBrowser roots={visibleFileRoots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasVisibleSessionAttachedItems || hasVisibleWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+                <FileBrowser roots={visibleFileRoots} access={fileAccess} projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath} showSessionBadge={false} hideToolbar embedded hideEmpty={hasVisibleSessionAttachedItems || hasVisibleWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} onOpenDirectoryTerminal={handleOpenDirectoryTerminal} />
                 {showSessionFiles && workspaceSlug && (
                   <FileDropZone workspaceSlug={workspaceSlug} sessionId={sessionId} target="session" onFilesUploaded={handleFilesUploaded} onFilesAttached={handleSessionFilesAttached} onAttachFolder={handleAttachSessionFolder} onFoldersDropped={handleSessionFoldersDropped} />
                 )}

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -266,10 +266,14 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
     window.electronAPI.showInFolder(entry.path, access).catch(console.error)
   }, [access])
 
-  /** 在系统终端中打开文件夹 */
+  /** 优先在右侧工作区中以文件夹路径为 cwd 打开终端，独立使用时回退到系统终端。 */
   const handleOpenInTerminal = React.useCallback((entry: FileEntry) => {
+    if (onOpenDirectoryTerminal) {
+      onOpenDirectoryTerminal(entry.path, entry.name)
+      return
+    }
     window.electronAPI.openFolderInTerminal(entry.path, access).catch(console.error)
-  }, [access])
+  }, [access, onOpenDirectoryTerminal])
 
   /** 开始重命名 */
   const handleStartRename = React.useCallback((entry: FileEntry) => {
@@ -577,7 +581,8 @@ function FileTreeItem({
   const [children, setChildren] = React.useState<ScopedFileEntry[]>([])
   const [childrenLoaded, setChildrenLoaded] = React.useState(false)
   const rowRef = React.useRef<HTMLDivElement>(null)
-  const supportsTerminalFolderOpen = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+  const supportsTerminalFolderOpen = Boolean(onOpenDirectoryTerminal)
+    || (typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac'))
 
   // 从其他工作区 Tab 返回时，已展开的目录会重新挂载；补载其子项以恢复原来的树形视图。
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

- 项目文件夹菜单改为在右侧内嵌终端打开。
- 将所选文件夹路径作为终端 cwd 传入。

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)