### PR TITLE
Perf: make project root I/O asynchronous

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.14",
+  "version": "0.19.15",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -310,6 +310,7 @@ import { calculateStorageStats, cleanupStorage, cleanupTempFiles } from './lib/s
 import type { CleanupOptions } from './lib/storage-service'
 import {
   listAgentWorkspaces,
+  listAgentWorkspacesWithProjectRootStatus,
   createAgentWorkspace,
   updateAgentWorkspace,
   relinkAgentWorkspaceProjectRoot,
@@ -2730,7 +2731,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_WORKSPACES,
     async (): Promise<AgentWorkspace[]> => {
-      const workspaces = listAgentWorkspaces()
+      const workspaces = await listAgentWorkspacesWithProjectRootStatus()
       for (const workspace of workspaces) {
         if (workspace.projectRootPath) watchAttachedDirectory(workspace.projectRootPath)
         for (const filePath of getWorkspaceAttachedFiles(workspace.slug)) {
@@ -2745,7 +2746,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.CREATE_WORKSPACE,
     async (_, input: import('@proma/shared').CreateAgentWorkspaceInput): Promise<AgentWorkspace> => {
-      const workspace = createAgentWorkspace(input)
+      const workspace = await createAgentWorkspace(input)
       if (workspace.projectRootPath) watchAttachedDirectory(workspace.projectRootPath)
       return workspace
     }
@@ -2755,7 +2756,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.CREATE_PROJECT,
     async (_, input: import('@proma/shared').CreateAgentWorkspaceInput, channelId?: string, modelId?: string): Promise<import('@proma/shared').CreateAgentProjectResult> => {
-      const workspace = createAgentWorkspace(input)
+      const workspace = await createAgentWorkspace(input)
       if (workspace.projectRootPath) watchAttachedDirectory(workspace.projectRootPath)
 
       try {
@@ -2788,7 +2789,7 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.RELINK_WORKSPACE_PROJECT_ROOT,
     async (_, id: string, projectRootPath: string): Promise<AgentWorkspace> => {
       const previousRoot = getAgentWorkspace(id)?.projectRootPath
-      const updated = relinkAgentWorkspaceProjectRoot(id, projectRootPath)
+      const updated = await relinkAgentWorkspaceProjectRoot(id, projectRootPath)
       if (previousRoot && previousRoot !== updated.projectRootPath) {
         releaseDirectoryWatcherIfUnreferenced(previousRoot)
       }
@@ -2801,7 +2802,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.RESTORE_WORKSPACE_PROJECT_ROOT,
     async (_, id: string): Promise<AgentWorkspace> => {
-      const updated = restoreAgentWorkspaceProjectRoot(id)
+      const updated = await restoreAgentWorkspaceProjectRoot(id)
       if (updated.projectRootPath) watchAttachedDirectory(updated.projectRootPath)
       return updated
     }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -17,7 +17,6 @@
 import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
-import { accessSync, constants, existsSync, mkdirSync, realpathSync } from 'node:fs'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
 import { app } from 'electron'
 import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, AgentActiveSessionSnapshot, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, SDKMessage, SDKAssistantMessage, AgentStreamPayload, AgentAssistantDeltaPayload, RewindSessionResult, SkillActivation } from '@proma/shared'
@@ -51,7 +50,8 @@ import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, removeSDKErrorMessage, updateSDKUserMessageSkillActivations, rewindPiAgentSession, resolveAgentCwd, getActiveWorktreePath, getAgentCwdMode, getSessionWorkbenchLayout } from './agent-session-manager'
-import { getAgentWorkspace, getLocalProjectRootStatus, getProjectFilesPath, getWorkspaceMcpConfig, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles, getWorkspaceAgentsMdPath, readWorkspaceAgentsMd, getWorkspaceMemoryGuidance, isWorkspaceProjectKnowledgeMaintenanceApproved } from './agent-workspace-manager'
+import { getAgentWorkspace, getProjectFilesPath, getWorkspaceMcpConfig, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles, getWorkspaceAgentsMdPath, readWorkspaceAgentsMd, getWorkspaceMemoryGuidance, isWorkspaceProjectKnowledgeMaintenanceApproved } from './agent-workspace-manager'
+import { getLocalProjectRootStatus } from './project-root-health'
 import { getMcpOAuthHeaders } from './mcp-oauth-service'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceSkillsDir } from './config-paths'
 import { getRuntimeStatus } from './runtime-init'
@@ -209,23 +209,6 @@ function createLocalProjectRootUnavailableError(projectRootPath: string, status?
   error.code = LOCAL_PROJECT_ROOT_UNAVAILABLE_CODE
   error.details = status ? [`目录状态: ${status}`] : undefined
   return error
-}
-
-/** 验证本地项目根，并返回用于跨会话比较的真实规范化路径。 */
-function resolveLocalProjectRootForRewind(projectRootPath: string): string {
-  const status = getLocalProjectRootStatus(projectRootPath)
-  if (status !== 'available') {
-    throw createLocalProjectRootUnavailableError(projectRootPath, status)
-  }
-
-  try {
-    accessSync(projectRootPath, constants.R_OK | constants.W_OK | constants.X_OK)
-    const realRoot = realpathSync(projectRootPath)
-    const normalizedRoot = normalizePathForCompare(realRoot) || realRoot
-    return process.platform === 'win32' ? normalizedRoot.toLowerCase() : normalizedRoot
-  } catch {
-    throw createLocalProjectRootUnavailableError(projectRootPath, 'unavailable')
-  }
 }
 
 // ===== AgentOrchestrator =====
@@ -818,7 +801,7 @@ export class AgentOrchestrator {
         return
       }
 
-      const projectRootStatus = getLocalProjectRootStatus(workspace.projectRootPath)
+      const projectRootStatus = await getLocalProjectRootStatus(workspace.projectRootPath)
       if (projectRootStatus && projectRootStatus !== 'available') {
         reportPreflightError({
           code: 'local_project_root_unavailable',
@@ -2252,29 +2235,6 @@ export class AgentOrchestrator {
   /** 是否存在任意运行中 Agent（含后台运行与外部触发的会话）。 */
   hasActiveSessions(): boolean {
     return this.activeSessions.size > 0
-  }
-
-  /** 同一个真实本地项目根只能由一个运行中会话执行文件回退。 */
-  private hasOtherActiveSessionForLocalProjectRoot(sessionId: string, localProjectRoot: string): boolean {
-    for (const activeSessionId of this.activeSessions.keys()) {
-      if (activeSessionId === sessionId) continue
-
-      const activeSessionMeta = getAgentSessionMeta(activeSessionId)
-      if (!activeSessionMeta?.workspaceId) continue
-
-      const activeWorkspace = getAgentWorkspace(activeSessionMeta.workspaceId)
-      if (!activeWorkspace?.projectRootPath) continue
-
-      try {
-        if (resolveLocalProjectRootForRewind(activeWorkspace.projectRootPath) === localProjectRoot) {
-          return true
-        }
-      } catch {
-        // 运行中的会话已通过启动时校验；若其根后来不可用，无法安全比较，跳过即可。
-      }
-    }
-
-    return false
   }
 
   /**

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -11,7 +11,8 @@
  */
 
 import { dirname, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path'
-import { accessSync, constants, existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdir as mkdirAsync, writeFile as writeFileAsync } from 'node:fs/promises'
 import { BrowserWindow } from 'electron'
 import type { WebContents } from 'electron'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
@@ -41,7 +42,8 @@ import { PiUtilityAdapter } from './adapters/pi-utility-adapter'
 import { AgentEventBus } from './agent-event-bus'
 import { AgentOrchestrator } from './agent-orchestrator'
 import { getAgentSessionWorkspacePath } from './config-paths'
-import { getAgentWorkspaceBySlug, getLocalProjectRootStatus, getProjectFilesPath } from './agent-workspace-manager'
+import { getAgentWorkspaceBySlug, getProjectFilesPath } from './agent-workspace-manager'
+import { getLocalProjectRootStatus } from './project-root-health'
 import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-manager'
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
 import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
@@ -750,21 +752,50 @@ function resolveSafeWorkspaceFilePath(workspaceRoot: string, filename: string): 
  *
  * 空白项目写入 Proma 托管的 workspace-files/；本地目录项目直接写入用户选择的原始目录。
  */
-export function saveFilesToWorkspaceFiles(input: AgentSaveWorkspaceFilesInput): AgentSavedFile[] {
+function isFileAlreadyExistsError(error: unknown): boolean {
+  return !!error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST'
+}
+
+async function writeUniqueWorkspaceFile(
+  workspaceFilesDir: string,
+  initialTargetPath: string,
+  buffer: Buffer,
+  usedPaths: Set<string>,
+): Promise<string> {
+  const relativeFilename = relative(workspaceFilesDir, initialTargetPath)
+  const dotIdx = relativeFilename.lastIndexOf('.')
+  const baseName = dotIdx > 0 ? relativeFilename.slice(0, dotIdx) : relativeFilename
+  const ext = dotIdx > 0 ? relativeFilename.slice(dotIdx) : ''
+
+  for (let counter = 0; ; counter++) {
+    const filename = counter === 0 ? relativeFilename : `${baseName}-${counter}${ext}`
+    const targetPath = resolveSafeWorkspaceFilePath(workspaceFilesDir, filename)
+    if (usedPaths.has(targetPath)) continue
+
+    await mkdirAsync(dirname(targetPath), { recursive: true })
+    try {
+      // `wx` 确保另一条 IPC 请求不会在碰撞检查与写入之间覆盖文件；
+      // 若目标已存在，则尝试下一个编号后缀。
+      await writeFileAsync(targetPath, buffer, { flag: 'wx' })
+      usedPaths.add(targetPath)
+      return targetPath
+    } catch (error) {
+      if (isFileAlreadyExistsError(error)) continue
+      throw error
+    }
+  }
+}
+
+export async function saveFilesToWorkspaceFiles(input: AgentSaveWorkspaceFilesInput): Promise<AgentSavedFile[]> {
   const workspace = getAgentWorkspaceBySlug(input.workspaceSlug)
   if (!workspace) {
     throw new Error(`指定的 Agent 项目不存在或已删除: ${input.workspaceSlug}`)
   }
 
   if (workspace.projectRootPath) {
-    const status = getLocalProjectRootStatus(workspace.projectRootPath)
+    const status = await getLocalProjectRootStatus(workspace.projectRootPath)
     if (status !== 'available') {
       throw createLocalProjectRootUnavailableError(workspace.projectRootPath, status)
-    }
-    try {
-      accessSync(workspace.projectRootPath, constants.R_OK | constants.W_OK | constants.X_OK)
-    } catch {
-      throw createLocalProjectRootUnavailableError(workspace.projectRootPath, 'unavailable')
     }
   }
 
@@ -783,28 +814,8 @@ export function saveFilesToWorkspaceFiles(input: AgentSaveWorkspaceFilesInput): 
   const results: AgentSavedFile[] = []
   const usedPaths = new Set<string>()
 
-  for (const { file, initialTargetPath, buffer } of decodedFiles) {
-    let targetPath = initialTargetPath
-
-    // 防止同名文件覆盖
-    if (usedPaths.has(targetPath) || existsSync(targetPath)) {
-      const relativeFilename = relative(wsFilesDir, targetPath)
-      const dotIdx = relativeFilename.lastIndexOf('.')
-      const baseName = dotIdx > 0 ? relativeFilename.slice(0, dotIdx) : relativeFilename
-      const ext = dotIdx > 0 ? relativeFilename.slice(dotIdx) : ''
-      let counter = 1
-      let candidate = resolveSafeWorkspaceFilePath(wsFilesDir, `${baseName}-${counter}${ext}`)
-      while (usedPaths.has(candidate) || existsSync(candidate)) {
-        counter++
-        candidate = resolveSafeWorkspaceFilePath(wsFilesDir, `${baseName}-${counter}${ext}`)
-      }
-      targetPath = candidate
-    }
-    usedPaths.add(targetPath)
-
-    mkdirSync(dirname(targetPath), { recursive: true })
-    writeFileSync(targetPath, buffer)
-
+  for (const { initialTargetPath, buffer } of decodedFiles) {
+    const targetPath = await writeUniqueWorkspaceFile(wsFilesDir, initialTargetPath, buffer, usedPaths)
     const actualFilename = relative(wsFilesDir, targetPath)
     results.push({ filename: actualFilename, targetPath })
     console.log(`[Agent 服务] 工作区文件已保存: ${targetPath} (${buffer.length} bytes)`)

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -6,10 +6,11 @@
  * - 工作区目录：~/.proma/agent-workspaces/{slug}/（Agent 的 cwd）
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, mkdirSync, statSync, lstatSync, openSync, readSync, closeSync, realpathSync, accessSync, constants } from 'node:fs'
-import { cp as cpAsync, readFile as readFileAsync, writeFile as writeFileAsync } from 'node:fs/promises'
+import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, mkdirSync, statSync, lstatSync, openSync, readSync, closeSync, realpathSync } from 'node:fs'
+import { cp as cpAsync, readFile as readFileAsync, realpath as realpathAsync, writeFile as writeFileAsync } from 'node:fs/promises'
 import type { Dirent } from 'node:fs'
 import { rmSyncWithRetry, renameIfDestinationAbsentWithRetry, renameWithRetry } from './fs-retry'
+import { getLocalProjectRootStatus } from './project-root-health'
 import { writeJsonFileAtomic, readJsonFileSafe, writeTextFileAtomic } from './safe-file'
 import { randomUUID } from 'node:crypto'
 import { join, resolve, relative, isAbsolute, dirname, basename } from 'node:path'
@@ -30,7 +31,7 @@ import { findAllGitRoots, normalizeGitRoot } from './git-diff-service'
 import { listBuiltinMcpServers } from './builtin-mcp/catalog'
 import { RESERVED_BUILTIN_KEYS } from './builtin-mcp/baseline'
 import { inferMcpTransportType, normalizeMcpTransportType } from '@proma/shared'
-import type { AgentWorkspace, CreateAgentWorkspaceInput, LocalProjectRootStatus, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent, WorkspaceMemorySummary, BulkImportSkillItemResult, BulkImportSkillsResult, BulkImportWorkspaceSelection } from '@proma/shared'
+import type { AgentWorkspace, CreateAgentWorkspaceInput, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent, WorkspaceMemorySummary, BulkImportSkillItemResult, BulkImportSkillsResult, BulkImportWorkspaceSelection } from '@proma/shared'
 
 interface AgentWorkspacesIndex {
   version: number
@@ -154,36 +155,45 @@ function slugify(name: string, existingSlugs: Set<string>): string {
 
 export function listAgentWorkspaces(): AgentWorkspace[] {
   const index = readIndex()
-  return index.workspaces.map(withProjectRootStatus)
+  // 根目录状态只能通过异步 I/O 取得；这里保持索引读取的纯同步语义，供
+  // 不需要展示状态的内部调用复用，避免一次列表操作扫描所有外部项目根。
+  return index.workspaces.map((workspace) => ({ ...workspace }))
 }
 
 /** 按 updatedAt 降序（桥接/飞书列表等与旧版内联 sort 一致；渲染进程仍用 listAgentWorkspaces） */
 export function listAgentWorkspacesByUpdatedAt(): AgentWorkspace[] {
-  const index = readIndex()
-  return index.workspaces.map(withProjectRootStatus).sort((a, b) => b.updatedAt - a.updatedAt)
+  return listAgentWorkspaces().sort((a, b) => b.updatedAt - a.updatedAt)
 }
 
-/**
- * 同步检查用户选择的本地项目根。该状态用于运行前硬阻断和工作区列表提示，
- * 不依赖目录 watcher，避免把临时监听失败误报为项目根丢失。
- */
-export function getLocalProjectRootStatus(projectRootPath: string | undefined): LocalProjectRootStatus | undefined {
-  if (!projectRootPath) return undefined
-  if (!existsSync(projectRootPath)) return 'missing'
+const PROJECT_ROOT_STATUS_CONCURRENCY = 4
 
-  try {
-    if (!statSync(projectRootPath).isDirectory()) return 'not_directory'
-    accessSync(projectRootPath, constants.R_OK | constants.W_OK | constants.X_OK)
-    return 'available'
-  } catch {
-    return 'unavailable'
-  }
+async function mapWithConcurrency<T, U>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<U>,
+): Promise<U[]> {
+  const results = new Array<U>(items.length)
+  let nextIndex = 0
+  const workerCount = Math.min(concurrency, items.length)
+
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const currentIndex = nextIndex++
+      if (currentIndex >= items.length) return
+      results[currentIndex] = await mapper(items[currentIndex]!)
+    }
+  }))
+
+  return results
 }
 
-/** 为 IPC/展示调用附加即时状态，绝不修改磁盘索引中的工作区记录。 */
-function withProjectRootStatus(workspace: AgentWorkspace): AgentWorkspace {
-  const projectRootStatus = getLocalProjectRootStatus(workspace.projectRootPath)
-  return projectRootStatus ? { ...workspace, projectRootStatus } : { ...workspace }
+/** 为 IPC/展示调用异步附加即时状态，绝不修改磁盘索引中的工作区记录。 */
+export async function listAgentWorkspacesWithProjectRootStatus(): Promise<AgentWorkspace[]> {
+  const workspaces = listAgentWorkspaces()
+  return mapWithConcurrency(workspaces, PROJECT_ROOT_STATUS_CONCURRENCY, async (workspace) => {
+    const projectRootStatus = await getLocalProjectRootStatus(workspace.projectRootPath)
+    return projectRootStatus ? { ...workspace, projectRootStatus } : workspace
+  })
 }
 
 /** 按指定 ID 顺序重排工作区，未列出的追加到末尾 */
@@ -253,29 +263,20 @@ function copyDefaultSkills(workspaceSlug: string, options: { throwOnError?: bool
   }
 }
 
-export function createAgentWorkspace(input: string | CreateAgentWorkspaceInput): AgentWorkspace {
+export async function createAgentWorkspace(input: string | CreateAgentWorkspaceInput): Promise<AgentWorkspace> {
   const { name, projectRootPath } = typeof input === 'string'
     ? { name: input, projectRootPath: undefined }
     : input
-  const index = readIndex()
-
-  const duplicate = index.workspaces.find((w) => w.name === name)
-  if (duplicate) {
-    throw new Error(`项目名称「${name}」已存在`)
-  }
-
-  const existingSlugs = new Set(index.workspaces.map((w) => w.slug))
-  const slug = slugify(name, existingSlugs)
-  const now = Date.now()
   let normalizedProjectRootPath: string | undefined
 
   if (projectRootPath) {
     try {
-      normalizedProjectRootPath = realpathSync(resolve(projectRootPath))
-      if (!statSync(normalizedProjectRootPath).isDirectory()) {
+      normalizedProjectRootPath = await realpathAsync(resolve(projectRootPath))
+      const status = await getLocalProjectRootStatus(normalizedProjectRootPath)
+      if (status === 'not_directory') {
         throw new Error('选择的路径不是文件夹')
       }
-      if (getLocalProjectRootStatus(normalizedProjectRootPath) !== 'available') {
+      if (status !== 'available') {
         throw new Error('选择的文件夹不可访问')
       }
     } catch (error) {
@@ -284,6 +285,17 @@ export function createAgentWorkspace(input: string | CreateAgentWorkspaceInput):
     }
   }
 
+  // 路径校验包含 await，必须在完成后才读取索引并进入无 await 的写入临界区。
+  // 这样并发创建/重连不会用过期索引覆盖其他工作区变更。
+  const index = readIndex()
+  const duplicate = index.workspaces.find((w) => w.name === name)
+  if (duplicate) {
+    throw new Error(`项目名称「${name}」已存在`)
+  }
+
+  const existingSlugs = new Set(index.workspaces.map((w) => w.slug))
+  const slug = slugify(name, existingSlugs)
+  const now = Date.now()
   const workspace: AgentWorkspace = {
     id: randomUUID(),
     name,
@@ -315,14 +327,14 @@ export function createAgentWorkspace(input: string | CreateAgentWorkspaceInput):
   writeIndex(index)
 
   console.log(`[Agent 工作区] 已创建工作区: ${name} (slug: ${slug})`)
-  return workspace
+  return normalizedProjectRootPath ? { ...workspace, projectRootStatus: 'available' } : workspace
 }
 
 /** 更新工作区名称（slug 和目录不变） */
-export function updateAgentWorkspace(
+export async function updateAgentWorkspace(
   id: string,
   updates: { name: string },
-): AgentWorkspace {
+): Promise<AgentWorkspace> {
   const index = readIndex()
   const idx = index.workspaces.findIndex((w) => w.id === id)
 
@@ -347,28 +359,32 @@ export function updateAgentWorkspace(
   writeIndex(index)
 
   console.log(`[Agent 工作区] 已更新工作区: ${updated.name} (${updated.id})`)
-  return withProjectRootStatus(updated)
+  const projectRootStatus = await getLocalProjectRootStatus(updated.projectRootPath)
+  return projectRootStatus ? { ...updated, projectRootStatus } : updated
 }
 
 /** 将本地项目重新关联到一个已有文件夹，保留项目、会话与配置。 */
-export function relinkAgentWorkspaceProjectRoot(id: string, projectRootPath: string): AgentWorkspace {
-  const index = readIndex()
-  const idx = index.workspaces.findIndex((workspace) => workspace.id === id)
-  if (idx === -1) throw new Error(`项目不存在: ${id}`)
-
+export async function relinkAgentWorkspaceProjectRoot(id: string, projectRootPath: string): Promise<AgentWorkspace> {
   let normalizedProjectRootPath: string
   try {
-    normalizedProjectRootPath = realpathSync(resolve(projectRootPath))
-    if (!statSync(normalizedProjectRootPath).isDirectory()) {
+    normalizedProjectRootPath = await realpathAsync(resolve(projectRootPath))
+    const status = await getLocalProjectRootStatus(normalizedProjectRootPath)
+    if (status === 'not_directory') {
       throw new Error('选择的路径不是文件夹')
     }
-    if (getLocalProjectRootStatus(normalizedProjectRootPath) !== 'available') {
+    if (status !== 'available') {
       throw new Error('选择的文件夹不可访问')
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : '无法访问选择的文件夹'
     throw new Error(`项目文件夹无效: ${message}`)
   }
+
+  // 与创建同理：根路径检查完成后重新读取索引，避免异步等待期间的其他
+  // 工作区写入被旧快照覆盖。
+  const index = readIndex()
+  const idx = index.workspaces.findIndex((workspace) => workspace.id === id)
+  if (idx === -1) throw new Error(`项目不存在: ${id}`)
 
   const updated: AgentWorkspace = {
     ...index.workspaces[idx]!,
@@ -378,25 +394,35 @@ export function relinkAgentWorkspaceProjectRoot(id: string, projectRootPath: str
   index.workspaces[idx] = updated
   writeIndex(index)
   console.log(`[Agent 工作区] 已重新关联项目根: ${updated.name} → ${normalizedProjectRootPath}`)
-  return withProjectRootStatus(updated)
+  return { ...updated, projectRootStatus: 'available' }
 }
 
 /** 在本地项目原路径恢复一个空目录。仅允许路径确实缺失时执行。 */
-export function restoreAgentWorkspaceProjectRoot(id: string): AgentWorkspace {
-  const index = readIndex()
-  const idx = index.workspaces.findIndex((workspace) => workspace.id === id)
-  if (idx === -1) throw new Error(`项目不存在: ${id}`)
+export async function restoreAgentWorkspaceProjectRoot(id: string): Promise<AgentWorkspace> {
+  const initialIndex = readIndex()
+  const initialWorkspace = initialIndex.workspaces.find((workspace) => workspace.id === id)
+  if (!initialWorkspace) throw new Error(`项目不存在: ${id}`)
+  if (!initialWorkspace.projectRootPath) throw new Error('该项目不是本地项目')
 
-  const workspace = index.workspaces[idx]!
-  if (!workspace.projectRootPath) throw new Error('该项目不是本地项目')
-  const status = getLocalProjectRootStatus(workspace.projectRootPath)
+  const projectRootPath = initialWorkspace.projectRootPath
+  const status = await getLocalProjectRootStatus(projectRootPath)
   if (status !== 'missing') {
     throw new Error('只能恢复已缺失的本地项目根目录')
   }
 
-  mkdirSync(workspace.projectRootPath, { recursive: true })
-  console.log(`[Agent 工作区] 已在原路径恢复空项目根: ${workspace.projectRootPath}`)
-  return withProjectRootStatus(workspace)
+  // 根状态检查会让出事件循环；恢复前重新读取索引，拒绝对等待期间已删除
+  // 或已重新关联的项目根产生副作用。mkdir 保持原有同步语义，避免检查后
+  // 再次让出事件循环而在旧路径创建目录。
+  const latestIndex = readIndex()
+  const latestWorkspace = latestIndex.workspaces.find((workspace) => workspace.id === id)
+  if (!latestWorkspace) throw new Error('项目已删除，无法恢复原项目根目录')
+  if (latestWorkspace.projectRootPath !== projectRootPath) {
+    throw new Error('项目根目录已变更，请重试恢复操作')
+  }
+
+  mkdirSync(projectRootPath, { recursive: true })
+  console.log(`[Agent 工作区] 已在原路径恢复空项目根: ${projectRootPath}`)
+  return { ...latestWorkspace, projectRootStatus: 'available' }
 }
 
 /** 删除工作区索引条目及其本地目录 */

--- a/apps/electron/src/main/lib/project-root-health.ts
+++ b/apps/electron/src/main/lib/project-root-health.ts
@@ -1,0 +1,44 @@
+import { constants } from 'node:fs'
+import { access, stat } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export type ProjectRootHealthStatus = 'available' | 'missing' | 'not_directory' | 'unavailable'
+
+const projectRootStatusChecks = new Map<string, Promise<ProjectRootHealthStatus>>()
+
+function statusCheckKey(projectRootPath: string): string {
+  return resolve(projectRootPath)
+}
+
+async function checkProjectRootStatus(projectRootPath: string): Promise<ProjectRootHealthStatus> {
+  try {
+    const stats = await stat(projectRootPath)
+    if (!stats.isDirectory()) return 'not_directory'
+    await access(projectRootPath, constants.R_OK | constants.W_OK | constants.X_OK)
+    return 'available'
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined
+    return code === 'ENOENT' || code === 'ENOTDIR' ? 'missing' : 'unavailable'
+  }
+}
+
+/**
+ * 异步检查用户选择的本地项目根。相同路径的并发检查共享同一 Promise，
+ * 防止工作区列表、Agent 预检和文件保存同时触发重复的慢速文件系统请求。
+ */
+export function getLocalProjectRootStatus(projectRootPath: string | undefined): Promise<ProjectRootHealthStatus | undefined> {
+  if (!projectRootPath) return Promise.resolve(undefined)
+
+  const key = statusCheckKey(projectRootPath)
+  const existing = projectRootStatusChecks.get(key)
+  if (existing) return existing
+
+  const check = checkProjectRootStatus(projectRootPath)
+  projectRootStatusChecks.set(key, check)
+  void check.finally(() => {
+    if (projectRootStatusChecks.get(key) === check) {
+      projectRootStatusChecks.delete(key)
+    }
+  })
+  return check
+}


### PR DESCRIPTION
## Summary

- 将项目根目录的 stat/access/realpath 校验改为异步 single-flight，工作区列表以最多 4 个并发探测根状态。
- Agent preflight 与保存工作区文件均等待真实根目录检查；工作区文件写入使用 async mkdir/writeFile 与 wx 排他创建，避免并发同名覆盖。
- 在异步路径校验后再读取工作区索引，避免陈旧快照覆盖并发更新；恢复缺失根目录前重新核对当前项目根。

## Performance

- 无新增 renderer 高频更新、IPC listener 或 timer；项目根状态与工作区文件写入的慢速 I/O 不再占用 Electron main JS 线程。
- 项目指令解析、watcher、session JSONL 和附件 base64 仍是后续批次范围。

## Validation

- `bun run typecheck`
- `bun run --filter @proma/electron build:main`
- 新增监测与测试文件按维护者要求未保留；Windows SMB/NAS 场景待设备验证。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)