### PR TITLE
Fix Skills folder paths and external refresh

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3186,8 +3186,8 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(
     AGENT_IPC_CHANNELS.WRITE_SKILL_CONTENT,
-    async (_, workspaceSlug: string, skillSlug: string, content: string): Promise<void> => {
-      writeWorkspaceSkillContent(workspaceSlug, skillSlug, content)
+    async (_, workspaceSlug: string, skillSlug: string, content: string, expectedContent: string) => {
+      return writeWorkspaceSkillContent(workspaceSlug, skillSlug, content, expectedContent)
     }
   )
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -327,6 +327,7 @@ import {
   importSkillFromWorkspace,
   batchImportSkillsFromWorkspaces,
   updateSkillFromSource,
+  getWorkspaceSkillFolder,
   readWorkspaceSkillContent,
   writeWorkspaceSkillContent,
   toggleWorkspaceSkill,
@@ -3108,6 +3109,15 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.GET_SKILLS_DIR,
     async (_, workspaceSlug: string): Promise<string> => {
       return getWorkspaceSkillsDir(workspaceSlug)
+    }
+  )
+
+  // 由主进程按 workspace + slug 重新定位目录，避免 renderer 的异步 Skills 根路径过期。
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.OPEN_SKILL_FOLDER,
+    async (_, workspaceSlug: string, skillSlug: string): Promise<void> => {
+      const error = await shell.openPath(getWorkspaceSkillFolder(workspaceSlug, skillSlug))
+      if (error) throw new Error(`无法打开 Skill 目录: ${error}`)
     }
   )
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3186,8 +3186,8 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(
     AGENT_IPC_CHANNELS.WRITE_SKILL_CONTENT,
-    async (_, workspaceSlug: string, skillSlug: string, content: string, expectedContent: string) => {
-      return writeWorkspaceSkillContent(workspaceSlug, skillSlug, content, expectedContent)
+    async (_, workspaceSlug: string, skillSlug: string, content: string): Promise<void> => {
+      writeWorkspaceSkillContent(workspaceSlug, skillSlug, content)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -1145,9 +1145,15 @@ function resolveSkillDir(workspaceSlug: string, skillSlug: string): string | nul
   return null
 }
 
-export function readWorkspaceSkillContent(workspaceSlug: string, skillSlug: string): string {
+/** 返回 Skill 的实际目录，避免 renderer 使用可能过期的 Skills 根路径。 */
+export function getWorkspaceSkillFolder(workspaceSlug: string, skillSlug: string): string {
   const dir = resolveSkillDir(workspaceSlug, skillSlug)
   if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  return dir
+}
+
+export function readWorkspaceSkillContent(workspaceSlug: string, skillSlug: string): string {
+  const dir = getWorkspaceSkillFolder(workspaceSlug, skillSlug)
   const mdPath = join(dir, 'SKILL.md')
   if (!existsSync(mdPath)) throw new Error(`SKILL.md 不存在: ${mdPath}`)
   return readFileSync(mdPath, 'utf-8')

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -1159,11 +1159,26 @@ export function readWorkspaceSkillContent(workspaceSlug: string, skillSlug: stri
   return readFileSync(mdPath, 'utf-8')
 }
 
-export function writeWorkspaceSkillContent(workspaceSlug: string, skillSlug: string, content: string): void {
+export type SkillContentWriteResult = { written: true } | { written: false; currentContent: string }
+
+/**
+ * 乐观并发写入：仅当磁盘内容仍等于 renderer 上次读取的版本时才覆盖，
+ * 让 renderer 能在外部 Agent 同时编辑时重新读取并合并本地脏字段。
+ */
+export function writeWorkspaceSkillContent(
+  workspaceSlug: string,
+  skillSlug: string,
+  content: string,
+  expectedContent: string,
+): SkillContentWriteResult {
   const dir = resolveSkillDir(workspaceSlug, skillSlug)
   if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
-  writeFileSync(join(dir, 'SKILL.md'), content, 'utf-8')
+  const mdPath = join(dir, 'SKILL.md')
+  const currentContent = readFileSync(mdPath, 'utf-8')
+  if (currentContent !== expectedContent) return { written: false, currentContent }
+  writeFileSync(mdPath, content, 'utf-8')
   console.log(`[Agent 工作区] 已更新 SKILL.md: ${workspaceSlug}/${skillSlug}`)
+  return { written: true }
 }
 
 // ===== Skill 子文件管理 =====

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -1159,26 +1159,11 @@ export function readWorkspaceSkillContent(workspaceSlug: string, skillSlug: stri
   return readFileSync(mdPath, 'utf-8')
 }
 
-export type SkillContentWriteResult = { written: true } | { written: false; currentContent: string }
-
-/**
- * 乐观并发写入：仅当磁盘内容仍等于 renderer 上次读取的版本时才覆盖，
- * 让 renderer 能在外部 Agent 同时编辑时重新读取并合并本地脏字段。
- */
-export function writeWorkspaceSkillContent(
-  workspaceSlug: string,
-  skillSlug: string,
-  content: string,
-  expectedContent: string,
-): SkillContentWriteResult {
+export function writeWorkspaceSkillContent(workspaceSlug: string, skillSlug: string, content: string): void {
   const dir = resolveSkillDir(workspaceSlug, skillSlug)
   if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
-  const mdPath = join(dir, 'SKILL.md')
-  const currentContent = readFileSync(mdPath, 'utf-8')
-  if (currentContent !== expectedContent) return { written: false, currentContent }
-  writeFileSync(mdPath, content, 'utf-8')
+  writeFileSync(join(dir, 'SKILL.md'), content, 'utf-8')
   console.log(`[Agent 工作区] 已更新 SKILL.md: ${workspaceSlug}/${skillSlug}`)
-  return { written: true }
 }
 
 // ===== Skill 子文件管理 =====

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -723,6 +723,9 @@ export interface ElectronAPI {
   /** 获取工作区 Skills 目录绝对路径 */
   getWorkspaceSkillsDir: (workspaceSlug: string) => Promise<string>
 
+  /** 用系统文件管理器打开指定 Skill 的实际目录 */
+  openWorkspaceSkillFolder: (workspaceSlug: string, skillSlug: string) => Promise<void>
+
   /** 删除工作区 Skill */
   deleteWorkspaceSkill: (workspaceSlug: string, skillSlug: string) => Promise<void>
 
@@ -2052,6 +2055,10 @@ const electronAPI: ElectronAPI = {
 
   getWorkspaceSkillsDir: (workspaceSlug: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SKILLS_DIR, workspaceSlug)
+  },
+
+  openWorkspaceSkillFolder: (workspaceSlug: string, skillSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_SKILL_FOLDER, workspaceSlug, skillSlug)
   },
 
   deleteWorkspaceSkill: (workspaceSlug: string, skillSlug: string) => {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -750,8 +750,8 @@ export interface ElectronAPI {
   /** 读取 SKILL.md 全文内容 */
   readSkillContent: (workspaceSlug: string, skillSlug: string) => Promise<string>
 
-  /** 写入 SKILL.md 全文内容 */
-  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string) => Promise<void>
+  /** 基于已读内容乐观写入 SKILL.md；发生外部冲突时返回最新全文。 */
+  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string, expectedContent: string) => Promise<{ written: boolean; currentContent?: string }>
 
   /** 列出 Skill 目录下的子文件树（不含 SKILL.md） */
   listSkillFiles: (workspaceSlug: string, skillSlug: string) => Promise<import('@proma/shared').SkillFileNode[]>
@@ -2110,12 +2110,13 @@ const electronAPI: ElectronAPI = {
     )
   },
 
-  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string) => {
+  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string, expectedContent: string) => {
     return ipcRenderer.invoke(
       AGENT_IPC_CHANNELS.WRITE_SKILL_CONTENT,
       workspaceSlug,
       skillSlug,
       content,
+      expectedContent,
     )
   },
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -750,8 +750,8 @@ export interface ElectronAPI {
   /** 读取 SKILL.md 全文内容 */
   readSkillContent: (workspaceSlug: string, skillSlug: string) => Promise<string>
 
-  /** 基于已读内容乐观写入 SKILL.md；发生外部冲突时返回最新全文。 */
-  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string, expectedContent: string) => Promise<{ written: boolean; currentContent?: string }>
+  /** 写入 SKILL.md 全文内容 */
+  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string) => Promise<void>
 
   /** 列出 Skill 目录下的子文件树（不含 SKILL.md） */
   listSkillFiles: (workspaceSlug: string, skillSlug: string) => Promise<import('@proma/shared').SkillFileNode[]>
@@ -2110,13 +2110,12 @@ const electronAPI: ElectronAPI = {
     )
   },
 
-  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string, expectedContent: string) => {
+  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string) => {
     return ipcRenderer.invoke(
       AGENT_IPC_CHANNELS.WRITE_SKILL_CONTENT,
       workspaceSlug,
       skillSlug,
       content,
-      expectedContent,
     )
   },
 

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -461,7 +461,7 @@ export function AgentSkillsView({
     return (
       <div className="flex h-full min-h-0 flex-col overflow-hidden">
         <SkillDetailView
-          key={selectedSkill.slug}
+          key={`${data.workspaceSlug}:${selectedSkill.slug}`}
           skill={selectedSkill}
           workspaceSlug={data.workspaceSlug}
           contentVersion={data.skillsRevision}

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -247,6 +247,7 @@ export function AgentSkillsView({
   const memoryCount = (data.capabilities?.memory.agentsMd.exists ? 1 : 0) + (data.capabilities?.memory.autoMemory.fileCount ?? 0)
 
   const selectedSkill = selectedSkillWorkspaceSlug === data.workspaceSlug
+    && data.loadedWorkspaceSlug === data.workspaceSlug
     ? data.skills.find((s) => s.slug === selectedSkillSlug) ?? null
     : null
   const selectedIsBuiltin = selectedSkill ? data.defaultSkillSlugs.has(selectedSkill.slug) : false

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -257,7 +257,11 @@ export function AgentSkillsView({
   }, [data.loading, data.skills, data.workspaceSlug, setSkillDetailNavigation, skillDetailNavigation])
 
   const openSkillFolder = (slug: string): void => {
-    if (data.skillsDir) window.electronAPI.openFile(`${data.skillsDir}/${slug}`)
+    if (!data.workspaceSlug) return
+    void window.electronAPI.openWorkspaceSkillFolder(data.workspaceSlug, slug).catch((error) => {
+      console.error('[Agent 技能] 打开 Skill 目录失败:', error)
+      toast.error('打开 Skill 目录失败')
+    })
   }
 
   const guideManualMcp = React.useCallback((): void => {
@@ -460,6 +464,7 @@ export function AgentSkillsView({
           key={selectedSkill.slug}
           skill={selectedSkill}
           workspaceSlug={data.workspaceSlug}
+          contentVersion={data.skillsRevision}
           isBuiltin={selectedIsBuiltin}
           updating={data.updatingSkill === selectedSkill.slug}
           onBack={() => setSelectedSkillSlug(null)}

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -169,6 +169,7 @@ export function AgentSkillsView({
   const tab = embedded && componentTab ? componentTab : storedTab
   const [search, setSearch] = React.useState('')
   const [selectedSkillSlug, setSelectedSkillSlug] = React.useState<string | null>(null)
+  const [selectedSkillWorkspaceSlug, setSelectedSkillWorkspaceSlug] = React.useState<string | null>(null)
   const [selectedMcpName, setSelectedMcpName] = React.useState<string | null>(null)
   const [showImport, setShowImport] = React.useState(false)
   const [wsPopoverOpen, setWsPopoverOpen] = React.useState(false)
@@ -180,6 +181,15 @@ export function AgentSkillsView({
   const [guidingManualMcp, setGuidingManualMcp] = React.useState(false)
   const [installingCatalogMcpId, setInstallingCatalogMcpId] = React.useState<string | null>(null)
   const [pendingCredentialIntegration, setPendingCredentialIntegration] = React.useState<CatalogCredentialIntegration | null>(null)
+
+  const selectSkill = React.useCallback((slug: string): void => {
+    setSelectedSkillSlug(slug)
+    setSelectedSkillWorkspaceSlug(data.workspaceSlug)
+  }, [data.workspaceSlug])
+  const closeSkill = React.useCallback((): void => {
+    setSelectedSkillSlug(null)
+    setSelectedSkillWorkspaceSlug(null)
+  }, [])
 
   const q = search.trim().toLowerCase()
 
@@ -236,7 +246,9 @@ export function AgentSkillsView({
   )
   const memoryCount = (data.capabilities?.memory.agentsMd.exists ? 1 : 0) + (data.capabilities?.memory.autoMemory.fileCount ?? 0)
 
-  const selectedSkill = data.skills.find((s) => s.slug === selectedSkillSlug) ?? null
+  const selectedSkill = selectedSkillWorkspaceSlug === data.workspaceSlug
+    ? data.skills.find((s) => s.slug === selectedSkillSlug) ?? null
+    : null
   const selectedIsBuiltin = selectedSkill ? data.defaultSkillSlugs.has(selectedSkill.slug) : false
   const selectedMcp = selectedMcpName ? data.mcpConfig.servers[selectedMcpName] ?? null : null
 
@@ -252,9 +264,9 @@ export function AgentSkillsView({
       setSkillDetailNavigation(null)
       return
     }
-    setSelectedSkillSlug(skillDetailNavigation.skillSlug)
+    selectSkill(skillDetailNavigation.skillSlug)
     setSkillDetailNavigation(null)
-  }, [data.loading, data.skills, data.workspaceSlug, setSkillDetailNavigation, skillDetailNavigation])
+  }, [data.loading, data.skills, data.workspaceSlug, selectSkill, setSkillDetailNavigation, skillDetailNavigation])
 
   const openSkillFolder = (slug: string): void => {
     if (!data.workspaceSlug) return
@@ -438,7 +450,7 @@ export function AgentSkillsView({
         const ok = await data.deleteSkill(pendingDeleteSkill.slug, pendingDeleteSkill.name)
         setIsDeletingSkill(false)
         setPendingDeleteSkill(null)
-        if (ok) setSelectedSkillSlug(null)
+        if (ok) closeSkill()
       }}
     />
   )
@@ -467,12 +479,11 @@ export function AgentSkillsView({
           contentVersion={data.skillsRevision}
           isBuiltin={selectedIsBuiltin}
           updating={data.updatingSkill === selectedSkill.slug}
-          onBack={() => setSelectedSkillSlug(null)}
+          onBack={closeSkill}
           onToggle={(enabled) => data.toggleSkill(selectedSkill.slug, enabled)}
           onUpdate={() => data.updateSkill(selectedSkill.slug)}
           onRequestDelete={() => setPendingDeleteSkill(selectedSkill)}
           onOpenFolder={() => openSkillFolder(selectedSkill.slug)}
-          onChanged={() => bumpCapabilities((v) => v + 1)}
         />
         {skillDeleteDialog}
       </div>
@@ -681,7 +692,7 @@ export function AgentSkillsView({
               updateCount={updateCount}
               updatingSkill={data.updatingSkill}
               isBuiltin={(slug) => data.defaultSkillSlugs.has(slug)}
-              onOpen={setSelectedSkillSlug}
+              onOpen={selectSkill}
               onToggle={data.toggleSkill}
               onUpdate={data.updateSkill}
             />

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -147,39 +147,61 @@ export function SkillDetailView({
 
     const requestId = ++saveRequestRef.current
     const snapshot = { ...draft }
-    const currentContent = contentRef.current
-    const nextContent = rebuildSkillMd(
-      rebuildSkillMd(currentContent, { name: snapshot.name, description: snapshot.description }),
-      { body: snapshot.body },
-    )
+    const changedName = snapshot.name !== saved.name
+    const changedDescription = snapshot.description !== saved.description
+    const changedBody = snapshot.body !== saved.body
+    const buildContent = (base: string): string => {
+      let next = base
+      if (changedName || changedDescription) {
+        next = rebuildSkillMd(next, {
+          ...(changedName ? { name: snapshot.name } : {}),
+          ...(changedDescription ? { description: snapshot.description } : {}),
+        })
+      }
+      if (changedBody) next = rebuildSkillMd(next, { body: snapshot.body })
+      return next
+    }
 
-    // 串行化磁盘写入；离开详情页时也会 flush 最后的草稿，避免 700ms 内导航丢失编辑。
+    // 串行化磁盘写入；冲突时从最新全文重新合并本地脏字段，避免覆盖外部 Agent 的其他修改。
     saveInFlightRef.current = true
     if (mountedRef.current) setSaving(true)
-    void window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, nextContent)
-      .then(() => {
-        if (saveRequestRef.current !== requestId) return
-        contentRef.current = nextContent
-        savedRef.current = snapshot
-        failedSnapshotRef.current = null
-        if (mountedRef.current) {
-          setContent(nextContent)
+    void (async () => {
+      try {
+        let expectedContent = contentRef.current as string
+        let nextContent = buildContent(expectedContent)
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const result = await window.electronAPI.writeSkillContent(
+            workspaceSlug,
+            skill.slug,
+            nextContent,
+            expectedContent,
+          )
+          if (result.written) {
+            if (saveRequestRef.current !== requestId) return
+            contentRef.current = nextContent
+            savedRef.current = snapshot
+            failedSnapshotRef.current = null
+            if (mountedRef.current) setContent(nextContent)
+            return
+          }
+          expectedContent = result.currentContent ?? expectedContent
+          nextContent = buildContent(expectedContent)
         }
-      })
-      .catch((err) => {
+        throw new Error('SKILL.md 在保存期间持续被外部修改')
+      } catch (err) {
         if (saveRequestRef.current !== requestId) return
         failedSnapshotRef.current = snapshot
         console.error('[SkillDetail] 自动保存失败:', err)
         if (mountedRef.current) toast.error('自动保存失败')
-      })
-      .finally(() => {
+      } finally {
         saveInFlightRef.current = false
         if (mountedRef.current && saveRequestRef.current === requestId) setSaving(false)
         if (flushPendingRef.current) {
           flushPendingRef.current = false
           saveDraftRef.current()
         }
-      })
+      }
+    })()
   }, [workspaceSlug, skill.slug])
 
   saveDraftRef.current = saveDraft

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -223,7 +223,16 @@ export function SkillDetailView({
       : '当前项目'
 
   return (
-    <div className="flex h-full flex-col min-h-0">
+    <div
+      className="flex h-full flex-col min-h-0"
+      onKeyDownCapture={(event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+          event.preventDefault()
+          event.stopPropagation()
+          retrySave()
+        }
+      }}
+    >
       {/* 头部 */}
       <div className="shrink-0 border-b border-border/60 px-5 pb-4 pt-5">
         <div className="flex items-center gap-3">

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -30,7 +30,6 @@ export interface SkillDetailViewProps {
   onUpdate: () => void
   onRequestDelete: () => void
   onOpenFolder: () => void
-  onChanged: () => void
 }
 
 export function SkillDetailView({
@@ -44,7 +43,6 @@ export function SkillDetailView({
   onUpdate,
   onRequestDelete,
   onOpenFolder,
-  onChanged,
 }: SkillDetailViewProps): React.ReactElement {
   const [content, setContent] = React.useState<string | null>(null)
   const [loadingContent, setLoadingContent] = React.useState(true)
@@ -63,12 +61,9 @@ export function SkillDetailView({
   const flushPendingRef = React.useRef(false)
   const failedSnapshotRef = React.useRef<{ name: string; description: string; body: string } | null>(null)
   const mountedRef = React.useRef(true)
-  const saveDraftRef = React.useRef<(force?: boolean) => void>(() => {})
-  const onChangedRef = React.useRef(onChanged)
+  const saveDraftRef = React.useRef<() => void>(() => {})
   const draftRef = React.useRef({ name: skill.name, description: skill.description ?? '', body: '' })
   const savedRef = React.useRef({ name: skill.name, description: skill.description ?? '', body: '' })
-
-  onChangedRef.current = onChanged
 
   const updateDraft = React.useCallback((next: Partial<typeof draftRef.current>) => {
     draftRef.current = { ...draftRef.current, ...next }
@@ -133,7 +128,7 @@ export function SkillDetailView({
       })
   }, [contentVersion, skill.slug, workspaceSlug, updateDraft])
 
-  const saveDraft = React.useCallback((force = false): void => {
+  const saveDraft = React.useCallback((): void => {
     const draft = draftRef.current
     const saved = savedRef.current
     const hasChanges = draft.name !== saved.name
@@ -143,7 +138,7 @@ export function SkillDetailView({
     const isKnownFailure = failed?.name === draft.name
       && failed.description === draft.description
       && failed.body === draft.body
-    if (!contentRef.current || !hasChanges || (!force && isKnownFailure)) return
+    if (!contentRef.current || !hasChanges || isKnownFailure) return
 
     if (saveInFlightRef.current) {
       flushPendingRef.current = true
@@ -169,7 +164,6 @@ export function SkillDetailView({
         failedSnapshotRef.current = null
         if (mountedRef.current) {
           setContent(nextContent)
-          onChangedRef.current()
         }
       })
       .catch((err) => {
@@ -183,7 +177,7 @@ export function SkillDetailView({
         if (mountedRef.current && saveRequestRef.current === requestId) setSaving(false)
         if (flushPendingRef.current) {
           flushPendingRef.current = false
-          saveDraftRef.current(true)
+          saveDraftRef.current()
         }
       })
   }, [workspaceSlug, skill.slug])
@@ -206,7 +200,7 @@ export function SkillDetailView({
     mountedRef.current = true
     return () => {
       mountedRef.current = false
-      saveDraftRef.current(true)
+      saveDraftRef.current()
     }
   }, [])
 

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -50,6 +50,7 @@ export function SkillDetailView({
   const [editDescription, setEditDescription] = React.useState(skill.description ?? '')
   const [editBody, setEditBody] = React.useState('')
   const [saving, setSaving] = React.useState(false)
+  const [saveFailed, setSaveFailed] = React.useState(false)
 
   const [detailTab, setDetailTab] = React.useState<'body' | 'files'>('body')
   const [fileCount, setFileCount] = React.useState<number | null>(null)
@@ -68,6 +69,7 @@ export function SkillDetailView({
   const updateDraft = React.useCallback((next: Partial<typeof draftRef.current>) => {
     draftRef.current = { ...draftRef.current, ...next }
     failedSnapshotRef.current = null
+    setSaveFailed(false)
     if (next.name !== undefined) setEditName(next.name)
     if (next.description !== undefined) setEditDescription(next.description)
     if (next.body !== undefined) setEditBody(next.body)
@@ -86,6 +88,7 @@ export function SkillDetailView({
       setEditName(next.name)
       setEditDescription(next.description)
       setEditBody(next.body)
+      setSaveFailed(false)
       return
     }
 
@@ -161,13 +164,19 @@ export function SkillDetailView({
         contentRef.current = nextContent
         savedRef.current = snapshot
         failedSnapshotRef.current = null
-        if (mountedRef.current) setContent(nextContent)
+        if (mountedRef.current) {
+          setContent(nextContent)
+          setSaveFailed(false)
+        }
       })
       .catch((err) => {
         if (saveRequestRef.current !== requestId) return
         failedSnapshotRef.current = snapshot
         console.error('[SkillDetail] 自动保存失败:', err)
-        if (mountedRef.current) toast.error('自动保存失败')
+        if (mountedRef.current) {
+          setSaveFailed(true)
+          toast.error('自动保存失败')
+        }
       })
       .finally(() => {
         saveInFlightRef.current = false
@@ -180,6 +189,12 @@ export function SkillDetailView({
   }, [workspaceSlug, skill.slug])
 
   saveDraftRef.current = saveDraft
+
+  const retrySave = React.useCallback(() => {
+    failedSnapshotRef.current = null
+    setSaveFailed(false)
+    saveDraft()
+  }, [saveDraft])
 
   React.useEffect(() => {
     const draft = draftRef.current
@@ -283,9 +298,15 @@ export function SkillDetailView({
             <div className="space-y-2">
             <div className="flex items-center justify-between">
               <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">元数据</h4>
-              <span className="text-xs text-muted-foreground" aria-live="polite">
-                {saving ? '正在保存…' : '自动保存'}
-              </span>
+              {saveFailed ? (
+                <Button size="sm" variant="outline" onClick={retrySave} disabled={saving}>
+                  重试保存
+                </Button>
+              ) : (
+                <span className="text-xs text-muted-foreground" aria-live="polite">
+                  {saving ? '正在保存…' : '自动保存'}
+                </span>
+              )}
             </div>
             <SettingsCard divided>
               <MetaEditRow label="名称" value={editName} onChange={(name) => updateDraft({ name })} />
@@ -319,6 +340,7 @@ export function SkillDetailView({
                     <LiveMarkdownEditor
                       value={editBody}
                       onChange={(body) => updateDraft({ body })}
+                      onSave={retrySave}
                       className="live-markdown-external-scroll skill-detail-live-markdown"
                     />
                   </div>

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react'
 import { toast } from 'sonner'
-import { Sparkles, Pencil, Save, X, FolderOpen, RefreshCw, Trash2, ArrowLeft } from 'lucide-react'
+import { Sparkles, FolderOpen, RefreshCw, Trash2, ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -48,73 +48,129 @@ export function SkillDetailView({
 }: SkillDetailViewProps): React.ReactElement {
   const [content, setContent] = React.useState<string | null>(null)
   const [loadingContent, setLoadingContent] = React.useState(true)
-
-  const [isEditingMeta, setIsEditingMeta] = React.useState(false)
-  const [editName, setEditName] = React.useState('')
-  const [editDescription, setEditDescription] = React.useState('')
+  const [editName, setEditName] = React.useState(skill.name)
+  const [editDescription, setEditDescription] = React.useState(skill.description ?? '')
   const [editBody, setEditBody] = React.useState('')
   const [saving, setSaving] = React.useState(false)
 
   const [detailTab, setDetailTab] = React.useState<'body' | 'files'>('body')
   const [fileCount, setFileCount] = React.useState<number | null>(null)
+  const contentRef = React.useRef<string | null>(null)
+  const skillSlugRef = React.useRef(skill.slug)
+  const loadRequestRef = React.useRef(0)
+  const saveRequestRef = React.useRef(0)
+  const saveInFlightRef = React.useRef(false)
+  const onChangedRef = React.useRef(onChanged)
+  const draftRef = React.useRef({ name: skill.name, description: skill.description ?? '', body: '' })
+  const savedRef = React.useRef({ name: skill.name, description: skill.description ?? '', body: '' })
+
+  onChangedRef.current = onChanged
+
+  const updateDraft = React.useCallback((next: Partial<typeof draftRef.current>) => {
+    draftRef.current = { ...draftRef.current, ...next }
+    if (next.name !== undefined) setEditName(next.name)
+    if (next.description !== undefined) setEditDescription(next.description)
+    if (next.body !== undefined) setEditBody(next.body)
+  }, [])
+
+  // 切换 Skill 或外部能力刷新时，只替换未修改的字段，避免覆盖本地的自动保存缓冲区。
+  React.useEffect(() => {
+    const isDifferentSkill = skillSlugRef.current !== skill.slug
+    if (isDifferentSkill) {
+      skillSlugRef.current = skill.slug
+      const next = { name: skill.name, description: skill.description ?? '', body: '' }
+      draftRef.current = next
+      savedRef.current = next
+      contentRef.current = null
+      setContent(null)
+      setEditName(next.name)
+      setEditDescription(next.description)
+      setEditBody(next.body)
+      return
+    }
+
+    const next: Partial<typeof draftRef.current> = {}
+    if (draftRef.current.name === savedRef.current.name) {
+      savedRef.current.name = skill.name
+      next.name = skill.name
+    }
+    if (draftRef.current.description === savedRef.current.description) {
+      const description = skill.description ?? ''
+      savedRef.current.description = description
+      next.description = description
+    }
+    if (Object.keys(next).length > 0) updateDraft(next)
+  }, [skill.slug, skill.name, skill.description, updateDraft])
 
   React.useEffect(() => {
+    const requestId = ++loadRequestRef.current
     setLoadingContent(true)
     window.electronAPI.readSkillContent(workspaceSlug, skill.slug)
       .then((text) => {
-        // 保留用户尚未保存的正文草稿；未编辑状态则立即显示外部 Agent 写入的新内容。
-        if (editBody === body) setEditBody(extractSkillBody(text))
+        if (loadRequestRef.current !== requestId) return
+        const externalBody = extractSkillBody(text)
+        contentRef.current = text
         setContent(text)
+        // 只在该字段未被本地修改时接收外部内容，避免覆盖自动保存等待中的草稿。
+        if (draftRef.current.body === savedRef.current.body) {
+          savedRef.current.body = externalBody
+          updateDraft({ body: externalBody })
+        }
       })
       .catch((err) => {
+        if (loadRequestRef.current !== requestId) return
         console.error('[SkillDetail] 加载内容失败:', err)
+        contentRef.current = null
         setContent(null)
       })
-      .finally(() => setLoadingContent(false))
-  }, [contentVersion, skill.slug, workspaceSlug])
+      .finally(() => {
+        if (loadRequestRef.current === requestId) setLoadingContent(false)
+      })
+  }, [contentVersion, skill.slug, workspaceSlug, updateDraft])
 
-  const body = React.useMemo(() => extractSkillBody(content ?? ''), [content])
+  React.useEffect(() => {
+    const draft = draftRef.current
+    const saved = savedRef.current
+    const hasChanges = draft.name !== saved.name
+      || draft.description !== saved.description
+      || draft.body !== saved.body
+    if (!contentRef.current || !hasChanges || saveInFlightRef.current) return
 
-  const startEditMeta = (): void => {
-    setEditName(skill.name)
-    setEditDescription(skill.description ?? '')
-    setIsEditingMeta(true)
-  }
+    const timer = window.setTimeout(() => {
+      if (saveInFlightRef.current) return
+      const requestId = ++saveRequestRef.current
+      const snapshot = { ...draftRef.current }
+      const currentContent = contentRef.current
+      if (!currentContent) return
+      const nextContent = rebuildSkillMd(
+        rebuildSkillMd(currentContent, { name: snapshot.name, description: snapshot.description }),
+        { body: snapshot.body },
+      )
 
-  const saveMeta = async (): Promise<void> => {
-    if (!content) return
-    setSaving(true)
-    try {
-      const newContent = rebuildSkillMd(content, { name: editName, description: editDescription })
-      await window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, newContent)
-      setContent(newContent)
-      setIsEditingMeta(false)
-      onChanged()
-      toast.success('元数据已保存')
-    } catch (err) {
-      console.error('[SkillDetail] 保存元数据失败:', err)
-      toast.error('保存失败')
-    } finally {
-      setSaving(false)
-    }
-  }
+      // 串行化磁盘写入，避免较早的异步写入在较晚草稿之后完成并回退文件内容。
+      saveInFlightRef.current = true
+      setSaving(true)
+      void window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, nextContent)
+        .then(() => {
+          if (saveRequestRef.current !== requestId) return
+          contentRef.current = nextContent
+          savedRef.current = snapshot
+          setContent(nextContent)
+          onChangedRef.current()
+        })
+        .catch((err) => {
+          if (saveRequestRef.current !== requestId) return
+          console.error('[SkillDetail] 自动保存失败:', err)
+          toast.error('自动保存失败')
+        })
+        .finally(() => {
+          saveInFlightRef.current = false
+          if (saveRequestRef.current === requestId) setSaving(false)
+        })
+    }, 700)
 
-  const saveBody = async (): Promise<void> => {
-    if (!content) return
-    setSaving(true)
-    try {
-      const newContent = rebuildSkillMd(content, { body: editBody })
-      await window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, newContent)
-      setContent(newContent)
-      onChanged()
-      toast.success('说明已保存')
-    } catch (err) {
-      console.error('[SkillDetail] 保存说明失败:', err)
-      toast.error('保存失败')
-    } finally {
-      setSaving(false)
-    }
-  }
+    return () => window.clearTimeout(timer)
+  }, [content, editName, editDescription, editBody, saving, skill.slug, workspaceSlug])
 
   const sourceLabel = isBuiltin
     ? 'PROMA 内置'
@@ -198,42 +254,13 @@ export function SkillDetailView({
             <div className="space-y-2">
             <div className="flex items-center justify-between">
               <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">元数据</h4>
-              {!isEditingMeta ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={startEditMeta}
-                      className="flex items-center rounded p-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                    >
-                      <Pencil size={12} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">编辑</TooltipContent>
-                </Tooltip>
-              ) : (
-                <div className="flex items-center gap-2">
-                  <Button size="sm" variant="ghost" onClick={() => setIsEditingMeta(false)} disabled={saving}>
-                    <X size={14} /> 取消
-                  </Button>
-                  <Button size="sm" onClick={() => void saveMeta()} disabled={saving}>
-                    <Save size={14} /> {saving ? '保存中...' : '保存'}
-                  </Button>
-                </div>
-              )}
+              <span className="text-xs text-muted-foreground" aria-live="polite">
+                {saving ? '正在保存…' : '自动保存'}
+              </span>
             </div>
             <SettingsCard divided>
-              {isEditingMeta ? (
-                <>
-                  <MetaEditRow label="名称" value={editName} onChange={setEditName} />
-                  <MetaEditRow label="描述" value={editDescription} onChange={setEditDescription} multiline />
-                </>
-              ) : (
-                <>
-                  <MetaRow label="名称" value={skill.name} />
-                  <MetaRow label="描述" value={skill.description ?? '无描述'} />
-                </>
-              )}
+              <MetaEditRow label="名称" value={editName} onChange={(name) => updateDraft({ name })} />
+              <MetaEditRow label="描述" value={editDescription} onChange={(description) => updateDraft({ description })} multiline />
               <MetaRow label="数据源" value={sourceLabel} />
               <MetaRow label="位置" value={`skills/${skill.slug}`} />
             </SettingsCard>
@@ -255,22 +282,14 @@ export function SkillDetailView({
 
             <TabsContent value="body" className="mt-3">
               <div className="flex flex-col">
-                <div className="flex min-h-[28px] shrink-0 items-center justify-between px-1 pb-2">
+                <div className="flex min-h-[28px] shrink-0 items-center px-1 pb-2">
                   <div className="font-mono text-xs text-muted-foreground">SKILL.md</div>
-                  <Button
-                    size="sm"
-                    onClick={() => void saveBody()}
-                    disabled={saving || !content || editBody === body}
-                  >
-                    <Save size={14} /> {saving ? '保存中...' : '保存'}
-                  </Button>
                 </div>
                 <SettingsCard divided={false}>
                   <div className="p-4">
                     <LiveMarkdownEditor
                       value={editBody}
-                      onChange={setEditBody}
-                      onSave={() => { void saveBody() }}
+                      onChange={(body) => updateDraft({ body })}
                       className="live-markdown-external-scroll skill-detail-live-markdown"
                     />
                   </div>

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -60,6 +60,10 @@ export function SkillDetailView({
   const loadRequestRef = React.useRef(0)
   const saveRequestRef = React.useRef(0)
   const saveInFlightRef = React.useRef(false)
+  const flushPendingRef = React.useRef(false)
+  const failedSnapshotRef = React.useRef<{ name: string; description: string; body: string } | null>(null)
+  const mountedRef = React.useRef(true)
+  const saveDraftRef = React.useRef<(force?: boolean) => void>(() => {})
   const onChangedRef = React.useRef(onChanged)
   const draftRef = React.useRef({ name: skill.name, description: skill.description ?? '', body: '' })
   const savedRef = React.useRef({ name: skill.name, description: skill.description ?? '', body: '' })
@@ -68,6 +72,7 @@ export function SkillDetailView({
 
   const updateDraft = React.useCallback((next: Partial<typeof draftRef.current>) => {
     draftRef.current = { ...draftRef.current, ...next }
+    failedSnapshotRef.current = null
     if (next.name !== undefined) setEditName(next.name)
     if (next.description !== undefined) setEditDescription(next.description)
     if (next.body !== undefined) setEditBody(next.body)
@@ -128,49 +133,82 @@ export function SkillDetailView({
       })
   }, [contentVersion, skill.slug, workspaceSlug, updateDraft])
 
+  const saveDraft = React.useCallback((force = false): void => {
+    const draft = draftRef.current
+    const saved = savedRef.current
+    const hasChanges = draft.name !== saved.name
+      || draft.description !== saved.description
+      || draft.body !== saved.body
+    const failed = failedSnapshotRef.current
+    const isKnownFailure = failed?.name === draft.name
+      && failed.description === draft.description
+      && failed.body === draft.body
+    if (!contentRef.current || !hasChanges || (!force && isKnownFailure)) return
+
+    if (saveInFlightRef.current) {
+      flushPendingRef.current = true
+      return
+    }
+
+    const requestId = ++saveRequestRef.current
+    const snapshot = { ...draft }
+    const currentContent = contentRef.current
+    const nextContent = rebuildSkillMd(
+      rebuildSkillMd(currentContent, { name: snapshot.name, description: snapshot.description }),
+      { body: snapshot.body },
+    )
+
+    // 串行化磁盘写入；离开详情页时也会 flush 最后的草稿，避免 700ms 内导航丢失编辑。
+    saveInFlightRef.current = true
+    if (mountedRef.current) setSaving(true)
+    void window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, nextContent)
+      .then(() => {
+        if (saveRequestRef.current !== requestId) return
+        contentRef.current = nextContent
+        savedRef.current = snapshot
+        failedSnapshotRef.current = null
+        if (mountedRef.current) {
+          setContent(nextContent)
+          onChangedRef.current()
+        }
+      })
+      .catch((err) => {
+        if (saveRequestRef.current !== requestId) return
+        failedSnapshotRef.current = snapshot
+        console.error('[SkillDetail] 自动保存失败:', err)
+        if (mountedRef.current) toast.error('自动保存失败')
+      })
+      .finally(() => {
+        saveInFlightRef.current = false
+        if (mountedRef.current && saveRequestRef.current === requestId) setSaving(false)
+        if (flushPendingRef.current) {
+          flushPendingRef.current = false
+          saveDraftRef.current(true)
+        }
+      })
+  }, [workspaceSlug, skill.slug])
+
+  saveDraftRef.current = saveDraft
+
   React.useEffect(() => {
     const draft = draftRef.current
     const saved = savedRef.current
     const hasChanges = draft.name !== saved.name
       || draft.description !== saved.description
       || draft.body !== saved.body
-    if (!contentRef.current || !hasChanges || saveInFlightRef.current) return
+    if (!contentRef.current || !hasChanges) return
 
-    const timer = window.setTimeout(() => {
-      if (saveInFlightRef.current) return
-      const requestId = ++saveRequestRef.current
-      const snapshot = { ...draftRef.current }
-      const currentContent = contentRef.current
-      if (!currentContent) return
-      const nextContent = rebuildSkillMd(
-        rebuildSkillMd(currentContent, { name: snapshot.name, description: snapshot.description }),
-        { body: snapshot.body },
-      )
-
-      // 串行化磁盘写入，避免较早的异步写入在较晚草稿之后完成并回退文件内容。
-      saveInFlightRef.current = true
-      setSaving(true)
-      void window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, nextContent)
-        .then(() => {
-          if (saveRequestRef.current !== requestId) return
-          contentRef.current = nextContent
-          savedRef.current = snapshot
-          setContent(nextContent)
-          onChangedRef.current()
-        })
-        .catch((err) => {
-          if (saveRequestRef.current !== requestId) return
-          console.error('[SkillDetail] 自动保存失败:', err)
-          toast.error('自动保存失败')
-        })
-        .finally(() => {
-          saveInFlightRef.current = false
-          if (saveRequestRef.current === requestId) setSaving(false)
-        })
-    }, 700)
-
+    const timer = window.setTimeout(() => saveDraft(), 700)
     return () => window.clearTimeout(timer)
-  }, [content, editName, editDescription, editBody, saving, skill.slug, workspaceSlug])
+  }, [content, editName, editDescription, editBody, saveDraft])
+
+  React.useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      saveDraftRef.current(true)
+    }
+  }, [])
 
   const sourceLabel = isBuiltin
     ? 'PROMA 内置'

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -147,61 +147,36 @@ export function SkillDetailView({
 
     const requestId = ++saveRequestRef.current
     const snapshot = { ...draft }
-    const changedName = snapshot.name !== saved.name
-    const changedDescription = snapshot.description !== saved.description
-    const changedBody = snapshot.body !== saved.body
-    const buildContent = (base: string): string => {
-      let next = base
-      if (changedName || changedDescription) {
-        next = rebuildSkillMd(next, {
-          ...(changedName ? { name: snapshot.name } : {}),
-          ...(changedDescription ? { description: snapshot.description } : {}),
-        })
-      }
-      if (changedBody) next = rebuildSkillMd(next, { body: snapshot.body })
-      return next
-    }
+    const nextContent = rebuildSkillMd(
+      rebuildSkillMd(contentRef.current as string, { name: snapshot.name, description: snapshot.description }),
+      { body: snapshot.body },
+    )
 
-    // 串行化磁盘写入；冲突时从最新全文重新合并本地脏字段，避免覆盖外部 Agent 的其他修改。
+    // 700ms 防抖后串行写入，避免快速连续输入造成写入乱序。
     saveInFlightRef.current = true
     if (mountedRef.current) setSaving(true)
-    void (async () => {
-      try {
-        let expectedContent = contentRef.current as string
-        let nextContent = buildContent(expectedContent)
-        for (let attempt = 0; attempt < 2; attempt += 1) {
-          const result = await window.electronAPI.writeSkillContent(
-            workspaceSlug,
-            skill.slug,
-            nextContent,
-            expectedContent,
-          )
-          if (result.written) {
-            if (saveRequestRef.current !== requestId) return
-            contentRef.current = nextContent
-            savedRef.current = snapshot
-            failedSnapshotRef.current = null
-            if (mountedRef.current) setContent(nextContent)
-            return
-          }
-          expectedContent = result.currentContent ?? expectedContent
-          nextContent = buildContent(expectedContent)
-        }
-        throw new Error('SKILL.md 在保存期间持续被外部修改')
-      } catch (err) {
+    void window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, nextContent)
+      .then(() => {
+        if (saveRequestRef.current !== requestId) return
+        contentRef.current = nextContent
+        savedRef.current = snapshot
+        failedSnapshotRef.current = null
+        if (mountedRef.current) setContent(nextContent)
+      })
+      .catch((err) => {
         if (saveRequestRef.current !== requestId) return
         failedSnapshotRef.current = snapshot
         console.error('[SkillDetail] 自动保存失败:', err)
         if (mountedRef.current) toast.error('自动保存失败')
-      } finally {
+      })
+      .finally(() => {
         saveInFlightRef.current = false
         if (mountedRef.current && saveRequestRef.current === requestId) setSaving(false)
         if (flushPendingRef.current) {
           flushPendingRef.current = false
           saveDraftRef.current()
         }
-      }
-    })()
+      })
   }, [workspaceSlug, skill.slug])
 
   saveDraftRef.current = saveDraft

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -21,6 +21,8 @@ import { extractSkillBody, rebuildSkillMd } from './skillMdUtils'
 export interface SkillDetailViewProps {
   skill: SkillMeta
   workspaceSlug: string
+  /** 外部能力变更后由数据层递增，用于重新读取 SKILL.md。 */
+  contentVersion: number
   isBuiltin: boolean
   updating: boolean
   onBack: () => void
@@ -34,6 +36,7 @@ export interface SkillDetailViewProps {
 export function SkillDetailView({
   skill,
   workspaceSlug,
+  contentVersion,
   isBuiltin,
   updating,
   onBack,
@@ -59,15 +62,16 @@ export function SkillDetailView({
     setLoadingContent(true)
     window.electronAPI.readSkillContent(workspaceSlug, skill.slug)
       .then((text) => {
+        // 保留用户尚未保存的正文草稿；未编辑状态则立即显示外部 Agent 写入的新内容。
+        if (editBody === body) setEditBody(extractSkillBody(text))
         setContent(text)
-        setEditBody(extractSkillBody(text))
       })
       .catch((err) => {
         console.error('[SkillDetail] 加载内容失败:', err)
         setContent(null)
       })
       .finally(() => setLoadingContent(false))
-  }, [skill.slug, workspaceSlug])
+  }, [contentVersion, skill.slug, workspaceSlug])
 
   const body = React.useMemo(() => extractSkillBody(content ?? ''), [content])
 

--- a/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
+++ b/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
@@ -52,6 +52,8 @@ export interface AgentSkillsData {
   skillsDir: string
   mcpConfig: WorkspaceMcpConfig
   capabilities: WorkspaceCapabilities | null
+  /** 每次从磁盘重新读取 Skills 后递增，供详情页刷新 SKILL.md 正文。 */
+  skillsRevision: number
   builtinMcpServers: BuiltinMcpServerSummary[]
   cliIntegrationStatuses: CliIntegrationStatus[]
   cliIntegrationProbeState: CatalogCliProbeState
@@ -74,6 +76,7 @@ export interface AgentSkillsData {
 export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const selectedWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const capabilitiesVersion = useAtomValue(workspaceCapabilitiesVersionAtom)
   const bumpCapabilitiesVersion = useSetAtom(workspaceCapabilitiesVersionAtom)
 
   const currentWorkspace = workspaces.find((w) => w.id === (workspaceId ?? selectedWorkspaceId))
@@ -85,12 +88,14 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
   const [skillsDir, setSkillsDir] = React.useState('')
   const [mcpConfig, setMcpConfig] = React.useState<WorkspaceMcpConfig>({ servers: {} })
   const [capabilities, setCapabilities] = React.useState<WorkspaceCapabilities | null>(null)
+  const [skillsRevision, setSkillsRevision] = React.useState(0)
   const [builtinMcpServers, setBuiltinMcpServers] = React.useState<BuiltinMcpServerSummary[]>([])
   const [cliIntegrationStatuses, setCliIntegrationStatuses] = React.useState<CliIntegrationStatus[]>([])
   const [cliIntegrationProbeState, setCliIntegrationProbeState] = React.useState<CatalogCliProbeState>('loading')
   const [updatingSkill, setUpdatingSkill] = React.useState<string | null>(null)
   const loadRequestRef = React.useRef(0)
   const cliProbeRequestRef = React.useRef(0)
+  const observedCapabilitiesVersionRef = React.useRef(capabilitiesVersion)
 
   const loadData = React.useCallback(async () => {
     const requestId = ++loadRequestRef.current
@@ -120,6 +125,7 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
       setSkillsDir(dir)
       setDefaultSkillSlugs(new Set(defaultSlugs))
       setCapabilities(capabilities)
+      setSkillsRevision((version) => version + 1)
       setBuiltinMcpServers(capabilities.builtinMcpServers)
       const cachedCliStatuses = cliIntegrationStatusCache.get(workspaceSlug)
       const hasFreshCliCache = cachedCliStatuses && Date.now() - cachedCliStatuses.cachedAt < CLI_STATUS_CACHE_TTL_MS
@@ -148,13 +154,20 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
     }
   }, [workspaceSlug])
 
-  // 只在进入页面或切换工作区时读取。文件监听会在切换开关后异步推送能力变化，
-  // 这里刻意不订阅 capabilitiesVersion，防止扫描 active/inactive 目录后重排当前列表。
+  // 首次进入或切换工作区时展示加载态；普通文件监听刷新则保留当前视图，避免闪烁。
   React.useEffect(() => {
     setLoading(true)
     void loadData()
     return () => { ++cliProbeRequestRef.current }
   }, [loadData])
+
+  // 外部 Agent 或其他进程编辑 Skills 后，主进程 watcher 会以 300ms debounce 推送
+  // capabilitiesVersion。这里仅重新读取当前工作区的数据，不触发加载占位或 CLI 重探测。
+  React.useEffect(() => {
+    if (observedCapabilitiesVersionRef.current === capabilitiesVersion) return
+    observedCapabilitiesVersionRef.current = capabilitiesVersion
+    void loadData()
+  }, [capabilitiesVersion, loadData])
 
   const setCliIntegrationEnabled = React.useCallback(async (id: string, enabled: boolean): Promise<void> => {
     const cliProbeRequestId = ++cliProbeRequestRef.current
@@ -299,6 +312,7 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
     skillsDir,
     mcpConfig,
     capabilities,
+    skillsRevision,
     builtinMcpServers,
     cliIntegrationStatuses,
     cliIntegrationProbeState,

--- a/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
+++ b/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
@@ -47,6 +47,8 @@ export interface AgentSkillsData {
   workspaceName: string
   hasWorkspace: boolean
   loading: boolean
+  /** 当前 skills 快照实际读取自的工作区；切换期间用于避免使用旧数据渲染详情。 */
+  loadedWorkspaceSlug: string
   skills: SkillMeta[]
   defaultSkillSlugs: Set<string>
   skillsDir: string
@@ -83,6 +85,7 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
   const workspaceSlug = currentWorkspace?.slug ?? ''
 
   const [loading, setLoading] = React.useState(true)
+  const [loadedWorkspaceSlug, setLoadedWorkspaceSlug] = React.useState('')
   const [skills, setSkills] = React.useState<SkillMeta[]>([])
   const [defaultSkillSlugs, setDefaultSkillSlugs] = React.useState<Set<string>>(new Set())
   const [skillsDir, setSkillsDir] = React.useState('')
@@ -106,6 +109,7 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
       setBuiltinMcpServers([])
       setCliIntegrationStatuses([])
       setCliIntegrationProbeState('ready')
+      setLoadedWorkspaceSlug(workspaceSlug)
       setLoading(false)
       return
     }
@@ -129,6 +133,7 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
       setBuiltinMcpServers(capabilities.builtinMcpServers)
       const cachedCliStatuses = cliIntegrationStatusCache.get(workspaceSlug)
       const hasFreshCliCache = cachedCliStatuses && Date.now() - cachedCliStatuses.cachedAt < CLI_STATUS_CACHE_TTL_MS
+      setLoadedWorkspaceSlug(workspaceSlug)
       setCliIntegrationProbeState(hasFreshCliCache ? 'ready' : 'loading')
       setCliIntegrationStatuses(cachedCliStatuses?.statuses ?? [])
       setLoading(false)
@@ -307,6 +312,7 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
     workspaceName: currentWorkspace?.name ?? '',
     hasWorkspace: !!currentWorkspace,
     loading,
+    loadedWorkspaceSlug,
     skills,
     defaultSkillSlugs,
     skillsDir,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1839,6 +1839,8 @@ export const AGENT_IPC_CHANNELS = {
   GET_SKILLS: 'agent:get-skills',
   /** 获取工作区 Skills 目录绝对路径 */
   GET_SKILLS_DIR: 'agent:get-skills-dir',
+  /** 使用系统文件管理器打开指定工作区 Skill 的实际目录 */
+  OPEN_SKILL_FOLDER: 'agent:open-skill-folder',
   /** 删除工作区 Skill */
   DELETE_SKILL: 'agent:delete-skill',
   /** 切换工作区 Skill 启用/禁用 */


### PR DESCRIPTION
## Summary

- Resolve each Skill folder in the main process from its workspace and slug, instead of relying on the renderer\u2019s cached Skills root.
- Refresh an open Skills Tab after an external Agent edits the workspace.
- Make Skill name, description, and SKILL.md body directly editable with 700ms debounced autosave; remove manual save and cancel controls.
- Keep detail state tied to the workspace that supplied its Skills snapshot, avoiding stale details during rapid workspace changes.

## Validation

- `bun run typecheck`
- `bun run --filter=\u0027@proma/electron\u0027 build:main`
- `bun run --filter=\u0027@proma/electron\u0027 build:renderer`
- Manual verification: external Skill edits refresh the open Skills Tab; direct edits autosave after 700ms; edits survive immediate navigation.

Performance: watcher notifications are debounced (300ms); editor writes are debounced by 700ms and serialized.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)