### PR TITLE
feat(agent): show token output speed (tok/s) and TTFT on turn completion

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { accessSync, constants, existsSync, mkdirSync, realpathSync } from 'node:fs'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
 import { app } from 'electron'
-import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, AgentActiveSessionSnapshot, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, SDKMessage, SDKAssistantMessage, AgentStreamPayload, AgentAssistantDeltaPayload, RewindSessionResult, SkillActivation } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, AgentActiveSessionSnapshot, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, SDKMessage, SDKAssistantMessage, AgentStreamPayload, AgentAssistantDeltaPayload, RewindSessionResult, SkillActivation, TurnTiming } from '@proma/shared'
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
@@ -133,6 +133,41 @@ function isAssistantDeltaSDKMessage(message: SDKMessage): message is SDKMessage 
   return record.type === 'assistant_delta'
     && typeof record.uuid === 'string'
     && !!record.delta
+}
+
+/**
+ * 单次回复的文本 delta 计时累加器。
+ *
+ * 只统计可见文本（`text_delta`）的活跃区间：思考与工具调用 token 不计入净生成时长。
+ * 累加器仅在运行时存在，最终经 `finalize` 附加到 result 消息（`_timing`）并随会话持久化。
+ */
+class TurnTimingAccumulator {
+  private firstDeltaAt = 0
+  private lastDeltaAt = 0
+  private segmentStartAt = 0
+  private genMs = 0
+
+  /** 记录一个可见文本 delta 到达时刻；首个 delta 同时开启新区间 */
+  recordTextDelta(now: number): void {
+    if (this.firstDeltaAt === 0) this.firstDeltaAt = now
+    if (this.segmentStartAt === 0) this.segmentStartAt = now
+    this.lastDeltaAt = now
+  }
+
+  /** 非 delta 消息到达时闭合当前活跃区间（工具执行/空闲间隔不计入生成净时长） */
+  closeSegment(): void {
+    if (this.segmentStartAt !== 0 && this.lastDeltaAt > this.segmentStartAt) {
+      this.genMs += this.lastDeltaAt - this.segmentStartAt
+    }
+    this.segmentStartAt = 0
+  }
+
+  /** turn 结束时产出计时；没有任何可见文本输出时返回 undefined */
+  finalize(runStartedAt: number): TurnTiming | undefined {
+    this.closeSegment()
+    if (this.firstDeltaAt === 0 || this.genMs <= 0) return undefined
+    return { ttftMs: Math.max(0, this.firstDeltaAt - runStartedAt), genMs: this.genMs }
+  }
 }
 
 /** 默认会话标题（用于判断是否需要自动生成） */
