### PR TITLE
feat(markdown): adopt LiveMarkdown across project memory

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -5,8 +5,6 @@
  */
 
 import * as React from 'react'
-import Markdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { toast } from 'sonner'
 import { Sparkles, Pencil, Save, X, FolderOpen, RefreshCw, Trash2, ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -15,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { SettingsCard } from '@/components/settings/primitives'
 import { SkillFilesPanel } from '@/components/settings/SkillFilesPanel'
+import { LiveMarkdownEditor } from '@/components/markdown/LiveMarkdownEditor'
 import { cn } from '@/lib/utils'
 import type { SkillMeta } from '@proma/shared'
 import { extractSkillBody, rebuildSkillMd } from './skillMdUtils'
@@ -48,7 +47,6 @@ export function SkillDetailView({
   const [loadingContent, setLoadingContent] = React.useState(true)
 
   const [isEditingMeta, setIsEditingMeta] = React.useState(false)
-  const [isEditingBody, setIsEditingBody] = React.useState(false)
   const [editName, setEditName] = React.useState('')
   const [editDescription, setEditDescription] = React.useState('')
   const [editBody, setEditBody] = React.useState('')
@@ -60,7 +58,10 @@ export function SkillDetailView({
   React.useEffect(() => {
     setLoadingContent(true)
     window.electronAPI.readSkillContent(workspaceSlug, skill.slug)
-      .then((text) => setContent(text))
+      .then((text) => {
+        setContent(text)
+        setEditBody(extractSkillBody(text))
+      })
       .catch((err) => {
         console.error('[SkillDetail] 加载内容失败:', err)
         setContent(null)
@@ -101,7 +102,6 @@ export function SkillDetailView({
       const newContent = rebuildSkillMd(content, { body: editBody })
       await window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, newContent)
       setContent(newContent)
-      setIsEditingBody(false)
       onChanged()
       toast.success('说明已保存')
     } catch (err) {
@@ -253,44 +253,22 @@ export function SkillDetailView({
               <div className="flex flex-col">
                 <div className="flex min-h-[28px] shrink-0 items-center justify-between px-1 pb-2">
                   <div className="font-mono text-xs text-muted-foreground">SKILL.md</div>
-                  {!isEditingBody ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => { setEditBody(body); setIsEditingBody(true) }}
-                          className="flex items-center gap-1 rounded p-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                        >
-                          <Pencil size={14} />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top">编辑</TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <div className="flex items-center gap-1">
-                      <Button size="sm" variant="ghost" onClick={() => setIsEditingBody(false)} disabled={saving}>
-                        <X size={14} /> 取消
-                      </Button>
-                      <Button size="sm" onClick={() => void saveBody()} disabled={saving}>
-                        <Save size={14} /> {saving ? '保存中...' : '保存'}
-                      </Button>
-                    </div>
-                  )}
+                  <Button
+                    size="sm"
+                    onClick={() => void saveBody()}
+                    disabled={saving || !content || editBody === body}
+                  >
+                    <Save size={14} /> {saving ? '保存中...' : '保存'}
+                  </Button>
                 </div>
                 <SettingsCard divided={false}>
                   <div className="p-4">
-                    {isEditingBody ? (
-                      <textarea
-                        value={editBody}
-                        onChange={(e) => setEditBody(e.target.value)}
-                        className="min-h-[420px] w-full resize-y rounded-md border border-border bg-transparent p-3 font-mono text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                        placeholder="输入 Skill 说明内容（支持 Markdown）..."
-                      />
-                    ) : (
-                      <div className="prose prose-sm dark:prose-invert max-w-none">
-                        <Markdown remarkPlugins={[remarkGfm]}>{body || '暂无说明内容'}</Markdown>
-                      </div>
-                    )}
+                    <LiveMarkdownEditor
+                      value={editBody}
+                      onChange={setEditBody}
+                      onSave={() => { void saveBody() }}
+                      className="live-markdown-external-scroll skill-detail-live-markdown"
+                    />
                   </div>
                 </SettingsCard>
               </div>

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryTab.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryTab.tsx
@@ -1,20 +1,19 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import { AlertTriangle, Brain, ChevronDown, ChevronRight, Code2, Eye, FileText, FolderOpen, Loader2, RefreshCw, Save, Sparkles } from 'lucide-react'
+import { AlertTriangle, Brain, ChevronDown, ChevronRight, FileText, FolderOpen, RefreshCw, Sparkles } from 'lucide-react'
 import type { SkillFileNode, WorkspaceMemorySummary } from '@proma/shared'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { SettingsCard } from '@/components/settings/primitives'
-import { DefaultAppOpenButton } from '@/components/diff/DefaultAppOpenButton'
 import { AgentActionHint } from '@/components/agent/AgentActionHint'
 import { WorkspaceMemoryChangeShelf } from './WorkspaceMemoryChangeShelf'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { MessageResponse } from '@/components/ai-elements/message'
 import { agentPendingPromptAtom } from '@/atoms/agent-atoms'
 import { memoryFileNavigationAtom, workspaceMemoryChangesAtom } from '@/atoms/memory-change-atoms'
 import { useCreateSession } from '@/hooks/useCreateSession'
 import { cn } from '@/lib/utils'
+import { LiveMarkdownEditor } from '@/components/markdown/LiveMarkdownEditor'
 import {
   buildWorkspaceKnowledgeBootstrapPrompt,
   buildWorkspaceSessionEvidencePrompt,
@@ -51,11 +50,6 @@ function autoMemoryPath(summary: WorkspaceMemorySummary, relativePath: string): 
   return `${trimmedDir}${sep}${normalizedRelative}`
 }
 
-/** 取绝对路径的父目录，兼容 / 与 \ 两种分隔符 */
-function dirnameOf(absolutePath: string): string {
-  const idx = Math.max(absolutePath.lastIndexOf('/'), absolutePath.lastIndexOf('\\'))
-  return idx < 0 ? absolutePath : absolutePath.slice(0, idx)
-}
 
 function filterNodes(nodes: SkillFileNode[], query: string, contentMatchPaths = new Set<string>()): SkillFileNode[] {
   const q = query.trim().toLowerCase()
@@ -93,10 +87,8 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
   const [saveConflict, setSaveConflict] = React.useState(false)
   const [loading, setLoading] = React.useState(true)
   const [loadingFile, setLoadingFile] = React.useState(false)
-  const [saving, setSaving] = React.useState(false)
   const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
   const [isDirty, setIsDirty] = React.useState(false)
-  const [viewMode, setViewMode] = React.useState<'preview' | 'edit'>('preview')
   const [bootstrapping, setBootstrapping] = React.useState(false)
   const [scanningHistory, setScanningHistory] = React.useState(false)
   const [historyRange, setHistoryRange] = React.useState<MemoryHistoryRange>('1m')
@@ -154,11 +146,9 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
 
   /**
    * 把待保存的脏内容立即刷盘（静默，失败才提示）。
-   * showSaving=true 时（防抖自动保存路径）在保存按钮上展示 loading 动画并保证最短可见时长；
-   * 切换文件/刷新/卸载前的 flush 传 false，保持即时不拖慢手感。
+   * 切换文件、刷新、卸载和 Cmd/Ctrl+S 都复用本入口，确保写入顺序一致。
    */
-  const flushPendingSave = React.useCallback(async (opts?: { showSaving?: boolean }): Promise<void> => {
-    const showSaving = opts?.showSaving ?? false
+  const flushPendingSave = React.useCallback(async (): Promise<void> => {
     if (autoSaveTimerRef.current) {
       clearTimeout(autoSaveTimerRef.current)
       autoSaveTimerRef.current = null
@@ -169,9 +159,6 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
     const { selected: curSelected, editText: curText, editBaseText: curBaseText, isDirty: curDirty, saveConflict: curSaveConflict } = saveStateRef.current
     if (!curSelected || !curDirty || curSaveConflict) return
     setIsDirty(false)
-    if (showSaving) setSaving(true)
-    // 写入通常很快，saving 一闪而过看不到动画；自动保存时保证"保存中"至少显示一小段时间
-    const startedAt = performance.now()
     try {
       const p = persistTarget(curSelected, curText, curBaseText)
       persistInFlightRef.current = p
@@ -184,14 +171,6 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
       setIsDirty(true)
     } finally {
       persistInFlightRef.current = null
-      if (showSaving) {
-        const elapsed = performance.now() - startedAt
-        const MIN_SAVING_MS = 450
-        if (elapsed < MIN_SAVING_MS) {
-          await new Promise((r) => setTimeout(r, MIN_SAVING_MS - elapsed))
-        }
-        setSaving(false)
-      }
     }
   }, [persistTarget])
 
@@ -261,7 +240,6 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
     }
     void (async () => {
       await openAutoFile(memoryNavigationRequest.relativePath)
-      setViewMode(memoryNavigationRequest.mode === 'edit' ? 'edit' : 'preview')
       setMemoryNavigationRequest(null)
     })()
   }, [memoryChanges, memoryNavigationRequest, openAutoFile, sessionId, setMemoryNavigationRequest, workspaceSlug])
@@ -334,12 +312,12 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
     return () => { cancelled = true }
   }, [workspaceSlug])
 
-  // 防抖自动保存：编辑内容变脏后 800ms 内无新输入则自动保存（按钮显示 loading 动画）
+  // 防抖自动保存：编辑内容变脏后 800ms 内无新输入则自动保存。
   React.useEffect(() => {
     if (!selected || !isDirty || loadingFile) return
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current)
     autoSaveTimerRef.current = setTimeout(() => {
-      void flushPendingSave({ showSaving: true })
+      void flushPendingSave()
     }, 800)
     return () => {
       if (autoSaveTimerRef.current) {
@@ -356,27 +334,6 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
     }
   }, [flushPendingSave])
 
-  const handleSave = async (): Promise<void> => {
-    if (!selected || saveConflict) return
-    if (autoSaveTimerRef.current) {
-      clearTimeout(autoSaveTimerRef.current)
-      autoSaveTimerRef.current = null
-    }
-    setSaving(true)
-    try {
-      setIsDirty(false)
-      await persistTarget(selected, editText, editBaseText)
-      toast.success('记忆文件已保存')
-    } catch (err) {
-      console.error('[工作区记忆] 保存失败:', err)
-      const message = err instanceof Error ? err.message : '保存失败'
-      toast.error(message)
-      if (message.startsWith('文件已被外部更新')) setSaveConflict(true)
-      setIsDirty(true)
-    } finally {
-      setSaving(false)
-    }
-  }
 
   const startGuidedSession = async (message: string, kind: 'bootstrap' | 'history'): Promise<void> => {
     const setLoadingState = kind === 'bootstrap' ? setBootstrapping : setScanningHistory
@@ -466,10 +423,7 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
         changes={memoryChanges}
         onOpenFile={(change) => {
           setActiveChangeId(null)
-          void (async () => {
-            await openAutoFile(change.relativePath)
-            setViewMode('preview')
-          })()
+          void openAutoFile(change.relativePath)
         }}
         onBackToMemory={() => setActiveChangeId(null)}
         className="h-full min-h-0 overflow-auto bg-content-area p-3"
@@ -566,6 +520,7 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
                 label="AGENTS.md"
                 meta="Proma 工作区项目指令"
                 onClick={() => void openAgents(summary)}
+                onReveal={() => window.electronAPI.showItemInFolder(summary.agentsMd.path)}
               />
               <div className="mt-3 px-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
                 长期记忆
@@ -591,6 +546,7 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
                         })
                       }}
                       onOpen={(path) => void openAutoFile(path, summary)}
+                      onReveal={(path) => window.electronAPI.showItemInFolder(autoMemoryPath(summary, path))}
                     />
                   ))
                 )}
@@ -610,62 +566,7 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
                   {selected?.absolutePath ?? '从左侧选择一个记忆文件'}
                 </div>
               </div>
-              <div className="flex shrink-0 items-center gap-2">
-                {selected && (
-                  <div className="flex items-center gap-1 rounded-lg bg-muted p-0.5">
-                    <button
-                      type="button"
-                      onClick={() => setViewMode('preview')}
-                      className={cn(
-                        'flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors',
-                        viewMode === 'preview' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
-                      )}
-                    >
-                      <Eye size={13} />
-                      预览
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setViewMode('edit')}
-                      className={cn(
-                        'flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors',
-                        viewMode === 'edit' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
-                      )}
-                    >
-                      <Code2 size={13} />
-                      编辑
-                    </button>
-                  </div>
-                )}
-                {selected && (
-                  <DefaultAppOpenButton
-                    filePath={selected.absolutePath}
-                    variant="labeled"
-                    className="h-8 max-w-[170px] border border-border/60 bg-background px-2 shadow-sm"
-                  />
-                )}
-                {selected && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => window.electronAPI.showItemInFolder(selected.absolutePath)}
-                  >
-                    <FolderOpen size={14} className="mr-1.5" />
-                    打开文件夹
-                  </Button>
-                )}
-                {selected && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button size="sm" onClick={handleSave} disabled={!selected || saving || loadingFile || saveConflict}>
-                        {saving ? <Loader2 size={14} className="mr-1.5 animate-spin" /> : <Save size={14} className="mr-1.5" />}
-                        {saving ? '保存中...' : '保存'}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">编辑后会自动保存，也可点此立即保存</TooltipContent>
-                  </Tooltip>
-                )}
-              </div>
+
             </div>
             {saveConflict && (
               <div className="mx-4 mt-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
@@ -675,33 +576,18 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
             )}
             {loadingFile ? (
               <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">读取文件中...</div>
-            ) : selected && viewMode === 'edit' ? (
-              <textarea
-                value={editText}
-                onChange={(event) => {
-                  setIsDirty(true)
-                  setEditText(event.target.value)
-                }}
-                spellCheck={false}
-                className="min-h-0 flex-1 resize-none bg-transparent p-4 font-mono text-[13px] leading-6 text-foreground outline-none placeholder:text-muted-foreground"
-                placeholder={selected.kind === 'agents'
-                  ? '# 项目指令\n\n写下未来 Agent 必须知道的项目规范、命令和决策。'
-                  : '# MEMORY\n\n写下稳定、可复用的自动记忆索引。'}
-              />
             ) : selected ? (
-              <div className="min-h-0 flex-1 overflow-y-auto p-5">
-                {editText.trim() ? (
-                  <MessageResponse
-                    className="text-[14px] prose-headings:scroll-mt-4"
-                    basePath={dirnameOf(selected.absolutePath)}
-                  >
-                    {editText}
-                  </MessageResponse>
-                ) : (
-                  <div className="flex h-full min-h-[240px] items-center justify-center rounded-lg border border-dashed border-border/70 text-sm text-muted-foreground">
-                    当前文件为空，切换到编辑后可以写入 Markdown 内容。
-                  </div>
-                )}
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <LiveMarkdownEditor
+                  value={editText}
+                  onChange={(value) => {
+                    setIsDirty(true)
+                    setEditText(value)
+                  }}
+                  onSave={() => { void flushPendingSave() }}
+                  readOnly={saveConflict}
+                  className="live-markdown-external-scroll"
+                />
               </div>
             ) : (
               <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">从左侧选择一个记忆文件</div>
@@ -719,26 +605,43 @@ function FileButton({
   label,
   meta,
   onClick,
+  onReveal,
 }: {
   active: boolean
   icon: React.ReactNode
   label: string
   meta?: string
   onClick: () => void
+  onReveal: () => void
 }): React.ReactElement {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors',
-        active ? 'bg-accent text-accent-foreground' : 'text-foreground/80 hover:bg-accent/60',
-      )}
-    >
-      <span className="shrink-0 text-muted-foreground">{icon}</span>
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      {meta && <span className="truncate text-[11px] text-muted-foreground">{meta}</span>}
-    </button>
+    <div className="flex items-center gap-0.5">
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors',
+          active ? 'bg-accent text-accent-foreground' : 'text-foreground/80 hover:bg-accent/60',
+        )}
+      >
+        <span className="shrink-0 text-muted-foreground">{icon}</span>
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {meta && <span className="truncate text-[11px] text-muted-foreground">{meta}</span>}
+      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onReveal}
+            className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label={`打开 ${label} 所在位置`}
+          >
+            <FolderOpen size={13} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">打开文件所在位置</TooltipContent>
+      </Tooltip>
+    </div>
   )
 }
 
