### PR TITLE
feat(search): index full current session messages

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -198,6 +198,7 @@ import {
   listConversations,
   createConversation,
   getConversationMessages,
+  getConversationMessagesAround,
   getRecentMessages,
   updateConversationMeta,
   deleteConversation,
@@ -206,6 +207,7 @@ import {
   updateContextDividers,
   autoArchiveConversations,
   searchConversationMessages,
+  searchConversationSessionMessages,
 } from './lib/conversation-manager'
 import { sendMessage, stopGeneration, generateTitle } from './lib/chat-service'
 import {
@@ -1772,6 +1774,14 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 获取搜索命中附近的有限消息窗口
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.GET_MESSAGES_AROUND,
+    async (_, id: string, messageId: string, radius?: number): Promise<ChatMessage[]> => {
+      return getConversationMessagesAround(id, messageId, radius)
+    }
+  )
+
   // 更新对话标题
   ipcMain.handle(
     CHAT_IPC_CHANNELS.UPDATE_TITLE,
@@ -1830,11 +1840,19 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 搜索对话消息内容
+  // 搜索所有对话消息内容
   ipcMain.handle(
     CHAT_IPC_CHANNELS.SEARCH_MESSAGES,
     async (_, query: string) => {
       return searchConversationMessages(query)
+    }
+  )
+
+  // 搜索当前对话的完整持久化历史（只返回命中元数据，避免传输整份 JSONL）
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.SEARCH_SESSION_MESSAGES,
+    async (_, conversationId: string, query: string) => {
+      return searchConversationSessionMessages(conversationId, query)
     }
   )
 

--- a/apps/electron/src/main/lib/conversation-manager.ts
+++ b/apps/electron/src/main/lib/conversation-manager.ts
@@ -7,6 +7,7 @@
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, unlinkSync, createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import { createInterface } from 'node:readline'
 import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
@@ -16,8 +17,17 @@ import {
   getConversationMessagesPath,
 } from './config-paths'
 import { deleteConversationAttachments, deleteAttachment } from './attachment-service'
-import type { ConversationMeta, ChatMessage, RecentMessagesResult, MessageSearchResult } from '@proma/shared'
-import { findBestSearchMatch, insertTopSearchResult } from '@proma/shared'
+import type { ConversationMeta, ChatMessage, RecentMessagesResult, MessageSearchResult, SessionMessageSearchResponse } from '@proma/shared'
+import {
+  createSearchSnippet,
+  MAX_NORMALIZED_SEARCH_QUERY_LENGTH,
+  MAX_SEARCH_QUERY_SOURCE_LENGTH,
+  findBestSearchMatch,
+  findBestSearchMatchInNormalized,
+  insertTopSearchResult,
+  normalizeSearchText,
+  type NormalizedSearchText,
+} from '@proma/shared'
 
 /**
  * 对话索引文件格式
@@ -33,6 +43,28 @@ interface ConversationsIndex {
 const INDEX_VERSION = 1
 const MAX_SEARCH_SESSIONS = 100
 const MAX_SEARCH_HITS_PER_SESSION = 2
+const MAX_SESSION_SEARCH_RESULTS = 50
+const MAX_SESSION_SEARCH_INDEX_CHARACTERS = 250_000
+const MAX_CACHED_SESSION_SEARCHES = 8
+const MAX_CACHED_SESSION_SEARCH_CHARACTERS = 1_000_000
+
+interface IndexedConversationSearchHit {
+  messageId: string
+  role: Extract<ChatMessage['role'], 'user' | 'assistant'>
+  text: string
+  normalizedText: NormalizedSearchText
+}
+
+interface ConversationSearchIndex {
+  fileSize: number
+  modifiedAt: number
+  characterCount: number
+  truncated: boolean
+  hits: IndexedConversationSearchHit[]
+}
+
+/** 以文件版本为准的 LRU；避免搜索时将整份历史转移到 renderer。 */
+const conversationSearchIndexCache = new Map<string, ConversationSearchIndex>()
 
 /**
  * 读取对话索引文件
@@ -163,6 +195,58 @@ export function getRecentMessages(id: string, limit: number): RecentMessagesResu
     console.error(`[对话管理] 读取最近消息失败 (${id}):`, error)
     return { messages: [], total: 0, hasMore: false }
   }
+}
+
+/**
+ * 从指定消息附近读取有限窗口，供搜索定位避免把完整历史跨 IPC 传给 renderer。
+ */
+export async function getConversationMessagesAround(
+  id: string,
+  messageId: string,
+  maxWindowSize = 41,
+): Promise<ChatMessage[]> {
+  const filePath = getConversationMessagesPath(id)
+  if (!existsSync(filePath)) return []
+  const safeWindowSize = Math.max(3, Math.min(maxWindowSize, 50))
+  const beforeLimit = Math.floor((safeWindowSize - 1) / 2)
+  const afterLimit = safeWindowSize - beforeLimit - 1
+
+  const stream = createReadStream(filePath, { encoding: 'utf-8' })
+  const rl = createInterface({ input: stream, crlfDelay: Infinity })
+  const before: ChatMessage[] = []
+  const messages: ChatMessage[] = []
+  let found = false
+  let afterCount = 0
+
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue
+      let message: ChatMessage
+      try {
+        message = JSON.parse(line) as ChatMessage
+      } catch {
+        continue
+      }
+      if (!found) {
+        if (message.id === messageId) {
+          found = true
+          messages.push(...before, message)
+        } else {
+          before.push(message)
+          if (before.length > beforeLimit) before.shift()
+        }
+        continue
+      }
+      messages.push(message)
+      afterCount++
+      if (afterCount >= afterLimit) break
+    }
+  } finally {
+    rl.close()
+    stream.destroy()
+  }
+
+  return messages
 }
 
 /**
@@ -402,6 +486,96 @@ export function autoArchiveConversations(daysThreshold: number): number {
  * 搜索对话消息内容。
  * 每个会话最多返回 2 个用户/助手正文命中，最多返回 100 个命中会话。
  */
