### PR TITLE
feat(linux): add Ubuntu distribution baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # GitHub Actions: 自动打包分发
 #
 # 触发条件：推送 v* tag（如 v0.4.0）
-# 构建 macOS 和 Windows 产物并发布到 GitHub Releases
+# 构建 macOS、Windows 和 Linux 产物并发布到 GitHub Releases
 #
 # 所需 GitHub Secrets（macOS 签名/公证，可选）:
 # - MAC_CERTS: Base64 编码的 macOS Developer ID Application 证书 (.p12)
@@ -308,6 +308,49 @@ jobs:
           echo "$UPLOAD_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'Uploaded: {d.get(\"name\")} ({d.get(\"size\")} bytes)')"
           echo "✅ latest-mac.yml merged and uploaded"
 
+  build-linux-x64:
+    name: build (ubuntu-22.04, linux, x64)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: 安装 Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: 安装 Linux 构建依赖
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3
+
+      - name: 安装依赖
+        run: bun install --frozen-lockfile
+
+      - name: 准备 OfficeCLI（Linux x64）
+        run: bun run --filter='@proma/electron' prepare:officecli
+
+      - name: 构建 Electron 应用
+        run: bun run electron:build
+
+      - name: 准备运行时依赖
+        run: |
+          bun run --filter='@proma/electron' sync:runtime-deps
+          bun run --filter='@proma/electron' rebuild:node-pty
+
+      - name: 打包并发布 (Linux x64)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx electron-builder --linux --x64 --publish always
+        working-directory: apps/electron
+
   build-windows-x64:
     name: build (windows-latest, win, x64, --x64)
     runs-on: windows-latest
@@ -333,7 +376,6 @@ jobs:
       - name: 准备 OfficeCLI（Windows x64）
         run: bun run --filter='@proma/electron' prepare:officecli
 
-      # 构建应用
       - name: 构建 Electron 应用
         run: bun run electron:build
         working-directory: .

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Proma 是一个本地优先的 AI 桌面应用，把多模型 Chat、通用 Agen
 
 ### 下载安装
 
