### PR TITLE
Fix automatic Skills/MCP focus and memory diff dismissal

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryChangeShelf.tsx
@@ -6,7 +6,8 @@ interface WorkspaceMemoryChangeShelfProps {
   changes: WorkspaceMemoryFileChange[]
   /** 用户主动从局部 Diff 打开某一个对应的原始记忆文件。 */
   onOpenFile?: (change: WorkspaceMemoryFileChange) => void
-  onBackToMemory?: () => void
+  /** 完成查看局部 Diff 后关闭其临时宿主（嵌入式右侧项目记忆 Tab）。 */
+  onDismissChanges?: () => void
   className?: string
 }
 
@@ -50,8 +51,8 @@ function MemoryChangeDiff({
   )
 }
 
-/** 项目记忆变更的只读 Diff 列表；完整记忆由用户主动切换查看。 */
-export function WorkspaceMemoryChangeShelf({ changes, onOpenFile, onBackToMemory, className }: WorkspaceMemoryChangeShelfProps): React.ReactElement | null {
+/** 项目记忆变更的只读 Diff 列表；完整记忆仅由用户主动从工作区 Tab 打开。 */
+export function WorkspaceMemoryChangeShelf({ changes, onOpenFile, onDismissChanges, className }: WorkspaceMemoryChangeShelfProps): React.ReactElement | null {
   if (changes.length === 0) return null
 
   return (
@@ -61,7 +62,7 @@ export function WorkspaceMemoryChangeShelf({ changes, onOpenFile, onBackToMemory
           <h2 className="text-sm font-semibold text-foreground">项目记忆已更新</h2>
           <p className="mt-1 text-xs text-muted-foreground">{changes.length} 个文件变更</p>
         </div>
-        {onBackToMemory && <Button size="sm" variant="ghost" className="h-8 shrink-0 px-2 text-xs" onClick={onBackToMemory}>全部记忆</Button>}
+        {onDismissChanges && <Button size="sm" variant="ghost" className="h-8 shrink-0 px-2 text-xs" onClick={onDismissChanges}>完成</Button>}
       </div>
       <div className="space-y-5">
         {changes.map((change) => <MemoryChangeDiff key={`${change.relativePath}:${change.changedAt}`} change={change} onOpenFile={onOpenFile} />)}

--- a/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryTab.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/WorkspaceMemoryTab.tsx
@@ -29,6 +29,8 @@ interface WorkspaceMemoryTabProps {
   workspaceSlug: string
   /** 仅嵌入 Agent 右侧工作区时传入，用于展示当前会话的记忆变更 Diff。 */
   sessionId?: string
+  /** 记忆 Diff 查看结束或失效时关闭当前会话的项目记忆 Tab，避免回退到完整记忆。 */
+  onCloseChangeView?: () => void
   /** 能力中心传入的统一搜索词；嵌入组件未传时提供自己的内容搜索。 */
   search?: string
   embedded?: boolean
@@ -68,7 +70,7 @@ function filterNodes(nodes: SkillFileNode[], query: string, contentMatchPaths = 
   return result
 }
 
-export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded = false }: WorkspaceMemoryTabProps): React.ReactElement {
+export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded = false, onCloseChangeView }: WorkspaceMemoryTabProps): React.ReactElement {
   const { createAgent } = useCreateSession()
   const setPendingPrompt = useSetAtom(agentPendingPromptAtom)
   const [memoryNavigationRequest, setMemoryNavigationRequest] = useAtom(memoryFileNavigationAtom)
@@ -243,6 +245,13 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
       setMemoryNavigationRequest(null)
     })()
   }, [memoryChanges, memoryNavigationRequest, openAutoFile, sessionId, setMemoryNavigationRequest, workspaceSlug])
