### PR TITLE
fix(browser): focus Agent links and isolate popup tabs

### DIFF
--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -635,7 +635,8 @@ export class BrowserController {
       let popup: BrowserTabRecord | null = null
       return {
         action: 'allow',
-        outlivesOpener: false,
+        // Proma 将 window.open 呈现为同级浏览器 Tab；关闭来源页面不能级联关闭它。
+        outlivesOpener: true,
         createWindow: (options) => {
           popup = this.createTab(browserSession, false, false, {
             openedByPopup: true,
@@ -704,7 +705,6 @@ export class BrowserController {
     view.webContents.on('did-navigate-in-page', () => { tab.popupInitialNavigationPending = false; this.invalidateTabDocument(tab); this.updateNavigationState(browserSession, tab) })
     view.webContents.on('destroyed', () => {
       if (!browserSession.tabs.has(tab.tabId)) return
-      this.disposePopupChildren(browserSession, tab.tabId)
       browserSession.tabs.delete(tab.tabId)
       browserSession.lastLayoutRevisionByTab.delete(tab.tabId)
       this.removePresentation(browserSession.sessionId, tab.tabId)
@@ -1038,12 +1038,6 @@ export class BrowserController {
     this.emit(browserSession)
   }
 
-  private disposePopupChildren(browserSession: BrowserSessionRecord, openerTabId: string): void {
-    for (const child of [...browserSession.tabs.values()]) {
-      if (child.openerTabId === openerTabId) this.disposeTab(browserSession, child)
-    }
-  }
-
   private repairTabSelection(browserSession: BrowserSessionRecord, removedTabId: string): void {
     if (browserSession.activeTabId === removedTabId || !browserSession.tabs.has(browserSession.activeTabId)) {
       browserSession.activeTabId = browserSession.tabs.keys().next().value as string
@@ -1055,8 +1049,6 @@ export class BrowserController {
 
   private disposeTab(browserSession: BrowserSessionRecord, tab: BrowserTabRecord): void {
     if (!browserSession.tabs.has(tab.tabId)) return
-    // Child windows use Electron's opener lifetime and must not outlive a tab closed from Proma UI either.
-    this.disposePopupChildren(browserSession, tab.tabId)
     browserSession.tabs.delete(tab.tabId)
     browserSession.lastLayoutRevisionByTab.delete(tab.tabId)
     this.removePresentation(browserSession.sessionId, tab.tabId)

--- a/apps/electron/src/renderer/atoms/browser-atoms.ts
+++ b/apps/electron/src/renderer/atoms/browser-atoms.ts
@@ -7,6 +7,8 @@ export const browserPanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 /** 用户最小化面板后保留浏览器 session，直到用户主动恢复或关闭。 */
 export const browserPanelMinimizedMapAtom = atom<Map<string, boolean>>(new Map())
 export const browserStateMapAtom = atom<Map<string, BrowserViewState>>(new Map())
+/** Agent 回复链接请求将右侧工作区切换到对应浏览器标签；值为目标 tab ID。 */
+export const browserFocusRequestMapAtom = atom<Map<string, string>>(new Map())
 /** 首次风险确认完成后自动加载的 Agent 回复链接。 */
 export const browserPendingNavigationMapAtom = atom<Map<string, string>>(new Map())
 

--- a/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/atoms/agent-atoms'
 import type { AgentSidePanelTab } from '@/atoms/agent-atoms'
 import { SidePanel } from '@/components/agent/SidePanel'
-import { browserPanelOpenMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
+import { browserFocusRequestMapAtom, browserPanelOpenMapAtom, browserStateMapAtom } from '@/atoms/browser-atoms'
 import { getPreviewFileId, previewFileMapAtom } from '@/atoms/preview-atoms'
 
 export function RightSidePanel({ width }: { width?: number }): React.ReactElement | null {
@@ -34,8 +34,11 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
   const setSidePanelOpen = useSetAtom(currentSessionSidePanelOpenAtom)
   const browserOpenMap = useAtomValue(browserPanelOpenMapAtom)
   const browserStateMap = useAtomValue(browserStateMapAtom)
+  const browserFocusRequestMap = useAtomValue(browserFocusRequestMapAtom)
+  const setBrowserFocusRequestMap = useSetAtom(browserFocusRequestMapAtom)
   const browserOpen = currentSessionId ? browserOpenMap.get(currentSessionId) === true : false
   const browserState = currentSessionId ? browserStateMap.get(currentSessionId) ?? null : null
+  const browserFocusRequestTabId = currentSessionId ? browserFocusRequestMap.get(currentSessionId) ?? null : null
   const previewFileMap = useAtomValue(previewFileMapAtom)
   const currentPreviewFile = currentSessionId ? previewFileMap.get(currentSessionId) ?? null : null
   const previousBrowserStateRef = React.useRef<{ sessionId: string | null; open: boolean }>({ sessionId: null, open: false })
@@ -50,8 +53,8 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
     })
   }, [currentSessionId, setDiffPanelTabMap])
 
-  // Agent 或回复链接在当前会话首次打开浏览器时，直接让右侧工作区承接它。
-  // 切换到一个已有浏览器的会话时不抢占用户当前视图，保留该会话上次的外层 Tab。
+  // 首次打开浏览器时承接到右侧工作区；Agent 回复链接还会显式携带目标标签，
+  // 即使当前浏览器已打开，也应切换到那个新网页而不是留在文件、Diff 或终端。
   React.useEffect(() => {
     const unsubscribeOpen = window.electronAPI.onAgentTerminalOpen((event) => {
       setTerminalTabsMap((previous) => {
@@ -98,16 +101,37 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
     const openedInCurrentSession = previous.sessionId === currentSessionId && !previous.open && browserOpen
     previousBrowserStateRef.current = { sessionId: currentSessionId, open: browserOpen }
     if (openedInCurrentSession && currentSessionId) pendingBrowserActivationRef.current = currentSessionId
-    if (!currentSessionId || pendingBrowserActivationRef.current !== currentSessionId || !browserState?.activeTabId) return
+
+    if (!currentSessionId || !browserState) return
+    if (browserFocusRequestTabId && !browserState.tabs.some((tab) => tab.tabId === browserFocusRequestTabId)) {
+      setBrowserFocusRequestMap((previous) => {
+        if (!previous.has(currentSessionId)) return previous
+        const next = new Map(previous)
+        next.delete(currentSessionId)
+        return next
+      })
+      return
+    }
+    const targetTabId = browserFocusRequestTabId
+      ?? (pendingBrowserActivationRef.current === currentSessionId ? browserState.activeTabId : null)
+    if (!targetTabId) return
 
     setSidePanelOpen(true)
     setDiffPanelTabMap((prev) => {
       const next = new Map(prev)
-      next.set(currentSessionId, getBrowserSidePanelTab(browserState.activeTabId))
+      next.set(currentSessionId, getBrowserSidePanelTab(targetTabId))
       return next
     })
+    if (browserFocusRequestTabId) {
+      setBrowserFocusRequestMap((previous) => {
+        if (previous.get(currentSessionId) !== targetTabId) return previous
+        const next = new Map(previous)
+        next.delete(currentSessionId)
+        return next
+      })
+    }
     pendingBrowserActivationRef.current = null
-  }, [browserOpen, browserState?.activeTabId, currentSessionId, setDiffPanelTabMap, setSidePanelOpen])
+  }, [browserFocusRequestTabId, browserOpen, browserState?.activeTabId, browserState?.tabs, currentSessionId, setBrowserFocusRequestMap, setDiffPanelTabMap, setSidePanelOpen])
 
   if (appMode !== 'agent' || !currentSessionId) {
     return null

--- a/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
+++ b/apps/electron/src/renderer/components/browser/AgentBrowserLinkProvider.tsx
@@ -3,6 +3,7 @@ import { useSetAtom } from 'jotai'
 import type { BrowserStateChange, BrowserViewState } from '@proma/shared'
 import { BROWSER_RISK_DISCLAIMER_VERSION } from '@/types/settings'
 import {
+  browserFocusRequestMapAtom,
   browserPanelMinimizedMapAtom,
   browserPanelOpenMapAtom,
   browserPendingNavigationMapAtom,
@@ -34,6 +35,7 @@ export function AgentBrowserLinkProvider({
   const setBrowserOpenMap = useSetAtom(browserPanelOpenMapAtom)
   const setBrowserMinimizedMap = useSetAtom(browserPanelMinimizedMapAtom)
   const setBrowserStateMap = useSetAtom(browserStateMapAtom)
+  const setBrowserFocusRequestMap = useSetAtom(browserFocusRequestMapAtom)
   const setPendingNavigationMap = useSetAtom(browserPendingNavigationMapAtom)
 
   const publishBrowserState = React.useCallback((state: BrowserStateChange) => {
@@ -41,6 +43,7 @@ export function AgentBrowserLinkProvider({
       setBrowserOpenMap((previous) => { const next = new Map(previous); next.set(state.sessionId, false); return next })
       setBrowserMinimizedMap((previous) => { const next = new Map(previous); next.delete(state.sessionId); return next })
       setBrowserStateMap((previous) => { const next = new Map(previous); next.delete(state.sessionId); return next })
+      setBrowserFocusRequestMap((previous) => { const next = new Map(previous); next.delete(state.sessionId); return next })
       setPendingNavigationMap((previous) => { const next = new Map(previous); next.delete(state.sessionId); return next })
       return
     }
@@ -54,7 +57,15 @@ export function AgentBrowserLinkProvider({
       next.set(state.sessionId, true)
       return next
     })
-  }, [setBrowserOpenMap, setBrowserMinimizedMap, setBrowserStateMap, setPendingNavigationMap])
+  }, [setBrowserFocusRequestMap, setBrowserOpenMap, setBrowserMinimizedMap, setBrowserStateMap, setPendingNavigationMap])
+
+  const requestBrowserFocus = React.useCallback((state: BrowserViewState) => {
+    setBrowserFocusRequestMap((previous) => {
+      const next = new Map(previous)
+      next.set(state.sessionId, state.activeTabId)
+      return next
+    })
+  }, [setBrowserFocusRequestMap])
 
   const openLink = React.useCallback((url: string) => {
     const openBrowser = (window.electronAPI as Partial<typeof window.electronAPI>).openAgentBrowser
@@ -80,7 +91,9 @@ export function AgentBrowserLinkProvider({
 
           if (!riskAcknowledged) {
             // 风险告知尚未确认时，先打开空白浏览器展示确认弹窗，确认后再导航。
-            publishBrowserState(existingState ?? await openBrowser(sessionId))
+            const state = existingState ?? await openBrowser(sessionId)
+            publishBrowserState(state)
+            requestBrowserFocus(state)
             setPendingNavigationMap((previous) => {
               const next = new Map(previous)
               next.set(sessionId, url)
@@ -95,6 +108,7 @@ export function AgentBrowserLinkProvider({
             ? await window.electronAPI.navigateAgentBrowser({ sessionId, url })
             : await window.electronAPI.createAgentBrowserTab({ sessionId, url })
           publishBrowserState(nextState)
+          requestBrowserFocus(nextState)
         } catch (error) {
           console.error('[Agent 回复链接] 在受管浏览器中打开失败:', error)
         }
@@ -103,7 +117,7 @@ export function AgentBrowserLinkProvider({
     void nextNavigation.finally(() => {
       if (navigationQueues.get(sessionId) === nextNavigation) navigationQueues.delete(sessionId)
     })
-  }, [publishBrowserState, sessionId, setBrowserMinimizedMap, setPendingNavigationMap])
+  }, [publishBrowserState, requestBrowserFocus, sessionId, setBrowserMinimizedMap, setPendingNavigationMap])
 
   const value = React.useMemo(() => ({ openLink }), [openLink])
   return <AgentBrowserLinkContext.Provider value={value}>{children}</AgentBrowserLinkContext.Provider>


### PR DESCRIPTION
## Summary

- 点击 Agent 回复中的链接时，无论浏览器是否已打开，右侧工作区都会聚焦到目标网页标签。
- 将网页 `window.open` 产生的 Tab 与来源页生命周期解耦，关闭任一标签不再级联关闭其他标签。

## Validation

- `bun run typecheck`
- `bun run --filter @proma/electron build:main`
- `bun run --filter @proma/electron build:preload`
- `bun run --filter @proma/electron build:renderer`
- `git diff --check`

## Performance

低风险：链接点击仅新增一次会话级焦点状态更新，不增加 IPC 或流式渲染路径的更新频率。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)