### PR TITLE
Fix terminal tab keyboard close

### DIFF
--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -137,7 +137,7 @@ export function GlobalShortcuts(): null {
       if (
         isActiveAgentSidePanelOpen
         && activeAgentSidePanelTab
-        && (isWorkspaceComponentTab(activeAgentSidePanelTab) || activeAgentSidePanelTab.startsWith('preview:') || activeAgentSidePanelTab.startsWith('browser:') || activeAgentSidePanelTab.startsWith('exploration:') || activeAgentSidePanelTab.startsWith('delegation:'))
+        && (isWorkspaceComponentTab(activeAgentSidePanelTab) || activeAgentSidePanelTab.startsWith('preview:') || activeAgentSidePanelTab.startsWith('browser:') || activeAgentSidePanelTab.startsWith('exploration:') || activeAgentSidePanelTab.startsWith('delegation:') || activeAgentSidePanelTab.startsWith('terminal:'))
       ) {
         window.dispatchEvent(new CustomEvent(CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT, {
           detail: { sessionId: activeTab.sessionId },

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -177,7 +177,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   {
     id: 'close-tab',
     name: '关闭当前标签',
-    description: '关闭当前 Chat 标签页，或 Agent 右侧组件、预览和浏览器标签',
+    description: '关闭当前 Chat 标签页，或 Agent 右侧组件、预览、浏览器和终端标签',
     defaultMac: 'Cmd+W',
     defaultWin: 'Ctrl+W',
     category: 'app',


### PR DESCRIPTION
## Summary

- Allow Cmd/Ctrl+W to close the active terminal tab in the Agent right workspace.
- Reuse the existing PTY termination and workspace-tab cleanup path.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)