### PR TITLE
fix(windows): isolate titlebar hit-test regions

### DIFF
--- a/apps/electron/src/renderer/components/WindowControls.tsx
+++ b/apps/electron/src/renderer/components/WindowControls.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react'
 import { detectIsWindows } from '@/lib/platform'
-import { cn } from '@/lib/utils'
-import { getWindowTitlebarDragInsetClass } from '@/lib/window-titlebar-layout'
+import {
+  getWindowTitlebarDragInsetStyle,
+  WINDOW_TITLEBAR_CONTROL_WIDTH_PX,
+  WINDOW_TITLEBAR_CONTROLS_WIDTH_PX,
+  WINDOW_TITLEBAR_HEIGHT_PX,
+} from '@/lib/window-titlebar-layout'
 
 export function WindowControls(): React.ReactElement | null {
   const isWindows = React.useMemo(() => detectIsWindows(), [])
@@ -21,12 +25,26 @@ export function WindowControls(): React.ReactElement | null {
   if (!isWindows) return null
 
   return (
-    <div className="window-titlebar fixed inset-x-0 top-0 z-[100] flex h-8 select-none">
-      <div aria-hidden="true" className={cn('titlebar-drag-region absolute inset-y-0 left-0', getWindowTitlebarDragInsetClass(isWindows))} />
-      <div className="window-controls relative ml-auto flex">
+    <div
+      className="window-titlebar fixed inset-x-0 top-0 z-[100] flex select-none"
+      style={{
+        height: WINDOW_TITLEBAR_HEIGHT_PX,
+        '--window-titlebar-controls-width': `${WINDOW_TITLEBAR_CONTROLS_WIDTH_PX}px`,
+      } as React.CSSProperties}
+    >
+      <div
+        aria-hidden="true"
+        className="titlebar-drag-region pointer-events-none absolute inset-y-0 left-0"
+        style={getWindowTitlebarDragInsetStyle(isWindows)}
+      />
+      <div
+        className="window-controls relative ml-auto flex"
+        style={{ width: WINDOW_TITLEBAR_CONTROLS_WIDTH_PX }}
+      >
         <button
           type="button"
           className="window-control-btn"
+          style={{ width: WINDOW_TITLEBAR_CONTROL_WIDTH_PX }}
           aria-label="最小化"
           onClick={() => window.electronAPI.windowMinimize()}
         >
@@ -38,6 +56,7 @@ export function WindowControls(): React.ReactElement | null {
         <button
           type="button"
           className="window-control-btn"
+          style={{ width: WINDOW_TITLEBAR_CONTROL_WIDTH_PX }}
           aria-label={isMaximized ? '还原' : '最大化'}
           onClick={() => window.electronAPI.windowMaximize()}
         >
@@ -56,6 +75,7 @@ export function WindowControls(): React.ReactElement | null {
         <button
           type="button"
           className="window-control-btn window-control-close"
+          style={{ width: WINDOW_TITLEBAR_CONTROL_WIDTH_PX }}
           aria-label="关闭"
           onClick={() => window.electronAPI.windowClose()}
         >

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -8,6 +8,8 @@
 import * as React from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { cn } from "@/lib/utils";
+import { detectIsWindows } from "@/lib/platform";
+import { getWindowTitlebarDragInsetStyle } from "@/lib/window-titlebar-layout";
 import {
   Settings,
   Radio,
@@ -167,6 +169,7 @@ interface SettingsPanelProps {
 export function SettingsPanel({
   onClose,
 }: SettingsPanelProps): React.ReactElement {
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
   const [activeTab, setActiveTab] = useAtom(settingsTabAtom);
   const channelFormDirty = useAtomValue(channelFormDirtyAtom);
   const [closeRequested, setCloseRequested] = useAtom(settingsCloseRequestedAtom);
@@ -296,7 +299,11 @@ export function SettingsPanel({
   return (
     <div className="flex h-full min-h-0 flex-col bg-content-area text-foreground">
       <div className="relative h-[35px] flex-shrink-0 bg-[hsl(var(--sidebar-surface))]">
-        <div aria-hidden="true" className="titlebar-drag-region pointer-events-none absolute inset-0" />
+        <div
+          aria-hidden="true"
+          className="titlebar-drag-region pointer-events-none absolute inset-y-0 left-0"
+          style={getWindowTitlebarDragInsetStyle(isWindows)}
+        />
       </div>
 
       {/* 主体：左导航 + 右内容 */}

--- a/apps/electron/src/renderer/lib/window-titlebar-layout.ts
+++ b/apps/electron/src/renderer/lib/window-titlebar-layout.ts
@@ -1,10 +1,12 @@
 export const WINDOW_TITLEBAR_HEIGHT_PX = 32
-export const WINDOW_TITLEBAR_CONTROLS_WIDTH_PX = 138
+export const WINDOW_TITLEBAR_CONTROL_COUNT = 3
+export const WINDOW_TITLEBAR_CONTROL_WIDTH_PX = 46
+export const WINDOW_TITLEBAR_CONTROLS_WIDTH_PX = WINDOW_TITLEBAR_CONTROL_COUNT * WINDOW_TITLEBAR_CONTROL_WIDTH_PX
 
 export function getWindowTitlebarContentInsetClass(isWindows: boolean): string {
   return isWindows ? 'pt-8' : ''
 }
 
-export function getWindowTitlebarDragInsetClass(isWindows: boolean): string {
-  return isWindows ? 'right-[138px]' : 'right-0'
+export function getWindowTitlebarDragInsetStyle(isWindows: boolean): { right: number } {
+  return { right: isWindows ? WINDOW_TITLEBAR_CONTROLS_WIDTH_PX : 0 }
 }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -576,14 +576,16 @@
 
 /* Windows 顶部标题栏与系统控制按钮。拖拽区和按钮组分属独立矩形，避免高 DPI 下的 hitmask 重叠。 */
 .window-titlebar {
+  --window-titlebar-controls-width: 138px;
   background-color: hsl(var(--background));
 }
-
 
 .window-controls {
   -webkit-app-region: no-drag;
   app-region: no-drag;
+  width: var(--window-titlebar-controls-width);
   height: 32px;
+  flex: 0 0 var(--window-titlebar-controls-width);
 }
 
 .window-control-btn {


### PR DESCRIPTION
## Summary

- Keep the Windows titlebar drag region disjoint from the custom minimize, maximize, and close controls.
- Derive the 138px control strip from shared titlebar geometry constants and use an exact pixel inset.
- Prevent the Settings overlay's top drag region from overlapping the window controls.

## Validation

- bun test v1.3.13 (bf2e2cec) (passed before removing the requested test file)
- 
- Full typecheck and Windows DPI smoke test remain environment-dependent.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)