### PR TITLE
Fix persisted Agent draft sessions

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2370,8 +2370,9 @@ export function registerIpcHandlers(): void {
   // 创建 Agent 会话
   ipcMain.handle(
     AGENT_IPC_CHANNELS.CREATE_SESSION,
-    async (_, title?: string, channelId?: string, workspaceId?: string, modelId?: string): Promise<AgentSessionMeta> => {
-      const session = createAgentSession(title, channelId, workspaceId, modelId)
+    async (_, title?: string, channelId?: string, workspaceId?: string, modelId?: string, isDraft?: boolean): Promise<AgentSessionMeta> => {
+      if (isDraft !== undefined && typeof isDraft !== 'boolean') throw new Error('Agent 草稿状态非法')
+      const session = createAgentSession(title, channelId, workspaceId, modelId, undefined, undefined, isDraft)
       feishuBridgeManager.ensureSessionMirror(session).catch((error) => {
         console.error('[飞书 Session 镜像] 新会话建群失败:', error)
       })
@@ -2581,6 +2582,10 @@ export function registerIpcHandlers(): void {
       if (newPinned && current.archived) {
         updates.archived = false
       }
+      // 用户明确置顶临时草稿时，将其提升为普通会话，避免被草稿过滤后不可见。
+      if (newPinned && current.isDraft) {
+        updates.isDraft = false
+      }
       return updateAgentSessionMeta(id, updates)
     }
   )
@@ -2623,6 +2628,10 @@ export function registerIpcHandlers(): void {
       const updates: Partial<AgentSessionMeta> = { archived: newArchived }
       if (newArchived && current.pinned) {
         updates.pinned = false
+      }
+      // 手动归档是明确的保留意图；将草稿提升为普通归档会话，保留可见入口。
+      if (newArchived && current.isDraft) {
+        updates.isDraft = false
       }
       return updateAgentSessionMeta(id, updates)
     }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -250,9 +250,10 @@ export async function runAgent(
   const route = registerWebContents(input.sessionId, webContents)
   // deferred queue runs carry their queue id as an internal extension.
   const queueMessageId = (input as Partial<AgentDeferredQueueMessageInput>).queueMessageId
-  // 开始新一轮执行时清除"完成未确认"标记
+  // 开始新一轮执行时清除"完成未确认"与持久化草稿标记。
+  // 草稿标记不能只留在 renderer 内存，否则重启后会重新出现在侧栏。
   try {
-    updateAgentSessionMeta(input.sessionId, { completedButUnconfirmed: false })
+    updateAgentSessionMeta(input.sessionId, { completedButUnconfirmed: false, isDraft: false })
   } catch { /* 新会话可能尚未写入索引 */ }
   // 自动任务会话"毕业"：用户手动发消息（非定时触发）即视为接管，标记后该会话回到普通项目列表，
   // 调度器也不再复用它注入新的定时运行。

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -307,13 +307,13 @@ export function listActiveAgentSessions(): AgentSessionMeta[] {
 /** 获取归档会话，只有用户进入归档视图时才调用。 */
 export function listArchivedAgentSessions(): AgentSessionMeta[] {
   const index = readIndex()
-  return sortSessionsByUpdatedAtDesc(index.sessions.filter((session) => session.archived))
+  return sortSessionsByUpdatedAtDesc(index.sessions.filter((session) => session.archived && !session.isDraft))
 }
 
 /** 获取归档数量，不把归档会话元数据传到 renderer。 */
 export function countArchivedAgentSessions(): number {
   const index = readIndex()
-  return index.sessions.reduce((count, session) => count + (session.archived ? 1 : 0), 0)
+  return index.sessions.reduce((count, session) => count + (session.archived && !session.isDraft ? 1 : 0), 0)
 }
 
 /**
@@ -393,6 +393,7 @@ export function createAgentSession(
   modelId?: string,
   agentCwdMode?: AgentCwdMode,
   sessionWorkbenchLayout?: SessionWorkbenchLayout,
+  isDraft?: boolean,
 ): AgentSessionMeta {
   const index = readIndex()
   const now = Date.now()
@@ -408,6 +409,8 @@ export function createAgentSession(
     workspaceId,
     agentCwdMode: workspaceId ? agentCwdMode ?? 'project' : undefined,
     sessionWorkbenchLayout: workspaceId ? sessionWorkbenchLayout ?? 'root' : undefined,
+    // 仅由会话入口显式创建的临时输入会话设置；必须跨重启保留。
+    isDraft: isDraft || undefined,
     // 新会话继承已持久化的全局思考偏好，之后仍可按会话单独调整。
     reasoningLevel: defaultThinkingLevel,
     createdAt: now,
@@ -590,7 +593,7 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'codexFastMode' | 'reasoningLevel' | 'openAIThinkingLevel' | 'workspaceId' | 'activeWorktree' | 'pinned' | 'starred' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'explorationParentSessionId' | 'explorationSourceMessageId' | 'explorationSourceLabel' | 'explorationTitleInitializedAt' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'codexFastMode' | 'reasoningLevel' | 'openAIThinkingLevel' | 'workspaceId' | 'activeWorktree' | 'pinned' | 'starred' | 'archived' | 'isDraft' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'explorationParentSessionId' | 'explorationSourceMessageId' | 'explorationSourceLabel' | 'explorationTitleInitializedAt' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -1214,7 +1217,8 @@ export function autoArchiveAgentSessions(daysThreshold: number): number {
   let count = 0
 
   for (const session of index.sessions) {
-    if (!session.pinned && !session.archived && session.updatedAt < threshold) {
+    // 草稿没有侧栏入口；自动归档后无法由 Welcome 恢复，会变成不可达记录。
+    if (!session.isDraft && !session.pinned && !session.archived && session.updatedAt < threshold) {
       session.archived = true
       count++
     }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -566,8 +566,8 @@ export interface ElectronAPI {
   /** 获取归档会话数量，不返回归档元数据 */
   countArchivedAgentSessions: () => Promise<number>
 
-  /** 创建 Agent 会话 */
-  createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => Promise<AgentSessionMeta>
+  /** 创建 Agent 会话；草稿会话在首条消息发送前不会出现在侧栏。 */
+  createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string, isDraft?: boolean) => Promise<AgentSessionMeta>
 
   /** 获取当前主进程仍在执行的 Agent 会话，供 renderer 重载后恢复运行态 */
   listActiveAgentSessionSnapshots: () => Promise<AgentActiveSessionSnapshot[]>
@@ -1839,8 +1839,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.COUNT_ARCHIVED_SESSIONS)
   },
 
-  createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CREATE_SESSION, title, channelId, workspaceId, modelId)
+  createAgentSession: (title?: string, channelId?: string, workspaceId?: string, modelId?: string, isDraft?: boolean) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CREATE_SESSION, title, channelId, workspaceId, modelId, isDraft)
   },
 
   listActiveAgentSessionSnapshots: () => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2139,13 +2139,17 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
       return next
     })
 