@@ -1683,6 +1718,7 @@ export class AgentOrchestrator {
           let drainTimeoutPromise: Promise<'drain_timeout'> | null = null
           const RESULT_DRAIN_TIMEOUT_MS = 2_000
           let visibleRunMessageCount = 0
+          const turnTiming = new TurnTimingAccumulator()
 
           while (true) {
             if (!pendingNext) {
@@ -1713,6 +1749,8 @@ export class AgentOrchestrator {
             pendingNext = null
             let msg = iterResult.value
             if (isAssistantDeltaSDKMessage(msg)) {
+              // 可见文本 delta 打点（思考/工具调用 delta 不计入净生成时长）
+              if (msg.delta.type === 'text_delta') turnTiming.recordTextDelta(Date.now())
               this.eventBus.emit(sessionId, {
                 kind: 'sdk_delta',
                 delta: {
@@ -1725,6 +1763,8 @@ export class AgentOrchestrator {
               })
               continue
             }
+            // 非 delta 消息意味着当前文本区间结束（工具执行/思考/结果等）
+            turnTiming.closeSegment()
             const isPartialMessage = isPartialSDKMessage(msg)
             if (msg.type === 'result') {
               const skillActivations = mergeSkillActivations(
@@ -1743,6 +1783,11 @@ export class AgentOrchestrator {
                 } as unknown as SDKMessage
               }
               pendingSkillActivations = []
+            }
+            // 为 result 消息附加生成计时（与 _durationMs 同模式的运行时字段，随会话持久化）
+            if (msg.type === 'result' && !(msg as { isSyntheticCompactionResult?: boolean }).isSyntheticCompactionResult) {
+              const timing = turnTiming.finalize(streamStartedAt)
+              if (timing) msg = { ...(msg as Record<string, unknown>), _timing: timing } as unknown as SDKMessage
             }
             // isVisibleRunMessage 已抽到独立模块，不含 partial 判断；
             // pi runtime 的流式 partial 消息不应计入可见消息数，故在此显式排除。

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -37,8 +37,9 @@ import { AgentBrowserLinkProvider } from '@/components/browser/AgentBrowserLinkP
 import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import { TaskProgressOverlay, type ContextCompactionProgress } from './TaskProgressOverlay'
 import { createMessageGroupRenderCache, groupMessagesForRendering } from './message-group-rendering'
-import type { AgentEventUsage, RetryAttempt, SDKAssistantMessage, SDKMessage, SDKSystemMessage, SDKTextBlock, SDKThinkingBlock } from '@proma/shared'
+import type { AgentEventUsage, RetryAttempt, SDKAssistantMessage, SDKMessage, SDKSystemMessage, SDKTextBlock, SDKThinkingBlock, TurnTiming } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
+import { computeTurnSpeed, formatTokPerSec } from '@proma/session-core'
 import { agentLiveMessagesAtomFamily, agentSessionStreamingStateAtomFamily, type AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 
@@ -525,9 +526,10 @@ export function formatDuration(ms: number): string {
 }
 
 /** 构建 usage tooltip 多行文本 */
-export function buildUsageTooltip(durationMs: number, usage?: AgentEventUsage): string {
+export function buildUsageTooltip(durationMs: number, usage?: AgentEventUsage, ttftMs?: number): string {
   const lines: string[] = []
   lines.push(`耗时: ${formatDuration(durationMs)}`)
+  if (ttftMs != null && ttftMs > 0) lines.push(`首字: ${formatDuration(ttftMs)}`)
 
   if (usage) {
     const pureInput = (usage.inputTokens ?? 0) - (usage.cacheReadTokens ?? 0) - (usage.cacheCreationTokens ?? 0)
@@ -540,17 +542,21 @@ export function buildUsageTooltip(durationMs: number, usage?: AgentEventUsage): 
   return lines.join('\n')
 }
 
-/** 耗时徽章 — 悬浮显示 token 用量明细 */
-export function DurationBadge({ durationMs, usage }: { durationMs: number; usage?: AgentEventUsage }): React.ReactElement {
+/** 耗时徽章 — 悬浮显示 token 用量明细；携带生成计时时显示 tok/s */
+export function DurationBadge({ durationMs, usage, timing }: { durationMs: number; usage?: AgentEventUsage; timing?: TurnTiming }): React.ReactElement {
+  const speed = computeTurnSpeed({ outputTokens: usage?.outputTokens, ttftMs: timing?.ttftMs, genMs: timing?.genMs })
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span className="text-[15px] tabular-nums font-light cursor-default">
           {formatDuration(durationMs)}
+          {speed.tokPerSec != null && (
+            <span className="text-muted-foreground/60"> · {formatTokPerSec(speed.tokPerSec)}</span>
+          )}
         </span>
       </TooltipTrigger>
       <TooltipContent side="top">
-        <p className="whitespace-pre-line text-left">{buildUsageTooltip(durationMs, usage)}</p>
+        <p className="whitespace-pre-line text-left">{buildUsageTooltip(durationMs, usage, speed.ttftMs)}</p>
       </TooltipContent>
     </Tooltip>
   )

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -37,6 +37,7 @@ import {
 export { groupIntoTurns, getGroupPreview, extractUserText } from '@proma/session-core'
 export type { MessageGroup, AssistantTurn } from '@proma/session-core'
 import { DurationBadge } from './AgentMessages'
+import { isTurnTiming } from '@proma/session-core'
 import {
   Message,
   MessageHeader,
@@ -74,6 +75,7 @@ import type {
   SDKContentBlock,
   SDKResultMessage,
   AgentEventUsage,
+  TurnTiming,
   SDKToolUseBlock,
   SDKToolResultBlock,
   RecoveryAction,
@@ -202,15 +204,16 @@ function CompactStatusNotice({ message }: { message: SDKSystemMessage }): React.
 
 // extractMeta / MessageMeta 已迁移至 @proma/session-core
 
-/** 从 turn 消息列表中提取 result 消息的耗时和用量数据 */
-function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; usage?: AgentEventUsage } {
+/** 从 turn 消息列表中提取 result 消息的耗时、用量与生成计时数据 */
+function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; usage?: AgentEventUsage; timing?: TurnTiming } {
   for (const msg of turnMessages) {
     if (msg.type !== 'result') continue
     const resultMsg = msg as SDKResultMessage
     const raw = msg as Record<string, unknown>
     const durationMs = typeof raw._durationMs === 'number' ? raw._durationMs : undefined
+    const timing = isTurnTiming(raw._timing) ? raw._timing : undefined
     const u = resultMsg.usage
-    if (!u) return { durationMs }
+    if (!u) return { durationMs, timing }
     // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow
     let contextWindow: number | undefined
     if (resultMsg.modelUsage) {
@@ -235,6 +238,7 @@ function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; us
         costUsd: resultMsg.total_cost_usd,
         contextWindow,
       },
+      timing,
     }
   }
   return {}
@@ -428,7 +432,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
   }
 
   // 从 turnMessages 中提取 result 消息的耗时和用量
-  const { durationMs, usage } = extractTurnUsage(turn.turnMessages)
+  const { durationMs, usage, timing } = extractTurnUsage(turn.turnMessages)
 
   // 只在用户点击停止时显示中断徽章。
   // aborted_streaming / aborted_tools 是流式追加消息时的软中断，语义是继续补充信息。
@@ -597,7 +601,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
         if (!hasDuration && !hasActions && !showStoppedBadge) return null
         return (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
-            {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
+            {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} timing={timing} />}
             {textContent && <CopyButton content={textContent} />}
             {textContent && onCreateTodo && (
               <MessageAction tooltip="标记为 Todo" onClick={() => onCreateTodo(textContent)}>

--- a/packages/session-core/package.json
+++ b/packages/session-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/session-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "AGPL-3.0-only",
   "description": "Headless core for reading, grouping, searching and rendering Proma agent sessions. Single source of truth shared by the Electron app, the proma CLI and future query surfaces.",
   "type": "module",

--- a/packages/session-core/src/index.ts
+++ b/packages/session-core/src/index.ts
@@ -50,3 +50,12 @@ export { searchTurns, type SearchHit, type SearchOptions } from './search'
 export { selectTurns, type SelectOptions } from './select'
 export { renderTranscriptMarkdown, type RenderMarkdownOptions } from './render-markdown'
 export { estimateTokens } from './tokens'
+
+// Turn 速度（tok/s / TTFT）计算
+export {
+  computeTurnSpeed,
+  formatTokPerSec,
+  isTurnTiming,
+  type TurnSpeed,
+  type TurnSpeedInput,
+} from './turn-speed'

--- a/packages/session-core/src/turn-speed.test.ts
+++ b/packages/session-core/src/turn-speed.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+import { computeTurnSpeed, formatTokPerSec, isTurnTiming } from './turn-speed'
+
+describe('computeTurnSpeed', () => {
+  test('正常路径：usage 与 timing 齐全时返回 tok/s 与 TTFT', () => {
+    const speed = computeTurnSpeed({ outputTokens: 425, ttftMs: 1200, genMs: 10_000 })
+    expect(speed.tokPerSec).toBe(42.5)
+    expect(speed.ttftMs).toBe(1200)
+  })
+
+  test('边界：输出 token 低于门槛时不返回速度，但保留 TTFT', () => {
+    const speed = computeTurnSpeed({ outputTokens: 9, ttftMs: 800, genMs: 5_000 })
+    expect(speed.tokPerSec).toBeUndefined()
+    expect(speed.ttftMs).toBe(800)
+  })
+
+  test('边界：净生成时长低于门槛时不返回速度', () => {
+    const speed = computeTurnSpeed({ outputTokens: 100, ttftMs: 300, genMs: 499 })
+    expect(speed.tokPerSec).toBeUndefined()
+  })
+
+  test('边界：字段缺失或非法时不抛错，速度与 TTFT 均为空', () => {
+    expect(computeTurnSpeed({})).toEqual({})
+    expect(computeTurnSpeed({ outputTokens: undefined, ttftMs: Number.NaN, genMs: 0 })).toEqual({})
+  })
+
+  test('边界：TTFT 为 0 时不输出 ttftMs，速度正常计算', () => {
+    const speed = computeTurnSpeed({ outputTokens: 100, ttftMs: 0, genMs: 4_000 })
+    expect(speed.ttftMs).toBeUndefined()
+    expect(speed.tokPerSec).toBe(25)
+  })
+})
+
+describe('formatTokPerSec', () => {
+  test('保留一位小数并携带单位', () => {
+    expect(formatTokPerSec(42.5)).toBe('42.5 tok/s')
+    expect(formatTokPerSec(42)).toBe('42.0 tok/s')
+  })
+})
+
+describe('isTurnTiming', () => {
+  test('合法结构通过校验，非法结构被拒绝', () => {
+    expect(isTurnTiming({ ttftMs: 100, genMs: 2000 })).toBe(true)
+    expect(isTurnTiming({ ttftMs: 'x', genMs: 2000 })).toBe(false)
+    expect(isTurnTiming(null)).toBe(false)
+    expect(isTurnTiming('timing')).toBe(false)
+  })
+})

--- a/packages/session-core/src/turn-speed.ts
+++ b/packages/session-core/src/turn-speed.ts
@@ -1,0 +1,57 @@
+import type { TurnTiming } from '@proma/shared'
+
+/**
+ * Turn 速度计算的纯函数：把 result 消息携带的官方 usage 与主进程打点的
+ * 生成计时（TurnTiming）换算为用户可读的输出速度与首字延迟。
+ *
+ * 语义：
+ * - tok/s = outputTokens ÷ genMs。genMs 只累计可见文本 delta 的活跃区间，
+ *   不含工具执行时间；outputTokens 来自 API usage，包含工具调用轮次的 token，
+ *   因此混合工具调用的 turn 结果为近似值。
+ * - 低于门槛（超短回复 / 极少 token）时不输出速度，避免噪声。
+ */
+
+/** 净生成时长低于该值（毫秒）时不显示速度 */
+const MIN_GEN_MS = 500
+/** 输出 token 低于该值时不显示速度 */
+const MIN_OUTPUT_TOKENS = 10
+
+export interface TurnSpeedInput {
+  outputTokens?: number
+  ttftMs?: number
+  genMs?: number
+}
+
+export interface TurnSpeed {
+  /** 输出速度（tokens/秒） */
+  tokPerSec?: number
+  /** 首字延迟（毫秒） */
+  ttftMs?: number
+}
+
+export function computeTurnSpeed(input: TurnSpeedInput): TurnSpeed {
+  const result: TurnSpeed = {}
+  const { outputTokens, ttftMs, genMs } = input
+  if (typeof ttftMs === 'number' && Number.isFinite(ttftMs) && ttftMs > 0) {
+    result.ttftMs = ttftMs
+  }
+  if (
+    typeof outputTokens === 'number'
+    && outputTokens >= MIN_OUTPUT_TOKENS
+    && typeof genMs === 'number'
+    && genMs >= MIN_GEN_MS
+  ) {
+    result.tokPerSec = Math.round((outputTokens / (genMs / 1000)) * 10) / 10
+  }
+  return result
+}
+
+export function formatTokPerSec(tokPerSec: number): string {
+  return `${tokPerSec.toFixed(1)} tok/s`
+}
+
+export function isTurnTiming(value: unknown): value is TurnTiming {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as Record<string, unknown>
+  return typeof record.ttftMs === 'number' && typeof record.genMs === 'number'
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -267,6 +267,14 @@ export interface SkillActivation {
   sources: SkillActivationSource[]
 }
 
+/** 一次回复的生成计时（主进程事件循环打点，随 result 消息持久化） */
+export interface TurnTiming {
+  /** 本次运行开始到首个可见文本 delta 的延迟（TTFT） */
+  ttftMs: number
+  /** 可见文本 delta 活跃区间的净时长之和，不含工具执行与空闲间隔 */
+  genMs: number
+}
+
 /** SDK result 消息（查询结束时返回） */
 export interface SDKResultMessage {
   type: 'result'
@@ -292,6 +300,8 @@ export interface SDKResultMessage {
   _channelModelId?: string
   /** 渠道 provider，用于按 Agent SDK 实际运行窗口计算压缩阈值 */
   _channelProvider?: ProviderType
+  /** 生成计时（TTFT 与净生成时长），由主进程编排器在运行时附加 */
+  _timing?: TurnTiming
 }
 
 /** SDK system 消息（init / compact_boundary / permission_denied / task_started / task_progress / task_notification） */


### PR DESCRIPTION
Closes #1918

## 功能

在 Agent 会话的耗时徽章旁显示 **token 输出速度（tok/s）**，tooltip 中新增**首字延迟（TTFT）**：

    19.8s · 142.2 tok/s     ← 回复完成后的 meta 行（hover 查看首字/输入/输出/缓存明细）

## 动机

- 界面已有用量统计（token 数 / 费用），但没有速度指标，无法直观判断渠道 / 模型的实际响应质量
- 长任务运行时，速度是感知"变慢"的关键线索：能帮助区分模型慢、渠道中转慢，还是前端渲染问题
- 便于横向对比不同渠道（官方 API / 中转 / Coding Plan）的真实体验，选择更合适的渠道

## 实现要点

| 关注点 | 方案 |
|---|---|
| 数据来源 | 主进程事件循环对可见文本 delta（`text_delta`）打点：首末 delta 时间差为净生成时长，首 delta 距运行开始为 TTFT |
| 持久化 | 计时以 `_timing: { ttftMs, genMs }` 附加到 result 消息（与 `_durationMs` 同模式），随会话 JSONL 持久化，**历史会话同样显示** |
| 速度语义 | tok/s = `usage.outputTokens ÷ genMs`。genMs 只累计文本 delta 活跃区间、不含工具执行，比整 turn 墙钟时间更贴近真实输出速度 |
| 性能 | 打点全部在主进程 mutable 累加器完成，流式渲染路径零改动，完成后仅一次额外渲染 |
| 噪声护栏 | 净生成 <500ms 或输出 <10 tokens 时不显示，避免超短回复噪声 |

### 为什么不用 `_durationMs` 做分母（真实案例）

实测一次带思考的回复：墙钟 48.1s，净生成仅 29.6s（18.5s 在思考与工具间隔）。按墙钟算出 24.9 tok/s，按净生成算出 **40.5 tok/s**——后者才是真实输出速度。

## 改动范围

+193 / −14，10 个文件：

- `packages/shared`：新增 `TurnTiming` 类型与 result 消息 `_timing` 可选字段
- `packages/session-core`：`computeTurnSpeed` / `formatTokPerSec` / `isTurnTiming` 纯函数 + 7 个 BDD 测试
- `apps/electron/src/main`：`TurnTimingAccumulator` 打点 + result 消息附加
- `apps/electron/src/renderer`：`extractTurnUsage` 读取 `_timing`，`DurationBadge` 展示速度与首字
- 三个受影响包版本号 patch +1（遵循 AGENTS.md 约定）

## 测试

- `bun test`：56 pass / 0 fail（新增 7 个：正常路径、token/时长门槛、字段缺失、TTFT=0、格式化、类型守卫）
- `bun run typecheck`：shared / session-core / electron 三包通过
- 真机验证（OSS dev 实例 + Kimi K3）：2022 tokens / 净生成 14.2s → meta 行显示 `19.8s · 142.2 tok/s`，tooltip 首字 6.4s，会话 JSONL 正确写入 `_timing`

## 边界与后续

- `outputTokens` 包含工具调用轮次的 token，混合工具的 turn 速度为近似值（tooltip 已注明）
- Chat 模式的消息结构不含 usage / result，需要独立管线，计划作为 follow-up

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)