### PR TITLE
fix(vault): serialize shared document saves

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.13",
+  "version": "0.19.14",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/vault-atoms.ts
+++ b/apps/electron/src/renderer/atoms/vault-atoms.ts
@@ -1,8 +1,14 @@
 import { atom } from 'jotai'
+import { atomFamily } from 'jotai/utils'
 import type { VaultReadResult } from '@proma/shared'
 
-export const selectedVaultFileAtom = atom<string | null>(null)
+/** A renderer can host several Agent sessions, each with independent Vault navigation. */
+export function getVaultSessionScope(sessionId?: string): string {
+  return sessionId ?? '__standalone_vault__'
+}
+
+export const selectedVaultFileAtomFamily = atomFamily((sessionScope: string) => atom<string | null>(null))
 /** Transient navigation target for an Obsidian context chip; not Agent state. */
-export const focusedVaultFolderAtom = atom<string | null>(null)
-export const vaultReadResultAtom = atom<VaultReadResult | null>(null)
+export const focusedVaultFolderAtomFamily = atomFamily((sessionScope: string) => atom<string | null>(null))
+export const vaultReadResultAtomFamily = atomFamily((sessionScope: string) => atom<VaultReadResult | null>(null))
 export const vaultRefreshTokenAtom = atom(0)

--- a/apps/electron/src/renderer/components/agent/TurnSkillUsageSummary.tsx
+++ b/apps/electron/src/renderer/components/agent/TurnSkillUsageSummary.tsx
@@ -5,7 +5,7 @@ import { collectSkillActivations } from '@proma/shared'
 import type { SDKMessage, SDKUserMessage, SkillActivation, VaultFocusAttribution } from '@proma/shared'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { currentAgentSessionIdAtom, openWorkspaceComponentAtom, skillDetailNavigationAtomFamily } from '@/atoms/agent-atoms'
-import { focusedVaultFolderAtom, selectedVaultFileAtom } from '@/atoms/vault-atoms'
+import { focusedVaultFolderAtomFamily, getVaultSessionScope, selectedVaultFileAtomFamily } from '@/atoms/vault-atoms'
 import { ObsidianIcon } from '@/components/obsidian/obsidian-brand'
 import { cn } from '@/lib/utils'
 
