### PR TITLE
Fix scene sound effect re-enable UX

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.15",
+  "version": "0.19.16",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -581,11 +581,11 @@ function SoundLibrary({ sounds, disabled, onSoundChange }: SoundLibraryProps): R
           type="button"
           disabled={disabled}
           aria-pressed={currentId === 'none'}
-          onClick={() => onSoundChange(activeType, 'none')}
-          className="inline-flex min-h-8 items-center gap-1.5 px-3 text-xs text-muted-foreground transition-colors hover:bg-muted/45 hover:text-foreground"
+          onClick={() => onSoundChange(activeType, currentId === 'none' ? DEFAULT_NOTIFICATION_SOUNDS[activeType] : 'none')}
+          className="inline-flex min-h-8 items-center gap-1.5 px-3 text-xs text-muted-foreground transition-colors hover:bg-muted/45 hover:text-foreground active:scale-[0.96]"
         >
           <Volume2 className="size-3.5" />
-          {currentId === 'none' ? '已关闭此场景音效' : '关闭此场景音效'}
+          {currentId === 'none' ? '恢复默认音效' : '关闭此场景音效'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make the scene sound button restore the default sound when the scene is disabled
- clarify the disabled-state label instead of presenting a non-actionable status
- add pressed-state feedback and bump the Electron app version to 0.19.16

## Validation
- `bun install --frozen-lockfile`
- `bun run --filter="@proma/electron" typecheck`
- `bun run --filter="@proma/electron" build:renderer`
- `git diff --check`

## Performance
This is a single-click renderer interaction using the existing settings update path. It adds no listeners, timers, subscriptions, IPC channels, or continuous rendering work.

Closes #1809

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)