### PR TITLE
Fix Changes Tab folder path

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -295,9 +295,11 @@ import {
   cleanupStaleAttachedPaths,
   searchAgentSessionMessages,
   searchAgentSessionReferences,
+  resolveAgentCwd,
 } from './lib/agent-session-manager'
 import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, isAgentSessionBusy, listActiveAgentSessionSnapshots, reserveAgentSessionStart, queueAgentMessage, submitOrEnqueueAgentMessage, enqueueAgentQueuedMessage, cancelAgentQueuedMessage, moveAgentQueuedMessage, clearAgentQueuedMessages, updateAgentPermissionMode, rewindAgentSession, setVisibleAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
+import { resolvePathAgainstAgentCwd } from './lib/agent-file-path'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
 import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getConfigDir, getWorkspaceSkillsDir, getScratchPadPath } from './lib/config-paths'
@@ -599,6 +601,15 @@ async function resolveFileAccessPath(filePath: string, options?: FileAccessOptio
     import('./lib/file-preview-service'),
   ])
   return resolveFilePath(filePath, getPreviewCandidateBasePaths(options)) ?? resolve(filePath)
+}
+
+/** 当前 Agent 的 Write/Edit 相对路径必须按实际运行 cwd 解析。 */
+function getAgentCwdForFileAccess(options?: FileAccessOptions): string | undefined {
+  if (!options?.sessionId) return undefined
+  const session = getAgentSessionMeta(options.sessionId)
+  if (!session?.workspaceId) return undefined
+  const workspace = getAgentWorkspace(session.workspaceId)
+  return resolveAgentCwd(workspace, session.id, session.agentCwdMode, session.activeWorktree)
 }
 
 async function getAccessRootMainRepo(root: string): Promise<string | null> {
@@ -4008,10 +4019,12 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SHOW_IN_FOLDER,
     async (_, filePath: string, access?: FileAccessOptions): Promise<void> => {
-      const { resolve } = await import('node:path')
-
-      const safePath = resolve(filePath)
-      if (!isPathAllowed(safePath, normalizeFileAccessOptions(access))) {
+      const options = normalizeFileAccessOptions(access)
+      const safePath = resolvePathAgainstAgentCwd(filePath, getAgentCwdForFileAccess(options))
+      if (!existsSync(safePath)) {
+        throw new Error('文件不存在或已被移动')
+      }
+      if (!isPathAllowed(safePath, options)) {
         throw new Error('访问路径超出当前会话的授权范围')
       }
 

--- a/apps/electron/src/main/lib/agent-file-path.ts
+++ b/apps/electron/src/main/lib/agent-file-path.ts
@@ -1,0 +1,13 @@
+import { isAbsolute, resolve } from 'node:path'
+
+/**
+ * 将 Agent 工具报告的文件路径解析到该会话实际运行的 cwd。
+ *
+ * Write/Edit 可接受相对路径；它们相对于 Agent cwd（项目目录或活动 worktree），
+ * 而不是 Electron 主进程 cwd。
+ */
+export function resolvePathAgainstAgentCwd(filePath: string, agentCwd?: string): string {
+  return isAbsolute(filePath)
+    ? resolve(filePath)
+    : resolve(agentCwd ?? process.cwd(), filePath)
+}

--- a/apps/electron/src/main/lib/agent-file-path.ts
+++ b/apps/electron/src/main/lib/agent-file-path.ts
@@ -1,13 +1,14 @@
+import { homedir } from 'node:os'
 import { isAbsolute, resolve } from 'node:path'
 
 /**
  * 将 Agent 工具报告的文件路径解析到该会话实际运行的 cwd。
  *
  * Write/Edit 可接受相对路径；它们相对于 Agent cwd（项目目录或活动 worktree），
- * 而不是 Electron 主进程 cwd。
+ * 未归属项目的会话则与 Agent 启动逻辑一致，回退到用户主目录。
  */
 export function resolvePathAgainstAgentCwd(filePath: string, agentCwd?: string): string {
   return isAbsolute(filePath)
     ? resolve(filePath)
-    : resolve(agentCwd ?? process.cwd(), filePath)
+    : resolve(agentCwd ?? homedir(), filePath)
 }

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -7,6 +7,7 @@
 import * as React from 'react'
 import { Box, ChevronRight, FolderSearch, Search, SquareTerminal, Undo2, X } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
@@ -610,7 +611,12 @@ function NonGitFileList({
                 <button
                   type="button"
                   aria-label="在文件夹中显示"
-                  onClick={() => window.electronAPI.showInFolder(change.path, { sessionId, unrestricted: true }).catch(console.error)}
+                  onClick={() => {
+                    void window.electronAPI.showInFolder(change.path, { sessionId, unrestricted: true }).catch((error) => {
+                      console.error('[DiffChangesList] 在文件夹中显示失败:', error)
+                      toast.error('无法在文件夹中显示该文件')
+                    })
+                  }}
                   className="mr-1 flex size-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground"
                 >
                   <FolderSearch className="size-3.5" />


### PR DESCRIPTION
## Summary
- Resolve relative Changes Tab file paths from the session Agent cwd or active worktree before revealing them in Finder.
- Match unassigned Agent sessions to their actual home-directory cwd.
- Show an error toast when the target file no longer exists or is outside the allowed path.
- Bump the Electron app version to 0.19.8.

## Test plan
- `bun run typecheck`
- `bun run electron:build`

## Performance
- User-click path only: one session metadata lookup, path resolution, and existence check. No new renderer subscriptions, IPC listeners, timers, or streaming work.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)