-    // 取消 draft 标记，让会话出现在侧边栏
+    // 取消 draft 标记，让会话出现在侧边栏。主进程会在实际启动时持久化清除
+    // isDraft；这里先乐观更新，避免 IPC 往返期间仍被侧栏过滤。
     setDraftSessionIds((prev: Set<string>) => {
       if (!prev.has(sessionId)) return prev
       const next = new Set(prev)
       next.delete(sessionId)
       return next
     })
+    setAgentSessions((prev) => prev.map((session) => (
+      session.id === sessionId && session.isDraft ? { ...session, isDraft: false } : session
+    )))
 
     // 初始化流式状态（startedAt 由渲染进程生成，传递给主进程原样回传，确保竞态保护使用同一个值）
     const streamStartedAt = Date.now()
@@ -2207,7 +2211,7 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
         return map
       })
     })
-  }, [createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage, isLegacyTranscript, isStopping])
+  }, [createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, setDraftSessionIds, setAgentSessions, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage, isLegacyTranscript, isStopping])
 
   /** 停止生成。异常流未发出终态时，允许再次下发幂等的 abort 请求。 */
   const handleStop = React.useCallback((): void => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -577,6 +577,7 @@ function getSyncableDelegatedChildren(
 ): AgentSessionMeta[] {
   return getDirectDelegatedChildren(sessions, parentSessionId).filter((child) => (
     !child.archived
+    && !child.isDraft
     && !draftSessionIds.has(child.id)
   ))
 }
@@ -592,6 +593,7 @@ function getArchivedDelegatedChildren(
 ): AgentSessionMeta[] {
   return getDirectDelegatedChildren(sessions, parentSessionId).filter((child) => (
     child.archived
+    && !child.isDraft
     && !draftSessionIds.has(child.id)
   ))
 }
@@ -1030,6 +1032,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       if (viewMode !== 'active') return []
       const filtered = agentSessions.filter((s) =>
         s.pinned
+        && !s.isDraft
         && !draftSessionIds.has(s.id)
         && !hasPinnedVisibleParent(s, agentSessions)
       )
@@ -1043,6 +1046,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       session,
       childSessions: getDirectDelegatedChildren(agentSessions, session.id).filter((child) => (
         !child.archived
+        && !child.isDraft
         && !draftSessionIds.has(child.id)
         && !isHiddenAutomationSession(child)
       )),
@@ -1643,6 +1647,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         agentSessions.filter((session) =>
           !session.archived
           && !session.pinned
+          && !session.isDraft
           && !draftSessionIds.has(session.id)
           && !!session.sourceAutomationId
         )
@@ -2290,6 +2295,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         agentSessions.filter((session) =>
           !session.archived
           && !session.pinned
+          && !session.isDraft
           && !draftSessionIds.has(session.id)
           // 自动任务会话不进入项目列表，统一归到「自动任务」视图
           && !isHiddenAutomationSession(session)
@@ -2365,7 +2371,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       return
     }
 
-    const recent = sessions.find((s) => !s.archived && !draftSessionIds.has(s.id))
+    const recent = isChatMode
+      ? conversations.find((conversation) => !conversation.archived && !draftSessionIds.has(conversation.id))
+      : agentSessions.find((session) => !session.archived && !session.isDraft && !draftSessionIds.has(session.id))
     if (recent) {
       openSession(targetMode, recent.id, recent.title)
       return
@@ -2414,6 +2422,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     return agentSessions
       .filter((session) =>
         !session.archived
+        && !session.isDraft
         && !draftSessionIds.has(session.id)
         && (!currentWorkspaceId || session.workspaceId === currentWorkspaceId)
         // 自动任务会话不出现在收起态 Rail，与展开态列表保持一致

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -130,7 +130,7 @@ export function TabSwitcher(): ReactElement | null {
       }))
 
     const agentCandidates = agentSessions
-      .filter((session) => !session.archived && !draftSessionIds.has(session.id))
+      .filter((session) => !session.archived && !session.isDraft && !draftSessionIds.has(session.id))
       .map(buildAgentCandidate)
 
     const allCandidates = [...chatCandidates, ...agentCandidates]

--- a/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
@@ -116,24 +116,10 @@ export function WelcomeView(): React.ReactElement {
           createAgent: currentCreateAgent,
         } = latestRef.current
 
-        // Agent 模式：按当前工作区过滤
-        // 1. 优先复用现有非归档、非 draft 会话
-        const existing = freshSessions.find(
-          (s) => !s.archived && s.workspaceId === currentWs && !currentDrafts.has(s.id),
-        )
-        if (existing) {
-          const result = openTab(currentTabs, {
-            type: 'agent',
-            sessionId: existing.id,
-            title: existing.title,
-          })
-          currentSetTabs(result.tabs)
-          currentSetActiveTabId(result.activeTabId)
-          return
-        }
-        // 2. 检查是否已有 draft 会话（当前工作区），复用而不是创建新的
+        // Agent 模式：按当前工作区过滤。持久化草稿在侧栏中无入口，必须优先恢复，
+        // 否则同项目的普通会话会让草稿永久不可访问。
         const draftSession = freshSessions.find(
-          (s) => !s.archived && s.workspaceId === currentWs && currentDrafts.has(s.id),
+          (s) => !s.archived && s.workspaceId === currentWs && (s.isDraft || currentDrafts.has(s.id)),
         )
         if (draftSession) {
           const result = openTab(currentTabs, {
@@ -145,7 +131,21 @@ export function WelcomeView(): React.ReactElement {
           currentSetActiveTabId(result.activeTabId)
           return
         }
-        // 3. 没有任何会话时才创建新的 draft 会话
+        // 没有草稿时，复用现有普通会话。
+        const existing = freshSessions.find(
+          (s) => !s.archived && s.workspaceId === currentWs && !s.isDraft && !currentDrafts.has(s.id),
+        )
+        if (existing) {
+          const result = openTab(currentTabs, {
+            type: 'agent',
+            sessionId: existing.id,
+            title: existing.title,
+          })
+          currentSetTabs(result.tabs)
+          currentSetActiveTabId(result.activeTabId)
+          return
+        }
+        // 没有任何会话时才创建新的 draft 会话
         currentCreateAgent({ draft: true })
       }).catch(console.error)
     }

--- a/apps/electron/src/renderer/hooks/useCreateSession.ts
+++ b/apps/electron/src/renderer/hooks/useCreateSession.ts
@@ -85,6 +85,7 @@ export function useCreateSession(): CreateSessionActions {
         options?.channelId ?? agentChannelId ?? undefined,
         currentWorkspaceId || undefined,
         options?.modelId ?? agentModelId ?? undefined,
+        options?.draft,
       )
       setAgentSessions((prev) => [meta, ...prev])
       if (options?.open !== false) openSession('agent', meta.id, meta.title)

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -49,7 +49,7 @@ export function groupArchivedAgentSessionsByProject({
   const unassignedSessions: AgentSessionMeta[] = []
 
   for (const session of sessions) {
-    if (!session.archived || excludedSessionIds.has(session.id)) continue
+    if (!session.archived || session.isDraft || excludedSessionIds.has(session.id)) continue
     if (session.sourceAutomationId) {
       automationSessions.push(session)
       continue

--- a/apps/electron/src/renderer/lib/tab-switcher-model.ts
+++ b/apps/electron/src/renderer/lib/tab-switcher-model.ts
@@ -81,7 +81,7 @@ export function buildTabSwitcherModel({
     }))
 
   const agentCandidates = agentSessions
-    .filter((session) => !session.archived && !draftSessionIds.has(session.id))
+    .filter((session) => !session.archived && !session.isDraft && !draftSessionIds.has(session.id))
     .map(buildAgentCandidate)
 
   const allCandidates = [...chatCandidates, ...agentCandidates]

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -763,6 +763,10 @@ export interface AgentSessionMeta {
   starred?: boolean
   /** 是否已归档 */
   archived?: boolean
+  /**
+   * 尚未发送首条消息的临时输入会话。该标记须持久化，避免应用重启后在侧栏中冒出空会话。
+   */
+  isDraft?: boolean
   /** 附加的外部目录路径列表（绝对路径，作为 SDK additionalDirectories 传递） */
   attachedDirectories?: string[]
   /** 附加的外部文件路径列表（绝对路径，发送时以父目录作为 SDK additionalDirectories） */


### PR DESCRIPTION
## Summary
- Persist the temporary Agent draft marker so it survives application restart.
- Keep persisted drafts out of the sidebar and tab switcher, then clear the marker on the first send.

## Validation
- `bun run typecheck`

## Performance
- No continuous update path added: the flag is written only on draft creation and the first run; existing list filters add a constant-time boolean check per displayed session.
- Electron runtime interaction was not exercised in this pass.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)