+/**
+ * 搜索单个对话的完整持久化历史，返回轻量命中元数据。
+ * 不将完整 JSONL 复制到渲染进程，供当前会话的消息导航使用。
+ */
+export async function searchConversationSessionMessages(
+  conversationId: string,
+  query: string,
+): Promise<SessionMessageSearchResponse> {
+  if (query.length > MAX_SEARCH_QUERY_SOURCE_LENGTH) {
+    return { results: [], truncated: false, queryTooLong: true }
+  }
+  const normalizedQuery = normalizeSearchText(query)
+  if (normalizedQuery.chars.length < 2) return { results: [], truncated: false, queryTooLong: false }
+  if (normalizedQuery.chars.length > MAX_NORMALIZED_SEARCH_QUERY_LENGTH) {
+    return { results: [], truncated: false, queryTooLong: true }
+  }
+
+  const index = await getConversationSearchIndex(conversationId)
+  if (!index) return { results: [], truncated: false, queryTooLong: false }
+  return {
+    results: findMatchesInConversationSearchIndex(index, normalizedQuery, MAX_SESSION_SEARCH_RESULTS)
+      .map(({ score: _score, ...hit }) => hit),
+    truncated: index.truncated,
+    queryTooLong: false,
+  }
+}
+
+async function getConversationSearchIndex(conversationId: string): Promise<ConversationSearchIndex | null> {
+  const filePath = getConversationMessagesPath(conversationId)
+  let stats: Awaited<ReturnType<typeof stat>>
+  try {
+    stats = await stat(filePath)
+  } catch {
+    return null
+  }
+  const cached = conversationSearchIndexCache.get(conversationId)
+  if (cached && cached.fileSize === stats.size && cached.modifiedAt === stats.mtimeMs) {
+    // Map 的插入顺序即 LRU 顺序；命中时移到末尾。
+    conversationSearchIndexCache.delete(conversationId)
+    conversationSearchIndexCache.set(conversationId, cached)
+    return cached
+  }
+
+  const index = await buildConversationSearchIndex(filePath, stats.size, stats.mtimeMs)
+  // 单个异常大的会话也可搜索，但不常驻缓存以限制主进程 RSS。
+  if (index.characterCount <= MAX_CACHED_SESSION_SEARCH_CHARACTERS) {
+    cacheConversationSearchIndex(conversationId, index)
+  }
+  return index
+}
+
+function cacheConversationSearchIndex(conversationId: string, index: ConversationSearchIndex): void {
+  conversationSearchIndexCache.delete(conversationId)
+  conversationSearchIndexCache.set(conversationId, index)
+
+  let cachedCharacters = 0
+  for (const entry of conversationSearchIndexCache.values()) {
+    cachedCharacters += entry.characterCount
+  }
+  while (
+    conversationSearchIndexCache.size > MAX_CACHED_SESSION_SEARCHES
+    || cachedCharacters > MAX_CACHED_SESSION_SEARCH_CHARACTERS
+  ) {
+    const oldestConversationId = conversationSearchIndexCache.keys().next().value as string | undefined
+    if (!oldestConversationId) break
+    const oldest = conversationSearchIndexCache.get(oldestConversationId)
+    conversationSearchIndexCache.delete(oldestConversationId)
+    cachedCharacters -= oldest?.characterCount ?? 0
+  }
+}
+
+function findMatchesInConversationSearchIndex(
+  index: ConversationSearchIndex,
+  normalizedQuery: NormalizedSearchText,
+  maxResults: number,
+): Array<ConversationSearchHit & { score: number }> {
+  const results: Array<ConversationSearchHit & { score: number }> = []
+  for (const record of index.hits) {
+    const match = findBestSearchMatchInNormalized(record.normalizedText, normalizedQuery)
+    if (!match) continue
+    insertTopSearchResult(results, {
+      messageId: record.messageId,
+      role: record.role,
+      ...createSearchSnippet(record.text, match.matchStart, match.matchLength),
+      score: match.score,
+    }, maxResults)
+  }
+  return results
+}
+
 export async function searchConversationMessages(query: string): Promise<MessageSearchResult[]> {
   if (!query || query.length < 2) return []
 
@@ -416,7 +590,7 @@ export async function searchConversationMessages(query: string): Promise<Message
     const filePath = getConversationMessagesPath(conv.id)
     if (!existsSync(filePath)) continue
 
-    const hits = await findMatchesInJsonl(filePath, query)
+    const hits = await findMatchesInJsonl(filePath, query, MAX_SEARCH_HITS_PER_SESSION)
     if (hits.length === 0) continue
     matchedSessionCount++
 
@@ -447,12 +621,57 @@ interface ConversationSearchHit {
 }
 
 /**
+ * 解析一次 JSONL 并预计算规范化文本。索引只保存可见 user/assistant 正文。
+ */
+async function buildConversationSearchIndex(
+  filePath: string,
+  fileSize: number,
+  modifiedAt: number,
+): Promise<ConversationSearchIndex> {
+  const stream = createReadStream(filePath, { encoding: 'utf-8' })
+  const rl = createInterface({ input: stream, crlfDelay: Infinity })
+  const hits: IndexedConversationSearchHit[] = []
+  let characterCount = 0
+  let truncated = false
+
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue
+      let msg: ChatMessage
+      try {
+        msg = JSON.parse(line) as ChatMessage
+      } catch {
+        continue
+      }
+      if ((msg.role !== 'user' && msg.role !== 'assistant') || !msg.content) continue
+      if (characterCount + msg.content.length > MAX_SESSION_SEARCH_INDEX_CHARACTERS) {
+        truncated = true
+        break
+      }
+      characterCount += msg.content.length
+      hits.push({
+        messageId: msg.id,
+        role: msg.role,
+        text: msg.content,
+        normalizedText: normalizeSearchText(msg.content),
+      })
+    }
+  } finally {
+    rl.close()
+    stream.destroy()
+  }
+
+  return { fileSize, modifiedAt, characterCount, truncated, hits }
+}
+
+/**
  * 在单个 Chat JSONL 中收集用户/助手正文命中。
  * 工具活动、工具参数和工具结果不属于 ChatMessage.content，不参与搜索。
  */
 async function findMatchesInJsonl(
   filePath: string,
   query: string,
+  maxResults: number,
 ): Promise<ConversationSearchHit[]> {
   const stream = createReadStream(filePath, { encoding: 'utf-8' })
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
@@ -472,21 +691,13 @@ async function findMatchesInJsonl(
       const match = findBestSearchMatch(msg.content, query)
       if (!match) continue
 
-      const snippetStart = Math.max(0, match.matchStart - 40)
-      const snippetEnd = Math.min(msg.content.length, match.matchStart + match.matchLength + 40)
-      const snippet = (snippetStart > 0 ? '...' : '') +
-        msg.content.slice(snippetStart, snippetEnd) +
-        (snippetEnd < msg.content.length ? '...' : '')
-      const matchStart = match.matchStart - snippetStart + (snippetStart > 0 ? 3 : 0)
-
+      const snippet = createSearchSnippet(msg.content, match.matchStart, match.matchLength)
       insertTopSearchResult(hits, {
         messageId: msg.id,
         role: msg.role,
-        snippet,
-        matchStart,
-        matchLength: match.matchLength,
+        ...snippet,
         score: match.score,
-      }, MAX_SEARCH_HITS_PER_SESSION)
+      }, maxResults)
     }
   } finally {
     rl.close()

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -37,6 +37,7 @@ import type {
   FileOrFolderDialogResult,
   RecentMessagesResult,
   MessageSearchResult,
+  SessionMessageSearchResponse,
   AgentSessionMeta,
   AgentActiveSessionSnapshot,
   SetAgentSessionActiveWorktreeInput,
@@ -355,6 +356,9 @@ export interface ElectronAPI {
   /** 获取对话最近 N 条消息（分页加载） */
   getRecentMessages: (id: string, limit: number) => Promise<RecentMessagesResult>
 
+  /** 获取指定消息附近的有限窗口，供搜索定位 */
+  getConversationMessagesAround: (id: string, messageId: string, radius?: number) => Promise<ChatMessage[]>
+
   /** 更新对话标题 */
   updateConversationTitle: (id: string, title: string) => Promise<ConversationMeta>
 
@@ -370,8 +374,11 @@ export interface ElectronAPI {
   /** 切换对话归档状态 */
   toggleArchiveConversation: (id: string) => Promise<ConversationMeta>
 
-  /** 搜索对话消息内容 */
+  /** 搜索全部对话消息内容 */
   searchConversationMessages: (query: string) => Promise<MessageSearchResult[]>
+
+  /** 搜索当前对话完整持久化历史（仅返回命中元数据） */
+  searchConversationSessionMessages: (conversationId: string, query: string) => Promise<SessionMessageSearchResponse>
 
   // ===== 教程 =====
 
@@ -1572,6 +1579,10 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.GET_RECENT_MESSAGES, id, limit)
   },
 
+  getConversationMessagesAround: (id: string, messageId: string, radius?: number) => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.GET_MESSAGES_AROUND, id, messageId, radius)
+  },
+
   updateConversationTitle: (id: string, title: string) => {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.UPDATE_TITLE, id, title)
   },