@@ -750,6 +653,7 @@ function MemoryTreeNode({
   contentMatches,
   onToggle,
   onOpen,
+  onReveal,
 }: {
   node: SkillFileNode
   level: number
@@ -758,6 +662,7 @@ function MemoryTreeNode({
   contentMatches: Map<string, string>
   onToggle: (path: string) => void
   onOpen: (path: string) => void
+  onReveal: (path: string) => void
 }): React.ReactElement {
   const isDirectory = node.type === 'directory'
   const isExpanded = expanded.has(node.relativePath)
@@ -767,28 +672,45 @@ function MemoryTreeNode({
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => isDirectory ? onToggle(node.relativePath) : onOpen(node.relativePath)}
-        className={cn(
-          'flex w-full items-center gap-1.5 rounded-md py-1.5 pr-2 text-left text-[13px] transition-colors',
-          isActive ? 'bg-accent text-accent-foreground' : 'text-foreground/80 hover:bg-accent/60',
+      <div className="flex items-center gap-0.5">
+        <button
+          type="button"
+          onClick={() => isDirectory ? onToggle(node.relativePath) : onOpen(node.relativePath)}
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-1.5 rounded-md py-1.5 pr-2 text-left text-[13px] transition-colors',
+            isActive ? 'bg-accent text-accent-foreground' : 'text-foreground/80 hover:bg-accent/60',
+          )}
+          style={{ paddingLeft }}
+        >
+          {isDirectory ? (
+            isExpanded ? <ChevronDown size={13} className="shrink-0 text-muted-foreground" /> : <ChevronRight size={13} className="shrink-0 text-muted-foreground" />
+          ) : (
+            <FileText size={13} className="shrink-0 text-muted-foreground" />
+          )}
+          <span className="min-w-0 flex-1 overflow-hidden">
+            <span className="block truncate">{node.name}</span>
+            {contentExcerpt && <span className="block truncate text-[10px] text-muted-foreground" title={contentExcerpt}>{contentExcerpt}</span>}
+          </span>
+          {!isDirectory && node.size != null && (
+            <span className="shrink-0 text-[10px] text-muted-foreground/75">{formatBytes(node.size)}</span>
+          )}
+        </button>
+        {!isDirectory && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => onReveal(node.relativePath)}
+                className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                aria-label={`打开 ${node.name} 所在位置`}
+              >
+                <FolderOpen size={13} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">打开文件所在位置</TooltipContent>
+          </Tooltip>
         )}
-        style={{ paddingLeft }}
-      >
-        {isDirectory ? (
-          isExpanded ? <ChevronDown size={13} className="shrink-0 text-muted-foreground" /> : <ChevronRight size={13} className="shrink-0 text-muted-foreground" />
-        ) : (
-          <FileText size={13} className="shrink-0 text-muted-foreground" />
-        )}
-        <span className="min-w-0 flex-1 overflow-hidden">
-          <span className="block truncate">{node.name}</span>
-          {contentExcerpt && <span className="block truncate text-[10px] text-muted-foreground" title={contentExcerpt}>{contentExcerpt}</span>}
-        </span>
-        {!isDirectory && node.size != null && (
-          <span className="shrink-0 text-[10px] text-muted-foreground/75">{formatBytes(node.size)}</span>
-        )}
-      </button>
+      </div>
       {isDirectory && isExpanded && node.children && (
         <div className="space-y-0.5">
           {node.children.map((child) => (
@@ -801,6 +723,7 @@ function MemoryTreeNode({
               contentMatches={contentMatches}
               onToggle={onToggle}
               onOpen={onOpen}
+              onReveal={onReveal}
             />
           ))}
         </div>

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -35,7 +35,7 @@ import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { useShortcut } from '@/hooks/useShortcut'
 import { initShortcutRegistry } from '@/lib/shortcut-registry'
 import { DiffView } from './DiffView'
-import { MarkdownRichEditor } from './MarkdownRichEditor'
+import { LiveMarkdownEditor } from '@/components/markdown/LiveMarkdownEditor'
 import { getPreviewCandidateBasePaths, isAbsoluteFilePath } from './preview-open-path'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
 import { UnsupportedFilePreview } from './UnsupportedFilePreview'
@@ -305,12 +305,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [newContent, setNewContent] = React.useState('')
   const [unsupportedPreviewReason, setUnsupportedPreviewReason] = React.useState('')
   const [previewMetadata, setPreviewMetadata] = React.useState<FilePreviewMetadata | undefined>()
+  // Markdown 预览本身就是 LiveMarkdown 编辑器，不再通过按钮切换编辑态。
   const [markdownEditing, setMarkdownEditing] = React.useState(
-    () => Boolean(initialMarkdownEditorState?.editing),
+    () => Boolean((isMarkdown && !readOnly) || initialMarkdownEditorState?.editing),
   )
-  const [markdownSourceMode, setMarkdownSourceMode] = React.useState(
-    () => Boolean(initialMarkdownEditorState?.editing && initialMarkdownEditorState.sourceMode && isMarkdown),
-  )
+  const [markdownSourceMode, setMarkdownSourceMode] = React.useState(false)
   const [markdownDraft, setMarkdownDraft] = React.useState(
     () => initialMarkdownEditorState?.draft ?? '',
   )
@@ -627,22 +626,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     themeType: theme as 'light' | 'dark' | 'system',
     unsafeCSS: PIERRE_FILE_CSS,
   }), [theme, codeWrap])
-  const markdownFileAccess = React.useMemo(() => {
-    const candidateBasePaths: string[] = []
-    const slash = filePath.lastIndexOf('/')
-    if (slash > 0) candidateBasePaths.push(filePath.slice(0, slash))
-    if (dirPath) candidateBasePaths.push(dirPath)
-    for (const basePath of basePaths ?? []) {
-      if (basePath && !candidateBasePaths.includes(basePath)) candidateBasePaths.push(basePath)
-    }
-    return {
-      sessionId,
-      ...(workspaceSkillSlug ? { workspaceSkillSlug } : {}),
-      ...(legacySkillFilePath ? { legacySkillFilePath } : {}),
-      candidateBasePaths,
-    }
-  }, [basePaths, dirPath, filePath, sessionId, workspaceSkillSlug, legacySkillFilePath])
-
   // props 变化时立即清空内容状态，避免在 useEffect 执行前渲染旧数据
   React.useEffect(() => {
     const restoredEditorState = !readOnly && isEditableText
@@ -656,7 +639,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       scrollPositionCache.set(scrollCacheKey(sessionId, filePath, markdownEditorScrollScope), restoredEditorState.previewScroll)
     }
     lastSavedDraftRef.current = nextEditorState.lastSavedDraft
-    markdownEditingRef.current = Boolean(nextEditorState.editing && isEditableText && !readOnly)
+    markdownEditingRef.current = Boolean((isMarkdown || nextEditorState.editing) && isEditableText && !readOnly)
     pendingPreviewScrollRestoreRef.current = null
 
     setOldContent('')
@@ -673,8 +656,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     setImageZoom(0.25)
     setImageNaturalSize({ w: 0, h: 0 })
     setLoading(!isLegacyOffice)
-    setMarkdownEditing(Boolean(nextEditorState.editing && isEditableText && !readOnly))
-    setMarkdownSourceMode(Boolean(nextEditorState.editing && nextEditorState.sourceMode && isMarkdown && !readOnly))
+    setMarkdownEditing(Boolean((isMarkdown || nextEditorState.editing) && isEditableText && !readOnly))
+    setMarkdownSourceMode(false)
     setMarkdownDraft(nextEditorState.draft)
     setMarkdownSaving(false)
     setAutosaveStatus('idle')
@@ -766,22 +749,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     persistMarkdownEditorViewState(nextState)
     setMarkdownDraft(content)
   }, [isEditableText, markdownEditorCacheKey, persistMarkdownEditorViewState, readOnly, sessionId])
-
-  const handleRichScrollPositionChange = React.useCallback((position: MarkdownScrollPosition) => {
-    if (!canPersistMarkdownEditorState(isEditableText, Boolean(readOnly))) return
-    updateMarkdownEditorViewState((state) => ({
-      ...state,
-      richScroll: { ...position },
-    }))
-  }, [isEditableText, readOnly, updateMarkdownEditorViewState])
-
-  const handleRichSelectionChange = React.useCallback((selection: { from: number; to: number }) => {
-    if (!canPersistMarkdownEditorState(isEditableText, Boolean(readOnly))) return
-    updateMarkdownEditorViewState((state) => ({
-      ...state,
-      richSelection: { ...selection },
-    }))
-  }, [isEditableText, readOnly, updateMarkdownEditorViewState])
 
   const handleSourceScroll = React.useCallback((event: React.UIEvent<HTMLTextAreaElement>) => {
     const { scrollTop, scrollLeft } = event.currentTarget
@@ -1151,11 +1118,13 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           updateMarkdownEditorViewState((state) => ({
             ...state,
             previewScroll: position,
+            // LiveMarkdown 的滚动由外层预览容器承接；编辑态离开后仍要恢复用户所在位置。
+            richScroll: activeMarkdownEditing && isMarkdown && !markdownSourceMode ? position : state.richScroll,
           }))
         }
       }
     })
