### PR TITLE
feat(models): adapt GLM-5.3-Flash reasoning depth

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -54,11 +54,8 @@ const ZERO_MODEL_COST: PiModelCost = { input: 0, output: 0, cacheRead: 0, cacheW
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 const DEFAULT_MAX_TOKENS = 64_000
 const VOLCENGINE_GLM_MAX_TOKENS = 128_000
-/**
- * 当 Pi catalog 尚未包含 GLM-5.3 时，补回其官方最大输出上限，避免落到默认 64K。
- * 智谱官方文档标注 GLM-5.3 最大输出 128K，与目录中 GLM-5.2 的 131072 同一口径。
- */
-const GLM_53_MAX_TOKENS = 131_072
+/** GLM-5.3 与 GLM-5.3-Flash 均支持 128K 最大输出。 */
+const GLM_53_FAMILY_MAX_TOKENS = 131_072
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api'
 const CODEX_MAX_TOKENS = 128_000
 /**
@@ -595,7 +592,8 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const glmModelId = input.model?.toLowerCase()
   const isVolcengineGlm5x = (input.provider === 'doubao' || input.provider === 'doubao-api' || input.provider === 'ark-coding-plan')
     && (glmModelId === 'glm-5.2' || glmModelId === 'glm-5.3')
-  const isCatalogMissingGlm53 = !catalogModel && glmModelId === 'glm-5.3'
+  const isCatalogMissingGlm53Family = !catalogModel
+    && (glmModelId === 'glm-5.3' || glmModelId === 'glm-5.3-flash')
   const catalogContextWindow = catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
   const inferredContextWindow = inferContextWindow(input.model) ?? DEFAULT_CONTEXT_WINDOW
   const shouldForceAdaptiveThinking = shouldForcePiAdaptiveThinking(api, catalogModel)
@@ -611,10 +609,10 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
     cost: catalogModel ? { ...catalogModel.cost } : { ...ZERO_MODEL_COST },
     // Codex 对齐策略优先；其他模型仍保留 catalog 与 shared inference 中更大的已验证能力。
     contextWindow: codexAlignedCapabilities?.contextWindow ?? Math.max(catalogContextWindow, inferredContextWindow),
-    // Pi 的智谱目录将 GLM-5.2 标为 131072，但火山方舟兼容端点上限为 128000；GLM-5.3 同理。
+    // Pi catalog 缺少时，GLM-5.3 系列仍按官方 128K 输出上限注册。
     maxTokens: isVolcengineGlm5x
       ? VOLCENGINE_GLM_MAX_TOKENS
-      : (catalogModel?.maxTokens ?? (isCatalogMissingGlm53 ? GLM_53_MAX_TOKENS : DEFAULT_MAX_TOKENS)),
+      : (catalogModel?.maxTokens ?? (isCatalogMissingGlm53Family ? GLM_53_FAMILY_MAX_TOKENS : DEFAULT_MAX_TOKENS)),
   }
 }
 

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -101,7 +101,7 @@ const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
 /**
  * 一次性预设更新 ID。独立于配置 schema 版本，保证高版本配置也能收到新增候选模型。
  */
-const PRESET_MODEL_CANDIDATE_UPDATE_ID = 'model-candidates-v2'
+const PRESET_MODEL_CANDIDATE_UPDATE_ID = 'model-candidates-v3'
 
 /**
  * 本次预设更新向存量渠道追加的候选模型，默认禁用。
@@ -122,12 +122,15 @@ const PRESET_MODEL_CANDIDATES: Partial<Record<ProviderType, readonly ChannelMode
   ],
   zhipu: [
     { id: 'glm-5.3', name: 'GLM-5.3', enabled: false },
+    { id: 'glm-5.3-flash', name: 'GLM-5.3-Flash', enabled: false },
   ],
   'zhipu-coding': [
     { id: 'glm-5.3', name: 'GLM-5.3', enabled: false },
+    { id: 'glm-5.3-flash', name: 'GLM-5.3-Flash', enabled: false },
   ],
   'zhipu-coding-team': [
     { id: 'glm-5.3', name: 'GLM-5.3', enabled: false },
+    { id: 'glm-5.3-flash', name: 'GLM-5.3-Flash', enabled: false },
   ],
 }
 

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -434,6 +434,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
       } else if (p === 'zhipu' || p === 'zhipu-coding' || p === 'zhipu-coding-team') {
         setModels([
           { id: 'glm-5.3', name: 'GLM-5.3', enabled: true },
+          { id: 'glm-5.3-flash', name: 'GLM-5.3-Flash', enabled: true },
           { id: 'glm-5.1', name: 'GLM-5.1', enabled: false },
         ])
       } else if (p === 'ark-coding-plan') {

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -330,7 +330,7 @@ export function resolveReasoningProfile(input: ResolveReasoningProfileInput): Re
       ? DEEPSEEK_V4_PRO_PROFILE
       : /^(?:k3(?:-256k)?|kimi-k3)$/.test(modelId)
         ? K3_PROFILE
-        : modelId === 'glm-5.3'
+        : modelId === 'glm-5.3' || modelId === 'glm-5.3-flash'
           ? GLM_53_PROFILE
           : modelId === 'glm-5.2'
             ? GLM_52_PROFILE

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -53,7 +53,7 @@ const ONE_MILLION_CONTEXT_RULES = {
   // DeepSeek
   deepseek: ['deepseek-v4'],
   // 智谱 GLM
-  glm: ['glm-5.3', 'glm-5.2'],
+  glm: ['glm-5.3', 'glm-5.3-flash', 'glm-5.2'],
   // 小米 MiMo
   mimo: ['mimo-v2.5'],
   // MiniMax


### PR DESCRIPTION
## Summary
- Reuse GLM-5.3 reasoning-depth profile for GLM-5.3-Flash.
- Register the official 1M context / 128K output defaults and Zhipu channel candidate.

## Validation
- `bun test packages/shared apps/electron/src/main/lib/agent-thinking-level.test.ts`
- `bun run --filter='@proma/shared' typecheck`\n\nPerformance impact: no runtime rendering, streaming, IPC, or subscription changes; only one-time model metadata resolution.\n\nMade with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)