### PR TITLE
Fix agent terminal reuse

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -1439,11 +1439,11 @@ function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDe
     sdk.defineTool({
       name: 'TerminalExecute',
       label: '在可见终端执行命令',
-      description: 'Run one command in a visible Agent-owned terminal Tab. Omit terminalId to open a new Tab, or provide the ID of a current-session running terminal to reuse it. The user can see and interrupt it. Call TerminalRead with the returned terminal ID when you need to inspect its output; output is never pushed into this tool result.',
-      promptSnippet: 'Use the visible terminal for user-attended commands that benefit from execution visibility. Before reusing a terminal, call TerminalList and reuse only a current-session terminal with a matching cwd whose previous command you observed finish; otherwise omit terminalId to open a new Tab. If the result matters, call TerminalRead after it has produced output instead of assuming output is returned automatically.',
+      description: 'Run one command in a visible Agent-owned terminal Tab. Prefer terminalId to reuse a safe matching current-session terminal; omit it only when no terminal can be reused. The user can see and interrupt it. Call TerminalRead with the returned terminal ID when you need to inspect its output; output is never pushed into this tool result.',
+      promptSnippet: 'Use the visible terminal only for user-attended commands that benefit from execution visibility. Before every visible terminal command, call TerminalList and prefer a current-session running terminal with a matching cwd whose previous command you observed finish; pass its terminalId to avoid opening another Tab. Omit terminalId only when no safe candidate exists, the cwd or shell must differ, or the user needs a separately visible concurrent session. Do not reuse an interactive, long-running, or unverified-busy terminal. Use TerminalRead to confirm completion or inspect results; do not assume output is returned automatically.',
       parameters: Type.Object({
         command: Type.String({ description: 'Complete command to execute in the controlled shell. Do not prepend shell wrappers.' }),
-        terminalId: Type.Optional(Type.String({ description: 'Current-session running Agent terminal to reuse. First inspect candidates with TerminalList; do not reuse an interactive, long-running, or unverified-busy terminal.' })),
+        terminalId: Type.Optional(Type.String({ description: 'Preferred when a matching safe current-session terminal is available. First inspect candidates with TerminalList; do not reuse an interactive, long-running, or unverified-busy terminal.' })),
         cwd: Type.Optional(Type.String({ description: 'Absolute or Agent-CWD-relative directory within the current authorized roots. Used only when opening a new terminal.' })),
         title: Type.Optional(Type.String({ description: 'Short visible terminal title. Used only when opening a new terminal.' })),
         shell: Type.Optional(Type.String({ description: `${shellProfileDescription} Used only when opening a new terminal. When reusing terminalId, an explicitly mismatching shell fails; omit it to keep the existing shell.` })),
@@ -1468,7 +1468,7 @@ function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDe
       name: 'TerminalRead',
       label: '读取 Agent 终端输出',
       description: 'Read bounded buffered output from one current-session Agent-owned terminal. By default returns the latest 12,000 characters of normalized text. Use offset and limit to page earlier output; it can read output after the terminal exits until the terminal or session is closed.',
-      promptSnippet: 'After starting a visible terminal command, use TerminalRead whenever you need its result. Start with the default tail; use the returned nextOffset to page forward or a smaller offset to inspect earlier output. Do not assume terminal output is automatically returned.',
+      promptSnippet: 'After starting a visible terminal command, use TerminalRead whenever you need its result or need to confirm it finished before reusing its terminal. Start with the default tail; use the returned nextOffset to page forward or a smaller offset to inspect earlier output. Do not assume terminal output is automatically returned.',
       parameters: Type.Object({
         terminalId: Type.String({ description: 'Terminal ID returned by TerminalOpen, TerminalExecute, or TerminalList.' }),
         offset: Type.Optional(Type.Number({ description: 'Optional non-negative character offset in the terminal output stream. Omit to read the latest output.' })),
@@ -1485,8 +1485,8 @@ function buildAgentTerminalTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDe
     sdk.defineTool({
       name: 'TerminalList',
       label: '列出 Agent 终端',
-      description: 'List terminals owned by the current Agent session, including cwd and running/exited state. Use this before deciding whether a visible terminal can be safely reused. It never exposes terminal output.',
-      promptSnippet: 'Inspect Agent-owned terminal metadata before deciding whether to reuse a visible terminal; do not read terminal output unless needed.',
+      description: 'List terminals owned by the current Agent session, including cwd and running/exited state. Use this before every visible terminal command to find a safe terminal to reuse. It never exposes terminal output.',
+      promptSnippet: 'Before every visible terminal command, inspect Agent-owned terminal metadata and prefer a safe matching terminal to avoid opening another Tab. Read terminal output only when needed to confirm its previous command finished.',
       parameters: Type.Object({}),
       async execute() {
         return jsonToolResult({ terminals: listAgentTerminals(ctx.sessionId) })

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -134,7 +134,7 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - 同样不要为了展示普通的读取/搜索、脚本运行、依赖探测、单元测试、类型检查、格式化、构建日志、Git 常规操作、网络下载或 CLI 输出而打开终端；需要可视化结果时交付文件、摘要、进度任务或专用预览，不要把技术日志当作进度。
 - Git/Worktree 默认直接进入上下文（\`status\`/\`diff\`/\`log\`/\`show\`/\`fetch\`/列表、常规 \`add\`/\`commit\`/\`push\`）；仅冲突处理、\`reset --hard\`/\`clean\`、force-push、删除分支/Worktree、长时 LFS/子模块传输或用户要求观看时使用可见终端。
 - 重要命令仍须遵守权限确认和安全规则；可见终端不替代确认。Automation、外部 Bridge 和协作子 Agent 没有可见终端时，不要假装可见。
-- 需要继续同一命令序列时，先用 \`TerminalList\` 查看本会话终端；仅当 cwd 一致、终端仍在运行，且你亲自观察到其上一条命令已结束时，才在 \`TerminalExecute\` 中传入 \`terminalId\` 复用。交互式、长驻或忙碌状态不明的终端一律新开，绝不向其中注入命令。需要命令结果时使用 \`TerminalRead\`。`,
+- 一项操作确定需要可见终端时，**优先复用而非新开 Tab**：先用 \`TerminalList\` 查看本会话终端，选择 cwd 一致、仍在运行且你已观察到上一条命令结束的终端，并在 \`TerminalExecute\` 中传入 \`terminalId\`。仅在没有这种安全候选、cwd 或 shell 必须改变、或需要让用户独立观察并行会话时，才新开终端。交互式、长驻或忙碌状态不明的终端不可复用；需要确认完成状态或命令结果时使用 \`TerminalRead\`。`,
     WORKFLOW_PROMPT,
     planningPrompt,
     ctx.collaborationAvailable


### PR DESCRIPTION
## Summary

- Prefer safely reusing visible Agent terminals instead of opening additional tabs.
- Align TerminalExecute, TerminalList, and TerminalRead guidance around reuse and completion checks.

## Validation

- `git diff --check`
- `bun run typecheck` is blocked by pre-existing Pi SDK type mismatches in `pi-agent-adapter.ts` (unrelated to this change).

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)