### PR TITLE
Fix preview stale content after reopen

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -101,6 +101,7 @@ import {
   previewPanelOpenMapAtom,
 } from '@/atoms/preview-atoms'
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
+import { clearPreviewContentCacheForFile } from '@/lib/preview-content-cache'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import type { FileEntry, AgentPendingFile, AgentSessionMeta, SDKMessage, WorktreeInfo } from '@proma/shared'
 import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
@@ -915,6 +916,9 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   }, [agentStreamState?.running, agentStreamState?.startedAt, effectiveActiveTab, isOpen, latestMemoryChange, onTabChange, setIsOpen, setMemoryNavigationRequest, setWorkspaceComponentTabs, workspaceSlug])
 
   const handleClosePreviewTab = React.useCallback((previewId: string) => {
+    const closingFile = previewFiles.find((file) => getPreviewFileId(file) === previewId)
+    // 关闭代表结束这次预览生命周期；下次打开必须重新读盘，不能回落到旧 v0 缓存。
+    if (closingFile?.previewOnly) clearPreviewContentCacheForFile(sessionId, closingFile.filePath)
     const remaining = previewFiles.filter((file) => getPreviewFileId(file) !== previewId)
     setPreviewFilesMap((previous) => {
       const next = new Map(previous)

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -54,6 +54,12 @@ import { insertAgentInputQuote } from '@/lib/agent-input-quote'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import {
+  clearPreviewContentCacheForFile,
+  clearPreviewContentCacheForSession,
+  getPreviewContentCache,
+  setPreviewContentCache,
+} from '@/lib/preview-content-cache'
+import {
   clearMarkdownEditorStateForSession,
   createMarkdownEditorCacheKey,
   createMarkdownEditorViewState,
@@ -91,31 +97,10 @@ function getParentFolderPath(filePath: string): string {
 const FILE_FIND_SHORTCUT_OPTIONS = { exclusive: true }
 
 /**
- * 简易 LRU 缓存：保留最近访问的 N 个 entries。
- * key 设计：
- * - diff 模式：`${sessionId}:diff:${filePath}@v${refreshVersion}:${scope}`
- * - preview 模式：`${sessionId}:preview:${filePath}@v${previewContentVersion}:${scope}`
- * Diff 使用会话级版本；纯预览使用文件级版本，只在当前文件实际变化时失效。
- * 老 entry 不会被命中，最终被 LRU 淘汰；无需主动失效。
+ * 预览内容按 session、路径、version 与解析范围做 LRU 缓存。
+ * - diff：`${sessionId}:diff:${filePath}@v${refreshVersion}:${scope}`
+ * - 纯预览：`${sessionId}:preview:${filePath}@v${previewContentVersion}:${scope}`
  */
-type CacheEntry = {
-  oldContent: string
-  newContent: string
-  /** 非文本文件预览数据 */
-  pdfSrc?: string
-  imageDataUrl?: string
-  imagePath?: string
-  officeHtml?: string
-  officeHtmlUrl?: string
-  officeText?: string
-  /** HTML 预览的目录级 token URL，允许加载同目录相对资源 */
-  htmlPreviewUrl?: string
-  /** 二进制或其他不可安全内联渲染的文件提示 */
-  unsupportedPreviewReason?: string
-  /** 无法内联预览时由主进程返回的安全基础元数据。 */
-  previewMetadata?: FilePreviewMetadata
-}
-
 interface DeepSelection {
   text: string
   rect: DOMRect | null
@@ -127,9 +112,6 @@ interface PreviewTextSelection {
   y: number
   filePath: string
 }
-
-const CACHE_MAX = 50
-const contentCache = new Map<string, CacheEntry>()
 
 /** 超过此字符数的文本文件将跳过 PierreFile 高亮，直接以纯文本展示，避免大文件卡顿 */
 const MAX_PREVIEW_CHARS = 500_000
@@ -157,26 +139,8 @@ export function clearPreviewCacheForSession(sessionId: string): void {
   for (const key of scrollPositionCache.keys()) {
     if (key.startsWith(prefix)) scrollPositionCache.delete(key)
   }
-  for (const key of contentCache.keys()) {
-    if (key.startsWith(prefix)) contentCache.delete(key)
-  }
+  clearPreviewContentCacheForSession(sessionId)
   clearMarkdownEditorStateForSession(sessionId)
-}
-function cacheGet(key: string): CacheEntry | undefined {
-  const v = contentCache.get(key)
-  if (!v) return undefined
-  // 重新插入到末尾，更新 LRU 位置
-  contentCache.delete(key)
-  contentCache.set(key, v)
-  return v
-}
-function cacheSet(key: string, value: CacheEntry): void {
-  if (contentCache.has(key)) contentCache.delete(key)
-  contentCache.set(key, value)
-  if (contentCache.size > CACHE_MAX) {
-    const oldestKey = contentCache.keys().next().value
-    if (oldestKey !== undefined) contentCache.delete(oldestKey)
-  }
 }
 
 function getExtension(filePath: string): string {
@@ -804,7 +768,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     const cacheKey = previewOnly
       ? getContentCacheKey('preview', previewContentVersion)
       : getContentCacheKey('diff', refreshVersion)
-    const cached = cacheGet(cacheKey)
+    const cached = getPreviewContentCache(cacheKey)
     // 保存或窗口恢复触发 refreshVersion 时，仍在编辑的 Markdown 必须继续留在
     // 当前 ProseMirror 实例中；后台读取可以更新预览缓存，但不能先挂载 loading
     // 占位，从而卸载编辑器并丢失内层滚动和选区。
@@ -897,7 +861,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             setOfficeHtml(html)
             setOfficeHtmlUrl(htmlUrl)
             setOfficeText(text)
-            cacheSet(cacheKey, { oldContent: '', newContent: '', officeHtml: html, officeHtmlUrl: htmlUrl, officeText: text })
+            setPreviewContentCache(cacheKey, { oldContent: '', newContent: '', officeHtml: html, officeHtmlUrl: htmlUrl, officeText: text })
             return
           }
           if (previewOnly) {
@@ -912,7 +876,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               if (cancelled) return
               const src = result?.tmpHtmlUrl ?? ''
               setPdfSrc(src)
-              cacheSet(cacheKey, { oldContent: '', newContent: '', pdfSrc: src })
+              setPreviewContentCache(cacheKey, { oldContent: '', newContent: '', pdfSrc: src })
               return
             }
             if (isImage) {
@@ -921,11 +885,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               if (resolved) {
                 setImagePath(filePath)
                 setImageDataUrl(resolved.url)
-                cacheSet(cacheKey, { oldContent: '', newContent: '', imagePath: filePath, imageDataUrl: resolved.url })
+                setPreviewContentCache(cacheKey, { oldContent: '', newContent: '', imagePath: filePath, imageDataUrl: resolved.url })
               } else {
                 setImagePath('')
                 setImageDataUrl('')
-                cacheSet(cacheKey, { oldContent: '', newContent: '', imagePath: '', imageDataUrl: '' })
+                setPreviewContentCache(cacheKey, { oldContent: '', newContent: '', imagePath: '', imageDataUrl: '' })
               }
               return
             }
@@ -939,7 +903,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                 : '此二进制或编码异常文件暂不支持内联预览，请使用默认应用打开。'
               setUnsupportedPreviewReason(reason)
               setPreviewMetadata(result.metadata)
-              cacheSet(cacheKey, {
+              setPreviewContentCache(cacheKey, {
                 oldContent: '',
                 newContent: '',
                 unsupportedPreviewReason: reason,
@@ -969,7 +933,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           setOldContent(old)
           setNewContent(content)
 
-          if (cacheKey) cacheSet(cacheKey, { oldContent: old, newContent: content, htmlPreviewUrl: htmlUrl || undefined })
+          if (cacheKey) setPreviewContentCache(cacheKey, { oldContent: old, newContent: content, htmlPreviewUrl: htmlUrl || undefined })
         }
 
         if (previewOnly && !MD_EXTS.has(ext) && content) {
@@ -1007,7 +971,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         const newC = result.newContent ?? ''
         const oldC = result.oldContent ?? ''
         // 用新 refreshVersion 写入缓存，让后续切走再切回来能命中
-        cacheSet(getContentCacheKey('diff', refreshVersion), { oldContent: oldC, newContent: newC })
+        setPreviewContentCache(getContentCacheKey('diff', refreshVersion), { oldContent: oldC, newContent: newC })
         if (newC === lastNewContentRef.current && oldC === lastOldContentRef.current) return
         lastNewContentRef.current = newC
         lastOldContentRef.current = oldC
@@ -1303,7 +1267,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         setOldContent('')
         setNewContent(draft)
         const nextPreviewContentVersion = previewContentVersion + 1
-        cacheSet(getContentCacheKey('preview', nextPreviewContentVersion), { oldContent: '', newContent: draft })
+        setPreviewContentCache(getContentCacheKey('preview', nextPreviewContentVersion), { oldContent: '', newContent: draft })
         setPreviewContentRefreshVersionMap((prev) => {
           const m = new Map(prev)
           m.set(previewContentRefreshKey, nextPreviewContentVersion)
@@ -1341,6 +1305,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   const handleManualRefresh = React.useCallback(() => {
     if (previewOnly) {
+      // 刷新是用户要求以磁盘内容为准，不能因恰好命中某个历史 version 缓存而无效。
+      clearPreviewContentCacheForFile(sessionId, filePath)
       setPreviewContentRefreshVersionMap((prev) => {
         const m = new Map(prev)
         m.set(previewContentRefreshKey, (prev.get(previewContentRefreshKey) ?? 0) + 1)
@@ -1354,7 +1320,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
       return m
     })
-  }, [previewContentRefreshKey, previewOnly, sessionId, setPreviewContentRefreshVersionMap, setRefreshVersionMap])
+  }, [filePath, previewContentRefreshKey, previewOnly, sessionId, setPreviewContentRefreshVersionMap, setRefreshVersionMap])
 
   const handleAddSelectionToAgent = React.useCallback(() => {
     if (!previewSelection) return

--- a/apps/electron/src/renderer/lib/preview-content-cache.ts
+++ b/apps/electron/src/renderer/lib/preview-content-cache.ts
@@ -1,0 +1,63 @@
+import type { FilePreviewMetadata } from '@proma/shared'
+
+/** 单份文件预览的已解析内容，按 session、路径、version 与解析范围缓存。 */
+export interface PreviewContentCacheEntry {
+  oldContent: string
+  newContent: string
+  /** 非文本文件预览数据 */
+  pdfSrc?: string
+  imageDataUrl?: string
+  imagePath?: string
+  officeHtml?: string
+  officeHtmlUrl?: string
+  officeText?: string
+  /** HTML 预览的目录级 token URL，允许加载同目录相对资源 */
+  htmlPreviewUrl?: string
+  /** 二进制或其他不可安全内联渲染的文件提示 */
+  unsupportedPreviewReason?: string
+  /** 无法内联预览时由主进程返回的安全基础元数据。 */
+  previewMetadata?: FilePreviewMetadata
+}
+
+const CACHE_MAX = 50
+const contentCache = new Map<string, PreviewContentCacheEntry>()
+
+/** 读取并提升 LRU 热度。 */
+export function getPreviewContentCache(key: string): PreviewContentCacheEntry | undefined {
+  const value = contentCache.get(key)
+  if (!value) return undefined
+  contentCache.delete(key)
+  contentCache.set(key, value)
+  return value
+}
+
+/** 写入并按最近访问顺序限制预览缓存规模。 */
+export function setPreviewContentCache(key: string, value: PreviewContentCacheEntry): void {
+  if (contentCache.has(key)) contentCache.delete(key)
+  contentCache.set(key, value)
+  if (contentCache.size > CACHE_MAX) {
+    const oldestKey = contentCache.keys().next().value
+    if (oldestKey !== undefined) contentCache.delete(oldestKey)
+  }
+}
+
+/** 清理一个会话的所有文件预览缓存。 */
+export function clearPreviewContentCacheForSession(sessionId: string): void {
+  const prefix = `${sessionId}:`
+  for (const key of contentCache.keys()) {
+    if (key.startsWith(prefix)) contentCache.delete(key)
+  }
+}
+
+/**
+ * 清理一份纯文件预览的所有版本缓存。
+ *
+ * 关闭后重新打开会从 version 0 开始；若保留旧的 v0 条目，会把首开时的内容
+ * 错当作当前磁盘内容。手动刷新也必须先清缓存，才能保证本次操作真正读盘。
+ */
+export function clearPreviewContentCacheForFile(sessionId: string, filePath: string): void {
+  const prefix = `${sessionId}:preview:${filePath}@`
+  for (const key of contentCache.keys()) {
+    if (key.startsWith(prefix)) contentCache.delete(key)
+  }
+}


### PR DESCRIPTION
## Summary

- 关闭右侧纯文件预览时清理该文件的历史内容缓存，重新打开始终从磁盘读取。
- 手动刷新先失效缓存，避免命中历史 version 条目。
- 将预览内容 LRU 缓存提取到独立模块；Markdown LiveMarkdownEditor 将收到新读盘内容。

## Test plan

- [x] `bun run --cwd apps/electron typecheck`
- [x] `bun run --cwd apps/electron build:renderer`
- [x] `git diff --check`（仓库 CRLF 规则）
- [ ] Electron 交互式关闭→重开与手动刷新冒烟

## Performance

- 无新增 IPC、watcher、timer 或持续渲染更新。
- 仅在关闭预览或点击刷新时遍历最多 50 条 LRU 缓存；低频、局部影响。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)