-  }, [isEditableText, readOnly, scrollKey, updateMarkdownEditorViewState])
+  }, [activeMarkdownEditing, isEditableText, isMarkdown, markdownSourceMode, readOnly, scrollKey, updateMarkdownEditorViewState])
 
   // Cleanup rAF on unmount to prevent stale writes
   React.useEffect(() => {
@@ -1178,7 +1147,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
 
   const startMarkdownEdit = React.useCallback(() => {
-    if (!isEditableText || readOnly) return
+    if (!isPlainTextEditable || readOnly) return
     const currentEditorState = getMarkdownEditorViewState(sessionId, markdownEditorCacheKey) ?? markdownEditorStateRef.current
     const hasPendingDraft = currentEditorState.draft !== currentEditorState.lastSavedDraft
     const draft = hasPendingDraft ? currentEditorState.draft : newContent
@@ -1205,7 +1174,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     setMarkdownSourceMode(false)
     setMarkdownDraft(draft)
     setMarkdownEditing(true)
-  }, [isEditableText, markdownEditorCacheKey, newContent, persistMarkdownEditorViewState, readOnly, sessionId])
+  }, [isPlainTextEditable, markdownEditorCacheKey, newContent, persistMarkdownEditorViewState, readOnly, sessionId])
 
   // ref 形式的 persist：避免 callback / effect 因 refreshVersion 频繁变化而重建
   const persistRef = React.useRef<(draft: string, fp: string, fa: typeof fileAccess, cacheKey: string) => Promise<boolean>>(async () => false)
