### PR TITLE
fix: render managed browser favicons

### DIFF
--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -72,6 +72,8 @@ type BrowserTabRecord = {
   popupInitialNavigationPending: boolean
   /** 用于在超限时优先回收最久未使用的 Agent 标签。 */
   lastActivityAt: number
+  /** 页面声明的 HTTP(S) favicon；仅用于 renderer 标签图标。 */
+  favicon: string | null
   highlightTimer?: ReturnType<typeof setTimeout>
   lastBounds?: BrowserViewLayout['bounds']
   /** 仅记录当前实际挂载的 owner；隐藏时 detach，但保留 WebContents 及页面状态。 */
@@ -292,6 +294,7 @@ export class BrowserController {
         tabId: tab.tabId,
         url: tab.state.url,
         title: tab.state.title,
+        ...(tab.favicon ? { favicon: tab.favicon } : {}),
         loading: tab.state.loading,
         openedByAgent: tab.openedByAgent,
         openedByPopup: tab.openedByPopup,
@@ -616,6 +619,7 @@ export class BrowserController {
       popupInitialUrl,
       popupInitialNavigationPending: popupInitialUrl !== null && isTransientBrowserPopupUrl(popupInitialUrl),
       lastActivityAt: Date.now(),
+      favicon: null,
       attachedOwner: null,
     }
     view.setVisible(false)
@@ -671,10 +675,32 @@ export class BrowserController {
       this.emit(browserSession)
       this.emitFocusedTab(browserSession, tab)
     })
-    view.webContents.on('did-start-loading', () => { this.invalidateTabDocument(tab); this.updateNavigationState(browserSession, tab) })
+    view.webContents.on('did-start-loading', () => {
+      // 加载状态会因子资源再次开始，不能在此清 favicon，否则已获取的页面图标会被覆盖回默认图标。
+      this.invalidateTabDocument(tab)
+      this.updateNavigationState(browserSession, tab)
+    })
+    view.webContents.on('page-favicon-updated', (_event, faviconUrls: string[]) => {
+      // favicon URL 来自不可信页面，renderer 仅允许加载普通 HTTP(S) 图片，避免 data/blob 等任意 scheme。
+      tab.favicon = faviconUrls.find((faviconUrl) => {
+        try {
+          const protocol = new URL(faviconUrl).protocol
+          return protocol === 'https:' || protocol === 'http:'
+        } catch {
+          return false
+        }
+      }) ?? null
+      this.emit(browserSession)
+    })
     view.webContents.on('did-stop-loading', () => this.updateNavigationState(browserSession, tab))
     view.webContents.on('page-title-updated', () => this.updateNavigationState(browserSession, tab))
-    view.webContents.on('did-navigate', () => { tab.popupInitialNavigationPending = false; this.invalidateTabDocument(tab); this.updateNavigationState(browserSession, tab) })
+    view.webContents.on('did-navigate', () => {
+      // 只在主框架真正完成跨文档导航时清理旧站点图标；新页面随后会通过 page-favicon-updated 重新发布。
+      tab.favicon = null
+      tab.popupInitialNavigationPending = false
+      this.invalidateTabDocument(tab)
+      this.updateNavigationState(browserSession, tab)
+    })
     view.webContents.on('did-navigate-in-page', () => { tab.popupInitialNavigationPending = false; this.invalidateTabDocument(tab); this.updateNavigationState(browserSession, tab) })
     view.webContents.on('destroyed', () => {
       if (!browserSession.tabs.has(tab.tabId)) return

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -123,6 +123,14 @@ import {
 } from '@/lib/right-workspace-split'
 import type { RightWorkspacePane, RightWorkspaceSplitState } from '@/lib/right-workspace-split'
 
+function BrowserTabIcon({ favicon }: { favicon?: string }): React.ReactElement {
+  const [loadFailed, setLoadFailed] = React.useState(false)
+  React.useEffect(() => setLoadFailed(false), [favicon])
+
+  if (!favicon || loadFailed) return <Globe className="size-3.5" />
+  return <img src={favicon} alt="" aria-hidden="true" referrerPolicy="no-referrer" className="size-3.5 shrink-0 rounded-sm object-contain" onError={() => setLoadFailed(true)} />
+}
+
 function MeasuredWorkspacePane({ children }: { children: (width: number) => React.ReactNode }): React.ReactElement {
   const ref = React.useRef<HTMLDivElement>(null)
   const [width, setWidth] = React.useState<number | null>(null)
@@ -1266,7 +1274,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     ...(browserState?.tabs.map((tab) => ({
       id: getBrowserSidePanelTab(tab.tabId),
       label: tab.title || '新建标签页',
-      icon: <Globe className="size-3.5" />,
+      icon: <BrowserTabIcon favicon={tab.favicon} />,
       // 用户可关闭任何浏览器标签；关闭 Agent 工作标签后，后续未指定 tabId 的工具会提示新建或选择工作标签。
       closable: true,
       activity: showBrowserActivity && activeBrowserTabId !== tab.tabId && browserState.activeTabId === tab.tabId,

--- a/packages/shared/src/types/browser.ts
+++ b/packages/shared/src/types/browser.ts
@@ -52,6 +52,8 @@ export interface BrowserTabSummary {
   tabId: string
   url: string
   title: string
+  /** 页面声明的 HTTP(S) favicon；未提供或加载失败时 renderer 使用默认图标。 */
+  favicon?: string
   loading: boolean
   /** 此标签由 Agent 创建（与当前默认工作标签无关）。 */
   openedByAgent: boolean


### PR DESCRIPTION
## Summary
- Surface page-provided HTTP(S) favicons in managed browser tabs.
- Preserve a favicon through subresource loading; clear it only on cross-document navigation.
- Keep the Globe icon when no favicon is available or its image fails to load.

## Validation
- `bun run --filter="@proma/electron" build:main`
- `bun run --filter="@proma/electron" build:renderer`
- `git diff --check`
- Full `bun run typecheck` remains blocked by the existing `Set.length` error in `useGlobalAgentListeners.ts:898` on `main`.

## Performance
- Low risk: favicon events occur only during page navigation, update only the affected browser tab summary, and add no timers, listeners beyond the WebContents lifecycle handler, or IPC polling.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)