### PR TITLE
feat(collaboration): 支持为协作子会话分配其他渠道的模型（cross-channel model assignment）

### DIFF
--- a/apps/electron/src/main/lib/agent-collaboration-tools.ts
+++ b/apps/electron/src/main/lib/agent-collaboration-tools.ts
@@ -38,7 +38,7 @@ import {
   createToolCallIdempotencyCache,
   resolveDelegationPermissionMode,
 } from './agent-collaboration-utils'
-import { assertEnabledModelForChannel, listEnabledAgentModelsForChannel } from './agent-model-selection'
+import { listEnabledAgentModelsForChannel, listEnabledAgentModelsGrouped, resolveDelegationModelTarget } from './agent-model-selection'
 
 interface CollaborationToolContext {
   sessionId: string
@@ -232,18 +232,21 @@ interface DelegateAgentArgs {
   task: string
   expectedOutput?: string
   permissionMode?: PromaPermissionMode
+  channelId?: string
   modelId?: string
 }
 
 interface StartDelegationResult {
   record: DelegationRecord
   effectivePermissionMode: PromaPermissionMode
+  effectiveChannelId: string
   effectiveModelId?: string
 }
 
 interface PiDelegationToolResult {
   delegationId: string
   effectivePermissionMode: PromaPermissionMode
+  effectiveChannelId?: string
   effectiveModelId?: string
 }
 
@@ -569,25 +572,31 @@ function getCurrentParentPermissionMode(
   return latestParent?.permissionMode ?? parent?.permissionMode ?? fallback
 }
 
-function getAvailableAgentModels(ctx: CollaborationToolContext): Record<string, unknown> {
+function getAvailableAgentModels(ctx: CollaborationToolContext, targetChannelId?: string): Record<string, unknown> {
   const currentModelId = ctx.modelId?.trim() || undefined
-  const summary = listEnabledAgentModelsForChannel(ctx.channelId, '读取协作子会话可用模型')
+  if (targetChannelId) {
+    const summary = listEnabledAgentModelsForChannel(targetChannelId, '读取协作子会话可用模型')
+    return {
+      ...summary,
+      models: summary.models.map((model) => ({
+        ...model,
+        current: model.id === currentModelId,
+      })),
+      currentModelId,
+    }
+  }
+  const grouped = listEnabledAgentModelsGrouped()
   return {
-    channelId: summary.channelId,
-    channelName: summary.channelName,
-    provider: summary.provider,
-    currentModelId,
-    currentModelAvailable: currentModelId
-      ? summary.models.some((model) => model.id === currentModelId)
-      : false,
-    models: summary.models.map((model) => ({
-      ...model,
-      current: model.id === currentModelId,
+    channels: grouped.channels.map((channel) => ({
+      ...channel,
+      models: channel.models.map((model) => ({
+        ...model,
+        current: channel.channelId === ctx.channelId && model.id === currentModelId,
+      })),
     })),
-    modelCount: summary.models.length,
-    note: summary.models.length > 0
-      ? '创建协作子会话时，可从 models[].id 中选择 modelId；不传则继承 currentModelId。'
-      : '当前渠道没有启用的 Agent 模型，请先在渠道设置中启用模型。',
+    currentChannelId: ctx.channelId,
+    currentModelId,
+    note: '创建协作子会话时：跨渠道请同时传 channelId + modelId；仅传 modelId 将在全部已启用渠道内解析（命中多个渠道会要求消歧）；都不传则继承父会话。',
   }
 }
 
@@ -634,17 +643,19 @@ function startDelegation(
     parentPermissionMode,
     args.permissionMode,
   )
-  const effectiveModelId = args.modelId !== undefined
-    ? assertEnabledModelForChannel({
-        channelId: ctx.channelId,
-        modelId: args.modelId,
-        purpose: '创建协作子会话',
-      })
-    : ctx.modelId?.trim() || undefined
+  const resolvedModelTarget = resolveDelegationModelTarget({
+    channelId: args.channelId,
+    modelId: args.modelId,
+    fallbackChannelId: ctx.channelId,
+    fallbackModelId: ctx.modelId?.trim() || undefined,
+    purpose: '创建协作子会话',
+  })
+  const effectiveChannelId = resolvedModelTarget.channelId
+  const effectiveModelId = resolvedModelTarget.modelId
 
   const { completion, resolveCompletion } = createDelegationCompletion()
 
-  const child = createAgentSession(title, ctx.channelId, ctx.workspaceId, effectiveModelId)
+  const child = createAgentSession(title, effectiveChannelId, ctx.workspaceId, effectiveModelId)
   const rootSessionId = parent?.rootSessionId ?? parent?.id ?? ctx.sessionId
   updateAgentSessionMeta(child.id, {
     parentSessionId: ctx.sessionId,
@@ -662,7 +673,7 @@ function startDelegation(
     delegationId,
     parentSessionId: ctx.sessionId,
     childSessionId: child.id,
-    channelId: ctx.channelId,
+    channelId: effectiveChannelId,
     modelId: effectiveModelId,
     title,
     role,
@@ -688,7 +699,7 @@ function startDelegation(
     {
       sessionId: child.id,
       userMessage: prompt,
-      channelId: ctx.channelId,
+      channelId: effectiveChannelId,
       modelId: effectiveModelId,
       workspaceId: ctx.workspaceId,
       permissionModeOverride: permissionMode,
@@ -716,7 +727,7 @@ function startDelegation(
     })
   })
 
-  return { record, effectivePermissionMode: permissionMode, effectiveModelId }
+  return { record, effectivePermissionMode: permissionMode, effectiveChannelId, effectiveModelId }
 }
 
 // ===== Pi Runtime 桥接 =====
@@ -745,7 +756,8 @@ export function buildPiCollaborationTools(
     role: roleType,
     task: Type.String({ description: '发送给子 Agent 的完整任务说明' }),
     expectedOutput: Type.Optional(Type.String({ description: '希望子 Agent 最终返回的格式或要点' })),
-    modelId: Type.Optional(Type.String({ description: '可选目标模型 ID' })),
+    channelId: Type.Optional(Type.String({ description: '可选目标渠道 ID；与 modelId 搭配可将子会话委派给其他渠道的模型' })),
+    modelId: Type.Optional(Type.String({ description: '可选目标模型 ID；未传 channelId 时在全部已启用渠道内解析' })),
   })
 
   function piJsonResult(payload: unknown): { content: Array<{ type: 'text'; text: string }>; details: unknown } {
@@ -759,10 +771,13 @@ export function buildPiCollaborationTools(
     sdk.defineTool({
       name: 'mcp__collaboration__list_available_agent_models',
       label: '列出可用模型',
-      description: '列出当前父会话渠道下已启用、可用于协作子 Agent 的模型。需要给 delegate_agent/delegate_agents 指定 modelId 前应先调用此工具。',
-      parameters: Type.Object({}),
-      async execute() {
-        return piJsonResult(getAvailableAgentModels(ctx))
+      description: '列出可用于协作子 Agent 的模型。不传参数时返回全部已启用渠道的分组视图；传入 channelId 则只返回该渠道的模型。需要给 delegate_agent/delegate_agents 指定 modelId（跨渠道时同时传 channelId）前应先调用此工具。',
+      parameters: Type.Object({
+        channelId: Type.Optional(Type.String({ description: '可选渠道 ID；传入则只返回该渠道的模型，不传则返回全部已启用渠道的分组视图' })),
+      }),
+      async execute(_toolCallId: string, params: unknown) {
+        const args = params as { channelId?: string }
+        return piJsonResult(getAvailableAgentModels(ctx, args.channelId))
       },
     }),
     sdk.defineTool({
@@ -774,7 +789,8 @@ export function buildPiCollaborationTools(
         role: roleType,
         task: Type.String({ description: '发送给子 Agent 的完整任务说明，必须自包含必要上下文' }),
         expectedOutput: Type.Optional(Type.String({ description: '希望子 Agent 最终返回的格式或要点' })),
-        modelId: Type.Optional(Type.String({ description: '可选目标模型 ID' })),
+        channelId: Type.Optional(Type.String({ description: '可选目标渠道 ID；与 modelId 搭配可将子会话委派给其他渠道的模型。仅传 channelId 时使用该渠道第一个启用模型' })),
+        modelId: Type.Optional(Type.String({ description: '可选目标模型 ID；未传 channelId 时在全部已启用渠道内解析，命中多个渠道会要求消歧' })),
       }),
       async execute(toolCallId: string, params: unknown) {
         const args = params as DelegateAgentArgs
@@ -784,6 +800,7 @@ export function buildPiCollaborationTools(
           return {
             delegationId: created.record.delegationId,
             effectivePermissionMode: created.effectivePermissionMode,
+            effectiveChannelId: created.effectiveChannelId,
             effectiveModelId: created.effectiveModelId,
           }
         })
@@ -821,6 +838,7 @@ export function buildPiCollaborationTools(
               created.push({
                 delegationId: started.record.delegationId,
                 effectivePermissionMode: started.effectivePermissionMode,
+                effectiveChannelId: started.effectiveChannelId,
                 effectiveModelId: started.effectiveModelId,
               })
             } catch (error) {
@@ -842,6 +860,10 @@ export function buildPiCollaborationTools(
           effectiveModels: batch.created.map((item) => ({
             delegationId: item.delegationId,
             modelId: item.effectiveModelId,
+          })),
+          effectiveChannels: batch.created.map((item) => ({
+            delegationId: item.delegationId,
+            channelId: item.effectiveChannelId,
           })),
           failures: batch.failures,
           createdCount: batch.created.length,

--- a/apps/electron/src/main/lib/agent-model-selection.test.ts
+++ b/apps/electron/src/main/lib/agent-model-selection.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveDelegationModelTargetFromChannels } from './agent-model-target'
+import type { Channel } from '@proma/shared'
+
+function makeChannel(
+  id: string,
+  models: Array<{ id: string; enabled: boolean }>,
+  enabled = true,
+): Channel {
+  const now = Date.now()
+  return {
+    id,
+    name: id,
+    provider: 'openai' as Channel['provider'],
+    baseUrl: 'https://example.test',
+    apiKey: 'test-key',
+    enabled,
+    createdAt: now,
+    updatedAt: now,
+    models: models.map((model) => ({
+      id: model.id,
+      name: model.id,
+      enabled: model.enabled,
+      source: 'manual' as const,
+    })),
+  }
+}
+
+const fixtures = (): Channel[] => [
+  makeChannel('chA', [
+    { id: 'glm-large', enabled: true },
+    { id: 'glm-flash', enabled: true },
+  ]),
+  makeChannel('chB', [{ id: 'k3', enabled: true }]),
+  makeChannel('chC', [{ id: 'glm-large', enabled: true }], false),
+]
+
+describe('resolveDelegationModelTargetFromChannels', () => {
+  test('显式渠道 + 模型：合法组合直接通过', () => {
+    const target = resolveDelegationModelTargetFromChannels(
+      { channelId: 'chA', modelId: 'glm-large', purpose: '测试' },
+      fixtures(),
+    )
+    expect(target.channelId).toBe('chA')
+    expect(target.modelId).toBe('glm-large')
+  })
+
+  test('显式渠道 + 模型：模型不属于该渠道时抛错', () => {
+    expect(() =>
+      resolveDelegationModelTargetFromChannels(
+        { channelId: 'chB', modelId: 'glm-large', purpose: '测试' },
+        fixtures(),
+      ),
+    ).toThrow(/不属于当前渠道或未启用/)
+  })
+
+  test('仅 modelId：唯一命中时解析到所在渠道', () => {
+    const target = resolveDelegationModelTargetFromChannels(
+      { modelId: 'k3', purpose: '测试' },
+      fixtures(),
+    )
+    expect(target.channelId).toBe('chB')
+    expect(target.modelId).toBe('k3')
+  })
+
+  test('仅 modelId：多渠道命中时要求消歧（禁用渠道不参与）', () => {
+    // glm-large 存在于 chA（启用）与 chC（禁用）：禁用渠道不参与解析，chA 唯一命中
+    const target = resolveDelegationModelTargetFromChannels(
+      { modelId: 'glm-large', purpose: '测试' },
+      fixtures(),
+    )
+    expect(target.channelId).toBe('chA')
+
+    // chD 也启用 glm-large 时命中多个渠道，要求消歧
+    const channels = [...fixtures(), makeChannel('chD', [{ id: 'glm-large', enabled: true }])]
+    expect(() =>
+      resolveDelegationModelTargetFromChannels({ modelId: 'glm-large', purpose: '测试' }, channels),
+    ).toThrow(/消歧/)
+  })
+
+  test('仅 modelId：所有渠道均无此模型时抛错', () => {
+    expect(() =>
+      resolveDelegationModelTargetFromChannels(
+        { modelId: 'no-such-model', purpose: '测试' },
+        fixtures(),
+      ),
+    ).toThrow(/均不存在或未启用/)
+  })
+
+  test('仅 channelId：使用该渠道第一个启用模型', () => {
+    const target = resolveDelegationModelTargetFromChannels(
+      { channelId: 'chB', purpose: '测试' },
+      fixtures(),
+    )
+    expect(target.channelId).toBe('chB')
+    expect(target.modelId).toBe('k3')
+  })
+
+  test('仅 channelId：渠道内没有启用模型时抛错', () => {
+    const channels = [...fixtures(), makeChannel('chEmpty', [{ id: 'm1', enabled: false }])]
+    expect(() =>
+      resolveDelegationModelTargetFromChannels({ channelId: 'chEmpty', purpose: '测试' }, channels),
+    ).toThrow(/没有已启用的模型/)
+  })
+
+  test('都不传：回退父会话渠道与模型', () => {
+    const target = resolveDelegationModelTargetFromChannels(
+      { fallbackChannelId: 'chA', fallbackModelId: 'glm-flash', purpose: '测试' },
+      fixtures(),
+    )
+    expect(target.channelId).toBe('chA')
+    expect(target.modelId).toBe('glm-flash')
+  })
+
+  test('回退：父会话模型已失效时抛错', () => {
+    expect(() =>
+      resolveDelegationModelTargetFromChannels(
+        { fallbackChannelId: 'chA', fallbackModelId: 'no-such-model', purpose: '测试' },
+        fixtures(),
+      ),
+    ).toThrow(/不属于当前渠道或未启用/)
+  })
+})

--- a/apps/electron/src/main/lib/agent-model-selection.ts
+++ b/apps/electron/src/main/lib/agent-model-selection.ts
@@ -1,5 +1,16 @@
-import { getChannelById } from './channel-manager'
+import { getChannelById, listChannels } from './channel-manager'
 import type { ProviderType } from '@proma/shared'
+import {
+  listEnabledAgentModelsGroupedFromChannels,
+  resolveDelegationModelTargetFromChannels,
+  type ResolvedAgentModelTarget,
+} from './agent-model-target'
+
+export {
+  listEnabledAgentModelsGroupedFromChannels,
+  resolveDelegationModelTargetFromChannels,
+  type ResolvedAgentModelTarget,
+} from './agent-model-target'
 
 export interface AvailableAgentModel {
   id: string
@@ -67,4 +78,22 @@ export function listEnabledAgentModelsForChannel(
         source: model.source,
       })),
   }
+}
+
+/** 读取全部已启用渠道，解析协作委派的目标模型（支持跨渠道） */
+export function resolveDelegationModelTarget(input: {
+  channelId?: string
+  modelId?: string
+  fallbackChannelId?: string
+  fallbackModelId?: string
+  purpose: string
+}): ResolvedAgentModelTarget {
+  return resolveDelegationModelTargetFromChannels(input, listChannels())
+}
+
+/** 全渠道分组视图：列出所有已启用渠道及其可用模型（供跨渠道委派选择） */
+export function listEnabledAgentModelsGrouped(): {
+  channels: AvailableAgentModelsForChannel[]
+} {
+  return listEnabledAgentModelsGroupedFromChannels(listChannels())
 }

--- a/apps/electron/src/main/lib/agent-model-target.ts
+++ b/apps/electron/src/main/lib/agent-model-target.ts
@@ -1,0 +1,124 @@
+import type { Channel, ProviderType } from '@proma/shared'
+
+export interface AvailableAgentModel {
+  id: string
+  name: string
+  source?: 'manual' | 'fetched'
+}
+
+export interface AvailableAgentModelsForChannel {
+  channelId: string
+  channelName: string
+  provider: ProviderType
+  models: AvailableAgentModel[]
+}
+
+/** 跨渠道委派的模型解析结果 */
+export interface ResolvedAgentModelTarget {
+  channelId: string
+  modelId?: string
+}
+
+/**
+ * 纯函数核心：在给定渠道集合内解析委派目标模型，便于 BDD 测试。
+ *
+ * 解析规则（按优先级）：
+ * 1. channelId + modelId：按指定渠道校验模型
+ * 2. 仅 modelId：在全部已启用渠道内解析；命中多个渠道时要求显式消歧
+ * 3. 仅 channelId：使用该渠道的第一个启用模型
+ * 4. 都未传：回退父会话渠道与模型
+ */
+export function resolveDelegationModelTargetFromChannels(
+  input: {
+    channelId?: string
+    modelId?: string
+    fallbackChannelId?: string
+    fallbackModelId?: string
+    purpose: string
+  },
+  channels: Channel[],
+): ResolvedAgentModelTarget {
+  const modelId = input.modelId?.trim() || undefined
+  const explicitChannelId = input.channelId?.trim() || undefined
+
+  if (explicitChannelId && modelId) {
+    assertChannelModelEnabled(channels, explicitChannelId, modelId, input.purpose)
+    return { channelId: explicitChannelId, modelId }
+  }
+
+  if (modelId) {
+    const matched = channels.filter(
+      (channel) => channel.enabled && channel.models.some((model) => model.id === modelId && model.enabled),
+    )
+    if (matched.length === 0) {
+      throw new Error(`${input.purpose}模型在所有已启用渠道中均不存在或未启用: ${modelId}`)
+    }
+    if (matched.length > 1) {
+      throw new Error(
+        `${input.purpose}模型存在于多个渠道（${matched.map((item) => item.id).join('、')}），请显式传入 channelId 消歧: ${modelId}`,
+      )
+    }
+    const target = matched[0]
+    if (!target) {
+      throw new Error(`${input.purpose}未找到可用的模型渠道: ${modelId}`)
+    }
+    return { channelId: target.id, modelId }
+  }
+
+  if (explicitChannelId) {
+    const channel = channels.find((item) => item.id === explicitChannelId && item.enabled)
+    if (!channel) {
+      throw new Error(`${input.purpose}引用的渠道不存在或未启用: ${explicitChannelId}`)
+    }
+    const model = channel.models.find((item) => item.enabled)
+    if (!model) {
+      throw new Error(`${input.purpose}渠道内没有已启用的模型: ${explicitChannelId}`)
+    }
+    return { channelId: channel.id, modelId: model.id }
+  }
+
+  const fallbackChannelId = input.fallbackChannelId?.trim() || undefined
+  const fallbackModelId = input.fallbackModelId?.trim() || undefined
+  if (!fallbackChannelId) {
+    throw new Error(`${input.purpose}需要可用的 channelId`)
+  }
+  if (fallbackModelId) {
+    assertChannelModelEnabled(channels, fallbackChannelId, fallbackModelId, input.purpose)
+  }
+  return { channelId: fallbackChannelId, modelId: fallbackModelId }
+}
+
+/** 全渠道分组视图：列出所有已启用渠道及其可用模型（供跨渠道委派选择） */
+export function listEnabledAgentModelsGroupedFromChannels(channels: Channel[]): {
+  channels: AvailableAgentModelsForChannel[]
+} {
+  return {
+    channels: channels
+      .filter((channel) => channel.enabled && channel.models.some((model) => model.enabled))
+      .map((channel) => ({
+        channelId: channel.id,
+        channelName: channel.name,
+        provider: channel.provider,
+        models: channel.models
+          .filter((model) => model.enabled)
+          .map((model) => ({ id: model.id, name: model.name, source: model.source })),
+      })),
+  }
+}
+
+/** 校验渠道存在且启用、模型已启用；不满足则抛错（纯函数版本，避免引入 electron 依赖链） */
+function assertChannelModelEnabled(
+  channels: Channel[],
+  channelId: string,
+  modelId: string,
+  purpose: string,
+): void {
+  const channel = channels.find((item) => item.id === channelId && item.enabled)
+  if (!channel) {
+    throw new Error(`${purpose}引用的渠道不存在或未启用: ${channelId}`)
+  }
+  const model = channel.models.find((item) => item.id === modelId && item.enabled)
+  if (!model) {
+    throw new Error(`${purpose}模型不属于当前渠道或未启用: ${modelId}`)
+  }
+}


### PR DESCRIPTION
Closes #1935

## 解决的问题

如 #1935 所述：协作子会话的可用模型列表与 `modelId` 校验均被限定在父会话渠道内，无法实现"主会话用旗舰模型规划 / Review，子会话用其他渠道的高性价比模型执行"的分层调度。手动切换子会话模型也只能绕行一次，后续委派会回落父会话模型。

## 实现方案

模型标识引入渠道维度（`{channelId, modelId}`），**默认行为完全不变**：

- **`delegate_agent` / `delegate_agents`** 新增可选 `channelId`：
  - `channelId + modelId`：在指定渠道内校验
  - 仅 `modelId`：在全部已启用渠道内解析；命中多个渠道时抛错要求消歧
  - 都不传：继承父会话渠道与模型（原行为）
- **`list_available_agent_models`**：默认返回全部已启用渠道的分组视图（`channels[].models[]`，带 current 标记）；传入 `channelId` 时保持单渠道视图
- **子会话创建与运行**：`createAgentSession` / `runRegisteredHeadlessAgent` 绑定目标渠道，委派记录（`record.channelId`）与工具返回值（`effectiveChannelId`）记录真实渠道
- **解析核心抽为纯函数** `agent-model-target.ts`：仅依赖 `@proma/shared` 类型、无 electron 依赖链，便于测试与复用；`agent-model-selection.ts` 保留 IO 包装层

## 测试

- 新增 9 个 BDD 测试（`bun:test`）：显式渠道+模型、跨渠道唯一命中、多渠道消歧、无命中、仅渠道取第一个启用模型、渠道无启用模型、继承回退、回退模型失效、禁用渠道不参与解析
- `bun test` main/lib：270 pass（5 个失败为预先存在的环境相关用例，与基线一致，见下方说明）
- `bun run typecheck` 通过

## 真机端到端验证（OSS dev 实例）

GLM 主会话 → 委派子会话并指定 Kimi 渠道 `k3`：

- 子会话在 k3 上完成完整开发任务（番茄钟网页：Write / Bash / Browser 预览全链路）
- 多轮委派渠道保持稳定（第二轮 UI 改版同样落在 k3）
- 会话 JSONL 正确记录目标 `channelId` + `modelId`

## 兼容性

不传新参数时，解析结果与原先完全一致（继承父会话渠道与模型）；基线上 5 个环境相关失败用例（OAuth proxy / planning DB / MCP transport）在改动前后表现一致。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)