-从 [GitHub Releases](https://github.com/proma-ai/Proma/releases) 下载开源版本，提供 macOS Apple Silicon、macOS Intel 和 Windows 安装包。
+从 [GitHub Releases](https://github.com/proma-ai/Proma/releases) 下载开源版本，提供 macOS Apple Silicon、macOS Intel、Windows、Ubuntu/Debian x86_64 的 `.deb` 安装包和 Linux x86_64 AppImage。Linux 的安装、安全边界和支持范围见 [Linux 说明](./docs/linux.md)。
 
 开源版可独立使用，并支持自行配置 AI 供应商渠道。如果你更希望使用 Proma 提供的内置模型渠道和订阅方案，也可以按需了解 [Proma 商业版](https://proma.cool/download)。两个版本面向不同的使用偏好，你可以自由选择适合自己的版本。
 

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -35,9 +35,10 @@ npmRebuild: false
 # 通用文件配置
 files:
   - dist/**/*
-  # 排除 build:resources 脚本拷到 dist/resources 的副本（electron-builder 已通过
-  # buildResources 从 resources/ 直接使用 icon/plist，避免产物里重复打包一份）
+  # build:resources 会把 resources 拷到 dist/，但 electron-builder 已通过 buildResources
+  # 直接使用原始资源；仅保留 Linux runtime 需要的 icon.png，避免重复打包。
   - "!dist/resources/**"
+  - "dist/resources/icon.png"
   - package.json
   # Pi runtime 作为主进程 external 运行。打包前 sync:runtime-deps 会
   # 将 external 依赖闭包同步到 apps/electron/node_modules。
@@ -155,9 +156,57 @@ nsis:
   createStartMenuShortcut: true
 
 # ============================================
+# Linux 配置（Ubuntu/Debian x86_64）
+# ============================================
+linux:
+  icon: resources/icon.png
+  executableName: proma
+  desktop:
+    StartupWMClass: proma
+  category: Development
+  synopsis: 本地优先的 AI 桌面 Agent
+  description: Proma 把多模型 Chat、通用 Agent、工作区、Skills、MCP 与记忆能力放进同一个开源客户端，数据和配置默认留在本地（~/.proma/）。
+  maintainer: ErlichLiu <erlichliu@gmail.com>
+  target:
+    - target: AppImage
+      arch:
+        - x64
+    - target: deb
+      arch:
+        - x64
+
+# electron-builder 25 对 AppImage 默认使用 --no-sandbox，这是 AppImage
+# 挂载文件系统无法可靠提供 SUID sandbox 的已知限制。deb 不继承该参数，
+# 而是通过 afterInstall 尝试配置 /opt/Proma/chrome-sandbox。
+appImage:
+  executableArgs:
+    - --no-sandbox
+
+deb:
+  packageName: proma
+  afterInstall: resources/linux/deb-after-install.sh
+  # 以 Ubuntu 22.04 为首个支持目标；显式声明，避免 electron-builder 的历史默认
+  # 依赖（如已废弃的 gconf2/libappindicator1）进入新包。
+  depends:
+    - libasound2
+    - libatk-bridge2.0-0
+    - libatspi2.0-0
+    - libdrm2
+    - libgbm1
+    - libgtk-3-0
+    - libnss3
+    - libx11-xcb1
+    - libxcomposite1
+    - libxdamage1
+    - libxfixes3
+    - libxkbcommon0
+    - libxrandr2
+    - libxss1
+  artifactName: proma_${version}_${arch}.${ext}
+
+# ============================================
 # 发布配置
 # 每个平台的 build job 通过 --publish always 直接上传到 GitHub Release。
-# electron-builder 会自动创建/复用 Release，并在多架构并行上传时合并 latest-mac.yml。
 # ============================================
 publish:
   provider: github

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.14",
+  "version": "0.19.15",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -133,7 +133,7 @@
     "cmdk": "^1.1.1",
     "concurrently": "^9.2.1",
     "dingtalk-stream-sdk-nodejs": "^2.0.4",
-    "electron": "^43.2.0",
+    "electron": "43.2.0",
     "electron-builder": "^25.1.8",
     "electron-updater": "^6.7.3",
     "electronmon": "^2.0.4",
@@ -181,5 +181,6 @@
   "build": {
     "extends": "electron-builder.yml"
   },
-  "proma": {}
+  "proma": {},
+  "homepage": "https://github.com/proma-ai/Proma"
 }

--- a/apps/electron/resources/linux/deb-after-install.sh
+++ b/apps/electron/resources/linux/deb-after-install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# 为 Debian/Ubuntu 安装包启用 Electron 的 SUID sandbox。
+#
+# chrome-sandbox 必须由 root 拥有并具有 4755 权限才会被 Chromium 使用。deb
+# 安装脚本以 root 身份执行；在只读或 nosuid 文件系统上，保留标准权限失败信息，
+# 不会将应用静默降级为 --no-sandbox。
+set -eu
+
+APP_DIR="/opt/Proma"
+SANDBOX="$APP_DIR/chrome-sandbox"
+
+if [ -f "$SANDBOX" ]; then
+  chown root:root "$SANDBOX"
+  chmod 4755 "$SANDBOX"
+else
+  echo "[Proma] 未找到 chrome-sandbox：$SANDBOX" >&2
+fi
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.18.4",
+      "version": "0.19.15",
       "dependencies": {
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",
@@ -123,7 +123,7 @@
         "cmdk": "^1.1.1",
         "concurrently": "^9.2.1",
         "dingtalk-stream-sdk-nodejs": "^2.0.4",
-        "electron": "^43.2.0",
+        "electron": "43.2.0",
         "electron-builder": "^25.1.8",
         "electron-updater": "^6.7.3",
         "electronmon": "^2.0.4",
@@ -1506,7 +1506,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@43.3.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew=="],
+    "electron": ["electron@43.2.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA=="],
 
     "electron-builder": ["electron-builder@25.1.8", "", { "dependencies": { "app-builder-lib": "25.1.8", "builder-util": "25.1.7", "builder-util-runtime": "9.2.10", "chalk": "^4.1.2", "dmg-builder": "25.1.8", "fs-extra": "^10.1.0", "is-ci": "^3.0.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig=="],
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,0 +1,86 @@
+# Proma Ubuntu / Linux 第一版支持说明
+
+Proma 第一版 Linux 发布目标是 **Ubuntu 22.04 x86_64**，提供：
+
+- `.deb`：Ubuntu/Debian 原生安装包，优先推荐；
+- `AppImage`：便携运行包，适用于不希望安装系统包的用户。
+
+当前不承诺 Fedora/RHEL、Arch、Linux arm64 或其他发行版的完整兼容性。
+
+## 下载与安装
+
+从 [GitHub Releases](https://github.com/proma-ai/Proma/releases) 下载对应版本：
+
+```bash
+# deb：推荐
+sudo apt install ./proma_<版本>_amd64.deb
+
+# AppImage：便携运行
+chmod +x ./Proma-<版本>.AppImage
+./Proma-<版本>.AppImage
+```
+
+`.deb` 安装后可以从应用菜单启动 Proma。AppImage 建议放在用户有写权限的本地目录；从只读目录、网络盘或部分企业挂载目录运行时，应用内更新可能不可用。
+
+## 系统范围
+
+| 系统 | 第一版状态 |
+| --- | --- |
+| Ubuntu 22.04 x86_64 | 目标支持平台 |
+| Ubuntu 24.04 x86_64 | 计划支持，待独立验证 |
+| Debian 12 x86_64 | 计划支持，待独立验证 |
+| Linux arm64 | 未支持 |
+| Fedora / RHEL / Arch | 未承诺 |
+
+应用包会声明并安装需要的运行库。若使用 AppImage，宿主系统通常需要兼容的 GTK、NSS、X11/音频库；FUSE 不可用时可使用 `--appimage-extract-and-run` 作为临时回退方式。
+
+Ubuntu 22.04 与 24.04 的系统包名称不同，不要直接复用其他版本的 `t64` 依赖名。遇到缺少共享库时，应优先通过 `.deb` 安装，让 apt 解析包依赖。
+
+## Chromium sandbox
+
+Proma 不在 Linux 全局关闭 Chromium sandbox。
+
+- `.deb` 安装后脚本会尝试将 `/opt/Proma/chrome-sandbox` 设置为 `root:root` 和 `4755`，以启用 SUID sandbox；
+- AppImage 使用 `--no-sandbox`，这是因为 AppImage 挂载文件系统无法可靠提供 SUID sandbox；
+- 如果 `.deb` 位于 `nosuid` 文件系统，或安装脚本无法设置权限，应用可能无法启动或需要用户显式排查；不建议把 `--no-sandbox` 作为长期默认解决方案。
+
+AppImage 的隔离能力低于正确配置的 `.deb`。Proma 内嵌浏览器处理不可信网页时，优先使用 `.deb` 版本。
+
+## 更新
+
+- AppImage：GitHub Release 提供 `latest-linux.yml` 时，electron-updater 可检查并下载新 AppImage；原文件必须位于可写目录；
+- `.deb`：第一版以重新下载并通过 apt 安装新版为主，后续再提供签名 APT repository；
+- 更新前 Proma 会等待正在运行的 Agent 结束，避免中断任务和写入会话。
+
+## 数据位置
+
+正式版本数据位于：
+
+```text
+~/.proma/
+```
+
+开发模式数据位于：
+
+```text
+~/.proma-dev/
+```
+
+会话、工作区、配置和 Skills 使用 JSON/JSONL 文件保存。迁移前请退出 Proma，并备份对应目录。
+
+Linux 下 `safeStorage` 依赖 GNOME Keyring、KWallet 或其他 Secret Service 实现。无可用系统密钥环时，不建议在共享机器上保存 API Key；请先配置桌面密钥环并重新启动 Proma。
+
+## 第一版验收边界
+
+Linux 第一版代码和发布配置以 Ubuntu 22.04 x86_64 为目标。发布前应在干净环境完成：
+
+1. `bun install --frozen-lockfile`；
+2. AppImage 和 deb 构建；
+3. deb 安装、卸载和升级；
+4. AppImage 启动与更新；
+5. Chat/Agent 流式响应和 JSONL 落盘；
+6. 工作区、Skills、MCP、内嵌终端和内嵌浏览器；
+7. X11 与 Wayland 基本启动；
+8. 中文输入、剪贴板、窗口图标和任务栏关联。
+
+本轮实现阶段不执行 Linux 实机打包、安装或 E2E；上述项目作为后续发布前验收清单。


### PR DESCRIPTION
## Summary

为 Proma 增加第一版 Linux 分发基础，首个目标为 Ubuntu 22.04 x86_64：

- GitHub Release 增加 Ubuntu Linux x64 构建 job；
- 发布 AppImage 与 `.deb`；
- `.deb` 声明 Ubuntu 22.04 运行依赖；
- 不对 Linux 全局关闭 Chromium sandbox；
- `.deb` 安装后尝试配置 `chrome-sandbox` 的 SUID 权限；
- 固定 Electron `43.2.0`，应用版本递增到 `0.19.15`；
- 补充 Linux 安装、安全边界、更新行为和支持范围文档。

## Scope

第一版只承诺 Ubuntu 22.04 x86_64。Ubuntu 24.04、Debian 12、Linux arm64、Fedora/RHEL/Arch 暂不视为已验证支持平台。

AppImage 因其挂载文件系统限制使用 `--no-sandbox`；`.deb` 不继承该参数，而是通过安装后脚本尝试启用 SUID sandbox。

## Validation

已完成：

- JSON 解析；
- Bun lockfile 一致性检查；
- Electron Builder YAML 静态断言；
- GitHub Actions workflow YAML 静态断言；
- deb 安装脚本 `sh -n`；
- `git diff --check`。

按当前任务要求，尚未执行 Linux 实机打包、安装、升级、Wayland/X11 或 Chat/Agent E2E 验证。这些内容已列入 `docs/linux.md` 的发布前验收清单。

## Files

- `.github/workflows/release.yml`
- `apps/electron/electron-builder.yml`
- `apps/electron/resources/linux/deb-after-install.sh`
- `apps/electron/package.json`
- `bun.lock`
- `docs/linux.md`
- `README.md`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
