### PR TITLE
fix(markdown): restore LiveMarkdown rendering

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -5894,6 +5894,23 @@ export function registerIpcHandlers(): void {
     return getConfiguredVaultFileSystem().readFile(relativePath)
   })
 
+  ipcMain.handle(VAULT_IPC_CHANNELS.RESOLVE_MEDIA, async (_, noteRelativePath: unknown, src: unknown): Promise<ResolvedFileUrl | null> => {
+    if (typeof noteRelativePath !== 'string' || typeof src !== 'string') return null
+    const resolvedPath = getConfiguredVaultFileSystem().resolveMedia(noteRelativePath, src)
+    return resolvedPath ? { url: registerPromaFilePath(resolvedPath) } : null
+  })
+
+  ipcMain.handle(VAULT_IPC_CHANNELS.SAVE_PASTED_IMAGE, async (_, input: unknown): Promise<{ src: string } | null> => {
+    if (!input || typeof input !== 'object') return null
+    const value = input as Record<string, unknown>
+    if (typeof value.noteRelativePath !== 'string' || typeof value.mimeType !== 'string' || typeof value.base64 !== 'string') return null
+    return getConfiguredVaultFileSystem().savePastedImage({
+      noteRelativePath: value.noteRelativePath,
+      mimeType: value.mimeType,
+      base64: value.base64,
+    })
+  })
+
   ipcMain.handle(VAULT_IPC_CHANNELS.WRITE_FILE, async (_, input: unknown) => {
     if (!input || typeof input !== 'object') throw new Error('Vault 写入参数非法')
     const value = input as Record<string, unknown>

--- a/apps/electron/src/main/lib/vault-service.ts
+++ b/apps/electron/src/main/lib/vault-service.ts
@@ -37,6 +37,8 @@ const MAX_VAULT_FILES = 5_000
 const MAX_VAULT_DEPTH = 16
 const HIDDEN_DIRECTORY_PREFIX = '.'
 const MAX_VAULT_PASTED_IMAGE_BYTES = 10 * 1024 * 1024
+// Reject oversize renderer IPC before decoding into an additional Node Buffer.
+const MAX_VAULT_PASTED_IMAGE_BASE64_CHARS = Math.ceil(MAX_VAULT_PASTED_IMAGE_BYTES / 3) * 4
 const PASTED_IMAGE_EXTENSIONS: Record<string, string> = {
   'image/png': 'png',
   'image/jpeg': 'jpg',
@@ -330,8 +332,9 @@ export function createVaultFileSystem(rootPath: string): VaultFileSystem {
 
   const savePastedImage = (input: VaultSavePastedImageInput): { src: string } | null => {
     const extension = PASTED_IMAGE_EXTENSIONS[input.mimeType]
-    const normalizedBase64 = typeof input.base64 === 'string' ? input.base64.replace(/\s/g, '') : ''
-    if (!extension || !normalizedBase64 || normalizedBase64.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalizedBase64)) return null
+    if (!extension || typeof input.base64 !== 'string' || input.base64.length === 0 || input.base64.length > MAX_VAULT_PASTED_IMAGE_BASE64_CHARS) return null
+    const normalizedBase64 = input.base64.replace(/\s/g, '')
+    if (!normalizedBase64 || normalizedBase64.length > MAX_VAULT_PASTED_IMAGE_BASE64_CHARS || normalizedBase64.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalizedBase64)) return null
 
     let data: Buffer
     try {

--- a/apps/electron/src/main/lib/vault-service.ts
+++ b/apps/electron/src/main/lib/vault-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import {
   closeSync,
   existsSync,
@@ -23,17 +23,26 @@ import type {
   VaultFocus,
   VaultReadResult,
   VaultRenameInput,
+  VaultSavePastedImageInput,
   VaultSummary,
   VaultWriteInput,
   VaultWriteResult,
 } from '@proma/shared'
 import { getDefaultVaultDir, getVaultConfigPath, resolveDefaultVaultDir } from './config-paths'
 import { readJsonFileSafe, writeJsonFileAtomic, writeTextFileAtomic } from './safe-file'
+import { isValidImageBytes } from './image-content-validation'
 
 const MAX_VAULT_FILE_BYTES = 2 * 1024 * 1024
 const MAX_VAULT_FILES = 5_000
 const MAX_VAULT_DEPTH = 16
 const HIDDEN_DIRECTORY_PREFIX = '.'
+const MAX_VAULT_PASTED_IMAGE_BYTES = 10 * 1024 * 1024
+const PASTED_IMAGE_EXTENSIONS: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+}
 
 function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf-8').digest('hex')
@@ -227,6 +236,8 @@ export function getVaultUserContext(sessionId: string): VaultUserContextSnapshot
 export interface VaultFileSystem {
   listFiles(): VaultFileEntry[]
   readFile(relativePath: string): VaultReadResult
+  resolveMedia(noteRelativePath: string, src: string): string | null
+  savePastedImage(input: VaultSavePastedImageInput): { src: string } | null
   writeFile(input: VaultWriteInput): VaultWriteResult
   createUntitledNote(inboxPath: string, content?: string, now?: Date): VaultWriteResult
   createUntitledNoteInFolder(folderPath: string, content?: string, now?: Date): VaultWriteResult
@@ -290,6 +301,56 @@ export function createVaultFileSystem(rootPath: string): VaultFileSystem {
       sha256: sha256(content),
       modifiedAt: stats.mtimeMs,
     }
+  }
+
+  const resolveMedia = (noteRelativePath: string, src: string): string | null => {
+    if (typeof src !== 'string' || !src.trim() || src.includes('\0')) return null
+    const note = getSafeVaultTarget(root, noteRelativePath)
+    const source = src.trim().replace(/[?#].*$/, '')
+    if (!source) return null
+
+    let candidate: string
+    try {
+      candidate = source.toLowerCase().startsWith('file:')
+        ? decodeURIComponent(new URL(source).pathname)
+        : resolve(dirname(note.absolutePath), decodeURIComponent(source))
+    } catch {
+      return null
+    }
+    if (!isWithinRoot(root, candidate)) return null
+
+    const relativeCandidate = toRelativePath(root, candidate)
+    try {
+      const target = getSafeVaultPath(root, relativeCandidate)
+      return existsSync(target.absolutePath) && lstatSync(target.absolutePath).isFile() ? target.absolutePath : null
+    } catch {
+      return null
+    }
+  }
+
+  const savePastedImage = (input: VaultSavePastedImageInput): { src: string } | null => {
+    const extension = PASTED_IMAGE_EXTENSIONS[input.mimeType]
+    const normalizedBase64 = typeof input.base64 === 'string' ? input.base64.replace(/\s/g, '') : ''
+    if (!extension || !normalizedBase64 || normalizedBase64.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalizedBase64)) return null
+
+    let data: Buffer
+    try {
+      data = Buffer.from(normalizedBase64, 'base64')
+    } catch {
+      return null
+    }
+    if (data.length === 0 || data.length > MAX_VAULT_PASTED_IMAGE_BYTES || !isValidImageBytes(input.mimeType, data)) return null
+
+    const note = getSafeVaultTarget(root, input.noteRelativePath)
+    const directory = dirname(note.relativePath)
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const filename = `pasted-image-${timestamp}-${randomUUID()}.${extension}`
+    const mediaRelativePath = directory === '.' ? `assets/${filename}` : `${directory}/assets/${filename}`
+    const target = getSafeVaultPath(root, mediaRelativePath)
+    mkdirSync(dirname(target.absolutePath), { recursive: true })
+    const revalidated = getSafeVaultPath(root, mediaRelativePath)
+    writeFileSync(revalidated.absolutePath, data, { flag: 'wx' })
+    return { src: toRelativePath(dirname(note.absolutePath), revalidated.absolutePath) }
   }
 
   const writeFile = (input: VaultWriteInput): VaultWriteResult => {
@@ -413,7 +474,7 @@ export function createVaultFileSystem(rootPath: string): VaultFileSystem {
     unlinkSync(revalidated.absolutePath)
   }
 
-  return { listFiles, readFile, writeFile, createUntitledNote, createUntitledNoteInFolder, createFolder, renameFile, deleteFile }
+  return { listFiles, readFile, resolveMedia, savePastedImage, writeFile, createUntitledNote, createUntitledNoteInFolder, createFolder, renameFile, deleteFile }
 }
 
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -121,6 +121,7 @@ import type {
   VaultFocus,
   VaultReadResult,
   VaultRenameInput,
+  VaultSavePastedImageInput,
   VaultSummary,
   VaultWriteInput,
   VaultWriteResult,
@@ -484,6 +485,8 @@ export interface ElectronAPI {
   authorizeDiscoveredVault: (rootPath: string, options?: { inboxPath?: string; allowAgentWrites?: boolean }) => Promise<VaultSummary>
   listVaultFiles: () => Promise<VaultFileEntry[]>
   readVaultFile: (relativePath: string) => Promise<VaultReadResult>
+  resolveVaultMedia: (noteRelativePath: string, src: string) => Promise<import('@proma/shared').ResolvedFileUrl | null>
+  saveVaultPastedImage: (input: VaultSavePastedImageInput) => Promise<{ src: string } | null>
   writeVaultFile: (input: VaultWriteInput) => Promise<VaultWriteResult>
   createUntitledVaultFile: () => Promise<VaultWriteResult>
   createUntitledVaultFileInFolder: (folderPath: string) => Promise<VaultWriteResult>
@@ -1736,6 +1739,8 @@ const electronAPI: ElectronAPI = {
   authorizeDiscoveredVault: (rootPath: string, options?: { inboxPath?: string; allowAgentWrites?: boolean }) => ipcRenderer.invoke(VAULT_IPC_CHANNELS.AUTHORIZE_CANDIDATE, rootPath, options),
   listVaultFiles: () => ipcRenderer.invoke(VAULT_IPC_CHANNELS.LIST_FILES),
   readVaultFile: (relativePath: string) => ipcRenderer.invoke(VAULT_IPC_CHANNELS.READ_FILE, relativePath),
+  resolveVaultMedia: (noteRelativePath: string, src: string) => ipcRenderer.invoke(VAULT_IPC_CHANNELS.RESOLVE_MEDIA, noteRelativePath, src),
+  saveVaultPastedImage: (input: VaultSavePastedImageInput) => ipcRenderer.invoke(VAULT_IPC_CHANNELS.SAVE_PASTED_IMAGE, input),
   writeVaultFile: (input: VaultWriteInput) => ipcRenderer.invoke(VAULT_IPC_CHANNELS.WRITE_FILE, input),
   createUntitledVaultFile: () => ipcRenderer.invoke(VAULT_IPC_CHANNELS.CREATE_UNTITLED_FILE),
   createUntitledVaultFileInFolder: (folderPath: string) => ipcRenderer.invoke(VAULT_IPC_CHANNELS.CREATE_UNTITLED_FILE_IN_FOLDER, folderPath),

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -429,10 +429,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     markdownSourceMode: activeMarkdownEditing && markdownSourceMode,
   }), [filePath, loading, activeMarkdownEditing, markdownSourceMode, newContent.length, officeHtml.length, officeHtmlUrl, htmlPreviewUrl, htmlSourceMode, oldContent.length, previewOnly, viewMode])
 
-  // 目录提取只需在「文件本身或其内容」变化时重建，避免 loading/编辑态切换造成的抖动
+  // 目录必须随完整 Markdown 内容更新：仅使用长度会漏掉等长标题修改，留下
+  // 旧标题、旧锚点或错误层级。loading/编辑态切换仍不参与该 key，避免无关抖动。
   const tocContentKey = React.useMemo(
-    () => JSON.stringify({ filePath, previewContentVersion, newLength: newContent.length }),
-    [filePath, previewContentVersion, newContent.length],
+    () => JSON.stringify({ filePath, previewContentVersion, content: newContent }),
+    [filePath, previewContentVersion, newContent],
   )
 
   // ===== 选中文本引用（Quoted Selection）=====

--- a/apps/electron/src/renderer/components/diff/MarkdownToc.tsx
+++ b/apps/electron/src/renderer/components/diff/MarkdownToc.tsx
@@ -50,7 +50,7 @@ export function MarkdownToc({ containerRef, contentKey, enabled, onOpenChange }:
   return (
     <nav
       aria-label="文档目录"
-      className="flex flex-col w-52 shrink-0 self-start max-h-full m-2 rounded-lg bg-muted/40"
+      className="m-2 flex h-[calc(100%-1rem)] min-h-0 w-52 shrink-0 self-start flex-col rounded-lg bg-muted/40"
     >
       <div className="flex items-center gap-2 px-3 pt-2 pb-1">
         <div className="min-w-0 flex-1 text-[11px] font-medium text-foreground/40 select-none">目录</div>
@@ -70,7 +70,7 @@ export function MarkdownToc({ containerRef, contentKey, enabled, onOpenChange }:
           </Tooltip>
         )}
       </div>
-      <div ref={listRef} className="min-h-0 overflow-auto scrollbar-thin px-1 pb-2">
+      <div ref={listRef} className="min-h-0 flex-1 overflow-auto scrollbar-thin px-1 pb-2">
         {headings.map((heading) => {
           const active = heading.id === activeId
           return (

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
@@ -4,7 +4,7 @@ import { Prec, RangeSetBuilder, StateEffect, StateField, type EditorState, type 
 import { Decoration, EditorView, ViewPlugin, keymap, type DecorationSet } from '@codemirror/view'
 import ink, { type Instance } from 'ink-mde'
 import { cn } from '@/lib/utils'
-import { liveMarkdownBlockPreview } from './LiveMarkdownPreview'
+import { createLiveMarkdownBlockPreview, type ResolveLiveMarkdownImageSrc, type SaveLiveMarkdownPastedImage } from './LiveMarkdownPreview'
 
 export interface LiveMarkdownEditorHandle {
   focus: () => void
@@ -20,6 +20,10 @@ interface LiveMarkdownEditorProps {
   onCancel?: () => void
   /** 只读时沿用同一套 Live Preview 渲染，但不允许修改源文档。 */
   readOnly?: boolean
+  /** 将本地 Markdown 图片映射为当前来源授权的安全 URL。 */
+  resolveImageSrc?: ResolveLiveMarkdownImageSrc
+  /** 保存剪贴板图片并返回其可写入 Markdown 的相对来源。 */
+  savePastedImage?: SaveLiveMarkdownPastedImage
   extensions?: readonly Extension[]
   className?: string
 }
@@ -185,6 +189,8 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
   onSave,
   onCancel,
   readOnly = false,
+  resolveImageSrc,
+  savePastedImage,
   extensions = [],
   className,
 }, ref): React.ReactElement {
@@ -246,7 +252,7 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
           return { destroy: () => { if (viewRef.current === view) viewRef.current = null } }
         }),
         ...markdownSyntaxVisibility,
-        liveMarkdownBlockPreview,
+        createLiveMarkdownBlockPreview(resolveImageSrc, savePastedImage),
         ...extensions,
       ].map((extension) => ({ type: 'default' as const, value: extension })),
       search: false,
@@ -291,7 +297,18 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
   React.useEffect(() => {
     const instance = instanceRef.current
     if (!instance || instance.getDoc() === value) return
+    // External document refreshes (for example an Agent writing the opened Vault
+    // note) must not eject a reader back to the top of a long CodeMirror document.
+    const scroller = hostRef.current?.querySelector<HTMLElement>('.cm-scroller')
+    const scrollTop = scroller?.scrollTop
+    const scrollLeft = scroller?.scrollLeft
     instance.update(value)
+    if (scroller && scrollTop !== undefined && scrollLeft !== undefined) {
+      requestAnimationFrame(() => {
+        scroller.scrollTop = scrollTop
+        scroller.scrollLeft = scrollLeft
+      })
+    }
   }, [value])
 
   return <div ref={hostRef} className={cn('live-markdown-editor vault-ink-mde h-full min-h-0', className)} />

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownPreview.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownPreview.tsx
@@ -1,5 +1,5 @@
 import { createRoot, type Root } from 'react-dom/client'
-import katex from 'katex'
+import DOMPurify from 'dompurify'
 import { RangeSetBuilder, StateEffect, StateField, type Extension, type EditorState } from '@codemirror/state'
 import { Decoration, EditorView, ViewPlugin, WidgetType, type DecorationSet } from '@codemirror/view'
 import { highlightCode, highlightToTokens } from '@proma/core'
@@ -7,8 +7,18 @@ import type { HighlightTokensResult } from '@proma/core'
 import { CodeBlock, MermaidBlock } from '@proma/ui'
 import { shouldRenderMermaidCodeBlock } from '@/lib/mermaid-detection'
 import { copyTextToClipboard } from '@/lib/clipboard'
+import { renderMarkdownMath } from '@/lib/markdown-math'
+import {
+  findInlineLiveMarkdownPreviews,
+  findRawHtmlBlockEnd,
+  getDisplayMathClosingDelimiter,
+} from './live-markdown-preview-syntax'
+import { shouldRenderLiveMarkdownBlockPreview } from './live-markdown-table'
 
-type PreviewKind = 'code' | 'table' | 'mermaid' | 'thematic-break' | 'math'
+type PreviewKind = 'code' | 'table' | 'mermaid' | 'thematic-break' | 'math' | 'raw-html'
+
+export type ResolveLiveMarkdownImageSrc = (src: string) => Promise<string | null>
+export type SaveLiveMarkdownPastedImage = (file: File) => Promise<string | null>
 
 interface PreviewBlock {
   kind: PreviewKind
@@ -25,6 +35,7 @@ interface FencedCodeBlock {
 }
 
 const shikiRefreshEffect = StateEffect.define<string>()
+const enterTableSourceEditEffect = StateEffect.define<number>()
 const shikiTokenCache = new Map<string, HighlightTokensResult>()
 const SHIKI_CACHE_LIMIT = 160
 
@@ -148,6 +159,7 @@ const liveMarkdownShikiHighlight: Extension = [
 interface PreviewState {
   activeLines: Set<number>
   blocks: PreviewBlock[]
+  editingTableFrom: number | null
   decorations: DecorationSet
 }
 
@@ -173,7 +185,7 @@ abstract class LiveMarkdownBlockWidget extends WidgetType {
     this.observer = null
   }
 
-  override ignoreEvent(): boolean { return false }
+  override ignoreEvent(_event?: Event): boolean { return false }
 }
 
 class CodeBlockWidget extends LiveMarkdownBlockWidget {
@@ -208,11 +220,16 @@ class CodeBlockWidget extends LiveMarkdownBlockWidget {
 
 class TableWidget extends LiveMarkdownBlockWidget {
   constructor(private readonly rows: string[][], private readonly from: number) { super() }
-  override eq(other: TableWidget): boolean { return this.from === other.from && JSON.stringify(this.rows) === JSON.stringify(other.rows) }
+
+  override eq(other: TableWidget): boolean {
+    return this.from === other.from && JSON.stringify(this.rows) === JSON.stringify(other.rows)
+  }
+
   override toDOM(view: EditorView): HTMLElement {
     const wrapper = document.createElement('div')
     wrapper.className = 'vault-markdown-table'
     wrapper.dataset.liveMarkdownBlockFrom = String(this.from)
+    wrapper.dataset.liveMarkdownBlockKind = 'table'
     const table = document.createElement('table')
     table.setAttribute('aria-label', 'Markdown 表格')
     this.rows.forEach((row, rowIndex) => {
@@ -270,28 +287,103 @@ class MathWidget extends LiveMarkdownBlockWidget {
     const wrapper = document.createElement('div')
     wrapper.className = 'live-markdown-math-block'
     wrapper.dataset.liveMarkdownBlockFrom = String(this.from)
-    try {
-      wrapper.innerHTML = katex.renderToString(this.latex, { displayMode: true, throwOnError: false })
-    } catch {
-      wrapper.textContent = this.latex
-    }
+    wrapper.innerHTML = renderMarkdownMath(this.latex, true)
     this.observeSize(wrapper, view)
     return wrapper
   }
 }
 
 class InlineMathWidget extends WidgetType {
-  constructor(private readonly latex: string) { super() }
-  override eq(other: InlineMathWidget): boolean { return this.latex === other.latex }
+  constructor(private readonly latex: string, private readonly from: number) { super() }
+  override eq(other: InlineMathWidget): boolean { return this.latex === other.latex && this.from === other.from }
   override toDOM(): HTMLElement {
     const element = document.createElement('span')
     element.className = 'live-markdown-math-inline'
-    try {
-      element.innerHTML = katex.renderToString(this.latex, { throwOnError: false })
-    } catch {
-      element.textContent = this.latex
+    element.dataset.liveMarkdownInlineFrom = String(this.from)
+    element.setAttribute('aria-label', '点击编辑公式')
+    element.innerHTML = renderMarkdownMath(this.latex)
+    return element
+  }
+  override ignoreEvent(): boolean { return false }
+}
+
+/** Raw HTML 在阅读态保持可用，但先经 DOMPurify 处理，避免 Markdown 文件执行脚本。 */
+class RawHtmlBlockWidget extends LiveMarkdownBlockWidget {
+  constructor(private readonly html: string, private readonly from: number) { super() }
+  override eq(other: RawHtmlBlockWidget): boolean { return this.from === other.from && this.html === other.html }
+  override toDOM(view: EditorView): HTMLElement {
+    const wrapper = document.createElement('div')
+    wrapper.className = 'live-markdown-raw-html-block'
+    wrapper.dataset.liveMarkdownBlockFrom = String(this.from)
+    wrapper.innerHTML = DOMPurify.sanitize(this.html, {
+      USE_PROFILES: { html: true },
+      FORBID_TAGS: ['style'],
+      FORBID_ATTR: ['style'],
+    })
+    for (const link of Array.from(wrapper.querySelectorAll('a'))) {
+      link.target = '_blank'
+      link.rel = 'noreferrer noopener'
+    }
+    this.observeSize(wrapper, view)
+    return wrapper
+  }
+}
+
+class InlineImageWidget extends WidgetType {
+  private destroyed = false
+
+  constructor(
+    private readonly src: string,
+    private readonly alt: string,
+    private readonly title: string,
+    private readonly from: number,
+    private readonly resolveImageSrc?: ResolveLiveMarkdownImageSrc,
+  ) { super() }
+
+  override eq(other: InlineImageWidget): boolean {
+    return this.src === other.src && this.alt === other.alt && this.title === other.title && this.from === other.from
+  }
+
+  override toDOM(view: EditorView): HTMLElement {
+    const element = document.createElement('span')
+    element.className = 'live-markdown-image'
+    element.dataset.liveMarkdownInlineFrom = String(this.from)
+    element.setAttribute('aria-label', '点击编辑图片')
+
+    const image = document.createElement('img')
+    image.alt = this.alt
+    image.title = this.title
+    image.loading = 'lazy'
+    image.addEventListener('load', () => view.requestMeasure())
+    image.addEventListener('error', () => view.requestMeasure())
+    element.appendChild(image)
+
+    if (/^(?:https?:|data:|blob:|proma-file:)/i.test(this.src)) {
+      image.src = this.src
+    } else if (this.resolveImageSrc) {
+      void this.resolveImageSrc(this.src).then((resolved) => {
+        if (!this.destroyed && resolved) image.src = resolved
+      }).catch(() => {})
     }
     return element
+  }
+
+  override destroy(): void { this.destroyed = true }
+  override ignoreEvent(): boolean { return false }
+}
+
+/** CommonMark angle autolinks are not interpreted by ink-mde, so retain their normal link behavior. */
+class AngleAutolinkWidget extends WidgetType {
+  constructor(private readonly href: string) { super() }
+  override eq(other: AngleAutolinkWidget): boolean { return this.href === other.href }
+  override toDOM(): HTMLElement {
+    const link = document.createElement('a')
+    link.className = 'live-markdown-autolink'
+    link.href = this.href
+    link.target = '_blank'
+    link.rel = 'noreferrer noopener'
+    link.textContent = this.href
+    return link
   }
   override ignoreEvent(): boolean { return false }
 }
@@ -342,15 +434,25 @@ function buildBlocks(state: EditorState): PreviewBlock[] {
       }
       continue
     }
-    if (line.trim() === '$$') {
+    const closingDelimiter = getDisplayMathClosingDelimiter(line)
+    if (closingDelimiter) {
       let closing = number + 1
-      while (closing <= lines.length && (lines[closing - 1] ?? '').trim() !== '$$') closing += 1
+      while (closing <= lines.length && (lines[closing - 1] ?? '').trim() !== closingDelimiter) closing += 1
       if (closing <= lines.length) {
         const from = state.doc.line(number).from
         const to = state.doc.line(closing).to
         blocks.push({ kind: 'math', from, to, decoration: Decoration.replace({ widget: new MathWidget(lines.slice(number, closing - 1).join('\n'), from), block: true }) })
         number = closing
       }
+      continue
+    }
+    const rawHtmlEnd = findRawHtmlBlockEnd(lines, number - 1)
+    if (rawHtmlEnd !== null) {
+      const from = state.doc.line(number).from
+      const to = state.doc.line(rawHtmlEnd + 1).to
+      const html = lines.slice(number - 1, rawHtmlEnd + 1).join('\n')
+      blocks.push({ kind: 'raw-html', from, to, decoration: Decoration.replace({ widget: new RawHtmlBlockWidget(html, from), block: true }) })
+      number = rawHtmlEnd + 1
       continue
     }
     if (/^ {0,3}([-*_])(?:\s*\1){2,}\s*$/.test(line)) {
@@ -366,32 +468,44 @@ function buildBlocks(state: EditorState): PreviewBlock[] {
       const width = Math.max(header.length, ...body.map((row) => row.length))
       const rows = [header, ...body].map((row) => Array.from({ length: width }, (_, index) => row[index] ?? ''))
       const from = state.doc.line(number).from
-      blocks.push({ kind: 'table', from, to: state.doc.line(end).to, decoration: Decoration.replace({ widget: new TableWidget(rows, from), block: true }) })
+      const to = state.doc.line(end).to
+      blocks.push({ kind: 'table', from, to, decoration: Decoration.replace({ widget: new TableWidget(rows, from), block: true }) })
       number = end
     }
   }
   return blocks
 }
 
-function buildDecorations(state: EditorState, blocks: PreviewBlock[], lines: Set<number>): DecorationSet {
+function buildDecorations(
+  state: EditorState,
+  blocks: PreviewBlock[],
+  lines: Set<number>,
+  editingTableFrom: number | null,
+  resolveImageSrc?: ResolveLiveMarkdownImageSrc,
+): DecorationSet {
   const entries: Array<{ from: number; to: number; decoration: Decoration }> = []
   const protectedRanges = blocks.map((block) => ({ from: block.from, to: block.to }))
   for (const block of blocks) {
     const first = state.doc.lineAt(block.from).number
     const last = state.doc.lineAt(block.to).number
-    if (![...lines].some((line) => line >= first && line <= last)) entries.push(block)
+    // 表格仅在用户主动点击预览后进入源码，避免初始光标刚好落在首行时阅读态消失。
+    const hasActiveSelectionInBlock = [...lines].some((line) => line >= first && line <= last)
+    const isExplicitlyEditingTable = block.kind === 'table' && editingTableFrom === block.from
+    if (shouldRenderLiveMarkdownBlockPreview(block.kind === 'table' ? 'table' : 'other', hasActiveSelectionInBlock, isExplicitlyEditingTable)) entries.push(block)
   }
   for (let number = 1; number <= state.doc.lines; number += 1) {
     if (lines.has(number)) continue
     const line = state.doc.line(number)
-    const pattern = /(^|[^\\])\$([^$\n]+)\$/g
-    let match: RegExpExecArray | null
-    while ((match = pattern.exec(line.text)) !== null) {
-      const markerOffset = match.index + match[1]!.length
-      const from = line.from + markerOffset
-      const to = from + match[0]!.length - match[1]!.length
+    for (const preview of findInlineLiveMarkdownPreviews(line.text)) {
+      const from = line.from + preview.from
+      const to = line.from + preview.to
       if (protectedRanges.some((range) => from >= range.from && to <= range.to)) continue
-      entries.push({ from, to, decoration: Decoration.replace({ widget: new InlineMathWidget(match[2]!) }) })
+      const widget = preview.kind === 'math'
+        ? new InlineMathWidget(preview.content, from)
+        : preview.kind === 'image'
+          ? new InlineImageWidget(preview.src, preview.alt, preview.title, from, resolveImageSrc)
+          : new AngleAutolinkWidget(preview.content)
+      entries.push({ from, to, decoration: Decoration.replace({ widget }) })
     }
   }
   entries.sort((left, right) => left.from - right.from || left.to - right.to)
@@ -401,36 +515,82 @@ function buildDecorations(state: EditorState, blocks: PreviewBlock[], lines: Set
 }
 
 /** Common live preview for block Markdown that ink-mde does not render itself. */
-export const liveMarkdownBlockPreview: Extension = [
+export function createLiveMarkdownBlockPreview(
+  resolveImageSrc?: ResolveLiveMarkdownImageSrc,
+  savePastedImage?: SaveLiveMarkdownPastedImage,
+): Extension {
+  return [
   liveMarkdownShikiHighlight,
   StateField.define<PreviewState>({
     create: (state) => {
       const lines = activeLines(state)
       const blocks = buildBlocks(state)
-      return { activeLines: lines, blocks, decorations: buildDecorations(state, blocks, lines) }
+      return {
+        activeLines: lines,
+        blocks,
+        editingTableFrom: null,
+        decorations: buildDecorations(state, blocks, lines, null, resolveImageSrc),
+      }
     },
     update: (value, transaction) => {
       const lines = activeLines(transaction.state)
-      if (!transaction.docChanged && sameLines(lines, value.activeLines)) return value
+      const enterSourceEdit = transaction.effects.find((effect) => effect.is(enterTableSourceEditEffect))
+      let editingTableFrom = enterSourceEdit ? enterSourceEdit.value : value.editingTableFrom
       const blocks = transaction.docChanged ? buildBlocks(transaction.state) : value.blocks
-      return { activeLines: lines, blocks, decorations: buildDecorations(transaction.state, blocks, lines) }
+      if (editingTableFrom !== null) {
+        const table = blocks.find((block) => block.kind === 'table' && block.from === editingTableFrom)
+        const selectionRemainsInTable = table && transaction.state.selection.ranges.every((range) => range.from >= table.from && range.to <= table.to)
+        if (!selectionRemainsInTable) editingTableFrom = null
+      }
+      if (!transaction.docChanged && sameLines(lines, value.activeLines) && editingTableFrom === value.editingTableFrom) return value
+      return {
+        activeLines: lines,
+        blocks,
+        editingTableFrom,
+        decorations: buildDecorations(transaction.state, blocks, lines, editingTableFrom, resolveImageSrc),
+      }
     },
     provide: (field) => EditorView.decorations.from(field, (value) => value.decorations),
   }),
   EditorView.domEventHandlers({
+    paste: (event, view) => {
+      const image = Array.from(event.clipboardData?.files ?? []).find((file) => /^image\/(?:png|jpeg|gif|webp)$/i.test(file.type))
+      if (!image || !savePastedImage || view.state.readOnly) return false
+      event.preventDefault()
+      void savePastedImage(image).then((src) => {
+        if (!src) return
+        const position = view.state.selection.main.from
+        const alt = image.name.replace(/[\\[\]]/g, '\\$&') || '粘贴的图片'
+        const markdown = `![${alt}](<${src}>)`
+        view.dispatch({ changes: { from: position, insert: markdown }, selection: { anchor: position + markdown.length } })
+      }).catch(() => {})
+      return true
+    },
     mousedown: (event, view) => {
       const target = event.target as HTMLElement | null
       const block = target?.closest<HTMLElement>('[data-live-markdown-block-from]')
-      if (!block) return false
+      const inlineMath = target?.closest<HTMLElement>('[data-live-markdown-inline-from]')
+      if (!block && !inlineMath) return false
       // CodeBlock 的复制按钮必须在外层选区切换之前收到完整 click 序列。
       // 否则 mousedown 会把预览切回源码并卸载按钮，导致 click 永远无法触发。
+      // `.cm-content` 本身就是 contenteditable；把它纳入排除条件会让所有
+      // widget 点击都被提前吞掉。只给真正需要原生 click 序列的交互控件让路。
       if (target?.closest('button, a, input, select, textarea, [role="button"]')) return true
-      const from = Number(block.dataset.liveMarkdownBlockFrom)
+      const from = Number(block?.dataset.liveMarkdownBlockFrom ?? inlineMath?.dataset.liveMarkdownInlineFrom)
       if (!Number.isSafeInteger(from)) return false
+      // Replacement widget 没有可供 CodeMirror 命中的文本位置；默认命中会跳到邻行。
+      // 直接选中其源码起点，下一次 decorations 更新便会展示该行的公式标记。
       event.preventDefault()
-      view.dispatch({ selection: { anchor: from } })
+      view.dispatch({
+        selection: { anchor: from },
+        effects: block?.dataset.liveMarkdownBlockKind === 'table' ? enterTableSourceEditEffect.of(from) : undefined,
+      })
       view.focus()
       return true
     },
   }),
-]
+  ]
+}
+
+/** Default extension for consumers that do not need local-media resolution. */
+export const liveMarkdownBlockPreview = createLiveMarkdownBlockPreview()

--- a/apps/electron/src/renderer/components/markdown/live-markdown-preview-syntax.ts
+++ b/apps/electron/src/renderer/components/markdown/live-markdown-preview-syntax.ts
@@ -46,12 +46,41 @@ export function isStandaloneRawMarkdownHtml(line: string): boolean {
   return findRawHtmlBlockEnd([line], 0) === 0
 }
 
+function isEscaped(source: string, offset: number): boolean {
+  let slashCount = 0
+  for (let index = offset - 1; index >= 0 && source[index] === '\\'; index -= 1) slashCount += 1
+  return slashCount % 2 === 1
+}
+
+function inlineCodeRanges(source: string): Array<{ from: number; to: number }> {
+  const ranges: Array<{ from: number; to: number }> = []
+  let opening: { from: number; length: number } | null = null
+  for (let index = 0; index < source.length; index += 1) {
+    if (source[index] !== '`' || isEscaped(source, index)) continue
+    let end = index + 1
+    while (source[end] === '`') end += 1
+    const length = end - index
+    if (!opening) opening = { from: index, length }
+    else if (opening.length === length) {
+      ranges.push({ from: opening.from, to: end })
+      opening = null
+    }
+    index = end - 1
+  }
+  return ranges
+}
+
+function overlapsInlineCode(ranges: Array<{ from: number; to: number }>, from: number, to: number): boolean {
+  return ranges.some((range) => from < range.to && to > range.from)
+}
+
 /**
  * Finds the inline syntaxes that ink-mde leaves literal in reading mode.
  * Ranges include the delimiters so CodeMirror can replace the complete source span.
  */
 export function findInlineLiveMarkdownPreviews(line: string): InlineLiveMarkdownPreview[] {
   const previews: InlineLiveMarkdownPreview[] = []
+  const codeRanges = inlineCodeRanges(line)
   const mathPatterns = [
     { pattern: /(^|[^\\])\$([^$\n]+)\$/g, contentIndex: 2, markerOffset: (match: RegExpExecArray) => match[1]!.length },
     { pattern: /\\\(([^\n]*?)\\\)/g, contentIndex: 1, markerOffset: () => 0 },
@@ -61,10 +90,12 @@ export function findInlineLiveMarkdownPreviews(line: string): InlineLiveMarkdown
     let match: RegExpExecArray | null
     while ((match = pattern.exec(line)) !== null) {
       const from = match.index + markerOffset(match)
+      const to = from + match[0]!.length - markerOffset(match)
+      if (isEscaped(line, from) || overlapsInlineCode(codeRanges, from, to)) continue
       previews.push({
         kind: 'math',
         from,
-        to: from + match[0]!.length - markerOffset(match),
+        to,
         content: match[contentIndex]!,
       })
     }
@@ -73,10 +104,13 @@ export function findInlineLiveMarkdownPreviews(line: string): InlineLiveMarkdown
   const imagePattern = /!\[([^\]]*)\]\((?:<([^>]+)>|([^\s)]+))(?:\s+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?\)/g
   let image: RegExpExecArray | null
   while ((image = imagePattern.exec(line)) !== null) {
+    const from = image.index
+    const to = image.index + image[0]!.length
+    if (isEscaped(line, from) || overlapsInlineCode(codeRanges, from, to)) continue
     previews.push({
       kind: 'image',
-      from: image.index,
-      to: image.index + image[0]!.length,
+      from,
+      to,
       src: image[2] ?? image[3] ?? '',
       alt: image[1] ?? '',
       title: image[4] ?? image[5] ?? image[6] ?? '',
@@ -86,10 +120,13 @@ export function findInlineLiveMarkdownPreviews(line: string): InlineLiveMarkdown
   const autoLinkPattern = /<(https?:\/\/[^\s<>]+)>/g
   let autoLink: RegExpExecArray | null
   while ((autoLink = autoLinkPattern.exec(line)) !== null) {
+    const from = autoLink.index
+    const to = autoLink.index + autoLink[0]!.length
+    if (isEscaped(line, from) || overlapsInlineCode(codeRanges, from, to)) continue
     previews.push({
       kind: 'autolink',
-      from: autoLink.index,
-      to: autoLink.index + autoLink[0]!.length,
+      from,
+      to,
       content: autoLink[1]!,
     })
   }

--- a/apps/electron/src/renderer/components/markdown/live-markdown-preview-syntax.ts
+++ b/apps/electron/src/renderer/components/markdown/live-markdown-preview-syntax.ts
@@ -1,0 +1,101 @@
+export type InlineLiveMarkdownPreview =
+  | { kind: 'math' | 'autolink'; from: number; to: number; content: string }
+  | { kind: 'image'; from: number; to: number; src: string; alt: string; title: string }
+
+/** Returns the closing delimiter for supported display math, if this line opens a block. */
+export function getDisplayMathClosingDelimiter(line: string): '$$' | '\\]' | null {
+  const trimmed = line.trim()
+  if (trimmed === '$$') return '$$'
+  if (trimmed === '\\[') return '\\]'
+  return null
+}
+
+const voidHtmlTags = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr',
+])
+
+/**
+ * Finds the last zero-based source line for an HTML block that starts on `start`.
+ * This deliberately tracks only the opening tag name: it handles nested divs and
+ * keeps Markdown outside a raw HTML block available to the normal renderer.
+ */
+export function findRawHtmlBlockEnd(lines: readonly string[], start: number): number | null {
+  const first = lines[start]?.trim()
+  if (!first || /^<https?:\/\//i.test(first)) return null
+  const opening = /^<([a-z][\w:-]*)(?=\s|\/?>)[^>]*>/i.exec(first)
+  if (!opening) return null
+  const tag = opening[1]!.toLowerCase()
+  if (voidHtmlTags.has(tag) || /\/>\s*$/.test(first)) return start
+
+  const pattern = new RegExp(`<\\/?${tag}\\b[^>]*>`, 'gi')
+  let depth = 0
+  for (let lineIndex = start; lineIndex < lines.length; lineIndex += 1) {
+    let match: RegExpExecArray | null
+    pattern.lastIndex = 0
+    while ((match = pattern.exec(lines[lineIndex] ?? '')) !== null) {
+      if (/^<\//.test(match[0])) depth -= 1
+      else if (!/\/>$/.test(match[0])) depth += 1
+      if (depth === 0) return lineIndex
+    }
+  }
+  return null
+}
+
+/** Raw HTML must occupy a complete Markdown line before the live editor replaces it with a widget. */
+export function isStandaloneRawMarkdownHtml(line: string): boolean {
+  return findRawHtmlBlockEnd([line], 0) === 0
+}
+
+/**
+ * Finds the inline syntaxes that ink-mde leaves literal in reading mode.
+ * Ranges include the delimiters so CodeMirror can replace the complete source span.
+ */
+export function findInlineLiveMarkdownPreviews(line: string): InlineLiveMarkdownPreview[] {
+  const previews: InlineLiveMarkdownPreview[] = []
+  const mathPatterns = [
+    { pattern: /(^|[^\\])\$([^$\n]+)\$/g, contentIndex: 2, markerOffset: (match: RegExpExecArray) => match[1]!.length },
+    { pattern: /\\\(([^\n]*?)\\\)/g, contentIndex: 1, markerOffset: () => 0 },
+  ]
+
+  for (const { pattern, contentIndex, markerOffset } of mathPatterns) {
+    let match: RegExpExecArray | null
+    while ((match = pattern.exec(line)) !== null) {
+      const from = match.index + markerOffset(match)
+      previews.push({
+        kind: 'math',
+        from,
+        to: from + match[0]!.length - markerOffset(match),
+        content: match[contentIndex]!,
+      })
+    }
+  }
+
+  const imagePattern = /!\[([^\]]*)\]\((?:<([^>]+)>|([^\s)]+))(?:\s+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?\)/g
+  let image: RegExpExecArray | null
+  while ((image = imagePattern.exec(line)) !== null) {
+    previews.push({
+      kind: 'image',
+      from: image.index,
+      to: image.index + image[0]!.length,
+      src: image[2] ?? image[3] ?? '',
+      alt: image[1] ?? '',
+      title: image[4] ?? image[5] ?? image[6] ?? '',
+    })
+  }
+
+  const autoLinkPattern = /<(https?:\/\/[^\s<>]+)>/g
+  let autoLink: RegExpExecArray | null
+  while ((autoLink = autoLinkPattern.exec(line)) !== null) {
+    previews.push({
+      kind: 'autolink',
+      from: autoLink.index,
+      to: autoLink.index + autoLink[0]!.length,
+      content: autoLink[1]!,
+    })
+  }
+
+  // 图片目标中可能包含尖括号 URL；优先保留完整图片范围，防止 replacement decorations 重叠。
+  return previews
+    .sort((left, right) => left.from - right.from || right.to - left.to)
+    .filter((preview, index, sorted) => !sorted.slice(0, index).some((previous) => previous.from <= preview.from && previous.to >= preview.to))
+}

--- a/apps/electron/src/renderer/components/markdown/live-markdown-table.ts
+++ b/apps/electron/src/renderer/components/markdown/live-markdown-table.ts
@@ -1,0 +1,11 @@
+/**
+ * Tables stay rendered for a passive selection (including the initial cursor),
+ * but switch to Markdown source after the user explicitly clicks the preview.
+ */
+export function shouldRenderLiveMarkdownBlockPreview(
+  kind: 'table' | 'other',
+  hasActiveSelectionInBlock: boolean,
+  isExplicitlyEditingTable = false,
+): boolean {
+  return kind === 'table' ? !isExplicitlyEditingTable : !hasActiveSelectionInBlock
+}

--- a/apps/electron/src/renderer/components/vault/VaultLiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultLiveMarkdownEditor.tsx
@@ -1,13 +1,33 @@
 import type * as React from 'react'
 import { LiveMarkdownEditor } from '@/components/markdown/LiveMarkdownEditor'
 
+async function fileToBase64(file: File): Promise<string> {
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}
+
 interface VaultLiveMarkdownEditorProps {
   value: string
   onChange: (value: string) => void
   onSave: () => void
+  relativePath: string
 }
 
 /** Vault's file adapter around the reusable, domain-neutral Markdown editor. */
-export function VaultLiveMarkdownEditor(props: VaultLiveMarkdownEditorProps): React.ReactElement {
-  return <LiveMarkdownEditor {...props} />
+export function VaultLiveMarkdownEditor({ relativePath, ...props }: VaultLiveMarkdownEditorProps): React.ReactElement {
+  return (
+    <LiveMarkdownEditor
+      {...props}
+      resolveImageSrc={async (src) => (await window.electronAPI.resolveVaultMedia(relativePath, src))?.url ?? null}
+      savePastedImage={async (file) => (await window.electronAPI.saveVaultPastedImage({
+        noteRelativePath: relativePath,
+        mimeType: file.type,
+        base64: await fileToBase64(file),
+      }))?.src ?? null}
+    />
+  )
 }

--- a/apps/electron/src/renderer/components/vault/VaultLiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultLiveMarkdownEditor.tsx
@@ -1,5 +1,7 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { LiveMarkdownEditor } from '@/components/markdown/LiveMarkdownEditor'
+
+const MAX_PASTED_IMAGE_BYTES = 10 * 1024 * 1024
 
 async function fileToBase64(file: File): Promise<string> {
   const bytes = new Uint8Array(await file.arrayBuffer())
@@ -19,15 +21,24 @@ interface VaultLiveMarkdownEditorProps {
 
 /** Vault's file adapter around the reusable, domain-neutral Markdown editor. */
 export function VaultLiveMarkdownEditor({ relativePath, ...props }: VaultLiveMarkdownEditorProps): React.ReactElement {
-  return (
-    <LiveMarkdownEditor
-      {...props}
-      resolveImageSrc={async (src) => (await window.electronAPI.resolveVaultMedia(relativePath, src))?.url ?? null}
-      savePastedImage={async (file) => (await window.electronAPI.saveVaultPastedImage({
-        noteRelativePath: relativePath,
-        mimeType: file.type,
-        base64: await fileToBase64(file),
-      }))?.src ?? null}
-    />
-  )
+  const mediaRequestsRef = React.useRef(new Map<string, Promise<string | null>>())
+  const resolveImageSrc = React.useCallback((src: string): Promise<string | null> => {
+    const cached = mediaRequestsRef.current.get(src)
+    if (cached) return cached
+    const request = window.electronAPI.resolveVaultMedia(relativePath, src).then((result) => result?.url ?? null)
+    mediaRequestsRef.current.set(src, request)
+    return request
+  }, [relativePath])
+
+  const savePastedImage = React.useCallback(async (file: File): Promise<string | null> => {
+    // Reject before allocating raw bytes, a binary string, Base64, and IPC copies.
+    if (file.size <= 0 || file.size > MAX_PASTED_IMAGE_BYTES) return null
+    return (await window.electronAPI.saveVaultPastedImage({
+      noteRelativePath: relativePath,
+      mimeType: file.type,
+      base64: await fileToBase64(file),
+    }))?.src ?? null
+  }, [relativePath])
+
+  return <LiveMarkdownEditor {...props} resolveImageSrc={resolveImageSrc} savePastedImage={savePastedImage} />
 }

--- a/apps/electron/src/renderer/components/vault/VaultView.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultView.tsx
@@ -311,6 +311,7 @@ function VaultMarkdownEditor({
         </div>
         <div className="min-h-0 flex-1">
           <VaultLiveMarkdownEditor
+            relativePath={readResult.relativePath}
             value={draft}
             onChange={setDraft}
             onSave={() => { void save() }}
@@ -494,6 +495,35 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
     initialRefreshRef.current = false
     void refresh({ showLoading })
   }, [refresh, refreshToken])
+
+  // Agent tools can edit a Vault file directly, outside the renderer's own save
+  // IPC. Poll only the currently open note, never the whole Vault tree, so this
+  // stays scoped and a remote edit is reflected without changing navigation.
+  React.useEffect(() => {
+    const relativePath = readResult?.relativePath
+    const sha256 = readResult?.sha256
+    if (!relativePath || !sha256) return
+    let cancelled = false
+    let checking = false
+    const checkCurrentFile = async (): Promise<void> => {
+      if (checking || cancelled || selectedFileRef.current !== relativePath) return
+      checking = true
+      try {
+        const next = await window.electronAPI.readVaultFile(relativePath)
+        if (!cancelled && selectedFileRef.current === relativePath && next.sha256 !== sha256) setReadResult(next)
+      } catch {
+        // A concurrent rename/delete follows the existing refresh and open-file
+        // error paths; the lightweight current-file check remains silent.
+      } finally {
+        checking = false
+      }
+    }
+    const timer = window.setInterval(() => { void checkCurrentFile() }, 1_000)
+    return () => {
+      cancelled = true
+      window.clearInterval(timer)
+    }
+  }, [readResult?.relativePath, readResult?.sha256, setReadResult])
 
   const refreshVaultCandidates = React.useCallback(async (): Promise<void> => {
     setCandidatesLoading(true)

--- a/apps/electron/src/renderer/components/vault/VaultView.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultView.tsx
@@ -342,6 +342,7 @@ function VaultMarkdownPane({
   readResult,
   loading,
   hasVault,
+  reopenVersion,
   onSave,
   onRename,
   onOpenTutorial,
@@ -349,6 +350,7 @@ function VaultMarkdownPane({
   readResult: VaultReadResult | null
   loading: boolean
   hasVault: boolean
+  reopenVersion: number
   onSave: (nextContent: string, options?: { silent?: boolean; expectedSha256?: string }) => Promise<void>
   onRename: (name: string) => Promise<void>
   onOpenTutorial: () => void
@@ -373,7 +375,7 @@ function VaultMarkdownPane({
   return (
     <section className="flex min-w-0 flex-1 flex-col bg-muted/25">
       <VaultMarkdownEditor
-        key={getVaultEditorKey(readResult.relativePath)}
+        key={getVaultEditorKey(readResult.relativePath, reopenVersion)}
         readResult={readResult}
         onSave={onSave}
         onRename={onRename}
@@ -391,6 +393,7 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   const [files, setFiles] = React.useState<VaultFileEntry[]>([])
   const [loading, setLoading] = React.useState(true)
   const [fileLoading, setFileLoading] = React.useState(false)
+  const [editorReopenVersion, setEditorReopenVersion] = React.useState(0)
   const [selectedFile, setSelectedFile] = useAtom(selectedVaultFileAtom)
   const [focusedFolder, setFocusedFolder] = useAtom(focusedVaultFolderAtom)
   const [readResult, setReadResult] = useAtom(vaultReadResultAtom)
@@ -557,12 +560,18 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   }, [refreshVaultCandidates])
 
   const openFile = React.useCallback(async (relativePath: string): Promise<void> => {
+    const reopenCurrentFile = selectedFileRef.current === relativePath
     const requestId = ++readRequestRef.current
     selectFile(relativePath)
     setFileLoading(true)
     try {
       const result = await window.electronAPI.readVaultFile(relativePath)
-      if (requestId === readRequestRef.current) setReadResult(result)
+      if (requestId === readRequestRef.current) {
+        setReadResult(result)
+        // An explicit click on the selected note is the recovery path after an
+        // external-write conflict: discard the local draft and remount from disk.
+        if (reopenCurrentFile) setEditorReopenVersion((version) => version + 1)
+      }
     } catch (error) {
       if (requestId === readRequestRef.current) {
         toast.error(error instanceof Error ? error.message : '无法打开笔记')
@@ -867,6 +876,7 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
             readResult={readResult}
             loading={fileLoading}
             hasVault={config !== null}
+            reopenVersion={editorReopenVersion}
             onSave={save}
             onRename={rename}
             onOpenTutorial={() => setVaultHelpOpen(true)}

--- a/apps/electron/src/renderer/components/vault/VaultView.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultView.tsx
@@ -222,21 +222,37 @@ function VaultMarkdownEditor({
   onOpenTutorial,
 }: {
   readResult: VaultReadResult
-  onSave: (nextContent: string, options?: { silent?: boolean }) => Promise<void>
+  onSave: (nextContent: string, options?: { silent?: boolean; expectedSha256?: string }) => Promise<void>
   onRename: (name: string) => Promise<void>
   onOpenTutorial: () => void
 }): React.ReactElement {
   const [draft, setDraft] = React.useState(readResult.content)
-  const previousReadContentRef = React.useRef(readResult.content)
+  const lastReadContentRef = React.useRef(readResult.content)
+  const saveBaseRef = React.useRef({ content: readResult.content, sha256: readResult.sha256 })
+  const externalConflictRef = React.useRef(false)
   const [saving, setSaving] = React.useState(false)
   const [filename, setFilename] = React.useState(displayDocumentTitle(readResult.relativePath.split('/').pop() ?? readResult.relativePath))
   const editorPageRef = React.useRef<HTMLDivElement>(null)
   React.useEffect(() => {
-    const previousReadContent = previousReadContentRef.current
-    previousReadContentRef.current = readResult.content
-    if (!shouldAdoptVaultReadContent(draft, previousReadContent)) return
+    const previousReadContent = lastReadContentRef.current
+    if (readResult.content === previousReadContent) return
+    lastReadContentRef.current = readResult.content
+
+    // A direct Agent/external write must never replace the revision used to save
+    // a dirty draft. Keeping the prior SHA forces the existing optimistic-write
+    // conflict path instead of silently overwriting the Agent's document.
+    if (!shouldAdoptVaultReadContent(draft, previousReadContent) && readResult.content !== draft) {
+      if (!externalConflictRef.current) {
+        externalConflictRef.current = true
+        toast.error('笔记已被外部修改；本地草稿未保存，请重新打开后合并')
+      }
+      return
+    }
+
+    externalConflictRef.current = false
+    saveBaseRef.current = { content: readResult.content, sha256: readResult.sha256 }
     setDraft(readResult.content)
-  }, [draft, readResult.content])
+  }, [draft, readResult.content, readResult.sha256])
 
 
   const handleEditorPageWheel = (event: React.WheelEvent<HTMLDivElement>): void => {
@@ -248,20 +264,20 @@ function VaultMarkdownEditor({
   }
 
   const save = React.useCallback(async (silent = false): Promise<void> => {
-    if (saving || draft === readResult.content) return
+    if (saving || externalConflictRef.current || draft === saveBaseRef.current.content) return
     setSaving(true)
     try {
-      await onSave(draft, { silent })
+      await onSave(draft, { silent, expectedSha256: saveBaseRef.current.sha256 })
     } finally {
       setSaving(false)
     }
-  }, [draft, onSave, readResult.content, saving])
+  }, [draft, onSave, saving])
 
   React.useEffect(() => {
-    if (saving || draft === readResult.content) return
+    if (saving || externalConflictRef.current || draft === saveBaseRef.current.content) return
     const timer = window.setTimeout(() => { void save(true) }, 700)
     return () => window.clearTimeout(timer)
-  }, [draft, readResult.content, save, saving])
+  }, [draft, save, saving])
 
   const rename = async (): Promise<void> => {
     const currentName = displayDocumentTitle(readResult.relativePath.split('/').pop() ?? readResult.relativePath)
@@ -333,7 +349,7 @@ function VaultMarkdownPane({
   readResult: VaultReadResult | null
   loading: boolean
   hasVault: boolean
-  onSave: (nextContent: string, options?: { silent?: boolean }) => Promise<void>
+  onSave: (nextContent: string, options?: { silent?: boolean; expectedSha256?: string }) => Promise<void>
   onRename: (name: string) => Promise<void>
   onOpenTutorial: () => void
 }): React.ReactElement {
@@ -646,13 +662,13 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
     }
   }
 
-  const save = async (content: string, { silent = false }: { silent?: boolean } = {}): Promise<void> => {
+  const save = async (content: string, { silent = false, expectedSha256 }: { silent?: boolean; expectedSha256?: string } = {}): Promise<void> => {
     if (!readResult) return
     try {
       const result = await window.electronAPI.writeVaultFile({
         relativePath: readResult.relativePath,
         content,
-        expectedSha256: readResult.sha256,
+        expectedSha256: expectedSha256 ?? readResult.sha256,
       })
       if (!result.ok) {
         toast.error('文件已在外部修改，请重新打开后再保存')

--- a/apps/electron/src/renderer/components/vault/vault-editor-lifecycle.ts
+++ b/apps/electron/src/renderer/components/vault/vault-editor-lifecycle.ts
@@ -1,5 +1,6 @@
-export function getVaultEditorKey(relativePath: string, _contentHash?: string): string {
-  return relativePath
+/** A deliberate reopen gets a new editor instance; passive external refreshes do not. */
+export function getVaultEditorKey(relativePath: string, reopenVersion = 0): string {
+  return `${relativePath}:${reopenVersion}`
 }
 
 export function shouldAdoptVaultReadContent(localDraft: string, previousReadContent: string): boolean {

--- a/apps/electron/src/renderer/hooks/useTocHeadings.ts
+++ b/apps/electron/src/renderer/hooks/useTocHeadings.ts
@@ -49,7 +49,13 @@ export function useTocHeadings(
         if (!text) continue
         const level = el.dataset.tocLevel ? Number(el.dataset.tocLevel) : Number(el.tagName.slice(1))
         if (!Number.isInteger(level) || level < 1 || level > 6) continue
-        if (!el.id) el.id = slug(text)
+        const generatedId = slug(text)
+        // Preserve author-provided heading ids, but keep our generated anchors in
+        // sync when a preview updates a heading in place (including same-length edits).
+        if (!el.id || el.dataset.tocGeneratedId === 'true') {
+          el.id = generatedId
+          el.dataset.tocGeneratedId = 'true'
+        }
         next.push({ id: el.id, level, text, el })
       }
       setHeadings((prev) => (sameHeadings(prev, next) ? prev : next))
@@ -73,7 +79,7 @@ export function useTocHeadings(
     }
 
     const observer = new MutationObserver(schedule)
-    observer.observe(container, { childList: true, subtree: true })
+    observer.observe(container, { childList: true, characterData: true, subtree: true })
 
     return () => {
       observer.disconnect()

--- a/apps/electron/src/renderer/lib/markdown-math.ts
+++ b/apps/electron/src/renderer/lib/markdown-math.ts
@@ -1,0 +1,18 @@
+import katex from 'katex'
+
+/**
+ * Shared KaTeX HTML renderer for editable Markdown surfaces.
+ * Keep math generation out of editor widgets so every surface starts from the
+ * same DOM contract as the Agent Markdown renderer.
+ */
+export function renderMarkdownMath(latex: string, displayMode = false): string {
+  try {
+    return katex.renderToString(latex, {
+      displayMode,
+      output: 'htmlAndMathml',
+      throwOnError: false,
+    })
+  } catch {
+    return latex
+  }
+}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2516,10 +2516,94 @@
   overflow-x: auto;
   padding: 0.9rem 0;
   text-align: center;
+  line-height: 1.2;
 }
+/* Match the Agent history's inline-block + baseline contract. CodeMirror's
+ * editor line-height must not leak into KaTeX's vlist/table positioning. */
 .live-markdown-editor .live-markdown-math-inline {
   display: inline-block;
-  vertical-align: -0.1em;
+  vertical-align: baseline;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.live-markdown-editor .live-markdown-math-inline .katex,
+.live-markdown-editor .live-markdown-math-block .katex {
+  font-size: 1.21em;
+  line-height: 1.2;
+}
+/* ink-mde has `.cm-line span { display: inline }`, whose specificity overrides
+ * KaTeX's structural span displays. Restore the KaTeX layout primitives inside
+ * widgets: vlist drives superscripts, fractions, roots, matrices and integrals. */
+.live-markdown-editor .ink-mde .cm-line .katex .base,
+.live-markdown-editor .ink-mde .cm-line .katex .strut,
+.live-markdown-editor .ink-mde .cm-line .katex .vlist > span > span,
+.live-markdown-editor .ink-mde .cm-line .katex .mfrac .frac-line,
+.live-markdown-editor .ink-mde .cm-line .katex .mspace,
+.live-markdown-editor .ink-mde .cm-line .katex .llap > .fix,
+.live-markdown-editor .ink-mde .cm-line .katex .rlap > .fix,
+.live-markdown-editor .ink-mde .cm-line .katex .clap > .fix,
+.live-markdown-editor .ink-mde .cm-line .katex .rule,
+.live-markdown-editor .ink-mde .cm-line .katex .overline .overline-line,
+.live-markdown-editor .ink-mde .cm-line .katex .underline .underline-line,
+.live-markdown-editor .ink-mde .cm-line .katex .hline,
+.live-markdown-editor .ink-mde .cm-line .katex .hdashline,
+.live-markdown-editor .ink-mde .cm-line .katex .nulldelimiter,
+.live-markdown-editor .ink-mde .cm-line .katex .mtable .vertical-separator,
+.live-markdown-editor .ink-mde .cm-line .katex .mtable .arraycolsep,
+.live-markdown-editor .ink-mde .cm-line .katex .cd-vert-arrow,
+.live-markdown-editor .ink-mde .cm-line .katex .cd-label-left,
+.live-markdown-editor .ink-mde .cm-line .katex .cd-label-right {
+  display: inline-block !important;
+}
+.live-markdown-editor .ink-mde .cm-line .katex .vlist-t {
+  display: inline-table !important;
+}
+.live-markdown-editor .ink-mde .cm-line .katex .vlist-r {
+  display: table-row !important;
+}
+.live-markdown-editor .ink-mde .cm-line .katex .vlist,
+.live-markdown-editor .ink-mde .cm-line .katex .vlist-s {
+  display: table-cell !important;
+}
+.live-markdown-editor .ink-mde .cm-line .katex .vlist > span,
+.live-markdown-editor .ink-mde .cm-line .katex .overlay,
+.live-markdown-editor .ink-mde .cm-line .katex .stretchy {
+  display: block !important;
+}
+.live-markdown-editor .ink-mde .cm-line .katex .vbox,
+.live-markdown-editor .ink-mde .cm-line .katex .hbox,
+.live-markdown-editor .ink-mde .cm-line .katex .thinbox {
+  display: inline-flex !important;
+}
+.live-markdown-editor .live-markdown-math-inline .katex .vlist,
+.live-markdown-editor .live-markdown-math-block .katex .vlist {
+  line-height: 1.2;
+}
+.live-markdown-editor .live-markdown-image {
+  display: inline-block;
+  max-width: 100%;
+  cursor: text;
+}
+.live-markdown-editor .live-markdown-image img {
+  display: block;
+  max-width: min(100%, 56rem);
+  max-height: 44rem;
+  border: 1px solid hsl(var(--border) / 0.38);
+  border-radius: 0.5rem;
+  background: hsl(var(--muted) / 0.2);
+  object-fit: contain;
+}
+.live-markdown-editor .live-markdown-raw-html-block {
+  display: block;
+  min-height: 1.625em;
+}
+.live-markdown-editor .live-markdown-raw-html-block center {
+  display: block;
+}
+.live-markdown-editor .live-markdown-autolink {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
 }
 .vault-ink-mde .vault-markdown-table table {
   width: 100%;
@@ -2541,6 +2625,7 @@
 .vault-ink-mde .vault-markdown-table td {
   color: hsl(var(--foreground) / 0.88);
 }
+
 .vault-ink-mde .vault-properties {
   display: block;
   box-sizing: border-box;

--- a/packages/shared/src/types/vault.ts
+++ b/packages/shared/src/types/vault.ts
@@ -54,6 +54,12 @@ export interface VaultDeleteInput {
   expectedSha256?: string
 }
 
+export interface VaultSavePastedImageInput {
+  noteRelativePath: string
+  mimeType: string
+  base64: string
+}
+
 export interface VaultReadResult {
   relativePath: string
   content: string
@@ -80,6 +86,8 @@ export const VAULT_IPC_CHANNELS = {
   AUTHORIZE_CANDIDATE: 'vault:authorize-candidate',
   LIST_FILES: 'vault:list-files',
   READ_FILE: 'vault:read-file',
+  RESOLVE_MEDIA: 'vault:resolve-media',
+  SAVE_PASTED_IMAGE: 'vault:save-pasted-image',
   WRITE_FILE: 'vault:write-file',
   CREATE_UNTITLED_FILE: 'vault:create-untitled-file',
   CREATE_UNTITLED_FILE_IN_FOLDER: 'vault:create-untitled-file-in-folder',


### PR DESCRIPTION
## Summary
- restore LiveMarkdown previews for tables, KaTeX math, raw HTML/div blocks, images, and inline editing
- safely resolve Vault-local media via token-gated `proma-file://` URLs and save pasted images beside their notes
- refresh only the currently open Vault note after external Agent writes while preserving its CodeMirror scroll position
- make preview TOC anchors and long-directory layout update reliably

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:main`
- `bun run --filter='@proma/electron' build:preload`
- `bun run --filter='@proma/electron' build:renderer`
- `bun test apps/electron/src/renderer/lib/slugify.test.ts apps/electron/src/renderer/lib/markdown-rich-text.test.ts` (32 passed)

## Performance
- The external-write refresh checks only the open Vault note once per second; it does not refresh the Vault tree or other notes, and its timer is cleaned up on unmount.
- Preview widgets request CodeMirror measurement only for their own ResizeObserver/image-load changes.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