@@ -38,8 +38,9 @@ function readVaultFocusAttribution(inputMessage?: SDKUserMessage): VaultFocusAtt
 function VaultFocusChip({ attribution }: { attribution: VaultFocusAttribution }): React.ReactElement {
   const sessionId = useAtomValue(currentAgentSessionIdAtom)
   const openWorkspaceComponent = useSetAtom(openWorkspaceComponentAtom)
-  const setSelectedFile = useSetAtom(selectedVaultFileAtom)
-  const setFocusedFolder = useSetAtom(focusedVaultFolderAtom)
+  const vaultSessionScope = getVaultSessionScope(sessionId ?? undefined)
+  const setSelectedFile = useSetAtom(selectedVaultFileAtomFamily(vaultSessionScope))
+  const setFocusedFolder = useSetAtom(focusedVaultFolderAtomFamily(vaultSessionScope))
   const { focus } = attribution
   const label = `${focus.relativePath.split('/').filter(Boolean).pop() || attribution.displayName}${focus.kind === 'folder' ? '/' : ''}`
   const handleOpenVault = React.useCallback(() => {

--- a/apps/electron/src/renderer/components/vault/VaultView.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultView.tsx
@@ -32,13 +32,15 @@ import {
 } from '@/atoms/chat-atoms'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
-  focusedVaultFolderAtom,
-  selectedVaultFileAtom,
-  vaultReadResultAtom,
+  focusedVaultFolderAtomFamily,
+  getVaultSessionScope,
+  selectedVaultFileAtomFamily,
+  vaultReadResultAtomFamily,
   vaultRefreshTokenAtom,
 } from '@/atoms/vault-atoms'
 import { cn } from '@/lib/utils'
-import { getVaultEditorKey, shouldAdoptVaultReadContent } from './vault-editor-lifecycle'
+import { getVaultEditorKey } from './vault-editor-lifecycle'
+import { getVaultDocumentController } from './vault-document-controller'
 import { buildVaultTree, getInitialVaultExpandedFolders, getVaultFolderAncestors, hasSameVaultTreeEntries, type VaultFolderNode } from './vault-tree-model'
 
 const VAULT_NAME = 'Vault'
@@ -240,12 +242,26 @@ function VaultFileList({
   )
 }
 
+type VaultSaveRequest = {
+  relativePath: string
+  content: string
+  expectedSha256: string
+}
+
+type VaultSaveResult =
+  | { ok: true; relativePath: string; sha256: string; modifiedAt: number }
+  | { ok: false; reason: 'conflict' | 'error'; message?: string }
+
+type VaultEditorFlush = () => Promise<boolean>
+
 function VaultMarkdownEditor({
   readResult,
   vaultId,
   sessionId,
   onSave,
   onRename,
+  onReload,
+  onRegisterFlush,
   onOpenTutorial,
 }: {
   readResult: VaultReadResult
@@ -253,15 +269,19 @@ function VaultMarkdownEditor({
   vaultId: string
   /** 嵌入 Agent 右侧工作区时，用于接入 Agent 引用与右侧问答。 */
   sessionId?: string
-  onSave: (nextContent: string, options?: { silent?: boolean; expectedSha256?: string }) => Promise<void>
+  onSave: (request: VaultSaveRequest, options?: { silent?: boolean }) => Promise<VaultSaveResult>
   onRename: (name: string) => Promise<void>
+  onReload: () => void
+  onRegisterFlush?: (flush: VaultEditorFlush | null) => void
   onOpenTutorial: () => void
 }): React.ReactElement {
-  const [draft, setDraft] = React.useState(readResult.content)
-  const lastReadContentRef = React.useRef(readResult.content)
-  const saveBaseRef = React.useRef({ content: readResult.content, sha256: readResult.sha256 })
-  const externalConflictRef = React.useRef(false)
-  const [saving, setSaving] = React.useState(false)
+  const documentController = React.useMemo(() => getVaultDocumentController(readResult, vaultId), [readResult.relativePath, vaultId])
+  const documentSnapshot = React.useSyncExternalStore(
+    documentController.subscribe,
+    documentController.getSnapshot,
+    documentController.getSnapshot,
+  )
+  const { draft, saving, conflict: saveConflict } = documentSnapshot
   const [filename, setFilename] = React.useState(displayDocumentTitle(readResult.relativePath.split('/').pop() ?? readResult.relativePath))
   const editorPageRef = React.useRef<HTMLDivElement>(null)
   const [selection, setSelection] = React.useState<VaultTextSelection | null>(null)
@@ -371,27 +391,15 @@ function VaultMarkdownEditor({
     sideChatMap,
   ])
 
+  const updateDraft = React.useCallback((nextDraft: string): void => {
+    documentController.setDraft(nextDraft)
+  }, [documentController])
+
   React.useEffect(() => {
-    const previousReadContent = lastReadContentRef.current
-    if (readResult.content === previousReadContent) return
-    lastReadContentRef.current = readResult.content
-
-    // A direct Agent/external write must never replace the revision used to save
-    // a dirty draft. Keeping the prior SHA forces the existing optimistic-write
-    // conflict path instead of silently overwriting the Agent's document.
-    if (!shouldAdoptVaultReadContent(draft, previousReadContent) && readResult.content !== draft) {
-      if (!externalConflictRef.current) {
-        externalConflictRef.current = true
-        toast.error('笔记已被外部修改；本地草稿未保存，请重新打开后合并')
-      }
-      return
+    if (documentController.observeRemote(readResult) === 'conflict') {
+      toast.error('笔记已被外部修改；已保留本地草稿')
     }
-
-    externalConflictRef.current = false
-    saveBaseRef.current = { content: readResult.content, sha256: readResult.sha256 }
-    setDraft(readResult.content)
-  }, [draft, readResult.content, readResult.sha256])
-
+  }, [documentController, readResult])
 
   const handleEditorPageWheel = (event: React.WheelEvent<HTMLDivElement>): void => {
     if ((event.target as HTMLElement).closest('.vault-ink-mde')) return
@@ -405,21 +413,33 @@ function VaultMarkdownEditor({
     scroller.scrollLeft += event.deltaX
   }
 
-  const save = React.useCallback(async (silent = false): Promise<void> => {
-    if (saving || externalConflictRef.current || draft === saveBaseRef.current.content) return
-    setSaving(true)
-    try {
-      await onSave(draft, { silent, expectedSha256: saveBaseRef.current.sha256 })
-    } finally {
-      setSaving(false)
+  const saveLatest = React.useCallback(async (silent = false): Promise<boolean> => {
+    const result = await documentController.flush((request) => onSave(request, { silent }))
+    if (!result.ok) {
+      toast.error(result.reason === 'conflict' ? '笔记已被外部修改；已保留本地草稿' : (result.message ?? '保存失败；已保留本地草稿'))
+      return false
     }
-  }, [draft, onSave, saving])
+    return true
+  }, [documentController, onSave])
+
+  const flushPendingSave = React.useCallback((): Promise<boolean> => saveLatest(true), [saveLatest])
 
   React.useEffect(() => {
-    if (saving || externalConflictRef.current || draft === saveBaseRef.current.content) return
-    const timer = window.setTimeout(() => { void save(true) }, 700)
+    onRegisterFlush?.(flushPendingSave)
+    return () => onRegisterFlush?.(null)
+  }, [flushPendingSave, onRegisterFlush])
+
+  React.useEffect(() => {
+    if (saving || saveConflict || draft === documentSnapshot.base.content) return
+    const timer = window.setTimeout(() => { void saveLatest(true) }, 700)
     return () => window.clearTimeout(timer)
-  }, [draft, save, saving])
+  }, [documentSnapshot.base.content, draft, saveConflict, saveLatest, saving])
+
+  React.useEffect(() => () => {
+    // Best effort for unmounts such as Session/side-panel changes. Explicit
+    // navigation paths await the same flush before replacing the editor.
+    void flushPendingSave()
+  }, [flushPendingSave])
 
   const rename = async (): Promise<void> => {
     const currentName = displayDocumentTitle(readResult.relativePath.split('/').pop() ?? readResult.relativePath)
@@ -427,7 +447,17 @@ function VaultMarkdownEditor({
       setFilename(currentName)
       return
     }
+    if (!await flushPendingSave()) return
     await onRename(filename.trim())
+  }
+
+  const copyLocalDraft = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(draft)
+      toast.success('未保存草稿已复制')
+    } catch {
+      toast.error('无法复制本地草稿')
+    }
   }
 
 
@@ -453,6 +483,13 @@ function VaultMarkdownEditor({
             }}
             className="h-9 min-w-0 flex-1 bg-transparent px-0 text-2xl font-semibold leading-tight text-foreground outline-none placeholder:text-muted-foreground/50"
           />
+          {saveConflict && (
+            <div className="flex shrink-0 items-center gap-1.5 text-xs text-destructive">
+              <span>草稿未保存</span>
+              <button type="button" onClick={() => { void copyLocalDraft() }} className="rounded px-1.5 py-1 hover:bg-destructive/10">复制草稿</button>
+              <button type="button" onClick={() => { documentController.discardLocalDraft(); onReload() }} className="rounded px-1.5 py-1 hover:bg-destructive/10">丢弃并重载</button>
+            </div>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -472,8 +509,8 @@ function VaultMarkdownEditor({
             ref={editorHandleRef}
             relativePath={readResult.relativePath}
             value={draft}
-            onChange={setDraft}
-            onSave={() => { void save() }}
+            onChange={updateDraft}
+            onSave={() => { void flushPendingSave() }}
             onReady={handleEditorReady}
             onTextSelectionChange={handleTextSelectionChange}
           />
@@ -500,6 +537,8 @@ function VaultMarkdownPane({
   reopenVersion,
   onSave,
   onRename,
+  onReload,
+  onRegisterFlush,
   onOpenTutorial,
 }: {
   readResult: VaultReadResult | null
@@ -508,8 +547,10 @@ function VaultMarkdownPane({
   loading: boolean
   hasVault: boolean
   reopenVersion: number
-  onSave: (nextContent: string, options?: { silent?: boolean; expectedSha256?: string }) => Promise<void>
+  onSave: (request: VaultSaveRequest, options?: { silent?: boolean }) => Promise<VaultSaveResult>
   onRename: (name: string) => Promise<void>
+  onReload: () => void
+  onRegisterFlush: (flush: VaultEditorFlush | null) => void
   onOpenTutorial: () => void
 }): React.ReactElement {
   if (loading || !readResult || !vaultId) {
@@ -538,6 +579,8 @@ function VaultMarkdownPane({
         sessionId={sessionId}
         onSave={onSave}
         onRename={onRename}
+        onReload={onReload}
+        onRegisterFlush={onRegisterFlush}
         onOpenTutorial={onOpenTutorial}
       />
     </section>
@@ -545,6 +588,7 @@ function VaultMarkdownPane({
 }
 
 export function VaultView({ embedded = false, sessionId }: { embedded?: boolean; sessionId?: string }): React.ReactElement {
+  const vaultSessionScope = getVaultSessionScope(sessionId)
   const [config, setConfig] = React.useState<VaultSummary | null>(null)
   const [candidates, setCandidates] = React.useState<VaultCandidate[]>([])
   const [vaultSwitcherOpen, setVaultSwitcherOpen] = React.useState(false)
@@ -553,9 +597,9 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   const [loading, setLoading] = React.useState(true)
   const [fileLoading, setFileLoading] = React.useState(false)
   const [editorReopenVersion, setEditorReopenVersion] = React.useState(0)
-  const [selectedFile, setSelectedFile] = useAtom(selectedVaultFileAtom)
-  const [focusedFolder, setFocusedFolder] = useAtom(focusedVaultFolderAtom)
-  const [readResult, setReadResult] = useAtom(vaultReadResultAtom)
+  const [selectedFile, setSelectedFile] = useAtom(selectedVaultFileAtomFamily(vaultSessionScope))
+  const [focusedFolder, setFocusedFolder] = useAtom(focusedVaultFolderAtomFamily(vaultSessionScope))
+  const [readResult, setReadResult] = useAtom(vaultReadResultAtomFamily(vaultSessionScope))
   const [refreshToken, setRefreshToken] = useAtom(vaultRefreshTokenAtom)
   const [vaultHelpOpen, setVaultHelpOpen] = React.useState(false)
   const [deleteTarget, setDeleteTarget] = React.useState<VaultFileEntry | null>(null)
@@ -580,6 +624,11 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   const focusSequenceRef = React.useRef(Date.now())
   const readRequestRef = React.useRef(0)
   const initialRefreshRef = React.useRef(true)
+  const editorFlushRef = React.useRef<VaultEditorFlush | null>(null)
+  const flushCurrentEditor = React.useCallback(async (): Promise<boolean> => editorFlushRef.current ? editorFlushRef.current() : true, [])
+  const registerEditorFlush = React.useCallback((flush: VaultEditorFlush | null): void => {
+    editorFlushRef.current = flush
+  }, [])
 
   React.useEffect(() => {
     selectedFileRef.current = selectedFile
@@ -718,7 +767,8 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
     void refreshVaultCandidates()
   }, [refreshVaultCandidates])
 
-  const openFile = React.useCallback(async (relativePath: string): Promise<void> => {
+  const openFile = React.useCallback(async (relativePath: string, { discardLocalDraft = false }: { discardLocalDraft?: boolean } = {}): Promise<void> => {
+    if (!discardLocalDraft && !await flushCurrentEditor()) return
     const reopenCurrentFile = selectedFileRef.current === relativePath
     const requestId = ++readRequestRef.current
     selectFile(relativePath)
@@ -739,9 +789,10 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
     } finally {
       if (requestId === readRequestRef.current) setFileLoading(false)
     }
-  }, [selectFile, setReadResult])
+  }, [flushCurrentEditor, selectFile, setReadResult])
 
   const selectVaultManually = async (): Promise<void> => {
+    if (!await flushCurrentEditor()) return
     const selected = await window.electronAPI.selectVault({ inboxPath: 'Proma Inbox', allowAgentWrites: false })
     if (!selected) return
     setConfig(selected)
@@ -753,6 +804,7 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   }
 
   const createPromaVault = async (): Promise<void> => {
+    if (!await flushCurrentEditor()) return
     try {
       const selected = await window.electronAPI.selectDefaultVault()
       setConfig(selected)
@@ -767,6 +819,7 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   }
 
   const connectDiscoveredVault = async (candidate: VaultCandidate): Promise<void> => {
+    if (!await flushCurrentEditor()) return
     try {
       const selected = candidate.isPromaManaged
         ? await window.electronAPI.selectDefaultVault()
@@ -830,41 +883,38 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
     }
   }
 
-  const save = async (content: string, { silent = false, expectedSha256 }: { silent?: boolean; expectedSha256?: string } = {}): Promise<void> => {
-    if (!readResult) return
+  const save = React.useCallback(async (request: VaultSaveRequest, { silent = false }: { silent?: boolean } = {}): Promise<VaultSaveResult> => {
     try {
-      const result = await window.electronAPI.writeVaultFile({
-        relativePath: readResult.relativePath,
-        content,
-        expectedSha256: expectedSha256 ?? readResult.sha256,
-      })
-      if (!result.ok) {
-        toast.error('文件已在外部修改，请重新打开后再保存')
-        return
-      }
-      // Preserve the live editor instance: update the known write result rather
-      // than rereading/rekeying the document through the global refresh path.
-      setReadResult({
+      const result = await window.electronAPI.writeVaultFile(request)
+      if (!result.ok) return { ok: false, reason: 'conflict' }
+
+      // A write can finish after the user has opened another note. Never replace
+      // that newer view with a stale save acknowledgement.
+      setReadResult((previous) => previous?.relativePath === request.relativePath ? {
         relativePath: result.relativePath,
-        content,
+        content: request.content,
         sha256: result.sha256,
         modifiedAt: result.modifiedAt,
-      })
+      } : previous)
       const nextFiles = await window.electronAPI.listVaultFiles()
       setFiles((current) => hasSameVaultTreeEntries(current, nextFiles) ? current : nextFiles)
       if (!silent) toast.success(`已保存到 ${VAULT_NAME}`)
+      return result
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : '保存失败')
+      return { ok: false, reason: 'error', message: error instanceof Error ? error.message : '保存失败' }
     }
-  }
+  }, [setReadResult])
 
   const rename = async (name: string): Promise<void> => {
     if (!readResult) return
     try {
+      // Re-read after the editor flushes so rename validates the revision that
+      // is actually on disk rather than a stale render snapshot.
+      const current = await window.electronAPI.readVaultFile(readResult.relativePath)
       const renamed = await window.electronAPI.renameVaultFile({
-        relativePath: readResult.relativePath,
+        relativePath: current.relativePath,
         name,
-        expectedSha256: readResult.sha256,
+        expectedSha256: current.sha256,
       })
       selectFile(renamed.relativePath)
       setReadResult(renamed)
@@ -877,15 +927,21 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
 
   const deleteNote = async (): Promise<void> => {
     if (!deleteTarget || deleting) return
+    const deletingCurrentFile = selectedFileRef.current === deleteTarget.relativePath
+    // Deleting is irreversible, so never let a pending debounce turn the
+    // current document's draft into a silent loss. A failed flush leaves the
+    // editor and its explicit copy/reload recovery controls intact.
+    if (deletingCurrentFile && !await flushCurrentEditor()) return
     setDeleting(true)
     try {
-      const deletingCurrentFile = selectedFileRef.current === deleteTarget.relativePath
-      const expectedSha256 = deletingCurrentFile && readResult?.relativePath === deleteTarget.relativePath
-        ? readResult.sha256
-        : undefined
+      // The flush can update the controller before React commits readResult.
+      // Read again so delete's CAS protects the exact version on disk.
+      const current = deletingCurrentFile
+        ? await window.electronAPI.readVaultFile(deleteTarget.relativePath)
+        : null
       await window.electronAPI.deleteVaultFile({
         relativePath: deleteTarget.relativePath,
-        expectedSha256,
+        expectedSha256: current?.sha256,
       })
 
       if (deletingCurrentFile) {
@@ -1040,6 +1096,8 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
             reopenVersion={editorReopenVersion}
             onSave={save}
             onRename={rename}
+            onReload={() => { if (readResult) void openFile(readResult.relativePath, { discardLocalDraft: true }) }}
+            onRegisterFlush={registerEditorFlush}
             onOpenTutorial={() => setVaultHelpOpen(true)}
           />
         </div>

--- a/apps/electron/src/renderer/components/vault/vault-document-controller.ts
+++ b/apps/electron/src/renderer/components/vault/vault-document-controller.ts
@@ -1,0 +1,184 @@
+import type { VaultReadResult } from '@proma/shared'
+
+export type VaultDocumentWriteRequest = {
+  relativePath: string
+  content: string
+  expectedSha256: string
+}
+
+export type VaultDocumentWriteResult =
+  | { ok: true; relativePath: string; sha256: string; modifiedAt: number }
+  | { ok: false; reason: 'conflict' | 'error'; message?: string }
+
+export type VaultDocumentSnapshot = {
+  base: VaultReadResult
+  draft: string
+  saving: boolean
+  conflict: boolean
+  remoteConflict: VaultReadResult | null
+}
+
+export type VaultDocumentRemoteDisposition = 'ignored' | 'adopted' | 'conflict'
+
+type Listener = () => void
+type Write = (request: VaultDocumentWriteRequest) => Promise<VaultDocumentWriteResult>
+
+/**
+ * A per-file, renderer-local document model. Every Vault view that opens the
+ * same note sees one draft and one optimistic-write queue instead of competing
+ * React-local drafts. The main-process SHA CAS remains the final guard against
+ * writes from Obsidian or an Agent outside this renderer.
+ */
+export class VaultDocumentController {
+  private snapshot: VaultDocumentSnapshot
+  private readonly listeners = new Set<Listener>()
+  private savePromise: Promise<VaultDocumentWriteResult> | null = null
+
+  constructor(
+    initial: VaultReadResult,
+    private readonly disposeWhenClean?: () => void,
+  ) {
+    this.snapshot = {
+      base: initial,
+      draft: initial.content,
+      saving: false,
+      conflict: false,
+      remoteConflict: null,
+    }
+  }
+
+  getSnapshot = (): VaultDocumentSnapshot => this.snapshot
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+      this.disposeIfUnobservedAndClean()
+    }
+  }
+
+  setDraft(draft: string): void {
+    if (draft === this.snapshot.draft) return
+    this.snapshot = { ...this.snapshot, draft }
+    this.emit()
+  }
+
+  /** Incorporate a disk read without allowing an older poll to roll state back. */
+  observeRemote(next: VaultReadResult): VaultDocumentRemoteDisposition {
+    const { base, draft } = this.snapshot
+    if (next.sha256 === base.sha256 || next.modifiedAt < base.modifiedAt) return 'ignored'
+
+    if (draft === base.content || draft === next.content) {
+      this.snapshot = {
+        base: next,
+        draft: next.content,
+        saving: this.snapshot.saving,
+        conflict: false,
+        remoteConflict: null,
+      }
+      this.emit()
+      return 'adopted'
+    }
+
+    const alreadyConflicted = this.snapshot.conflict
+      && this.snapshot.remoteConflict?.sha256 === next.sha256
+    this.snapshot = { ...this.snapshot, conflict: true, remoteConflict: next }
+    this.emit()
+    return alreadyConflicted ? 'ignored' : 'conflict'
+  }
+
+  discardLocalDraft(): void {
+    // A CAS failure does not include remote content; reset to our last known
+    // base and let the caller's fresh read adopt the actual disk revision.
+    const remote = this.snapshot.remoteConflict ?? this.snapshot.base
+    this.snapshot = {
+      base: remote,
+      draft: remote.content,
+      saving: false,
+      conflict: false,
+      remoteConflict: null,
+    }
+    this.emit()
+  }
+
+  async flush(write: Write): Promise<VaultDocumentWriteResult> {
+    if (this.snapshot.conflict) return { ok: false, reason: 'conflict' }
+    if (this.savePromise) return this.savePromise
+
+    const pending = (async (): Promise<VaultDocumentWriteResult> => {
+      let lastResult: VaultDocumentWriteResult = {
+        ok: true,
+        relativePath: this.snapshot.base.relativePath,
+        sha256: this.snapshot.base.sha256,
+        modifiedAt: this.snapshot.base.modifiedAt,
+      }
+      while (this.snapshot.draft !== this.snapshot.base.content) {
+        const content = this.snapshot.draft
+        const base = this.snapshot.base
+        this.snapshot = { ...this.snapshot, saving: true }
+        this.emit()
+        const result = await write({
+          relativePath: base.relativePath,
+          content,
+          expectedSha256: base.sha256,
+        })
+        if (!result.ok) {
+          this.snapshot = {
+            ...this.snapshot,
+            saving: false,
+            conflict: true,
+            remoteConflict: this.snapshot.remoteConflict,
+          }
+          this.emit()
+          return result
+        }
+
+        // Retain edits made while this write was in flight; the next iteration
+        // writes that newer generation against the returned SHA.
+        this.snapshot = {
+          ...this.snapshot,
+          base: {
+            relativePath: result.relativePath,
+            content,
+            sha256: result.sha256,
+            modifiedAt: result.modifiedAt,
+          },
+          saving: false,
+        }
+        this.emit()
+        lastResult = result
+      }
+      return lastResult
+    })()
+    this.savePromise = pending
+    try {
+      return await pending
+    } finally {
+      if (this.savePromise === pending) this.savePromise = null
+      this.disposeIfUnobservedAndClean()
+    }
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener()
+  }
+
+  private disposeIfUnobservedAndClean(): void {
+    if (this.listeners.size === 0 && !this.savePromise && !this.snapshot.saving && !this.snapshot.conflict && this.snapshot.draft === this.snapshot.base.content) {
+      this.disposeWhenClean?.()
+    }
+  }
+}
+
+const controllers = new Map<string, VaultDocumentController>()
+
+export function getVaultDocumentController(initial: VaultReadResult, vaultScope: string): VaultDocumentController {
+  const key = `${vaultScope}:${initial.relativePath}`
+  const existing = controllers.get(key)
+  if (existing) return existing
+  const controller = new VaultDocumentController(initial, () => {
+    if (controllers.get(key) === controller) controllers.delete(key)
+  })
+  controllers.set(key, controller)
+  return controller
+}

--- a/apps/electron/src/renderer/components/vault/vault-editor-lifecycle.ts
+++ b/apps/electron/src/renderer/components/vault/vault-editor-lifecycle.ts
@@ -2,7 +2,3 @@
 export function getVaultEditorKey(relativePath: string, reopenVersion = 0): string {
   return `${relativePath}:${reopenVersion}`
 }
-
-export function shouldAdoptVaultReadContent(localDraft: string, previousReadContent: string): boolean {
-  return localDraft === previousReadContent
-}


### PR DESCRIPTION
#### Summary
- Share a per-Vault-file document controller across Vault views, serializing optimistic SHA-CAS saves and preserving edits made while a write is in flight.
- Scope Vault navigation state by Agent Session; preserve drafts on true external-write conflicts and flush pending edits before navigation, rename, or deleting the current note.
- Retain upstream reading-position restoration and bump Electron to 0.19.14.

#### Validation
- `bun run --filter @proma/electron typecheck`
- `bun run --filter @proma/electron build:renderer`
- `git diff --check`

#### Performance
- The document controller is scoped to an open Vault file and releases clean, unobserved state. No new IPC listener or polling loop was introduced; existing per-open-note polling remains a follow-up optimization. Electron manual multi-session smoke testing remains outstanding.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