+
+  React.useEffect(() => {
+    if (!embedded || !activeChangeId || activeMemoryChange) return
+    // Diff 对应的临时变更已经被消费或被新变更替换时，不能落回完整记忆列表。
+    // 完整记忆只由用户主动打开项目记忆 Tab 查看。
+    onCloseChangeView?.()
+  }, [activeChangeId, activeMemoryChange, embedded, onCloseChangeView])
 
   React.useEffect(() => {
     if (!latestMemoryChange) return
@@ -425,7 +434,7 @@ export function WorkspaceMemoryTab({ workspaceSlug, sessionId, search, embedded 
           setActiveChangeId(null)
           void openAutoFile(change.relativePath)
         }}
-        onBackToMemory={() => setActiveChangeId(null)}
+        onDismissChanges={embedded ? onCloseChangeView : undefined}
         className="h-full min-h-0 overflow-auto bg-content-area p-3"
       />
     )

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -1580,7 +1580,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     ) : paneTab === 'memory' ? (
       workspaceSlug ? (
         <div className="min-h-0 flex-1 overflow-hidden p-2">
-          <WorkspaceMemoryTab workspaceSlug={workspaceSlug} sessionId={sessionId} embedded />
+          <WorkspaceMemoryTab workspaceSlug={workspaceSlug} sessionId={sessionId} embedded onCloseChangeView={() => handleCloseWorkspaceTab('memory')} />
         </div>
       ) : (
         <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">等待项目初始化...</div>

--- a/apps/electron/src/renderer/lib/agent-component-activation.ts
+++ b/apps/electron/src/renderer/lib/agent-component-activation.ts
@@ -42,17 +42,16 @@ function getFilePath(input: Record<string, unknown>): string | null {
 
 function getWorkspaceManagedFileComponent(path: string): WorkspaceComponentTab | null {
   const normalized = path.replace(/\\/g, '/').toLowerCase()
-  // 只响应 Proma workspace 下的配置，避免用户项目中同名 skills/ 或 mcp.json 误触发。
+  // 工作区的 Skills/MCP 配置变更仅刷新能力数据，不自动打开、添加或聚焦右侧工作区 Tab。
+  // 仅 memory 写入仍需被识别，后续由 watcher 提供真实受限 Diff 后再打开。
   if (!normalized.includes('/agent-workspaces/')) return null
-  if (normalized.includes('/skills/')) return 'skills'
   if (normalized.includes('/memory/')) return 'memory'
-  if (normalized.endsWith('/mcp.json')) return 'mcp'
   return null
 }
 
 /**
  * 将 Agent 的变更工具调用映射为应展示的项目级组件。
- * 仅匹配增删改操作；读取、列举与执行定时任务不触发界面抢焦点。
+ * 仅匹配需要自动展示的增删改操作；Skills/MCP 配置变更不添加、打开或聚焦右侧 Tab。
  */
 export function getChangedWorkspaceComponentForTool(
   toolName: unknown,
@@ -77,7 +76,8 @@ export function getChangedWorkspaceComponentForTool(
     const filePath = getFilePath(input)
     return filePath ? getWorkspaceManagedFileComponent(filePath) : null
   }
-  // Skills/MCP 的创建和删除有时由 Bash 完成；仅识别 Proma workspace 路径和明确写入命令。
+  // Skills/MCP 的创建和删除有时由 Bash 完成；它们不会自动展示或抢焦点。
+  // 这里只保留对 workspace memory 写入的识别。
   if (toolName === 'Bash' && typeof input.command === 'string' && BASH_MUTATION_PATTERN.test(input.command)) {
     return getWorkspaceManagedFileComponent(input.command)
   }


### PR DESCRIPTION
## Summary
- stop workspace Skills and MCP mutations from opening or focusing right-side tabs
- close the embedded project memory tab after its temporary diff is dismissed instead of falling back to the full memory browser
- preserve explicit user navigation to Skills, MCP, and original memory files

## Test plan
- `bun run typecheck` (all 6 packages)
- `git diff --check`

## Performance
- Low risk: removes a one-shot UI focus/state transition from capability mutations; no new subscriptions, IPC loops, or render-frequency paths.
- Memory diff close handling is event/effect based and scoped to the active embedded session.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)