### PR TITLE
feat(tabs): support mouse wheel scrolling in workspace tabs

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -169,6 +169,20 @@ export function DiffPanelTabBar({
     return () => tabList.removeEventListener('scroll', syncScrollbarThumb)
   }, [syncScrollbarThumb])
 
+  // 右侧 Tab 栏只有横向溢出；让普通滚轮与 Shift + 滚轮都直接横向浏览标签。
+  React.useEffect(() => {
+    const tabList = tabListRef.current
+    if (!tabList) return
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault()
+      tabList.scrollLeft += event.deltaY || event.deltaX
+    }
+
+    tabList.addEventListener('wheel', handleWheel, { passive: false })
+    return () => tabList.removeEventListener('wheel', handleWheel)
+  }, [])
+
   const handleScrollbarThumbPointerDown = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     const tabList = tabListRef.current
     const track = scrollbarTrackRef.current


### PR DESCRIPTION
## Summary

- Allow a standard mouse-wheel scroll over the right workspace Tab bar to browse tabs horizontally.
- Preserve existing Shift + scroll and trackpad horizontal-scroll behavior.

## Validation

- `bun run --cwd apps/electron typecheck`
- `bun run --cwd apps/electron build:renderer`
- `git diff --check`
- Manual desktop interaction confirmed by ErlichLiu before submission.

## Performance

- The non-passive wheel listener is scoped to the Tab list and only updates `scrollLeft`; it introduces no React state updates, IPC, timers, or subscriptions.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
