### PR TITLE
Fix macOS terminal readback and agnoster glyphs

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.15",
+  "version": "0.19.16",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/terminal-output-buffer.ts
+++ b/apps/electron/src/main/lib/terminal-output-buffer.ts
@@ -100,14 +100,19 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /**
- * PTY 输出含颜色、窗口标题、光标移动等控制序列，直接交给模型会降低可读性。
- * 保留换行；孤立 \r 转为换行以让进度刷新仍有可检索文本。
+ * PTY 输出含颜色、窗口标题、光标移动和 ZLE 重绘控制序列，直接交给模型会降低可读性。
+ * 这是可读文本摘要而非终端模拟器：保留真实换行，但忽略孤立 \r 与其他光标操作，
+ * 防止交互行重绘被误表现为多行命令回显。
  */
 function normalizeTerminalText(output: string): string {
   return output
     .replace(/\u001B\][\s\S]*?(?:\u0007|\u001B\\)/g, '') // OSC（如窗口标题）
+    .replace(/\u001BP[\s\S]*?\u001B\\/g, '') // DCS（如光标样式请求）
     .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, '') // CSI（颜色、光标、清屏等）
-    .replace(/\u001B[()][0-?]*[ -/]*[@-~]/g, '') // charset 切换
-    .replace(/\u0000/g, '')
-    .replace(/\r(?!\n)/g, '\n')
+    .replace(/\u001B[()][0-?]*[ -/]*[@-~]/g, '') // 字符集切换
+    .replace(/\u001B[=>78DEHMNOVWXYZc]/g, '') // ESC 单字符控制（如 zsh 的 keypad mode）
+    .replace(/\u001B(?:[ -/][0-~]?|[0-~])?/g, '') // 残留或不完整 ESC 序列
+    .replace(/\r\n/g, '\n')
+    .replace(/[\u0000-\u0008\u000B-\u001A\u001C-\u001F\u007F]/g, '')
+    .replace(/\r/g, '')
 }

--- a/apps/electron/src/renderer/components/tabs/TerminalTabContent.tsx
+++ b/apps/electron/src/renderer/components/tabs/TerminalTabContent.tsx
@@ -6,6 +6,21 @@ import '@xterm/xterm/css/xterm.css'
 import { detectIsWindows } from '@/lib/platform'
 import { getWindowsPtyOptions } from '@/lib/terminal-windows-pty'
 
+// 保持系统等宽字体的字形度量；仅在 Powerline 私有区字符缺字时回退到 Nerd Font。
+const TERMINAL_FONT_FALLBACKS = [
+  'ui-monospace',
+  'SFMono-Regular',
+  'Menlo',
+  'Monaco',
+  'Consolas',
+  '"MesloLGS NF"',
+  '"JetBrainsMono Nerd Font"',
+  '"JetBrains Mono Nerd Font"',
+  '"FiraCode Nerd Font"',
+  '"Fira Code Nerd Font"',
+  'monospace',
+].join(', ')
+
 export interface TerminalTabContentProps {
   terminalId: string
   sessionId: string
@@ -36,7 +51,7 @@ export function TerminalTabContent({ terminalId, sessionId, cwd, terminateOnUnmo
       // ConPTY 已经负责终端行布局；固定保守 build 让 xterm.js 使用 Windows 的
       // 兼容路径，避免 resize 或输入回车时与 ConPTY 重复重排而导致光标上跳。
       reflowCursorLine: false,
-      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+      fontFamily: TERMINAL_FONT_FALLBACKS,
       fontSize: 13,
       lineHeight: 1.25,
       scrollback: 5_000,

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.19.15",
+      "version": "0.19.16",
       "dependencies": {
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",


### PR DESCRIPTION
## Summary
- normalize zsh/ZLE control sequences and lone carriage returns before terminal output is read back
- retain system terminal typography while falling back to Nerd Fonts for missing Powerline glyphs
- bump Electron version to 0.19.16

## Validation
- `bun run --filter=@proma/electron typecheck`
- `bun run --filter=@proma/electron build:main`
- `bun run --filter=@proma/electron build:renderer`
- macOS + oh-my-zsh agnoster manual visual verification

## Performance
The font fallback list is static at terminal creation; it adds no IPC, subscriptions, listeners, or terminal rebuilds.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)