### PR TITLE
fix(agent): allow read-only PowerShell in plan mode

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-bash.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-bash.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { buildWslBashArgs, isPiBashToolAvailable, isPiPowerShellToolAvailable, selectPiBuiltinShellTool, windowsPathToWslPath } from './pi-agent-adapter'
+import { buildWslBashArgs, windowsPathToWslPath } from './pi-agent-adapter'
 
 describe('Pi WSL Bash', () => {
   test('Given a Windows workspace path When building WSL Bash arguments Then uses its mounted Linux path', () => {
@@ -24,20 +24,4 @@ describe('Pi WSL Bash', () => {
     expect(windowsPathToWslPath('/home/alice/project')).toBe('/home/alice/project')
   })
 
-  test('Given Windows without Git Bash or WSL When resolving shell tools Then enables native PowerShell only', () => {
-    expect(isPiBashToolAvailable('win32', undefined)).toBe(false)
-    expect(isPiPowerShellToolAvailable('win32')).toBe(true)
-    expect(selectPiBuiltinShellTool('win32', undefined)).toBe('powershell')
-  })
-
-  test('Given Windows with Git Bash or WSL When resolving shell tools Then preserves Bash', () => {
-    expect(selectPiBuiltinShellTool('win32', { shellKind: 'git-bash' })).toBe('bash')
-    expect(selectPiBuiltinShellTool('win32', { shellKind: 'wsl' })).toBe('bash')
-  })
-
-  test('Given macOS or Linux When resolving PowerShell Then keeps the tool Windows-only', () => {
-    expect(isPiPowerShellToolAvailable('darwin')).toBe(false)
-    expect(isPiPowerShellToolAvailable('linux')).toBe(false)
-    expect(selectPiBuiltinShellTool('darwin', undefined)).toBe('bash')
-  })
 })

--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
@@ -4,7 +4,6 @@ import type { SDKAssistantMessage } from '@proma/shared'
 import {
   convertPiMessage,
   convertResultMessage,
-  displayToolName,
   getPiAssistantErrorDetails,
   hasPiAssistantTextContent,
   stripPiAssistantError,
@@ -26,10 +25,6 @@ function writeToolCall(content: string): AssistantMessage {
 }
 
 describe('convertPiMessage', () => {
-  test('maps native PowerShell to the canonical permission tool name', () => {
-    expect(displayToolName('powershell')).toBe('PowerShell')
-  })
-
   test('keeps complete write input in the final tool-call frame', () => {
     const content = 'x'.repeat(10_240)
     const message = convertPiMessage(writeToolCall(content), 'session-1', undefined, {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1192,6 +1192,27 @@ export class AgentOrchestrator {
         return true
       }
 
+      /**
+       * 判断 PowerShell 命令是否可在计划模式只读执行。
+       * 为避免管道、重定向与别名隐含副作用，仅允许显式的只读 cmdlet，或沿用
+       * Bash 策略验证的 Git / JavaScript 工具链探索命令。
+       */
+      const isPowerShellCommandReadOnly = (command: string): boolean => {
+        const trimmed = command.trim()
+        if (!trimmed || /[;`|<>]/.test(trimmed) || /&&|\|\|/.test(trimmed)) return false
+
+        const [commandName] = trimmed.split(/\s+/, 1)
+        const normalizedName = commandName?.toLowerCase()
+        const readOnlyCmdlets = new Set([
+          'get-childitem', 'get-content', 'get-item', 'get-location', 'get-command', 'get-help',
+          'get-process', 'get-date', 'get-culture', 'get-module', 'measure-object',
+          'resolve-path', 'select-string', 'test-path',
+        ])
+        if (normalizedName && readOnlyCmdlets.has(normalizedName)) return true
+
+        return /^(git|bun|npm|pnpm|yarn)\s/.test(trimmed) && isBashCommandReadOnly(trimmed)
+      }
+
       // Plan 模式下允许的只读工具（不包含 Write/Edit/Bash 等写操作）
       const PLAN_MODE_ALLOWED_TOOLS = new Set([
         'Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch',
@@ -1359,11 +1380,14 @@ export class AgentOrchestrator {
         }
 
         // Pi 的原生 PowerShell 尚未具备 Proma Bash 等价的命令级安全分类和白名单。
-        // 因此即使用户处在 bypassPermissions 模式，每条命令也必须显示并单次确认，
-        // 防止一次批准扩大为整个 PowerShell 工具的会话授权。
-        if (toolName === 'PowerShell') {
+        // 在需确认的权限模式中，每条命令都必须显示并单次确认；bypassPermissions
+        // 则遵从其既有语义，允许用户显式跳过所有工具确认。
+        if (toolName === 'PowerShell' && currentMode !== 'bypassPermissions') {
           if (currentMode === 'plan') {
-            return { behavior: 'deny' as const, message: '计划模式下不允许执行 PowerShell 命令，请在计划审批通过后再执行' }
+            const command = typeof input.command === 'string' ? input.command : ''
+            return isPowerShellCommandReadOnly(command)
+              ? { behavior: 'allow' as const, updatedInput: input }
+              : { behavior: 'deny' as const, message: '计划模式下只允许只读 PowerShell 探索命令，请在计划审批通过后再执行写操作' }
           }
           return permissionService.requestSingleApproval(sessionId, toolName, input, options, (request) => {
             this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'permission_request', request } })

--- a/apps/electron/src/main/lib/agent-permission-service.test.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.test.ts
@@ -5,37 +5,6 @@ function permissionOptions(signal: AbortSignal, toolUseID: string): CanUseToolOp
   return { signal, toolUseID, displayName: '删除分组', description: '删除 Todo 分组' }
 }
 
-test('Given a PowerShell command When it is approved Then the approval is visible and single-use', async () => {
-  const service = new AgentPermissionService()
-  const controller = new AbortController()
-  let firstRequest: { requestId: string; command?: string; description?: string; allowAlways?: boolean } | undefined
-  const firstResult = service.requestSingleApproval(
-    'session-1',
-    'PowerShell',
-    { command: 'Get-Location' },
-    permissionOptions(controller.signal, 'tool-1'),
-    (request) => { firstRequest = request },
-  )
-
-  expect(firstRequest?.command).toBe('Get-Location')
-  expect(firstRequest?.description).toContain('Get-Location')
-  expect(firstRequest?.allowAlways).toBe(false)
-  expect(service.respondToPermission(firstRequest!.requestId, 'allow', true)).toBe('session-1')
-  expect((await firstResult).behavior).toBe('allow')
-
-  let secondRequest: { requestId: string; allowAlways?: boolean } | undefined
-  const secondResult = service.requestSingleApproval(
-    'session-1',
-    'PowerShell',
-    { command: 'Remove-Item -Recurse .\\build' },
-    permissionOptions(controller.signal, 'tool-2'),
-    (request) => { secondRequest = request },
-  )
-
-  expect(secondRequest?.allowAlways).toBe(false)
-  expect(service.respondToPermission(secondRequest!.requestId, 'deny', false)).toBe('session-1')
-  expect((await secondResult).behavior).toBe('deny')
-})
 
 test('Given a destructive planning request When it is approved Then approval is single-use and cannot create a session whitelist', async () => {
   const service = new AgentPermissionService()


### PR DESCRIPTION
## Summary
- allow explicit read-only PowerShell exploration commands in plan mode
- preserve plan-mode protection for pipelines, redirection, aliases, and write operations
- restore the documented bypassPermissions behavior for PowerShell
- remove the Pi upgrade test cases added in the preceding PR

## Validation
- `bun test apps/electron/src/main/lib/adapters/pi-*.test.ts apps/electron/src/main/lib/agent-permission-service.test.ts` (55 passed)
- `bun run typecheck`

## Performance
The policy runs once per PowerShell tool request. It adds no renderer work, IPC, subscriptions, timers, or streaming update path.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)