### PR TITLE
fix(preview): restore selection references

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.2",
+  "version": "0.19.5",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1847,8 +1847,8 @@ export function registerIpcHandlers(): void {
   // 注意：通过 event.sender 获取 webContents 用于推送流式事件
   ipcMain.handle(
     CHAT_IPC_CHANNELS.SEND_MESSAGE,
-    async (event, input: ChatSendInput): Promise<void> => {
-      await sendMessage(input, event.sender)
+    async (event, input: ChatSendInput): Promise<boolean> => {
+      return sendMessage(input, event.sender)
     }
   )
 

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -193,7 +193,7 @@ function filterHistory(
 export async function sendMessage(
   input: ChatSendInput,
   webContents: WebContents,
-): Promise<void> {
+): Promise<boolean> {
   const {
     conversationId, userMessage, channelId,
     modelId, systemMessage, contextLength, contextDividers, attachments,
@@ -208,7 +208,7 @@ export async function sendMessage(
       conversationId,
       error: '渠道不存在',
     })
-    return
+    return false
   }
 
   // Subscription OAuth uses Pi provider-specific transports, which Chat mode does
@@ -220,7 +220,7 @@ export async function sendMessage(
       conversationId,
       error: `Chat 模式暂不支持 ${providerName}，请切换到 Agent 模式使用。`,
     })
-    return
+    return false
   }
 
   // 2. 解密 API Key
@@ -232,7 +232,7 @@ export async function sendMessage(
       conversationId,
       error: '解密 API Key 失败',
     })
-    return
+    return false
   }
 
   // 3. 先读取历史消息（在追加用户消息之前，避免 adapter 重复发送当前消息）
@@ -451,6 +451,7 @@ export async function sendMessage(
       model: modelId,
       messageId: (accumulatedContent.trim() || accumulatedGeneratedAttachments.length > 0) ? assistantMsgId : undefined,
     })
+    return true
   } catch (error) {
     // 被中止的请求：保存已输出的部分内容，通知前端停止
     if (controller.signal.aborted) {
@@ -488,7 +489,7 @@ export async function sendMessage(
           model: modelId,
         })
       }
-      return
+      return true
     }
 
     const errorMessage = error instanceof Error ? error.message : '未知错误'
@@ -541,6 +542,7 @@ export async function sendMessage(
       conversationId,
       error: errorMessage,
     })