@@ -1333,30 +1302,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
   }, [componentMountedRef, fileAccess, filePath, isEditableText, markdownDraft, markdownEditorCacheKey, markdownSaving, ownerGeneration, persistMarkdownDraft, readOnly])
 
-  const toggleMarkdownSourceMode = React.useCallback(() => {
-    if (!isEditableText || readOnly) return
-    const sourceTextarea = sourceTextareaRef.current
-    const sourceScroll = sourceTextarea
-      ? { top: sourceTextarea.scrollTop, left: sourceTextarea.scrollLeft }
-      : markdownEditorStateRef.current.sourceScroll
-    const sourceSelection = sourceTextarea
-      ? { start: sourceTextarea.selectionStart, end: sourceTextarea.selectionEnd }
-      : markdownEditorStateRef.current.sourceSelection
-    const nextSourceMode = !markdownSourceMode
-    const nextEditorState: MarkdownEditorViewState = {
-      ...markdownEditorStateRef.current,
-      sourceMode: nextSourceMode,
-      richScroll: nextSourceMode
-        ? markdownEditorStateRef.current.richScroll
-        : { ...sourceScroll },
-      sourceScroll: nextSourceMode
-        ? { ...markdownEditorStateRef.current.richScroll }
-        : sourceScroll,
-      sourceSelection,
-    }
-    persistMarkdownEditorViewState(nextEditorState)
-    setMarkdownSourceMode(nextSourceMode)
-  }, [isEditableText, markdownSourceMode, persistMarkdownEditorViewState, readOnly])
 
   const handleManualRefresh = React.useCallback(() => {
     if (previewOnly) {
@@ -1613,20 +1558,9 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           </button>
         )}
 
-        {previewOnly && isEditableText && !readOnly && (
+        {previewOnly && isPlainTextEditable && !readOnly && (
           markdownEditing ? (
             <div className="ml-auto flex items-center gap-1">
-              {isMarkdown && (
-                <button
-                  type="button"
-                  onClick={toggleMarkdownSourceMode}
-                  disabled={markdownSaving}
-                  className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 disabled:opacity-50 shrink-0"
-                  title={markdownSourceMode ? '切换到富文本编辑' : '切换到源码编辑'}
-                >
-                  {markdownSourceMode ? <Eye className="size-3.5" /> : <Code2 className="size-3.5" />}
-                </button>
-              )}
               <button
                 type="button"
                 onClick={exitMarkdownEdit}
@@ -1662,27 +1596,40 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               type="button"
               onClick={startMarkdownEdit}
               className="ml-auto p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0"
-              title={isMarkdown ? '编辑 Markdown' : '编辑文本'}
+              title="编辑文本"
             >
               <Pencil className="size-3.5" />
             </button>
           )
         )}
 
-        <button type="button" onClick={handleCopy}
-          className={cn("p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0", previewOnly && !isEditableText && "ml-auto")}
-          title="复制文件内容">
-          {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className={cn('p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0', previewOnly && !isEditableText && 'ml-auto')}
+              aria-label={copied ? '已复制文件内容' : '复制文件内容'}
+            >
+              {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{copied ? '已复制文件内容' : '复制文件内容'}</TooltipContent>
+        </Tooltip>
 
-        <button
-          type="button"
-          onClick={handleManualRefresh}
-          className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0"
-          title="刷新文件内容（检测外部编辑器的修改）"
-        >
-          <RotateCw className="size-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleManualRefresh}
+              className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0"
+              aria-label="刷新文件内容（检测外部编辑器的修改）"
+            >
+              <RotateCw className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">刷新文件内容（检测外部编辑器的修改）</TooltipContent>
+        </Tooltip>
 
         {canTogglePreviewWrap && (
           <Tooltip>
@@ -1705,18 +1652,23 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           </Tooltip>
         )}
 
-        {isMarkdown && !activeMarkdownEditing && (
-          <button
-            type="button"
-            onClick={() => setTocOpen((v) => !v)}
-            className={cn(
-              'p-1 rounded hover:bg-foreground/[0.06] shrink-0',
-              tocOpen ? 'text-foreground/70' : 'text-foreground/40 hover:text-foreground/60',
-            )}
-            title={tocOpen ? '隐藏目录' : '显示目录'}
-          >
-            <List className="size-3.5" />
-          </button>
+        {isMarkdown && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setTocOpen((v) => !v)}
+                className={cn(
+                  'p-1 rounded hover:bg-foreground/[0.06] shrink-0',
+                  tocOpen ? 'text-foreground/70' : 'text-foreground/40 hover:text-foreground/60',
+                )}
+                aria-label={tocOpen ? '隐藏目录' : '显示目录'}
+              >
+                <List className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{tocOpen ? '隐藏目录' : '显示目录'}</TooltipContent>
+          </Tooltip>
         )}
 
         {toolbarActions}
@@ -1733,10 +1685,10 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         <MarkdownToc
           containerRef={scrollContainerRef}
           contentKey={tocContentKey}
-          enabled={Boolean(isMarkdown && !activeMarkdownEditing && tocOpen)}
+          enabled={Boolean(isMarkdown && tocOpen)}
           onOpenChange={setTocOpen}
         />
-        {isMarkdown && !activeMarkdownEditing && !tocOpen && (
+        {isMarkdown && !tocOpen && (
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -1879,44 +1831,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                 </div>
               )
             ) : isMarkdown ? (
-              activeMarkdownEditing && markdownSourceMode ? (
-                <textarea
-                  ref={sourceTextareaRef}
-                  value={markdownDraft}
-                  onChange={(e) => updateMarkdownDraft(e.target.value)}
-                  onScroll={handleSourceScroll}
-                  onSelect={handleSourceSelection}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Escape') {
-                      e.preventDefault()
-                      exitMarkdownEdit()
-                    }
-                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                      e.preventDefault()
-                      void saveMarkdownEdit()
-                    }
-                  }}
-                  autoFocus
-                  spellCheck={false}
-                  className="w-full min-h-full resize-none border-0 bg-transparent px-4 py-3 font-mono text-[13px] leading-relaxed text-foreground outline-none focus:outline-none"
-                />
-              ) : (
-                <MarkdownRichEditor
-                  value={activeMarkdownEditing ? markdownDraft : newContent}
-                  editing={activeMarkdownEditing}
-                  onChange={updateMarkdownDraft}
-                  onSave={() => void saveMarkdownEdit()}
-                  onCancel={exitMarkdownEdit}
-                  renderMermaidInEditor
-                  disabled={markdownSaving || Boolean(readOnly)}
-                  fileAccess={markdownFileAccess}
-                  shikiTheme={theme === 'dark' ? 'github-dark' : 'github-light'}
-                  initialScrollPosition={activeMarkdownEditing ? markdownEditorStateRef.current.richScroll : undefined}
-                  onScrollPositionChange={handleRichScrollPositionChange}
-                  initialSelection={activeMarkdownEditing ? markdownEditorStateRef.current.richSelection : undefined}
-                  onSelectionChange={handleRichSelectionChange}
-                />
-              )
+              <LiveMarkdownEditor
+                key={readOnly ? 'readonly' : 'editable'}
+                value={readOnly ? newContent : markdownDraft}
+                onChange={updateMarkdownDraft}
+                onSave={() => void saveMarkdownEdit()}
+                readOnly={Boolean(readOnly)}
+                className="live-markdown-external-scroll"
+              />
             ) : isPlainTextEditable && activeMarkdownEditing ? (
               <textarea
                 ref={sourceTextareaRef}

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
@@ -17,6 +17,9 @@ interface LiveMarkdownEditorProps {
   value: string
   onChange: (value: string) => void
   onSave?: () => void
+  onCancel?: () => void
+  /** 只读时沿用同一套 Live Preview 渲染，但不允许修改源文档。 */
+  readOnly?: boolean
   extensions?: readonly Extension[]
   className?: string
 }
@@ -35,6 +38,68 @@ const markdownSyntaxMarkerNames = new Set([
 ])
 const hiddenMarkdownSyntax = Decoration.replace({ class: 'live-markdown-syntax-hidden' })
 const pendingListHeading = Decoration.mark({ class: 'live-markdown-pending-list-heading' })
+
+interface MarkdownHeading {
+  from: number
+  to: number
+  level: number
+  text: string
+}
+
+/**
+ * ink-mde / CodeMirror 以 span 呈现标题，而现有 TOC 通过 DOM 语义节点采集。
+ * 为每个 Markdown 标题行加入稳定 data 属性，让同一套 TOC 能继续发现、定位和高亮它们。
+ */
+function findMarkdownHeadings(state: EditorState): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = []
+  let fence: string | null = null
+  for (let number = 1; number <= state.doc.lines; number += 1) {
+    const line = state.doc.line(number)
+    const fenceMatch = line.text.match(/^ {0,3}(`{3,}|~{3,})/)
+    if (fenceMatch) {
+      const marker = fenceMatch[1]![0]!
+      if (!fence) fence = marker
+      else if (fence === marker) fence = null
+      continue
+    }
+    if (fence) continue
+
+    const atx = line.text.match(/^ {0,3}(#{1,6})(?:[ \t]+(.*?)\s*|[ \t]*)$/)
+    if (atx) {
+      const text = (atx[2] ?? '').replace(/[ \t]+#+[ \t]*$/, '').trim()
+      if (text) headings.push({ from: line.from, to: line.to, level: atx[1]!.length, text })
+      continue
+    }
+
+    if (number >= state.doc.lines || !line.text.trim()) continue
+    const underline = state.doc.line(number + 1)
+    const setext = underline.text.match(/^ {0,3}(=+|-+)\s*$/)
+    if (!setext) continue
+    headings.push({ from: line.from, to: line.to, level: setext[1]![0] === '=' ? 1 : 2, text: line.text.trim() })
+    number += 1
+  }
+  return headings
+}
+
+function markdownHeadingDecorations(state: EditorState): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>()
+  for (const heading of findMarkdownHeadings(state)) {
+    builder.add(heading.from, heading.to, Decoration.mark({
+      attributes: {
+        'data-markdown-heading': 'true',
+        'data-toc-level': String(heading.level),
+        'data-toc-text': heading.text,
+      },
+    }))
+  }
+  return builder.finish()
+}
+
+const markdownHeadingMarkers = StateField.define<DecorationSet>({
+  create: markdownHeadingDecorations,
+  update: (value, transaction) => transaction.docChanged ? markdownHeadingDecorations(transaction.state) : value,
+  provide: (field) => EditorView.decorations.from(field),
+})
 
 type MarkdownSyntaxVisibility = {
   focused: boolean
@@ -130,6 +195,8 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
   value,
   onChange,
   onSave,
+  onCancel,
+  readOnly = false,
   extensions = [],
   className,
 }, ref): React.ReactElement {
@@ -139,9 +206,11 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
   const valueRef = React.useRef(value)
   const onChangeRef = React.useRef(onChange)
   const onSaveRef = React.useRef(onSave)
+  const onCancelRef = React.useRef(onCancel)
   valueRef.current = value
   onChangeRef.current = onChange
   onSaveRef.current = onSave
+  onCancelRef.current = onCancel
 
   React.useImperativeHandle(ref, () => ({
     focus: () => instanceRef.current?.focus(),
@@ -167,7 +236,7 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
       hooks: { afterUpdate: (nextValue) => { if (ready) onChangeRef.current(nextValue) } },
       interface: {
         appearance: 'auto', attribution: false, autocomplete: false, images: false,
-        lists: true, readonly: false, spellcheck: false, toolbar: false,
+        lists: true, readonly: readOnly, spellcheck: false, toolbar: false,
       },
       plugins: [
         Prec.highest(keymap.of([{
@@ -176,7 +245,14 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
             onSaveRef.current?.()
             return true
           },
+        }, {
+          key: 'Escape',
+          run: () => {
+            onCancelRef.current?.()
+            return Boolean(onCancelRef.current)
+          },
         }])),
+        markdownHeadingMarkers,
         ViewPlugin.define((view) => {
           viewRef.current = view
           return { destroy: () => { if (viewRef.current === view) viewRef.current = null } }

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
@@ -52,32 +52,20 @@ interface MarkdownHeading {
  */
 function findMarkdownHeadings(state: EditorState): MarkdownHeading[] {
   const headings: MarkdownHeading[] = []
-  let fence: string | null = null
-  for (let number = 1; number <= state.doc.lines; number += 1) {
-    const line = state.doc.line(number)
-    const fenceMatch = line.text.match(/^ {0,3}(`{3,}|~{3,})/)
-    if (fenceMatch) {
-      const marker = fenceMatch[1]![0]!
-      if (!fence) fence = marker
-      else if (fence === marker) fence = null
-      continue
-    }
-    if (fence) continue
-
-    const atx = line.text.match(/^ {0,3}(#{1,6})(?:[ \t]+(.*?)\s*|[ \t]*)$/)
-    if (atx) {
-      const text = (atx[2] ?? '').replace(/[ \t]+#+[ \t]*$/, '').trim()
-      if (text) headings.push({ from: line.from, to: line.to, level: atx[1]!.length, text })
-      continue
-    }
-
-    if (number >= state.doc.lines || !line.text.trim()) continue
-    const underline = state.doc.line(number + 1)
-    const setext = underline.text.match(/^ {0,3}(=+|-+)\s*$/)
-    if (!setext) continue
-    headings.push({ from: line.from, to: line.to, level: setext[1]![0] === '=' ? 1 : 2, text: line.text.trim() })
-    number += 1
-  }
+  // 复用 CodeMirror 已维护的 Markdown 语法树：不会把 fenced code 中的 # 当标题，
+  // 也避免每次输入手写扫描整份文档和处理 fence 长度规则。
+  syntaxTree(state).iterate({
+    enter: ({ type, from }) => {
+      const match = /^(ATX|Setext)Heading([1-6])$/.exec(type.name)
+      if (!match) return
+      const line = state.doc.lineAt(from)
+      const text = match[1] === 'ATX'
+        ? line.text.replace(/^ {0,3}#{1,6}(?:[ \t]+|$)/, '').replace(/[ \t]+#+[ \t]*$/, '').trim()
+        : line.text.trim()
+      if (!text) return
+      headings.push({ from: line.from, to: line.to, level: Number(match[2]), text })
+    },
+  })
   return headings
 }
 
@@ -295,9 +283,10 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
       if (instanceRef.current === localInstance) instanceRef.current = null
       mount.remove()
     }
-  // The editor owns its state after initialization; external reloads use the effect below.
+  // The editor owns its document state after initialization; external reloads use the effect below.
+  // `readOnly` is an ink-mde construction option, so changing it must recreate the instance.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [readOnly])
 
   React.useEffect(() => {
     const instance = instanceRef.current

--- a/apps/electron/src/renderer/hooks/useTocHeadings.ts
+++ b/apps/electron/src/renderer/hooks/useTocHeadings.ts
@@ -8,7 +8,8 @@ export interface TocHeading {
   el: HTMLElement
 }
 
-const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6'
+// TipTap 输出 h1–h6；LiveMarkdown 基于 CodeMirror 输出 span，并为标题标注 data 属性。
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6, [data-markdown-heading]'
 
 /**
  * 从滚动容器内的渲染结果中提取标题树，并为每个标题注入锚点 id。
@@ -44,9 +45,10 @@ export function useTocHeadings(
       const next: TocHeading[] = []
       const nodes = container.querySelectorAll<HTMLElement>(HEADING_SELECTOR)
       for (const el of Array.from(nodes)) {
-        const text = (el.textContent ?? '').trim()
+        const text = (el.dataset.tocText ?? el.textContent ?? '').trim()
         if (!text) continue
-        const level = Number(el.tagName.slice(1))
+        const level = el.dataset.tocLevel ? Number(el.dataset.tocLevel) : Number(el.tagName.slice(1))
+        if (!Number.isInteger(level) || level < 1 || level > 6) continue
         if (!el.id) el.id = slug(text)
         next.push({ id: el.id, level, text, el })
       }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2424,6 +2424,22 @@
   min-height: 100%;
   padding: 0.75rem var(--vault-editor-horizontal-inset, 1rem) !important;
 }
+/* 预览/详情页的滚动由外层统一承接：TOC、查找与选区引用必须和正文
+ * 使用同一个 scroll root，避免 CodeMirror 内层滚动导致目录跳转、ScrollSpy 失联。 */
+.live-markdown-external-scroll,
+.live-markdown-external-scroll .ink-mde,
+.live-markdown-external-scroll .ink-mde-editor,
+.live-markdown-external-scroll .cm-editor,
+.live-markdown-external-scroll .cm-scroller {
+  height: auto !important;
+  min-height: 100%;
+}
+.live-markdown-external-scroll .cm-scroller {
+  overflow: visible !important;
+}
+.skill-detail-live-markdown {
+  min-height: 26.25rem;
+}
 .vault-ink-mde .cm-selectionBackground,
 .vault-ink-mde .cm-searchMatch,
 .vault-ink-mde .cm-searchMatch-selected {


### PR DESCRIPTION
## Summary

- Replace Markdown file preview, Skill detail, and project memory content with LiveMarkdown.
- Keep the file-preview TOC, add header anchor markers for CodeMirror-rendered headings, and keep preview actions accessible with tooltips.
- Make project memory directly editable with existing debounce/flush persistence; move “open file location” into compact left-list icons.

## Validation

- `bun run build:renderer`
- `bun test` — 452 passed; 4 existing Electron/environment failures (agent-session-manager, OAuth proxy scope, channel-runtime-api-key, planning-manager).
- `bun run typecheck` is blocked by the existing `useGlobalAgentListeners.ts:898` `Set.length` error from `origin/main`.

## Performance

- Each surface mounts only the current LiveMarkdown instance; no new renderer IPC, timers, or dependencies.
- Project-memory persistence retains the existing 800 ms debounce plus flush on file switch/unmount.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)