@@ -1594,6 +1605,10 @@ const electronAPI: ElectronAPI = {
 
   searchConversationMessages: (query: string) => {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.SEARCH_MESSAGES, query)
+  },
+
+  searchConversationSessionMessages: (conversationId: string, query: string) => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.SEARCH_SESSION_MESSAGES, conversationId, query)
   },
 
   // 教程

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -29,6 +29,14 @@ import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
 import { cn } from '@/lib/utils'
+import {
+  createLocalSearchRecords,
+  searchLocalSessionMessages,
+  type LocalSearchRecord,
+  type LocalSearchRecordInput,
+  type SessionMessageSearch,
+} from '@/lib/session-message-search'
+import { toTranscript } from '@proma/session-core'
 import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { groupIntoTurns, AssistantLogo, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, buildTaskProgressDataForTurn, type MessageGroup } from './SDKMessageRenderer'
@@ -1097,6 +1105,24 @@ export const AgentMessages = React.memo(function AgentMessages({
   }
   const structuralGroups = structuralGroupsRef.current
 
+  // 搜索记录与迷你地图一样只依赖结构快照，流式 token 不触发全文重建。
+  const localSearchRecordInputs = React.useMemo<LocalSearchRecordInput[]>(
+    () => toTranscript(structuralGroups).map((turn, index) => ({
+      messageId: getGroupId(structuralGroups[index]!),
+      role: turn.role,
+      text: turn.text,
+    })),
+    [structuralGroups],
+  )
+  const localSearchRecords = React.useMemo<LocalSearchRecord[]>(
+    () => createLocalSearchRecords(localSearchRecordInputs),
+    [localSearchRecordInputs],
+  )
+  const searchMessages = React.useCallback<SessionMessageSearch>(
+    async (query) => searchLocalSessionMessages(localSearchRecords, query),
+    [localSearchRecords],
+  )
+
   // 迷你地图数据 — 只依赖结构快照，流式 token 不触发 getGroupPreview 正则
   const minimapItems: MinimapItem[] = React.useMemo(
     () => structuralGroups.map((group) => ({
@@ -1215,7 +1241,7 @@ export const AgentMessages = React.memo(function AgentMessages({
             </>
           )}
         </ConversationContent>
-        <ScrollMinimap items={minimapItems} />
+        <ScrollMinimap items={minimapItems} searchMessages={searchMessages} />
         <TaskProgressOverlay
           key={sessionId}
           activities={liveTaskActivities}

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -19,6 +19,9 @@ import { getModelLogo, resolveModelProvider } from '@/lib/model-logo'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { useShortcut } from '@/hooks/useShortcut'
 import { cn } from '@/lib/utils'
+import { MAX_SEARCH_QUERY_SOURCE_LENGTH } from '@proma/shared'
+import type { SessionMessageSearchResponse, SessionMessageSearchResult } from '@proma/shared'
+import type { SessionMessageSearch } from '@/lib/session-message-search'
 
 export interface MinimapItem {
   id: string
@@ -29,7 +32,17 @@ export interface MinimapItem {
 }
 
 interface ScrollMinimapProps {
+  /** 用于显示位置与未搜索状态预览的轻量条目 */
   items: MinimapItem[]
+  /** 独立搜索数据源；Chat 可在主进程查完整 JSONL，Agent 可查结构化内存快照 */
+  searchMessages?: SessionMessageSearch
+  /** 搜索结果尚未渲染时，调用方可先补载历史 */
+  onRevealSearchResult?: (messageId: string) => Promise<boolean | void> | boolean | void
+}
+
+interface SearchListItem extends MinimapItem {
+  matchStart?: number
+  matchLength?: number
 }
 
 /** 最少消息数才显示迷你地图 */
@@ -74,7 +87,7 @@ function escapeRegExp(str: string): string {
 
 // ── 主组件 ──
 
-export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement | null {
+export function ScrollMinimap({ items, searchMessages, onRevealSearchResult }: ScrollMinimapProps): React.ReactElement | null {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const [hovered, setHovered] = React.useState(false)
   const [isLeaving, setIsLeaving] = React.useState(false)
@@ -84,6 +97,10 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const [canScroll, setCanScroll] = React.useState(false)
   const [thumbHeightPct, setThumbHeightPct] = React.useState(100)
   const [searchQuery, setSearchQuery] = React.useState('')
+  const [searchResults, setSearchResults] = React.useState<SessionMessageSearchResult[]>([])
+  const [searchTruncated, setSearchTruncated] = React.useState(false)
+  const [searchQueryTooLong, setSearchQueryTooLong] = React.useState(false)
+  const [isSearching, setIsSearching] = React.useState(false)
   const [isDragging, setIsDragging] = React.useState(false)
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const fadeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
@@ -99,6 +116,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const canScrollRef = React.useRef(false)
   const thumbHeightPctRef = React.useRef(100)
   const thumbRef = React.useRef<HTMLDivElement>(null)
+  const searchRequestRef = React.useRef(0)
 
   // ── 组件卸载时清理计时器 ──
 
@@ -304,7 +322,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     setHovered(true)
   }, [])
 
-  useShortcut('file-find', handleShortcutOpen, items.length >= MIN_ITEMS && canScroll)
+  useShortcut('file-find', handleShortcutOpen, items.length >= MIN_ITEMS)
 
   // ── 鼠标进出控制（仅迷你地图区域） ──
 
@@ -373,13 +391,83 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     setHovered(false)
   }, [scrollRef, stopScroll, stickyState])
 
-  // ── 搜索过滤 ──
+  const scrollToMessageWhenRendered = React.useCallback((id: string): void => {
+    const container = scrollRef.current
+    if (!container) return
+    if (container.querySelector(`[data-message-id="${CSS.escape(id)}"]`)) {
+      scrollToMessage(id)
+      return
+    }
 
-  const filteredItems = React.useMemo(() => {
-    if (!searchQuery.trim()) return items
-    const q = searchQuery.toLowerCase()
-    return items.filter((item) => item.preview.toLowerCase().includes(q))
-  }, [items, searchQuery])
+    const observer = new MutationObserver(() => {
+      if (!container.querySelector(`[data-message-id="${CSS.escape(id)}"]`)) return
+      observer.disconnect()
+      window.clearTimeout(timeout)
+      scrollToMessage(id)
+    })
+    const timeout = window.setTimeout(() => observer.disconnect(), 1_000)
+    observer.observe(container, { childList: true, subtree: true })
+  }, [scrollRef, scrollToMessage])
+
+  // ── 搜索：延迟请求，按请求序号丢弃陈旧结果 ──
+
+  React.useEffect(() => {
+    const query = searchQuery.trim()
+    const requestId = ++searchRequestRef.current
+    if (!query || !searchMessages) {
+      setIsSearching(false)
+      setSearchResults([])
+      setSearchTruncated(false)
+      setSearchQueryTooLong(false)
+      return
+    }
+
+    setIsSearching(true)
+    const timer = window.setTimeout(() => {
+      void searchMessages(query)
+        .then((response: SessionMessageSearchResponse) => {
+          if (searchRequestRef.current === requestId) {
+            setSearchResults(response.results)
+            setSearchTruncated(response.truncated)
+            setSearchQueryTooLong(response.queryTooLong)
+          }
+        })
+        .catch((error: unknown) => {
+          if (searchRequestRef.current === requestId) {
+            console.warn('[消息导航] 搜索失败:', error)
+            setSearchResults([])
+            setSearchTruncated(false)
+            setSearchQueryTooLong(false)
+          }
+        })
+        .finally(() => {
+          if (searchRequestRef.current === requestId) setIsSearching(false)
+        })
+    }, 150)
+    return () => window.clearTimeout(timer)
+  }, [searchMessages, searchQuery])
+
+  const filteredItems = React.useMemo<SearchListItem[]>(() => {
+    const query = searchQuery.trim()
+    if (!query) return items
+    if (!searchMessages) {
+      const normalizedQuery = query.toLowerCase()
+      return items.filter((item) => item.preview.toLowerCase().includes(normalizedQuery))
+    }
+    const itemById = new Map(items.map((item) => [item.id, item]))
+    return searchResults.map((result) => {
+      const item = itemById.get(result.messageId)
+      return {
+        id: result.messageId,
+        role: result.role === 'system' ? 'status' : result.role,
+        preview: result.snippet,
+        avatar: item?.avatar,
+        model: item?.model,
+        matchStart: result.matchStart,
+        matchLength: result.matchLength,
+      }
+    })
+  }, [items, searchMessages, searchQuery, searchResults])
 
   /** 列表居中锚点：优先用主区视口中心对应的消息；该消息被搜索过滤掉时退回第一条可见消息 */
   const anchorId = React.useMemo(() => {
@@ -457,7 +545,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     el.scrollTo({ top: Math.max(0, targetTop), behavior: 'smooth' })
   }, [scrollRef, stopScroll, stickyState])
 
-  if (items.length < MIN_ITEMS || !canScroll) return null
+  if (items.length < MIN_ITEMS) return null
 
   // ── 迷你地图条纹 ──
 
@@ -496,6 +584,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
                   ref={searchInputRef}
                   placeholder="搜索消息..."
                   value={searchQuery}
+                  maxLength={MAX_SEARCH_QUERY_SOURCE_LENGTH}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   onFocus={() => {
                     if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
@@ -509,7 +598,19 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
 
             {/* 消息列表 */}
             <div ref={listRef} className="overflow-y-auto flex-1 p-1.5 space-y-0.5 scrollbar-thin">
-              {filteredItems.length === 0 ? (
+              {searchQueryTooLong && (
+                <div className="px-2 py-1 text-[11px] text-muted-foreground">
+                  查询过长，请缩短后重试。
+                </div>
+              )}
+              {searchTruncated && (
+                <div className="px-2 py-1 text-[11px] text-muted-foreground">
+                  历史过长，仅显示可索引范围内的结果；请缩小范围。
+                </div>
+              )}
+              {isSearching ? (
+                <div className="py-6 text-center text-xs text-muted-foreground">搜索中...</div>
+              ) : filteredItems.length === 0 ? (
                 <div className="py-6 text-center text-xs text-muted-foreground">
                   未找到匹配消息
                 </div>
@@ -523,11 +624,20 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
                       'flex items-start gap-2 w-full rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent',
                       visibleIds.has(item.id) && 'bg-accent/50'
                     )}
-                    onClick={() => scrollToMessage(item.id)}
+                    onClick={() => {
+                      void Promise.resolve(onRevealSearchResult?.(item.id)).then((revealed) => {
+                        if (revealed !== false) scrollToMessageWhenRendered(item.id)
+                      })
+                    }}
                   >
                     <ItemIcon item={item} />
                     <div className="flex-1 min-w-0">
-                      <HighlightedPreview text={item.preview} query={searchQuery} />
+                      <HighlightedPreview
+                        text={item.preview}
+                        query={searchQuery}
+                        matchStart={item.matchStart}
+                        matchLength={item.matchLength}
+                      />
                     </div>
                   </button>
                 ))
@@ -537,7 +647,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
         )}
 
         {/* ── 迷你地图横杠 —— 只有这里触发面板展开 ── */}
-        <div
+        {canScroll && <div
           className="relative mt-3 flex-shrink-0 pointer-events-auto"
           style={{ width: 24, height: barCount * MINIMAP_BAR_SPACING }}
           onMouseEnter={handleMouseEnter}
@@ -565,11 +675,11 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
               />
             )
           })}
-        </div>
+        </div>}
       </div>
 
       {/* ── 滚动进度条 ── */}
-      <div className="relative ml-[4px] py-4 flex-shrink-0 pointer-events-auto" style={{ width: SCROLL_PROGRESS_WIDTH }}>
+      {canScroll && <div className="relative ml-[4px] py-4 flex-shrink-0 pointer-events-auto" style={{ width: SCROLL_PROGRESS_WIDTH }}>
         <div
           ref={trackRef}
           className="relative h-full rounded-full cursor-pointer scroll-progress-track"
@@ -590,7 +700,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
             onMouseDown={handleThumbMouseDown}
           />
         </div>
-      </div>
+      </div>}
     </div>
   )
 }
@@ -618,9 +728,30 @@ function ItemIcon({ item }: { item: MinimapItem }): React.ReactElement {
 }
 
 /** Markdown 预览（无搜索时）或 纯文本+高亮（搜索时） */
-function HighlightedPreview({ text, query }: { text: string; query: string }): React.ReactElement {
+function HighlightedPreview({
+  text,
+  query,
+  matchStart,
+  matchLength,
+}: {
+  text: string
+  query: string
+  matchStart?: number
+  matchLength?: number
+}): React.ReactElement {
   if (!text) {
     return <span className="text-xs opacity-40">(空消息)</span>
+  }
+
+  if (query.trim() && matchStart !== undefined && matchLength !== undefined) {
+    const before = text.slice(0, matchStart)
+    const match = text.slice(matchStart, matchStart + matchLength)
+    const after = text.slice(matchStart + matchLength)
+    return (
+      <span className="text-xs text-popover-foreground/80 line-clamp-3">
+        {before}<mark className="bg-primary/20 text-primary rounded-sm px-0.5">{match}</mark>{after}
+      </span>
+    )
   }
 
   if (query.trim()) {

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/components/ai-elements/conversation'
 import { ScrollMinimap } from '@/components/ai-elements/scroll-minimap'
 import type { MinimapItem } from '@/components/ai-elements/scroll-minimap'
+import type { SessionMessageSearch } from '@/lib/session-message-search'
 import { useStickToBottomContext } from 'use-stick-to-bottom'
 import { ContextDivider } from '@/components/ai-elements/context-divider'
 import {
@@ -86,19 +87,43 @@ function ScrollTopLoader({ hasMore, loading, onLoadMore }: ScrollTopLoaderProps)
       // 滚动到顶部 100px 以内时触发
       if (el.scrollTop < 100 && !triggeredRef.current) {
         triggeredRef.current = true
-        const prevHeight = el.scrollHeight
+        const interactionVersion = manualInteractionVersion
+        const anchor = el.querySelector<HTMLElement>('[data-message-id]')
+        const anchorId = anchor?.dataset.messageId
+        const anchorOffset = anchor ? anchor.getBoundingClientRect().top - el.getBoundingClientRect().top : 0
 
         onLoadMore().then(() => {
-          // 加载完成后恢复滚动位置：新内容插入顶部，保持用户视角不变
           requestAnimationFrame(() => {
-            el.scrollTop = el.scrollHeight - prevHeight
+            // 用户在异步补载期间主动滚动时，绝不覆盖其位置。
+            if (interactionVersion !== manualInteractionVersion || !anchorId) return
+            const restoredAnchor = el.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(anchorId)}"]`)
+            if (!restoredAnchor) return
+            const nextOffset = restoredAnchor.getBoundingClientRect().top - el.getBoundingClientRect().top
+            el.scrollTop += nextOffset - anchorOffset
           })
         })
       }
     }
 
+    let manualInteractionVersion = 0
+    const markManualInteraction = (): void => { manualInteractionVersion++ }
+    const markKeyboardScrollInteraction = (event: KeyboardEvent): void => {
+      if ([' ', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'].includes(event.key)) {
+        markManualInteraction()
+      }
+    }
     el.addEventListener('scroll', handleScroll, { passive: true })
-    return () => el.removeEventListener('scroll', handleScroll)
+    el.addEventListener('wheel', markManualInteraction, { passive: true })
+    el.addEventListener('touchstart', markManualInteraction, { passive: true })
+    el.addEventListener('pointerdown', markManualInteraction, { passive: true })
+    el.addEventListener('keydown', markKeyboardScrollInteraction)
+    return () => {
+      el.removeEventListener('scroll', handleScroll)
+      el.removeEventListener('wheel', markManualInteraction)
+      el.removeEventListener('touchstart', markManualInteraction)
+      el.removeEventListener('pointerdown', markManualInteraction)
+      el.removeEventListener('keydown', markKeyboardScrollInteraction)
+    }
   }, [scrollRef, hasMore, onLoadMore])
 
   if (!hasMore) return null
@@ -155,6 +180,8 @@ interface ChatMessagesProps {
   onDeleteDivider?: (messageId: string) => void
   /** 加载更多历史消息回调 */
   onLoadMore?: () => Promise<void>
+  /** 加载搜索命中附近的有限消息窗口 */
+  onLoadMessagesAround?: (messageId: string) => Promise<boolean>
   /** 图片编辑完成回调 */
   onImageEditComplete?: (editedDataUrl: string) => void
 }
@@ -184,6 +211,7 @@ export function ChatMessages({
   inlineEditingMessageId,
   onDeleteDivider,
   onLoadMore,
+  onLoadMessagesAround,
   onImageEditComplete,
 }: ChatMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
@@ -312,6 +340,16 @@ export function ChatMessages({
   }, [parallelMode, hasMore, handleLoadMore])
 
   // 迷你地图数据（必须在所有条件分支之前调用，遵守 hooks 规则）
+  const searchMessages = React.useCallback<SessionMessageSearch>(
+    (query) => window.electronAPI.searchConversationSessionMessages(conversationId, query),
+    [conversationId],
+  )
+
+  const revealSearchResult = React.useCallback(async (messageId: string): Promise<boolean> => {
+    if (messages.some((message) => message.id === messageId)) return true
+    return await onLoadMessagesAround?.(messageId) ?? false
+  }, [messages, onLoadMessagesAround])
+
   const minimapItems: MinimapItem[] = React.useMemo(
     () => messages.map((m) => ({
       id: m.id,
@@ -444,7 +482,11 @@ export function ChatMessages({
           </>
         )}
       </ConversationContent>
-      <ScrollMinimap items={minimapItems} />
+      <ScrollMinimap
+        items={minimapItems}
+        searchMessages={searchMessages}
+        onRevealSearchResult={revealSearchResult}
+      />
       <ConversationScrollButton />
     </Conversation>
   )

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -90,6 +90,10 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   const [hasMoreMessages, setHasMoreMessages] = React.useState(false)
   const [messagesLoaded, setMessagesLoaded] = React.useState(false)
   const [inlineEditingMessageId, setInlineEditingMessageId] = React.useState<string | null>(null)
+  // 会话切换不会必然卸载当前组件；异步搜索补载必须验证归属后才可写入 state。
+  const activeConversationIdRef = React.useRef(conversationId)
+  activeConversationIdRef.current = conversationId
+  const searchWindowRequestRef = React.useRef(0)
   const store = useStore()
   const stopShortcutTarget = React.useMemo(() => ({ kind: 'chat' as const, sessionId: conversationId }), [conversationId])
   const markStopShortcutTarget = React.useCallback(() => {
@@ -621,6 +625,23 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     setHasMoreMessages(false)
   }, [conversationId])
 
+  /** 搜索定位仅补载命中附近窗口，避免把完整历史跨 IPC 回传。 */
+  const handleLoadMessagesAround = React.useCallback(async (messageId: string): Promise<boolean> => {
+    const requestId = ++searchWindowRequestRef.current
+    const around = await window.electronAPI.getConversationMessagesAround(conversationId, messageId)
+    if (
+      around.length === 0
+      || activeConversationIdRef.current !== conversationId
+      || searchWindowRequestRef.current !== requestId
+    ) return false
+    setMessages((previous) => {
+      const byId = new Map(previous.map((message) => [message.id, message]))
+      for (const message of around) byId.set(message.id, message)
+      return [...byId.values()].sort((left, right) => left.createdAt - right.createdAt)
+    })
+    return true
+  }, [conversationId])
+
   /** 消息历史中的图片编辑完成 → 作为新附件加入输入框 */
   const handleImageEditComplete = React.useCallback((editedDataUrl: string): void => {
     const base64 = editedDataUrl.split(',')[1]
@@ -675,6 +696,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
             inlineEditingMessageId={inlineEditingMessageId}
             onDeleteDivider={handleDeleteDivider}
             onLoadMore={handleLoadMore}
+            onLoadMessagesAround={handleLoadMessagesAround}
             onImageEditComplete={handleImageEditComplete}
           />
 

--- a/apps/electron/src/renderer/lib/session-message-search.ts
+++ b/apps/electron/src/renderer/lib/session-message-search.ts
@@ -1,0 +1,72 @@
+import {
+  createSearchSnippet,
+  MAX_NORMALIZED_SEARCH_QUERY_LENGTH,
+  MAX_SEARCH_QUERY_SOURCE_LENGTH,
+  findBestSearchMatchInNormalized,
+  normalizeSearchText,
+} from '@proma/shared'
+import type { SessionMessageSearchResponse, SessionMessageSearchResult } from '@proma/shared'
+
+/**
+ * 搜索数据源与迷你地图展示解耦：数据源只返回命中元数据，不向 UI 泄露完整历史正文。
+ */
+export type SessionMessageSearch = (query: string) => Promise<SessionMessageSearchResponse>
+
+export interface LocalSearchRecordInput {
+  messageId: string
+  role: SessionMessageSearchResult['role']
+  text: string
+}
+
+export interface LocalSearchRecord extends LocalSearchRecordInput {
+  normalizedText: ReturnType<typeof normalizeSearchText>
+}
+
+/** 在 Agent 结构快照更新时预计算规范化文本，而不是随每次输入重复规范化全文。 */
+export function createLocalSearchRecords(records: readonly LocalSearchRecordInput[]): LocalSearchRecord[] {
+  return records.map((record) => ({
+    ...record,
+    normalizedText: normalizeSearchText(record.text),
+  }))
+}
+
+/**
+ * 在 Agent 已加载的结构化快照中检索全文。
+ * 调用方只应在消息结构改变或流式轮次结束时重建 records，避免 token 级的全历史扫描。
+ */
+export function searchLocalSessionMessages(
+  records: readonly LocalSearchRecord[],
+  query: string,
+  maxResults = 50,
+): SessionMessageSearchResponse {
+  if (query.length > MAX_SEARCH_QUERY_SOURCE_LENGTH) {
+    return { results: [], truncated: false, queryTooLong: true }
+  }
+  const normalizedQuery = normalizeSearchText(query)
+  if (normalizedQuery.chars.length < 2) return { results: [], truncated: false, queryTooLong: false }
+  if (normalizedQuery.chars.length > MAX_NORMALIZED_SEARCH_QUERY_LENGTH) {
+    return { results: [], truncated: false, queryTooLong: true }
+  }
+
+  const results: Array<SessionMessageSearchResult & { score: number }> = []
+  for (const record of records) {
+    const match = findBestSearchMatchInNormalized(record.normalizedText, normalizedQuery)
+    if (!match) continue
+    const snippet = createSearchSnippet(record.text, match.matchStart, match.matchLength)
+    results.push({
+      messageId: record.messageId,
+      role: record.role,
+      ...snippet,
+      score: match.score,
+    })
+  }
+
+  return {
+    results: results
+      .sort((a, b) => b.score - a.score)
+      .slice(0, maxResults)
+      .map(({ score: _score, ...result }) => result),
+    truncated: false,
+    queryTooLong: false,
+  }
+}

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -177,21 +177,33 @@ export interface ConversationMeta {
 /**
  * 消息搜索结果
  */
-export interface MessageSearchResult {
-  /** 对话 ID */
-  conversationId: string
-  /** 对话标题 */
-  conversationTitle: string
+export interface SessionMessageSearchResult {
   /** 消息 ID */
   messageId: string
   /** 消息角色 */
   role: MessageRole
-  /** 匹配上下文片段（约 80 字符） */
+  /** 匹配上下文片段，完整保留命中的查询文本 */
   snippet: string
   /** snippet 内匹配起始位置 */
   matchStart: number
   /** 匹配长度 */
   matchLength: number
+}
+
+export interface SessionMessageSearchResponse {
+  /** 当前查询返回的最佳命中 */
+  results: SessionMessageSearchResult[]
+  /** 为防止主进程资源耗尽，是否只检索了当前会话的可索引前缀 */
+  truncated: boolean
+  /** 查询文本过长，已拒绝模糊匹配以保护事件循环 */
+  queryTooLong: boolean
+}
+
+export interface MessageSearchResult extends SessionMessageSearchResult {
+  /** 对话 ID */
+  conversationId: string
+  /** 对话标题 */
+  conversationTitle: string
   /** 是否已归档 */
   archived?: boolean
 }
@@ -364,6 +376,8 @@ export const CHAT_IPC_CHANNELS = {
   GET_MESSAGES: 'chat:get-messages',
   /** 获取对话最近 N 条消息（分页加载） */
   GET_RECENT_MESSAGES: 'chat:get-recent-messages',
+  /** 获取指定消息附近的小窗口，供搜索定位避免回传完整历史 */
+  GET_MESSAGES_AROUND: 'chat:get-messages-around',
   /** 更新对话标题 */
   UPDATE_TITLE: 'chat:update-title',
   /** 删除对话 */
@@ -406,8 +420,10 @@ export const CHAT_IPC_CHANNELS = {
   TOGGLE_PIN: 'chat:toggle-pin',
   /** 切换对话归档状态 */
   TOGGLE_ARCHIVE: 'chat:toggle-archive',
-  /** 搜索对话消息内容 */
+  /** 搜索所有对话消息内容 */
   SEARCH_MESSAGES: 'chat:search-messages',
+  /** 搜索当前对话的完整消息历史（仅返回命中元数据） */
+  SEARCH_SESSION_MESSAGES: 'chat:search-session-messages',
 
   // 教程
   /** 获取教程内容 */

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -47,11 +47,18 @@ export {
 } from './thinking-signature-error'
 export { normalizePathForCompare } from './normalize-path'
 export {
+  MAX_NORMALIZED_SEARCH_QUERY_LENGTH,
+  MAX_SEARCH_QUERY_SOURCE_LENGTH,
   findBestSearchMatch,
+  findBestSearchMatchInNormalized,
+  normalizeSearchText,
+  createSearchSnippet,
   insertTopSearchResult,
   type SearchMatch,
   type SearchMatchKind,
+  type NormalizedSearchText,
   type SearchResultRank,
+  type SearchSnippet,
 } from './search-matching'
 export {
   AUTOMATION_OCCURRENCE_SAMPLES_PER_DAY,

--- a/packages/shared/src/utils/search-matching.ts
+++ b/packages/shared/src/utils/search-matching.ts
@@ -7,15 +7,19 @@ export interface SearchMatch {
   kind: SearchMatchKind
 }
 
-interface NormalizedText {
+export interface NormalizedSearchText {
   chars: string[]
   starts: number[]
   ends: number[]
 }
 
 const IGNORABLE_SEPARATOR_RE = /^[\s,.!?;:，。！？、；：“”‘’（）()【】\[\]《》<>〈〉「」『』·…—–\-_\\/]+$/u
+/** 在规范化前拒绝异常长输入，避免粘贴日志耗尽事件循环与内存。 */
+export const MAX_SEARCH_QUERY_SOURCE_LENGTH = 4_096
+/** 防止 fragment / fuzzy 匹配在粘贴超长文本时占用事件循环。 */
+export const MAX_NORMALIZED_SEARCH_QUERY_LENGTH = 256
 
-function normalizeText(text: string): NormalizedText {
+export function normalizeSearchText(text: string): NormalizedSearchText {
   const chars: string[] = []
   const starts: number[] = []
   const ends: number[] = []
@@ -56,7 +60,7 @@ function findSequence(haystack: string[], needle: string[]): number {
 }
 
 function buildMatch(
-  normalizedHaystack: NormalizedText,
+  normalizedHaystack: NormalizedSearchText,
   start: number,
   length: number,
   score: number,
@@ -95,6 +99,34 @@ export interface SearchResultRank {
   role: 'user' | 'assistant'
 }
 
+export interface SearchSnippet {
+  snippet: string
+  matchStart: number
+  matchLength: number
+}
+
+/**
+ * 生成可高亮的结果摘要。摘要会缩短前后上下文，但永远不会截断命中的文本。
+ */
+export function createSearchSnippet(
+  text: string,
+  matchStart: number,
+  matchLength: number,
+  contextLength = 40,
+): SearchSnippet {
+  const safeStart = Math.max(0, Math.min(matchStart, text.length))
+  const safeLength = Math.max(0, Math.min(matchLength, text.length - safeStart))
+  const snippetStart = Math.max(0, safeStart - contextLength)
+  const snippetEnd = Math.min(text.length, safeStart + safeLength + contextLength)
+  const prefix = snippetStart > 0 ? '...' : ''
+  const suffix = snippetEnd < text.length ? '...' : ''
+  return {
+    snippet: `${prefix}${text.slice(snippetStart, snippetEnd)}${suffix}`,
+    matchStart: safeStart - snippetStart + prefix.length,
+    matchLength: safeLength,
+  }
+}
+
 /** Maintains a fixed-size, score-sorted set of the best message search results. */
 export function insertTopSearchResult<T extends SearchResultRank>(
   results: T[],
@@ -123,11 +155,17 @@ export function insertTopSearchResult<T extends SearchResultRank>(
  * 在文本中查找一处最佳命中，同时保留原文坐标供 UI 高亮。
  * 1～2 字符只做精确匹配；更长查询允许连续片段和最多一个编辑距离。
  */
-export function findBestSearchMatch(text: string, query: string): SearchMatch | null {
-  const normalizedHaystack = normalizeText(text)
-  const needle = normalizeText(query).chars
+export function findBestSearchMatchInNormalized(
+  normalizedHaystack: NormalizedSearchText,
+  normalizedQuery: NormalizedSearchText,
+): SearchMatch | null {
+  const needle = normalizedQuery.chars
   const haystack = normalizedHaystack.chars
-  if (needle.length < 2 || haystack.length === 0) return null
+  if (
+    needle.length < 2
+    || needle.length > MAX_NORMALIZED_SEARCH_QUERY_LENGTH
+    || haystack.length === 0
+  ) return null
 
   const exactStart = findSequence(haystack, needle)
   if (exactStart >= 0) return buildMatch(normalizedHaystack, exactStart, needle.length, 1000, 'exact')
@@ -156,4 +194,9 @@ export function findBestSearchMatch(text: string, query: string): SearchMatch | 
   }
 
   return best
+}
+
+export function findBestSearchMatch(text: string, query: string): SearchMatch | null {
+  if (query.length > MAX_SEARCH_QUERY_SOURCE_LENGTH) return null
+  return findBestSearchMatchInNormalized(normalizeSearchText(text), normalizeSearchText(query))
 }


### PR DESCRIPTION
## Summary
- Search the current Chat session through a narrow IPC result contract instead of transferring full history to the renderer.
- Build file-versioned, bounded main-process indexes for Chat and structural-snapshot indexes for Agent.
- Preserve long-query highlighting, safely reveal unloaded results through a bounded message window, and prevent stale scroll/history work from crossing sessions.

## Validation
- `bun run typecheck`
- `bun run --filter='@proma/electron' build`\n\n## Performance\n- Search input is debounced 150ms; stale responses are ignored.\n- Chat returns hit metadata only; its index is capped at 250,000 indexed characters and LRU-cached across at most 8 sessions / 1,000,000 characters. Truncated searches are explicit in UI.\n- Query source input is capped at 4,096 characters before normalization and fuzzy matching is capped at 256 normalized characters.\n- Search navigation loads at most 50 nearby messages rather than transferring all persisted history.\n- Agent index rebuilds only for structural history changes, not streaming tokens.\n- No live Electron profiler trace was recorded; typecheck and production Electron build pass.\n\nMade with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)