+    return false
   } finally {
     activeControllers.delete(conversationId)
   }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -384,7 +384,7 @@ export interface ElectronAPI {
   // ===== 消息发送 =====
 
   /** 发送消息（触发 AI 流式响应） */
-  sendMessage: (input: ChatSendInput) => Promise<void>
+  sendMessage: (input: ChatSendInput) => Promise<boolean>
 
   /** 中止生成 */
   stopGeneration: (conversationId: string) => Promise<void>

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -8,6 +8,7 @@
 import { atom } from 'jotai'
 import { atomFamily, atomWithStorage } from 'jotai/utils'
 import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
+import type { QuotedSelection } from './preview-atoms'
 
 /** 全局渠道列表缓存（启动时加载一次，设置变更时刷新） */
 export const channelsAtom = atom<Channel[]>([])
@@ -38,6 +39,9 @@ export const currentConversationIdAtom = atom<string | null>(null)
 
 /** Agent 会话右侧 Chat 面板，key 为 Agent sessionId，value 为 Chat conversationId */
 export const agentSideChatMapAtom = atom<Map<string, string>>(new Map())
+
+/** 右侧 Chat 的单条选区引用；与 Agent 的引用状态隔离，发送后由 ChatView 消费。 */
+export const conversationQuotedSelectionMapAtom = atom<Map<string, QuotedSelection>>(new Map())
 
 /** 当前对话的消息列表 */
 export const currentMessagesAtom = atom<ChatMessage[]>([])

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -112,7 +112,10 @@ export interface QuotedSelection {
   capturedAt: number
 }
 
-/** 每会话的引用选中文本 Map（每次新选中覆盖旧值） */
+/**
+ * 每会话的单条外置选区引用（兼容 Chat 与输入框尚未挂载时的回退）。
+ * Agent 主输入框的多条引用由 RichTextInput 内联 chip 持久化在草稿中。
+ */
 export const quotedSelectionMapAtom = atom<Map<string, QuotedSelection>>(new Map())
 
 /** 当前会话的引用选中文本（派生） */

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -129,6 +129,7 @@ import { inferContextWindow, inferReasoningTransport, isCodexFastModeSupportedMo
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
 import { getFilePanelDragData, INSERT_FILE_MENTION_EVENT, type FilePanelDragItem } from '@/lib/file-panel-drag'
 import { buildQuotedSelectionBlock, expandAgentHistoryQuoteMentions } from '@/lib/quoted-selection'
+import { INSERT_AGENT_INPUT_QUOTE_EVENT, type InsertAgentInputQuoteDetail } from '@/lib/agent-input-quote'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import {
@@ -716,6 +717,15 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
   const handleAddHistoryQuote = React.useCallback((quote: QuotedSelection): boolean => {
     return richTextInputRef.current?.insertAgentHistoryQuoteMention(quote) ?? false
   }, [])
+  React.useEffect(() => {
+    const handleInsertQuote = (event: Event): void => {
+      const detail = (event as CustomEvent<InsertAgentInputQuoteDetail>).detail
+      if (!detail || detail.sessionId !== sessionId) return
+      detail.inserted = richTextInputRef.current?.insertQuotedSelectionMention(detail.quote) ?? false
+    }
+    window.addEventListener(INSERT_AGENT_INPUT_QUOTE_EVENT, handleInsertQuote)
+    return () => window.removeEventListener(INSERT_AGENT_INPUT_QUOTE_EVENT, handleInsertQuote)
+  }, [sessionId])
   const handleAgentHistoryQuoteClick = React.useCallback((quote: QuotedSelection): void => {
     if (
       quote.sourceType !== 'agent-history'

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -38,8 +38,11 @@ import {
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   buildAgentHistoryQuoteLabel,
+  buildQuotedSelectionLabel,
   parseAgentHistoryQuoteMention,
+  parseQuotedSelectionMention,
   serializeAgentHistoryQuoteMention,
+  serializeQuotedSelectionMention,
 } from '@/lib/quoted-selection'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { isImageFilePath } from './file-path-chip'
@@ -191,6 +194,8 @@ export interface RichTextInputHandle {
   insertFileMentions: (items: FilePanelDragItem[]) => void
   /** 在光标处插入可定位的 Agent 历史引用 chip。 */
   insertAgentHistoryQuoteMention: (quote: QuotedSelection) => boolean
+  /** 在光标处插入文件或 Vault 的选区引用 chip；可重复插入、多条并存。 */
+  insertQuotedSelectionMention: (quote: QuotedSelection) => boolean
 }
 
 /**
@@ -621,6 +626,8 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
             const quotePayload = typeof node.attrs.agentHistoryQuote === 'string' && node.attrs.agentHistoryQuote.length > 0
               ? node.attrs.agentHistoryQuote
               : null
+            const quotedSelection = quotePayload ? parseQuotedSelectionMention(`&quote:${quotePayload}`) : null
+            const isNavigableHistoryQuote = quotedSelection?.sourceType === 'agent-history'
             let chipClass = isDirectory ? 'directory-mention-chip' : 'mention-chip'
             if (quotePayload) chipClass = 'agent-history-quote-chip'
             else if (referenceType === 'todo') chipClass = 'todo-mention-chip'
@@ -638,9 +645,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
                 ...(referenceType === 'todo' || referenceType === 'calendar_event'
                   ? { 'data-mention-reference-type': referenceType }
                   : {}),
-                ...(quotePayload
+                ...(quotePayload ? { 'data-mention-quote': quotePayload } : {}),
+                ...(isNavigableHistoryQuote
                   ? {
-                      'data-mention-quote': quotePayload,
                       title: '跳转到引用位置并高亮',
                       role: 'button',
                       tabindex: '0',
@@ -1074,6 +1081,30 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
       const payload = marker.slice('&quote:'.length)
       const label = buildAgentHistoryQuoteLabel(quote)
       const id = `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`
+      editor.chain().focus()
+        .insertContent({
+          type: 'mention',
+          attrs: {
+            id,
+            label,
+            mentionSuggestionChar: '&',
+            agentHistoryQuote: payload,
+          },
+        })
+        .insertContent(' ')
+        .run()
+      return true
+    },
+    insertQuotedSelectionMention(quote: QuotedSelection): boolean {
+      if (!editor) return false
+      const marker = serializeQuotedSelectionMention(quote)
+      if (!marker) return false
+
+      const payload = marker.slice('&quote:'.length)
+      const label = buildQuotedSelectionLabel(quote)
+      const id = quote.sourceType === 'agent-history'
+        ? `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`
+        : `${quote.filePath}:${quote.capturedAt}`
       editor.chain().focus()
         .insertContent({
           type: 'mention',

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -31,6 +31,7 @@ import {
   conversationThinkingEnabledAtom,
   conversationParallelModeAtom,
   agentSideChatMapAtom,
+  conversationQuotedSelectionMapAtom,
 } from '@/atoms/chat-atoms'
 import {
   agentSessionsAtom,
@@ -868,6 +869,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setPreviewContentRefreshVersion = useSetAtom(previewContentRefreshVersionAtom)
   const setPreviewResolvedPaths = useSetAtom(previewResolvedPathAtom)
   const setAgentSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const setConversationQuotedSelections = useSetAtom(conversationQuotedSelectionMapAtom)
   const setDiffPanelTab = useSetAtom(agentDiffPanelTabAtom)
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
   const setDiffUnseen = useSetAtom(agentDiffUnseenChangesAtom)
@@ -907,6 +909,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     }
     setPreviewContentRefreshVersion(deletePreviewSessionEntries)
     setPreviewResolvedPaths(deletePreviewSessionEntries)
+    setConversationQuotedSelections(deleteKey)
     setAgentSideChatMap((prev) => {
       let changed = false
       const map = new Map(prev)
@@ -981,7 +984,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     sessionExistsAtom.remove(id)
 
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setPreviewFiles, setPreviewContentRefreshVersion, setPreviewResolvedPaths, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setPreviewFiles, setPreviewContentRefreshVersion, setPreviewResolvedPaths, setConversationQuotedSelections, setAgentSideChatMap, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setAgentSidePanelOpenMap, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -40,11 +40,11 @@ import {
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
   conversationDraftsAtom,
+  conversationQuotedSelectionMapAtom,
   conversationDraftSyncVersionsAtom,
   conversationDraftSyncVersionAtomFamily,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
-import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
   useConversationModel,
   useConversationThinkingEnabled,
@@ -77,8 +77,8 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   // 从 Map atom 读写草稿
   const draftsMap = useAtomValue(conversationDraftsAtom)
   const setDraftsMap = useSetAtom(conversationDraftsAtom)
-  const quotedSelectionMap = useAtomValue(quotedSelectionMapAtom)
-  const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const quotedSelectionMap = useAtomValue(conversationQuotedSelectionMapAtom)
+  const setQuotedSelectionMap = useSetAtom(conversationQuotedSelectionMapAtom)
   const currentQuotedSelection = quotedSelectionMap.get(conversationId) ?? null
   const content = draftsMap.get(conversationId) ?? ''
   const draftSyncVersion = useAtomValue(conversationDraftSyncVersionAtomFamily(conversationId))
@@ -335,7 +335,8 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   }, [])
 
   const toolbarItems = React.useMemo<ToolbarItem[]>(() => [
-    { key: 'model', node: <ModelSelector excludedProviders={['openai-codex', 'xai']} useSharedOpenState /> },
+    // Chat 可能与主 Agent 输入框并存；不能复用其全局 open atom，否则两个 Popover 会同时打开、互相关闭。
+    { key: 'model', node: <ModelSelector excludedProviders={['openai-codex', 'xai']} /> },
     {
       key: 'thinking',
       node: (
@@ -434,7 +435,11 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   )
 
   return (
-    <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px]" data-input-mode="chat">
+    <div
+      className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px]"
+      data-input-mode="chat"
+      data-conversation-id={conversationId}
+    >
         {/* 卡片式输入容器 — 对标 Cherry Studio: border-radius 17px, 0.5px border */}
         <div
           className={cn(

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -65,7 +65,7 @@ interface ChatInputProps {
   /** 设置待发送附件 */
   onSetPendingAttachments: React.Dispatch<React.SetStateAction<PendingAttachment[]>>
   /** 发送消息回调 */
-  onSend: (content: string) => void
+  onSend: (content: string) => Promise<boolean>
   /** 停止生成回调 */
   onStop: () => void
   /** 清除上下文回调 */
@@ -94,14 +94,21 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
       return map
     })
   }, [conversationId, setDraftsMap])
-  const setContent = React.useCallback((value: string) => {
+  const setContent = React.useCallback((value: React.SetStateAction<string>) => {
     setDraftSyncVersions((prev) => {
       const map = new Map(prev)
       map.set(conversationId, (map.get(conversationId) ?? 0) + 1)
       return map
     })
-    setContentFromEditor(value)
-  }, [conversationId, setContentFromEditor, setDraftSyncVersions])
+    setDraftsMap((prev) => {
+      const current = prev.get(conversationId) ?? ''
+      const nextValue = typeof value === 'function' ? value(current) : value
+      const map = new Map(prev)
+      if (nextValue.trim() === '') map.delete(conversationId)
+      else map.set(conversationId, nextValue)
+      return map
+    })
+  }, [conversationId, setDraftsMap, setDraftSyncVersions])
 
   const [selectedModel] = useConversationModel()
   const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
@@ -269,7 +276,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   }, [setPendingAttachments])
 
   /** 发送消息 */
-  const handleSend = React.useCallback((contentOverride?: string): void => {
+  const handleSend = React.useCallback(async (contentOverride?: string): Promise<void> => {
     const contentToSend = contentOverride ?? content
     const canSendCurrentContent = (contentToSend.trim().length > 0 || pendingAttachments.length > 0)
       && selectedModel !== null
@@ -280,8 +287,14 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
       toast.error('当前无网络连接，请检查网络后重试')
       return
     }
-    onSend(contentToSend.trim())
+    const submittedContent = contentToSend
+    // sendMessage 的 IPC Promise 会等到完整流式结束才 resolve。提交时先清空，
+    // 但失败时无损恢复；函数式更新不会覆盖等待期间输入的新草稿。
     setContent('')
+    const sent = await onSend(contentToSend.trim())
+    if (!sent) {
+      setContent((current) => current ? `${submittedContent}\n${current}` : submittedContent)
+    }
     // 附件清理由 ChatView 的 handleSend 负责
   }, [content, onSend, pendingAttachments.length, selectedModel, streaming])
 

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -241,8 +241,8 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       messageCountBeforeSend?: number
       contextDividersOverride?: string[]
     },
-  ): Promise<void> => {
-    if (!selectedModel) return
+  ): Promise<boolean> => {
+    if (!selectedModel) return false
 
     const consumePending = options?.consumePendingAttachments ?? true
 
@@ -311,17 +311,6 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       ? buildQuotedSelectionBlock(quotedSelection) + content
       : content
 
-    if (quotedSelection) {
-      const capturedAt = quotedSelection.capturedAt
-      store.set(conversationQuotedSelectionMapAtom, (prev) => {
-        const current = prev.get(conversationId)
-        if (!current || current.capturedAt !== capturedAt) return prev
-        const next = new Map(prev)
-        next.delete(conversationId)
-        return next
-      })
-    }
-
     // 初始化当前对话的流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
@@ -363,11 +352,12 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       enabledToolIds: activeToolIds.length > 0 ? activeToolIds : undefined,
     }
 
-    // 乐观更新：立即在 UI 中显示用户消息
+    // 乐观更新：立即在 UI 中显示用户消息；若 IPC 拒绝则移除该临时消息并保留草稿/引用。
+    const temporaryMessageId = `temp-${Date.now()}`
     setMessages((prev) => [
       ...prev,
       {
-        id: `temp-${Date.now()}`,
+        id: temporaryMessageId,
         role: 'user',
         content: finalContent,
         createdAt: Date.now(),
@@ -375,21 +365,35 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       },
     ])
 
-    window.electronAPI.sendMessage(input).catch((error) => {
+    try {
+      const completed = await window.electronAPI.sendMessage(input)
+      if (!completed) {
+        setMessages((prev) => prev.filter((message) => message.id !== temporaryMessageId))
+        return false
+      }
+      if (quotedSelection) {
+        const capturedAt = quotedSelection.capturedAt
+        store.set(conversationQuotedSelectionMapAtom, (prev) => {
+          const current = prev.get(conversationId)
+          if (!current || current.capturedAt !== capturedAt) return prev
+          const next = new Map(prev)
+          next.delete(conversationId)
+          return next
+        })
+      }
+      return true
+    } catch (error) {
       console.error('[ChatView] 发送消息失败:', error)
+      setMessages((prev) => prev.filter((message) => message.id !== temporaryMessageId))
       setStreamingStates((prev) => {
         if (!prev.has(conversationId)) return prev
         const map = new Map(prev)
         map.delete(conversationId)
         return map
       })
-      // 显示错误横幅，确保用户看到发送失败的反馈
-      setChatStreamErrors((prev) => {
-        const map = new Map(prev)
-        map.set(conversationId, '发送失败，请重试')
-        return map
-      })
-    })
+      setChatStreamErrors((prev) => new Map(prev).set(conversationId, '发送失败，请重试'))
+      return false
+    }
   }, [
     conversationId,
     selectedModel,

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -24,6 +24,7 @@ import { PromptEditorSidebar } from './PromptEditorSidebar'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import {
   conversationsAtom,
+  conversationQuotedSelectionMapAtom,
   streamingStatesAtom,
   chatStreamErrorsAtom,
   chatMessageRefreshAtom,
@@ -33,7 +34,6 @@ import {
   INITIAL_MESSAGE_LIMIT,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment, ChatPendingMessage } from '@/atoms/chat-atoms'
-import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import { promptConfigAtom, promptSidebarOpenAtom, conversationPromptIdAtom, resolveSystemMessage, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
@@ -306,14 +306,14 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       setPendingAttachments([])
     }
 
-    const quotedSelection = store.get(quotedSelectionMapAtom).get(conversationId)
+    const quotedSelection = store.get(conversationQuotedSelectionMapAtom).get(conversationId)
     const finalContent = quotedSelection
       ? buildQuotedSelectionBlock(quotedSelection) + content
       : content
 
     if (quotedSelection) {
       const capturedAt = quotedSelection.capturedAt
-      store.set(quotedSelectionMapAtom, (prev) => {
+      store.set(conversationQuotedSelectionMapAtom, (prev) => {
         const current = prev.get(conversationId)
         if (!current || current.capturedAt !== capturedAt) return prev
         const next = new Map(prev)

--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -140,6 +140,7 @@ export function ModelSelector({
   const [sharedOpen, setSharedOpen] = useAtom(modelSelectorOpenAtom)
   const open = useSharedOpenState ? sharedOpen : localOpen
   const setOpen = useSharedOpenState ? setSharedOpen : setLocalOpen
+  const [tooltipOpen, setTooltipOpen] = React.useState(false)
   const [search, setSearch] = React.useState('')
 
   // 外部模型优先 → per-conversation 模型
@@ -218,6 +219,12 @@ export function ModelSelector({
   if (currentModelInfo) stableModelInfoRef.current = currentModelInfo
   const displayModelInfo = currentModelInfo ?? stableModelInfoRef.current
 
+  // Tooltip 必须始终保持 controlled 或 uncontrolled 之一。此前在 Popover 打开时传 false、关闭时传
+  // undefined，Radix 会发出 controlled/uncontrolled 告警，且与模型 Popover 的 trigger 竞争焦点。
+  React.useEffect(() => {
+    if (open || !displayModelInfo) setTooltipOpen(false)
+  }, [displayModelInfo, open])
+
   /** 选择模型并持久化到当前对话 */
   const handleSelect = (option: ModelOption): void => {
     if (onModelSelect) {
@@ -275,7 +282,10 @@ export function ModelSelector({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       {/* 触发按钮 */}
-      <Tooltip open={open || !displayModelInfo ? false : undefined}>
+      <Tooltip
+        open={tooltipOpen}
+        onOpenChange={(nextOpen) => setTooltipOpen(nextOpen && !open && Boolean(displayModelInfo))}
+      >
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
             <button

--- a/apps/electron/src/renderer/components/chat/focus-chat-input.ts
+++ b/apps/electron/src/renderer/components/chat/focus-chat-input.ts
@@ -1,0 +1,14 @@
+/** 在右侧 Chat 已渲染后聚焦指定会话的编辑器，避免误聚焦主区域的 Chat。 */
+export function focusChatInput(conversationId: string): void {
+  const selector = `[data-input-mode="chat"][data-conversation-id="${CSS.escape(conversationId)}"] .ProseMirror`
+  const focus = (attemptsLeft: number): void => {
+    const editor = document.querySelector<HTMLElement>(selector)
+    if (editor) {
+      editor.focus()
+      return
+    }
+    // 新建会话会在切换右侧 Tab 后才挂载输入框；最多等待两帧，不轮询常驻。
+    if (attemptsLeft > 0) requestAnimationFrame(() => focus(attemptsLeft - 1))
+  }
+  requestAnimationFrame(() => focus(1))
+}

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -49,6 +49,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
 import { focusChatInput } from '@/components/chat/focus-chat-input'
+import { getOrCreateSideChat } from '@/lib/side-chat'
 import { insertAgentInputQuote } from '@/lib/agent-input-quote'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 import { copyTextToClipboard } from '@/lib/clipboard'
@@ -1398,11 +1399,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
     openSelectionChatPendingRef.current = true
     try {
-      const conversation = await window.electronAPI.createConversation(
+      const conversation = await getOrCreateSideChat(sessionId, () => window.electronAPI.createConversation(
         '预览选区问答',
         selectedChatModel?.modelId,
         selectedChatModel?.channelId,
-      )
+      ))
       setConversations((prev) => prev.some((item) => item.id === conversation.id) ? prev : [conversation, ...prev])
       setConversationDrafts((prev) => new Map(prev).set(conversation.id, '我的问题：'))
       setSideChatMap((prev) => new Map(prev).set(sessionId, conversation.id))

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -18,9 +18,6 @@ import {
   agentDiffViewModeAtom,
   agentDiffRefreshVersionAtom,
   agentSidePanelOpenAtomFamily,
-  agentSessionsAtom,
-  agentSideTemporaryAgentMapAtom,
-  getExplorationSidePanelTab,
 } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import {
@@ -30,12 +27,19 @@ import {
   previewResolvedPathAtom,
   quotedSelectionMapAtom,
 } from '@/atoms/preview-atoms'
+import {
+  agentSideChatMapAtom,
+  conversationsAtom,
+  conversationDraftsAtom,
+  conversationQuotedSelectionMapAtom,
+  selectedModelAtom,
+} from '@/atoms/chat-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
 import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { useShortcut } from '@/hooks/useShortcut'
 import { initShortcutRegistry } from '@/lib/shortcut-registry'
 import { DiffView } from './DiffView'
-import { LiveMarkdownEditor } from '@/components/markdown/LiveMarkdownEditor'
+import { LiveMarkdownEditor, type LiveMarkdownTextSelection } from '@/components/markdown/LiveMarkdownEditor'
 import { getPreviewCandidateBasePaths, isAbsoluteFilePath } from './preview-open-path'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
 import { UnsupportedFilePreview } from './UnsupportedFilePreview'
@@ -44,6 +48,8 @@ import { MarkdownToc } from './MarkdownToc'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
+import { focusChatInput } from '@/components/chat/focus-chat-input'
+import { insertAgentInputQuote } from '@/lib/agent-input-quote'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import {
@@ -439,9 +445,13 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   // ===== 选中文本引用（Quoted Selection）=====
 
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
-  const agentSessions = useAtomValue(agentSessionsAtom)
-  const setAgentSessions = useSetAtom(agentSessionsAtom)
-  const setSideTemporaryAgentMap = useSetAtom(agentSideTemporaryAgentMapAtom)
+  const selectedChatModel = useAtomValue(selectedModelAtom)
+  const conversations = useAtomValue(conversationsAtom)
+  const sideChatMap = useAtomValue(agentSideChatMapAtom)
+  const setConversations = useSetAtom(conversationsAtom)
+  const setConversationDrafts = useSetAtom(conversationDraftsAtom)
+  const setChatQuotedSelectionMap = useSetAtom(conversationQuotedSelectionMapAtom)
+  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
   const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtomFamily(sessionId))
   const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const focusAgentSessionInput = useFocusAgentSessionInput()
@@ -451,7 +461,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const shadowRootsRef = React.useRef<Set<ShadowRoot>>(new Set())
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
-  const openTemporaryAgentPendingRef = React.useRef(false)
+  const openSelectionChatPendingRef = React.useRef(false)
   /** 当前正在展示的截断 toast id；选中回落到上限内或选区消失时主动 dismiss */
   const lastToastIdRef = React.useRef<string | null>(null)
 
@@ -466,35 +476,20 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     setPreviewSelection(null)
   }, [])
 
-  /** 捕获预览面板中的文本选中，显示动作弹层 */
-  const handleSelectionCapture = React.useCallback(() => {
-    if (!previewOnly) return
-    if (activeMarkdownEditing) return
-    const container = scrollContainerRef.current
-    if (!container) return
-
-    const deepSel = getDeepSelection(container, shadowRootsRef.current)
-    if (!deepSel) {
-      clearPreviewSelection()
-      return
-    }
-
-    const truncated = deepSel.text.length > MAX_QUOTED_CHARS
-    const newText = truncated ? deepSel.text.slice(0, MAX_QUOTED_CHARS) : deepSel.text
-    const newFilePath = filePathRef.current
-    const anchorRect = deepSel.rect
-    if (!anchorRect) return
-
+  /** 将 DOM 或 CodeMirror 的选区归一为同一套引用动作。 */
+  const capturePreviewSelection = React.useCallback((text: string, x: number, y: number) => {
+    const truncated = text.length > MAX_QUOTED_CHARS
+    const quotedText = truncated ? text.slice(0, MAX_QUOTED_CHARS) : text
     setPreviewSelection({
-      text: newText,
-      x: anchorRect.left + anchorRect.width / 2,
-      y: Math.max(12, anchorRect.top - 12),
-      filePath: newFilePath,
+      text: quotedText,
+      x,
+      y: Math.max(12, y),
+      filePath: filePathRef.current,
     })
 
     // 超过上限时按千位分档 toast；跨档时撤掉上一档，回到上限内则全部撤掉
     if (truncated) {
-      const k = Math.floor(deepSel.text.length / 1000) * 1000
+      const k = Math.floor(text.length / 1000) * 1000
       const id = `quoted-chars-cap:${sessionId}:${k}`
       if (lastToastIdRef.current && lastToastIdRef.current !== id) {
         toast.dismiss(lastToastIdRef.current)
@@ -507,7 +502,38 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     } else {
       dismissTruncationToast()
     }
-  }, [clearPreviewSelection, dismissTruncationToast, activeMarkdownEditing, previewOnly, sessionId])
+  }, [dismissTruncationToast, sessionId])
+
+  /** 捕获预览面板中的 DOM 文本选中，显示动作弹层。 */
+  const handleSelectionCapture = React.useCallback(() => {
+    if (!previewOnly || activeMarkdownEditing) return
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    const deepSel = getDeepSelection(container, shadowRootsRef.current)
+    if (!deepSel?.rect) {
+      clearPreviewSelection()
+      return
+    }
+
+    capturePreviewSelection(
+      deepSel.text,
+      deepSel.rect.left + deepSel.rect.width / 2,
+      deepSel.rect.top - 12,
+    )
+  }, [activeMarkdownEditing, capturePreviewSelection, clearPreviewSelection, previewOnly])
+
+  /**
+   * ink-mde 的选择由 CodeMirror state 管理，不能可靠地从 window.getSelection() 读取。
+   * 预览 Markdown 也可能是可编辑的，因此直接接收其精确文本与坐标。
+   */
+  const handleLiveMarkdownSelectionChange = React.useCallback((selection: LiveMarkdownTextSelection | null) => {
+    if (!selection) {
+      clearPreviewSelection()
+      return
+    }
+    capturePreviewSelection(selection.text, selection.x, selection.y)
+  }, [capturePreviewSelection, clearPreviewSelection])
 
   const scheduleSelectionCapture = React.useCallback((): void => {
     if (captureTimerRef.current != null) {
@@ -1036,6 +1062,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const restoreScrollRef = React.useRef(false)
   const restoreRafRef = React.useRef(0)
 
+  const handleLiveMarkdownReady = React.useCallback(() => {
+    // Live Markdown 异步挂载前外层没有可恢复的内容高度，首轮恢复会被浏览器钳制到 0。
+    // 只有编辑器就绪后重新设置标记，才会在真实内容高度上恢复原阅读位置。
+    if (!scrollPositionCache.has(scrollKey)) return
+    restoreScrollRef.current = true
+    setPreviewScrollRestoreVersion((version) => version + 1)
+  }, [scrollKey])
+
   // WHEN content version changes (refreshVersion bump): delete stored scroll position
   // 只在内容变化时清除，切换文件时保留位置以支持返回导航。正在编辑的 Markdown
   // 由独立内层滚动容器维护，refresh 不应把它当作新文档重置。
@@ -1323,71 +1357,82 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   const handleAddSelectionToAgent = React.useCallback(() => {
     if (!previewSelection) return
-    setQuotedSelectionMap((prev) => {
-      const next = new Map(prev)
-      next.set(sessionId, {
-        text: previewSelection.text,
-        filePath: previewSelection.filePath,
-        sourceType: 'file',
-        sourceLabel: previewSelection.filePath,
-        capturedAt: Date.now(),
-      })
-      return next
-    })
+    const quote = {
+      text: previewSelection.text,
+      filePath: previewSelection.filePath,
+      sourceType: 'file' as const,
+      sourceLabel: previewSelection.filePath,
+      capturedAt: Date.now(),
+    }
+    // 与 Agent 历史选区相同：直接向 RichTextInput 插入 chip，因而可多次引用并与草稿共存。
+    // 仅在输入框尚未挂载的非常规场景回退旧的单条引用状态。
+    if (!insertAgentInputQuote(sessionId, quote)) {
+      setQuotedSelectionMap((prev) => new Map(prev).set(sessionId, quote))
+    }
     window.getSelection()?.removeAllRanges()
     clearPreviewSelection()
     focusAgentSessionInput(sessionId)
   }, [clearPreviewSelection, focusAgentSessionInput, previewSelection, sessionId, setQuotedSelectionMap])
 
-  const handleOpenExplorationBranch = React.useCallback(async (): Promise<void> => {
-    if (!previewSelection || openTemporaryAgentPendingRef.current) return
-    const parentSession = agentSessions.find((item) => item.id === sessionId)
-    // 文件预览不是一条对话消息；从当前主线最近一个可恢复的 Pi 节点分叉。
-    const sourceMessageId = Object.keys(parentSession?.piEntryBindings ?? {}).at(-1)
-    if (!sourceMessageId) {
-      toast.info('当前还没有可探索的 Agent 回复，请先完成一轮对话')
+  const handleOpenSelectionChat = React.useCallback(async (): Promise<void> => {
+    if (!previewSelection || openSelectionChatPendingRef.current) return
+
+    const quote = {
+      text: previewSelection.text,
+      filePath: previewSelection.filePath,
+      sourceType: 'file' as const,
+      sourceLabel: previewSelection.filePath,
+      capturedAt: Date.now(),
+    }
+    const activeConversationId = sideChatMap.get(sessionId) ?? null
+    // 右侧已绑定有效 Chat 时始终复用，避免因激活 Tab 状态短暂不同步而重复创建会话。
+    if (activeConversationId) {
+      setChatQuotedSelectionMap((previous) => new Map(previous).set(activeConversationId, quote))
+      setSidePanelOpen(true)
+      setSidePanelTabMap((previous) => new Map(previous).set(sessionId, 'chat'))
+      window.getSelection()?.removeAllRanges()
+      clearPreviewSelection()
+      focusChatInput(activeConversationId)
       return
     }
 
-    openTemporaryAgentPendingRef.current = true
+    openSelectionChatPendingRef.current = true
     try {
-      const branch = await window.electronAPI.forkAgentSession({
-        sessionId,
-        upToMessageUuid: sourceMessageId,
-        explorationSourceLabel: `当前节点 · ${getPreviewPathLabel(previewSelection.filePath)}`,
-      })
-      setAgentSessions((prev) => prev.some((item) => item.id === branch.id) ? prev : [branch, ...prev])
-      setQuotedSelectionMap((prev) => new Map(prev).set(branch.id, {
-        text: previewSelection.text,
-        filePath: previewSelection.filePath,
-        sourceType: 'file',
-        sourceLabel: previewSelection.filePath,
-        capturedAt: Date.now(),
-      }))
-      setSideTemporaryAgentMap((prev) => {
-        const openBranches = prev.get(sessionId) ?? []
-        const next = new Map(prev)
-        next.set(sessionId, openBranches.some((item) => item.sessionId === branch.id)
-          ? openBranches
-          : [...openBranches, {
-              sessionId: branch.id,
-              sourceMessageId,
-              sourceLabel: `当前节点 · ${getPreviewPathLabel(previewSelection.filePath)}`,
-            }])
-        return next
-      })
+      const conversation = await window.electronAPI.createConversation(
+        '预览选区问答',
+        selectedChatModel?.modelId,
+        selectedChatModel?.channelId,
+      )
+      setConversations((prev) => prev.some((item) => item.id === conversation.id) ? prev : [conversation, ...prev])
+      setConversationDrafts((prev) => new Map(prev).set(conversation.id, '我的问题：'))
+      setSideChatMap((prev) => new Map(prev).set(sessionId, conversation.id))
       setSidePanelOpen(true)
-      setSidePanelTabMap((prev) => new Map(prev).set(sessionId, getExplorationSidePanelTab(branch.id)))
+      setSidePanelTabMap((prev) => new Map(prev).set(sessionId, 'chat'))
+      setChatQuotedSelectionMap((previous) => new Map(previous).set(conversation.id, quote))
       window.getSelection()?.removeAllRanges()
       clearPreviewSelection()
-      toast.success('已从当前节点创建探索分支', { description: '文件选区已带入分支；结论可回到主线输入框。' })
+      focusChatInput(conversation.id)
     } catch (error) {
-      console.error('[DiffTabContent] 创建文件探索分支失败:', error)
-      toast.error('创建探索分支失败', { description: error instanceof Error ? error.message : undefined })
+      console.error('[DiffTabContent] 打开预览选区聊天标签失败:', error)
+      toast.error('打开右侧问答失败')
     } finally {
-      openTemporaryAgentPendingRef.current = false
+      openSelectionChatPendingRef.current = false
     }
-  }, [agentSessions, clearPreviewSelection, previewSelection, sessionId, setAgentSessions, setQuotedSelectionMap, setSidePanelOpen, setSidePanelTabMap, setSideTemporaryAgentMap])
+  }, [
+    clearPreviewSelection,
+    conversations,
+    previewSelection,
+    selectedChatModel,
+    sessionId,
+    setConversationDrafts,
+    setConversations,
+    setChatQuotedSelectionMap,
+    setQuotedSelectionMap,
+    setSideChatMap,
+    setSidePanelOpen,
+    setSidePanelTabMap,
+    sideChatMap,
+  ])
 
   // persistRef 始终持有最新 persistMarkdownDraft，供 setTimeout / unmount cleanup 调用。
   // 用 effect 而非渲染期赋值，避免 React 19 严格模式下并发渲染中途读到中间态。
@@ -1837,6 +1882,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                 value={readOnly ? newContent : markdownDraft}
                 onChange={updateMarkdownDraft}
                 onSave={() => void saveMarkdownEdit()}
+                onReady={handleLiveMarkdownReady}
+                onTextSelectionChange={handleLiveMarkdownSelectionChange}
                 readOnly={Boolean(readOnly)}
                 className="live-markdown-external-scroll"
               />
@@ -1888,7 +1935,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             x={previewSelection.x}
             y={previewSelection.y}
             onAddToAgent={handleAddSelectionToAgent}
-            onOpenExplorationBranch={handleOpenExplorationBranch}
+            onOpenChat={handleOpenSelectionChat}
           />
         )}
       </div>

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
@@ -298,6 +298,14 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
           // rAF 仍可覆盖 ink-mde 只读预览的 selection transaction 时序。
           view.dom.addEventListener('mouseup', scheduleSelectionReport)
           return {
+            update: (update) => {
+              // Pointer selections are reported on mouseup to avoid a moving popover;
+              // keyboard selection has no mouseup, so report it after CodeMirror commits.
+              const isPointerSelection = update.transactions.some((transaction) => transaction.isUserEvent('select.pointer'))
+              if (update.selectionSet && update.view.hasFocus && !isPointerSelection) {
+                scheduleSelectionReport()
+              }
+            },
             destroy: () => {
               view.dom.removeEventListener('mouseup', scheduleSelectionReport)
               if (selectionFrame) cancelAnimationFrame(selectionFrame)

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
@@ -13,11 +13,22 @@ export interface LiveMarkdownEditorHandle {
   getView: () => EditorView | null
 }
 
+/** CodeMirror 选区的文本与可用于浮层定位的视口坐标。 */
+export interface LiveMarkdownTextSelection {
+  text: string
+  x: number
+  y: number
+}
+
 interface LiveMarkdownEditorProps {
   value: string
   onChange: (value: string) => void
   onSave?: () => void
   onCancel?: () => void
+  /** 编辑器异步挂载完成后通知外层（用于恢复外层滚动位置）。 */
+  onReady?: () => void
+  /** CodeMirror 的选区不必经过 DOM Selection，直接向外提供可靠的文本与锚点。 */
+  onTextSelectionChange?: (selection: LiveMarkdownTextSelection | null) => void
   /** 只读时沿用同一套 Live Preview 渲染，但不允许修改源文档。 */
   readOnly?: boolean
   /** 将本地 Markdown 图片映射为当前来源授权的安全 URL。 */
@@ -39,6 +50,8 @@ const markdownSyntaxMarkerNames = new Set([
   'HeaderMark',
   'LinkMark',
   'QuoteMark',
+  // ink-mde 使用 GFM parser；隐藏 ~~ 定界符，让删除线呈现与 Obsidian Live Preview 一致。
+  'StrikethroughMark',
 ])
 const hiddenMarkdownSyntax = Decoration.replace({ class: 'live-markdown-syntax-hidden' })
 const pendingListHeading = Decoration.mark({ class: 'live-markdown-pending-list-heading' })
@@ -188,6 +201,8 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
   onChange,
   onSave,
   onCancel,
+  onReady,
+  onTextSelectionChange,
   readOnly = false,
   resolveImageSrc,
   savePastedImage,
@@ -201,10 +216,14 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
   const onChangeRef = React.useRef(onChange)
   const onSaveRef = React.useRef(onSave)
   const onCancelRef = React.useRef(onCancel)
+  const onReadyRef = React.useRef(onReady)
+  const onTextSelectionChangeRef = React.useRef(onTextSelectionChange)
   valueRef.current = value
   onChangeRef.current = onChange
   onSaveRef.current = onSave
   onCancelRef.current = onCancel
+  onReadyRef.current = onReady
+  onTextSelectionChangeRef.current = onTextSelectionChange
 
   React.useImperativeHandle(ref, () => ({
     focus: () => instanceRef.current?.focus(),
@@ -249,7 +268,42 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
         markdownHeadingMarkers,
         ViewPlugin.define((view) => {
           viewRef.current = view
-          return { destroy: () => { if (viewRef.current === view) viewRef.current = null } }
+          let selectionFrame = 0
+          const reportSelection = (): void => {
+            selectionFrame = 0
+            const range = view.state.selection.main
+            if (range.empty) {
+              onTextSelectionChangeRef.current?.(null)
+              return
+            }
+            const text = view.state.sliceDoc(range.from, range.to).trim()
+            // Mouse drag 结束后 CodeMirror 才会同步 selection；延迟到下一帧读取，
+            // 覆盖只读/Live Preview 中浏览器 DOM selection 与 editor state 的时序差异。
+            const coords = view.coordsAtPos(range.head) ?? view.coordsAtPos(range.from)
+            if (!text || !coords) {
+              onTextSelectionChangeRef.current?.(null)
+              return
+            }
+            onTextSelectionChangeRef.current?.({
+              text,
+              x: (coords.left + coords.right) / 2,
+              y: coords.top - 12,
+            })
+          }
+          const scheduleSelectionReport = (): void => {
+            if (selectionFrame) cancelAnimationFrame(selectionFrame)
+            selectionFrame = requestAnimationFrame(reportSelection)
+          }
+          // 只在鼠标松开后展示动作，不要在拖选过程中不断弹出、跟随选区移动。
+          // rAF 仍可覆盖 ink-mde 只读预览的 selection transaction 时序。
+          view.dom.addEventListener('mouseup', scheduleSelectionReport)
+          return {
+            destroy: () => {
+              view.dom.removeEventListener('mouseup', scheduleSelectionReport)
+              if (selectionFrame) cancelAnimationFrame(selectionFrame)
+              if (viewRef.current === view) viewRef.current = null
+            },
+          }
         }),
         ...markdownSyntaxVisibility,
         createLiveMarkdownBlockPreview(resolveImageSrc, savePastedImage),
@@ -267,6 +321,7 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
       instanceRef.current = instance
       if (instance.getDoc() !== valueRef.current) instance.update(valueRef.current)
       ready = true
+      onReadyRef.current?.()
     })
 
     const scheduler = createMeasureScheduler(() => viewRef.current)

--- a/apps/electron/src/renderer/components/selection/SelectionActionPopover.tsx
+++ b/apps/electron/src/renderer/components/selection/SelectionActionPopover.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { createPortal } from 'react-dom'
 import { Bot, MessageSquarePlus } from 'lucide-react'
 
 interface SelectionActionPopoverProps {
@@ -22,17 +23,27 @@ export function SelectionActionPopover({
   onOpenChat,
 }: SelectionActionPopoverProps): React.ReactElement {
   const openSideAssistant = onOpenExplorationBranch ?? onOpenTemporaryAgent ?? onOpenChat
-  return (
+  // 顶部选区若仍向上展开，浮窗会被窗口边缘裁掉；此时改为在选区下方展示。
+  const openBelow = y < 72
+  // 浮窗有两个不可换行的动作。靠近视口边缘时改为向内对齐，避免 flex item 收缩后中文逐字竖排。
+  const viewportWidth = window.innerWidth
+  const edgePadding = 12
+  const estimatedPopoverWidth = 292
+  const alignRight = x > viewportWidth - estimatedPopoverWidth - edgePadding
+  const alignLeft = !alignRight && x < estimatedPopoverWidth / 2 + edgePadding
+  const horizontalTransform = alignRight ? '-translate-x-full' : alignLeft ? 'translate-x-0' : '-translate-x-1/2'
+  const left = alignRight ? x - edgePadding : alignLeft ? x + edgePadding : x
+  const content = (
     <div
       data-selection-action-popover
-      className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
-      style={{ left: x, top: y }}
+      className={`fixed z-[90] ${horizontalTransform} rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur ${openBelow ? 'translate-y-0' : '-translate-y-full'}`}
+      style={{ left, top: openBelow ? y + 20 : y }}
       onMouseDown={(event) => event.preventDefault()}
     >
-      <div className="flex items-center gap-1">
+      <div className="flex flex-nowrap items-center gap-1 whitespace-nowrap">
         <button
           type="button"
-          className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+          className="inline-flex h-8 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
           onClick={onAddToAgent}
         >
           <Bot className="size-4" />
@@ -41,7 +52,7 @@ export function SelectionActionPopover({
         {openSideAssistant && (
           <button
             type="button"
-            className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+            className="inline-flex h-8 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
             onClick={() => {
               void openSideAssistant()
             }}
@@ -53,4 +64,7 @@ export function SelectionActionPopover({
       </div>
     </div>
   )
+
+  // 预览与 Vault 均位于 overflow/transform 容器内；挂到 body 才不会被裁切或压在右侧工作区下层。
+  return createPortal(content, document.body)
 }

--- a/apps/electron/src/renderer/components/vault/VaultLiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultLiveMarkdownEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { LiveMarkdownEditor } from '@/components/markdown/LiveMarkdownEditor'
+import { LiveMarkdownEditor, type LiveMarkdownTextSelection } from '@/components/markdown/LiveMarkdownEditor'
 
 const MAX_PASTED_IMAGE_BYTES = 10 * 1024 * 1024
 
@@ -16,6 +16,8 @@ interface VaultLiveMarkdownEditorProps {
   value: string
   onChange: (value: string) => void
   onSave: () => void
+  /** 选区变化由 Vault 外层处理为引用/右侧问答浮窗。 */
+  onTextSelectionChange?: (selection: LiveMarkdownTextSelection | null) => void
   relativePath: string
 }
 

--- a/apps/electron/src/renderer/components/vault/VaultView.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultView.tsx
@@ -14,6 +14,7 @@ import { VaultLiveMarkdownEditor } from './VaultLiveMarkdownEditor'
 import type { LiveMarkdownTextSelection } from '@/components/markdown/LiveMarkdownEditor'
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
 import { focusChatInput } from '@/components/chat/focus-chat-input'
+import { getOrCreateSideChat } from '@/lib/side-chat'
 import { insertAgentInputQuote } from '@/lib/agent-input-quote'
 import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import {
@@ -322,11 +323,11 @@ function VaultMarkdownEditor({
 
     openSelectionChatPendingRef.current = true
     try {
-      const conversation = await window.electronAPI.createConversation(
+      const conversation = await getOrCreateSideChat(sessionId, () => window.electronAPI.createConversation(
         'Obsidian 选区问答',
         selectedChatModel?.modelId,
         selectedChatModel?.channelId,
-      )
+      ))
       setConversations((previous) => previous.some((item) => item.id === conversation.id) ? previous : [conversation, ...previous])
       setConversationDrafts((previous) => new Map(previous).set(conversation.id, '我的问题：'))
       setSideChatMap((previous) => new Map(previous).set(sessionId, conversation.id))

--- a/apps/electron/src/renderer/components/vault/VaultView.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { BookOpen, ChevronDown, ChevronRight, ChevronsUpDown, CircleHelp, Folder, FolderOpen, Loader2, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import type { VaultCandidate, VaultFileEntry, VaultFocus, VaultReadResult, VaultSummary } from '@proma/shared'
@@ -11,6 +11,23 @@ import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { VaultLiveMarkdownEditor } from './VaultLiveMarkdownEditor'
+import type { LiveMarkdownTextSelection } from '@/components/markdown/LiveMarkdownEditor'
+import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
+import { focusChatInput } from '@/components/chat/focus-chat-input'
+import { insertAgentInputQuote } from '@/lib/agent-input-quote'
+import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
+import {
+  agentDiffPanelTabAtom,
+  agentSidePanelOpenAtomFamily,
+} from '@/atoms/agent-atoms'
+import {
+  agentSideChatMapAtom,
+  conversationsAtom,
+  conversationDraftsAtom,
+  conversationQuotedSelectionMapAtom,
+  selectedModelAtom,
+} from '@/atoms/chat-atoms'
+import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
   focusedVaultFolderAtom,
   selectedVaultFileAtom,
@@ -26,6 +43,11 @@ const VAULT_SIDEBAR_MIN_WIDTH = 180
 const VAULT_SIDEBAR_MAX_WIDTH = 520
 const PROMA_MANAGED_VAULT_DISPLAY_NAME = 'Proma Vault'
 const PROMA_SELF_MANAGED_VAULT_LABEL = 'Proma 自建 Vault'
+const MAX_QUOTED_CHARS = 2000
+
+interface VaultTextSelection extends LiveMarkdownTextSelection {
+  text: string
+}
 
 function getVaultCandidateDisplayName(candidate: VaultCandidate): string {
   return candidate.isPromaManaged ? PROMA_MANAGED_VAULT_DISPLAY_NAME : candidate.displayName
@@ -217,11 +239,14 @@ function VaultFileList({
 
 function VaultMarkdownEditor({
   readResult,
+  sessionId,
   onSave,
   onRename,
   onOpenTutorial,
 }: {
   readResult: VaultReadResult
+  /** 嵌入 Agent 右侧工作区时，用于接入 Agent 引用与右侧问答。 */
+  sessionId?: string
   onSave: (nextContent: string, options?: { silent?: boolean; expectedSha256?: string }) => Promise<void>
   onRename: (name: string) => Promise<void>
   onOpenTutorial: () => void
@@ -233,6 +258,105 @@ function VaultMarkdownEditor({
   const [saving, setSaving] = React.useState(false)
   const [filename, setFilename] = React.useState(displayDocumentTitle(readResult.relativePath.split('/').pop() ?? readResult.relativePath))
   const editorPageRef = React.useRef<HTMLDivElement>(null)
+  const [selection, setSelection] = React.useState<VaultTextSelection | null>(null)
+  const openSelectionChatPendingRef = React.useRef(false)
+  const selectedChatModel = useAtomValue(selectedModelAtom)
+  const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const conversations = useAtomValue(conversationsAtom)
+  const sideChatMap = useAtomValue(agentSideChatMapAtom)
+  const setConversations = useSetAtom(conversationsAtom)
+  const setConversationDrafts = useSetAtom(conversationDraftsAtom)
+  const setChatQuotedSelectionMap = useSetAtom(conversationQuotedSelectionMapAtom)
+  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtomFamily(sessionId ?? 'standalone'))
+  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const focusAgentSessionInput = useFocusAgentSessionInput()
+
+  const clearSelection = React.useCallback(() => setSelection(null), [])
+  const handleTextSelectionChange = React.useCallback((nextSelection: LiveMarkdownTextSelection | null) => {
+    if (!nextSelection) {
+      clearSelection()
+      return
+    }
+    const text = nextSelection.text.slice(0, MAX_QUOTED_CHARS)
+    setSelection({ ...nextSelection, text })
+  }, [clearSelection])
+  const createQuote = React.useCallback(() => selection ? ({
+    text: selection.text,
+    filePath: readResult.relativePath,
+    sourceType: 'file' as const,
+    sourceLabel: `Obsidian · ${readResult.relativePath}`,
+    capturedAt: Date.now(),
+  }) : null, [readResult.relativePath, selection])
+  const addSelectionToAgent = React.useCallback(() => {
+    if (!sessionId) {
+      toast.info('请从 Agent 会话右侧打开 Obsidian 后再添加引用')
+      return
+    }
+    const quote = createQuote()
+    if (!quote) return
+    if (!insertAgentInputQuote(sessionId, quote)) {
+      setQuotedSelectionMap((previous) => new Map(previous).set(sessionId, quote))
+    }
+    clearSelection()
+    focusAgentSessionInput(sessionId)
+  }, [clearSelection, createQuote, focusAgentSessionInput, sessionId, setQuotedSelectionMap])
+  const openSelectionChat = React.useCallback(async (): Promise<void> => {
+    if (!sessionId) {
+      toast.info('请从 Agent 会话右侧打开 Obsidian 后再发起右侧问答')
+      return
+    }
+    const quote = createQuote()
+    if (!quote || openSelectionChatPendingRef.current) return
+
+    const activeConversationId = sideChatMap.get(sessionId) ?? null
+    // 右侧已绑定有效 Chat 时始终复用，避免因激活 Tab 状态短暂不同步而重复创建会话。
+    if (activeConversationId) {
+      setChatQuotedSelectionMap((previous) => new Map(previous).set(activeConversationId, quote))
+      setSidePanelOpen(true)
+      setSidePanelTabMap((previous) => new Map(previous).set(sessionId, 'chat'))
+      clearSelection()
+      focusChatInput(activeConversationId)
+      return
+    }
+
+    openSelectionChatPendingRef.current = true
+    try {
+      const conversation = await window.electronAPI.createConversation(
+        'Obsidian 选区问答',
+        selectedChatModel?.modelId,
+        selectedChatModel?.channelId,
+      )
+      setConversations((previous) => previous.some((item) => item.id === conversation.id) ? previous : [conversation, ...previous])
+      setConversationDrafts((previous) => new Map(previous).set(conversation.id, '我的问题：'))
+      setSideChatMap((previous) => new Map(previous).set(sessionId, conversation.id))
+      setSidePanelOpen(true)
+      setSidePanelTabMap((previous) => new Map(previous).set(sessionId, 'chat'))
+      setChatQuotedSelectionMap((previous) => new Map(previous).set(conversation.id, quote))
+      clearSelection()
+      focusChatInput(conversation.id)
+    } catch (error) {
+      console.error('[VaultView] 打开 Obsidian 选区聊天失败:', error)
+      toast.error('打开右侧问答失败')
+    } finally {
+      openSelectionChatPendingRef.current = false
+    }
+  }, [
+    clearSelection,
+    conversations,
+    createQuote,
+    selectedChatModel,
+    sessionId,
+    setConversationDrafts,
+    setConversations,
+    setChatQuotedSelectionMap,
+    setQuotedSelectionMap,
+    setSideChatMap,
+    setSidePanelOpen,
+    setSidePanelTabMap,
+    sideChatMap,
+  ])
+
   React.useEffect(() => {
     const previousReadContent = lastReadContentRef.current
     if (readResult.content === previousReadContent) return
@@ -331,15 +455,25 @@ function VaultMarkdownEditor({
             value={draft}
             onChange={setDraft}
             onSave={() => { void save() }}
+            onTextSelectionChange={handleTextSelectionChange}
           />
         </div>
       </div>
+      {selection && (
+        <SelectionActionPopover
+          x={selection.x}
+          y={selection.y}
+          onAddToAgent={addSelectionToAgent}
+          onOpenChat={openSelectionChat}
+        />
+      )}
     </div>
   )
 }
 
 function VaultMarkdownPane({
   readResult,
+  sessionId,
   loading,
   hasVault,
   reopenVersion,
@@ -348,6 +482,7 @@ function VaultMarkdownPane({
   onOpenTutorial,
 }: {
   readResult: VaultReadResult | null
+  sessionId?: string
   loading: boolean
   hasVault: boolean
   reopenVersion: number
@@ -377,6 +512,7 @@ function VaultMarkdownPane({
       <VaultMarkdownEditor
         key={getVaultEditorKey(readResult.relativePath, reopenVersion)}
         readResult={readResult}
+        sessionId={sessionId}
         onSave={onSave}
         onRename={onRename}
         onOpenTutorial={onOpenTutorial}
@@ -874,6 +1010,7 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
           </aside>
           <VaultMarkdownPane
             readResult={readResult}
+            sessionId={sessionId}
             loading={fileLoading}
             hasVault={config !== null}
             reopenVersion={editorReopenVersion}

--- a/apps/electron/src/renderer/lib/agent-input-quote.ts
+++ b/apps/electron/src/renderer/lib/agent-input-quote.ts
@@ -1,0 +1,21 @@
+import type { QuotedSelection } from '@/atoms/preview-atoms'
+
+export const INSERT_AGENT_INPUT_QUOTE_EVENT = 'proma:insert-agent-input-quote'
+
+interface InsertAgentInputQuoteDetail {
+  sessionId: string
+  quote: QuotedSelection
+  inserted: boolean
+}
+
+/**
+ * 请求指定 Agent 输入框插入一个可累积的选区 chip。
+ * 事件同步分发，由持有 RichTextInput ref 的 AgentView 回写 inserted，调用者可安全决定是否降级。
+ */
+export function insertAgentInputQuote(sessionId: string, quote: QuotedSelection): boolean {
+  const detail: InsertAgentInputQuoteDetail = { sessionId, quote, inserted: false }
+  window.dispatchEvent(new CustomEvent<InsertAgentInputQuoteDetail>(INSERT_AGENT_INPUT_QUOTE_EVENT, { detail }))
+  return detail.inserted
+}
+
+export type { InsertAgentInputQuoteDetail }

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -1,9 +1,9 @@
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
-  buildAgentHistoryQuoteLabel,
+  buildQuotedSelectionLabel,
   expandAgentHistoryQuoteMentions,
-  parseAgentHistoryQuoteMention,
+  parseQuotedSelectionMention,
 } from './quoted-selection'
 import { ENCODED_MENTION_VALUE_PATTERN, PLAIN_MENTION_VALUE_PATTERN } from './mention-patterns'
 
@@ -174,13 +174,15 @@ function renderQueuedParagraphHtml(text: string): string {
     }
 
     const marker = match[0]
-    const quote = parseAgentHistoryQuoteMention(marker)
+    const quote = parseQuotedSelectionMention(marker)
     if (!quote) {
       html += escapeHtml(marker)
     } else {
       const payload = marker.slice('&quote:'.length)
-      const id = `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`
-      const label = buildAgentHistoryQuoteLabel(quote)
+      const id = quote.sourceType === 'agent-history'
+        ? `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`
+        : `${quote.filePath}:${quote.capturedAt}`
+      const label = buildQuotedSelectionLabel(quote)
       html += `<span data-type="mention" data-id="${escapeHtmlAttribute(id)}" data-label="${escapeHtmlAttribute(label)}" data-mention-suggestion-char="&" data-mention-quote="${escapeHtmlAttribute(payload)}">${escapeHtml(label)}</span>`
     }
     lastIndex = match.index + marker.length
@@ -236,13 +238,15 @@ export function getQueuedMessageDisplayParts(text: string): QueuedMessageDisplay
 
     const groups = match.groups ?? {}
     if (groups.quote) {
-      const quote = parseAgentHistoryQuoteMention(`&quote:${groups.quote}`)
+      const quote = parseQuotedSelectionMention(`&quote:${groups.quote}`)
       if (quote) {
         parts.push({
           type: 'reference',
           referenceType: 'quote',
-          id: `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`,
-          label: buildAgentHistoryQuoteLabel(quote),
+          id: quote.sourceType === 'agent-history'
+            ? `${quote.messageId ?? ''}:${quote.selectionStart ?? ''}:${quote.selectionEnd ?? ''}`
+            : `${quote.filePath}:${quote.capturedAt}`,
+          label: buildQuotedSelectionLabel(quote),
         })
       } else {
         parts.push({ type: 'text', value: match[0] })

--- a/apps/electron/src/renderer/lib/quoted-selection.ts
+++ b/apps/electron/src/renderer/lib/quoted-selection.ts
@@ -29,6 +29,17 @@ interface AgentHistoryQuoteMarkerPayload {
   turn?: number
 }
 
+/** 可嵌入输入框、支持多条的通用选区引用 payload（文件或 Vault 选区）。 */
+interface InlineQuotedSelectionPayload {
+  version: 2
+  text: string
+  filePath: string
+  sourceType: QuotedSelectionSourceType
+  sourceLabel?: string
+  startLine?: number
+  endLine?: number
+}
+
 export function escapeXmlAttribute(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -157,6 +168,31 @@ export function serializeAgentHistoryQuoteMention(quote: QuotedSelection): strin
   return `${AGENT_HISTORY_QUOTE_MENTION_PREFIX}${encodeURIComponent(JSON.stringify(payload))}`
 }
 
+/** 将文件/Vault 选区编码为与历史引用同款的内联 chip marker，可在一条草稿中累积多次。 */
+export function serializeQuotedSelectionMention(quote: QuotedSelection): string | null {
+  if (!isNonEmptyString(quote.text) || !isNonEmptyString(quote.filePath)) return null
+  if (quote.sourceType === 'agent-history') return serializeAgentHistoryQuoteMention(quote)
+
+  const payload: InlineQuotedSelectionPayload = {
+    version: 2,
+    text: quote.text,
+    filePath: quote.filePath,
+    sourceType: 'file',
+    ...(isNonEmptyString(quote.sourceLabel) && { sourceLabel: quote.sourceLabel }),
+    ...(isPositiveInteger(quote.startLine) && { startLine: quote.startLine }),
+    ...(isPositiveInteger(quote.endLine) && { endLine: quote.endLine }),
+  }
+  return `${AGENT_HISTORY_QUOTE_MENTION_PREFIX}${encodeURIComponent(JSON.stringify(payload))}`
+}
+
+/** 为输入框内的历史或文件选区构建简短 chip 标签。 */
+export function buildQuotedSelectionLabel(quote: QuotedSelection): string {
+  if (quote.sourceType === 'agent-history') return buildAgentHistoryQuoteLabel(quote)
+  const filename = (quote.sourceLabel ?? quote.filePath).split('/').pop() || quote.filePath
+  const preview = Array.from(quote.text.replace(/\s+/g, ' ').trim()).slice(0, 25).join('')
+  return `${filename}：${preview}`
+}
+
 /** 为已发送消息生成展示用历史引用 marker，允许缺少旧版本的定位字段。 */
 export function serializeAgentHistoryQuoteDisplayMention(quote: QuotedSelection): string | null {
   if (quote.sourceType !== 'agent-history' || !isNonEmptyString(quote.text) || !isNonEmptyString(quote.messageId)) {
@@ -179,26 +215,59 @@ export function serializeAgentHistoryQuoteDisplayMention(quote: QuotedSelection)
   return `${AGENT_HISTORY_QUOTE_MENTION_PREFIX}${encodeURIComponent(JSON.stringify(payload))}`
 }
 
-/** 将历史引用 marker 替换为可复制的 chip 文案，避免把内部 payload 暴露给剪贴板。 */
+/** 将选区引用 marker 替换为可复制的 chip 文案，避免把内部 payload 暴露给剪贴板。 */
 export function replaceAgentHistoryQuoteMentionsWithLabels(text: string): string {
   return text.replace(AGENT_HISTORY_QUOTE_MENTION_REGEX, (marker) => {
-    const quote = parseAgentHistoryQuoteMention(marker)
-    return quote ? buildAgentHistoryQuoteLabel(quote) : marker
+    const quote = parseQuotedSelectionMention(marker)
+    return quote ? buildQuotedSelectionLabel(quote) : marker
   })
 }
 
-/** 解码单个内联 Agent 历史引用 marker；无效输入保持为普通文本。 */
-export function parseAgentHistoryQuoteMention(marker: string): QuotedSelection | null {
+/** 解码任意内联选区引用 marker；兼容既有 version 1 Agent 历史 payload。 */
+export function parseQuotedSelectionMention(marker: string): QuotedSelection | null {
   if (!marker.startsWith(AGENT_HISTORY_QUOTE_MENTION_PREFIX)) return null
   const payload = marker.slice(AGENT_HISTORY_QUOTE_MENTION_PREFIX.length)
   if (!payload || /\s/.test(payload)) return null
+  try {
+    const value: unknown = JSON.parse(decodeURIComponent(payload))
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>
+      if (
+        record.version === 2
+        && isNonEmptyString(record.text)
+        && isNonEmptyString(record.filePath)
+        && record.sourceType === 'file'
+        && (record.sourceLabel === undefined || isNonEmptyString(record.sourceLabel))
+        && (record.startLine === undefined || isPositiveInteger(record.startLine))
+        && (record.endLine === undefined || isPositiveInteger(record.endLine))
+      ) {
+        return {
+          text: record.text,
+          filePath: record.filePath,
+          sourceType: 'file',
+          ...(isNonEmptyString(record.sourceLabel) && { sourceLabel: record.sourceLabel }),
+          ...(isPositiveInteger(record.startLine) && { startLine: record.startLine }),
+          ...(isPositiveInteger(record.endLine) && { endLine: record.endLine }),
+          capturedAt: 0,
+        }
+      }
+    }
+  } catch {
+    return null
+  }
   return parseAgentHistoryQuotePayload(payload)
+}
+
+/** 兼容旧调用：仅返回可定位的 Agent 历史引用。 */
+export function parseAgentHistoryQuoteMention(marker: string): QuotedSelection | null {
+  const quote = parseQuotedSelectionMention(marker)
+  return quote?.sourceType === 'agent-history' ? quote : null
 }
 
 /** 在真正发送给 Agent 前，将草稿内联 marker 替换为既有 XML 上下文块。 */
 export function expandAgentHistoryQuoteMentions(text: string): string {
   return text.replace(AGENT_HISTORY_QUOTE_MENTION_REGEX, (marker) => {
-    const quote = parseAgentHistoryQuoteMention(marker)
+    const quote = parseQuotedSelectionMention(marker)
     if (!quote) return marker
     return buildQuotedSelectionBlock(quote)
   })

--- a/apps/electron/src/renderer/lib/quoted-selection.ts
+++ b/apps/electron/src/renderer/lib/quoted-selection.ts
@@ -188,7 +188,7 @@ export function serializeQuotedSelectionMention(quote: QuotedSelection): string 
 /** 为输入框内的历史或文件选区构建简短 chip 标签。 */
 export function buildQuotedSelectionLabel(quote: QuotedSelection): string {
   if (quote.sourceType === 'agent-history') return buildAgentHistoryQuoteLabel(quote)
-  const filename = (quote.sourceLabel ?? quote.filePath).split('/').pop() || quote.filePath
+  const filename = (quote.sourceLabel ?? quote.filePath).split(/[\\/]/).pop() || quote.filePath
   const preview = Array.from(quote.text.replace(/\s+/g, ' ').trim()).slice(0, 25).join('')
   return `${filename}：${preview}`
 }

--- a/apps/electron/src/renderer/lib/side-chat.ts
+++ b/apps/electron/src/renderer/lib/side-chat.ts
@@ -1,0 +1,30 @@
+import type { ConversationMeta } from '@proma/shared'
+
+/**
+ * Deduplicate concurrent first-use requests for an Agent session's side Chat.
+ * Preview and Vault are mounted independently, so component-local pending refs
+ * cannot prevent both from issuing createConversation at the same time.
+ */
+const pendingSideChatCreates = new Map<string, Promise<ConversationMeta>>()
+
+export function getOrCreateSideChat(
+  sessionId: string,
+  create: () => Promise<ConversationMeta>,
+): Promise<ConversationMeta> {
+  const pending = pendingSideChatCreates.get(sessionId)
+  if (pending) return pending
+
+  const created = create()
+  pendingSideChatCreates.set(sessionId, created)
+  const clearPending = (): void => {
+    // Keep the settled promise through the callers' state updates, so another
+    // same-tick selection still shares it rather than creating an orphan chat.
+    window.setTimeout(() => {
+      if (pendingSideChatCreates.get(sessionId) === created) {
+        pendingSideChatCreates.delete(sessionId)
+      }
+    }, 0)
+  }
+  void created.then(clearPending, clearPending)
+  return created
+}


### PR DESCRIPTION
## Summary
- restore file, Live Markdown, and Obsidian selection actions with reliable popover positioning
- route selection questions to the bound right-side Chat, reuse that Chat, and isolate Chat quote state from Agent quote state
- retain multi-reference Agent chips and restore reading scroll position
- bump Electron app version to v0.19.5

## Validation
- `bun run --filter @proma/electron typecheck`
- `bun run --filter @proma/electron build:renderer`
- `git diff --check`

## Performance
- Selection updates occur only after pointer release; quote state is scoped to a single Agent/Chat session and cleared when sent.
- No new streaming, polling, or IPC listener is added. New Chat creation remains user-action-only; focus retry is capped at two animation frames.
- Manual Electron interaction verification remains pending; static type/build validation passed.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)