### PR TITLE
feat(vault): 支持折叠 Vault 文件目录【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.16",
+  "version": "0.19.17",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/vault/VaultView.tsx
+++ b/apps/electron/src/renderer/components/vault/VaultView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { BookOpen, ChevronDown, ChevronRight, ChevronsUpDown, CircleHelp, Folder, FolderOpen, Loader2, Plus, Trash2 } from 'lucide-react'
+import { BookOpen, ChevronDown, ChevronLeft, ChevronRight, ChevronsUpDown, CircleHelp, Folder, FolderOpen, Loader2, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import type { VaultCandidate, VaultFileEntry, VaultFocus, VaultReadResult, VaultSummary } from '@proma/shared'
 import { Button } from '@/components/ui/button'
@@ -42,6 +42,7 @@ import { cn } from '@/lib/utils'
 import { getVaultEditorKey } from './vault-editor-lifecycle'
 import { getVaultDocumentController } from './vault-document-controller'
 import { buildVaultTree, getInitialVaultExpandedFolders, getVaultFolderAncestors, hasSameVaultTreeEntries, type VaultFolderNode } from './vault-tree-model'
+import { getVaultSidebarDisplayWidth, getVaultSidebarToggleLabel } from './vault-sidebar-layout'
 
 const VAULT_NAME = 'Vault'
 const VAULT_SIDEBAR_MIN_WIDTH = 180
@@ -588,6 +589,7 @@ function VaultMarkdownPane({
 }
 
 export function VaultView({ embedded = false, sessionId }: { embedded?: boolean; sessionId?: string }): React.ReactElement {
+  const vaultSidebarContentId = React.useId()
   const vaultSessionScope = getVaultSessionScope(sessionId)
   const [config, setConfig] = React.useState<VaultSummary | null>(null)
   const [candidates, setCandidates] = React.useState<VaultCandidate[]>([])
@@ -608,9 +610,13 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   const [newFolderName, setNewFolderName] = React.useState('')
   const [creatingFolder, setCreatingFolder] = React.useState(false)
   const [vaultTreeAction, setVaultTreeAction] = React.useState<{ type: 'expand' | 'collapse'; version: number }>({ type: 'collapse', version: 0 })
+  const [vaultSidebarCollapsed, setVaultSidebarCollapsed] = React.useState(false)
   const [vaultSidebarWidth, setVaultSidebarWidth] = React.useState(embedded ? 200 : 280)
   const vaultSidebarWidthRef = React.useRef(vaultSidebarWidth)
   const vaultSidebarDragCleanupRef = React.useRef<(() => void) | null>(null)
+  const vaultSidebarCollapseButtonRef = React.useRef<HTMLButtonElement>(null)
+  const vaultSidebarExpandButtonRef = React.useRef<HTMLButtonElement>(null)
+  const vaultSidebarFocusTransferRequestedRef = React.useRef(false)
   const selectedFileRef = React.useRef(selectedFile)
   // Keep the ref in sync synchronously with user actions. Refreshes can start
   // before React commits the atom update (notably after rename), so relying on
@@ -637,6 +643,18 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
   React.useEffect(() => {
     vaultSidebarWidthRef.current = vaultSidebarWidth
   }, [vaultSidebarWidth])
+
+  React.useLayoutEffect(() => {
+    if (!vaultSidebarFocusTransferRequestedRef.current) return
+    vaultSidebarFocusTransferRequestedRef.current = false
+    const target = vaultSidebarCollapsed ? vaultSidebarExpandButtonRef : vaultSidebarCollapseButtonRef
+    target.current?.focus()
+  }, [vaultSidebarCollapsed])
+
+  const setVaultSidebarCollapsedWithFocus = React.useCallback((collapsed: boolean): void => {
+    vaultSidebarFocusTransferRequestedRef.current = true
+    setVaultSidebarCollapsed(collapsed)
+  }, [])
 
   React.useEffect(() => () => {
     vaultSidebarDragCleanupRef.current?.()
@@ -972,14 +990,58 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
         {!embedded && <div className="relative z-10 h-[100px] shrink-0 border-b border-border/60 bg-muted/25" />}
         <div className="relative flex min-h-0 flex-1">
           <aside
-            className="relative flex shrink-0 flex-col border-r border-border/50 bg-muted/25"
-            style={{ width: vaultSidebarWidth }}
+            className={cn(
+              'relative flex shrink-0 flex-col overflow-hidden bg-muted/25',
+              !vaultSidebarCollapsed && 'border-r border-border/50',
+            )}
+            style={{ width: getVaultSidebarDisplayWidth(vaultSidebarWidth, vaultSidebarCollapsed) }}
           >
+            {vaultSidebarCollapsed && (
+              <header className={cn('flex h-14 shrink-0 items-center justify-center', embedded ? 'titlebar-no-drag' : 'titlebar-drag-region')}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      ref={vaultSidebarExpandButtonRef}
+                      type="button"
+                      aria-controls={vaultSidebarContentId}
+                      aria-expanded="false"
+                      aria-label={getVaultSidebarToggleLabel(true)}
+                      onClick={() => setVaultSidebarCollapsedWithFocus(false)}
+                      className="titlebar-no-drag flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    >
+                      <ChevronRight size={15} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{getVaultSidebarToggleLabel(true)}</TooltipContent>
+                </Tooltip>
+              </header>
+            )}
+            <div
+              id={vaultSidebarContentId}
+              aria-hidden={vaultSidebarCollapsed}
+              className={cn('min-h-0 flex-1 flex-col', vaultSidebarCollapsed ? 'hidden' : 'flex')}
+            >
               <header className={cn('flex h-14 items-center gap-2 px-3', embedded ? 'titlebar-no-drag' : 'titlebar-drag-region')}>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-[13px] font-medium text-foreground">{config?.displayName ?? '选择 Vault'}</p>
                 </div>
                 <div className="flex items-center gap-0.5 titlebar-no-drag">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        ref={vaultSidebarCollapseButtonRef}
+                        type="button"
+                        aria-controls={vaultSidebarContentId}
+                        aria-expanded="true"
+                        aria-label={getVaultSidebarToggleLabel(false)}
+                        onClick={() => setVaultSidebarCollapsedWithFocus(true)}
+                        className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        <ChevronLeft size={15} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>{getVaultSidebarToggleLabel(false)}</TooltipContent>
+                  </Tooltip>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button
@@ -1081,11 +1143,14 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
                   </PopoverContent>
                 </Popover>
               </div>
-            <div
-              aria-hidden="true"
-              className="titlebar-no-drag absolute right-0 top-0 bottom-0 z-10 w-3 translate-x-1/2 cursor-col-resize"
-              onMouseDown={handleVaultSidebarResizeStart}
-            />
+            </div>
+            {!vaultSidebarCollapsed && (
+              <div
+                aria-hidden="true"
+                className="titlebar-no-drag absolute right-0 top-0 bottom-0 z-10 w-3 translate-x-1/2 cursor-col-resize"
+                onMouseDown={handleVaultSidebarResizeStart}
+              />
+            )}
           </aside>
           <VaultMarkdownPane
             readResult={readResult}
@@ -1155,7 +1220,7 @@ export function VaultView({ embedded = false, sessionId }: { embedded?: boolean;
             </section>
             <section>
               <p className="font-medium text-foreground">浏览与新建笔记</p>
-              <p>点击文件夹可展开或收起；左侧顶部按钮可一键展开或折叠全部文件夹，拖动中间分隔线可调整文件树宽度。右键点击文件夹可在该目录中新建笔记或文件夹。</p>
+              <p>点击文件夹可展开或收起；顶部左箭头可收起整个文件目录，收起后点击靠边的右箭头即可恢复。旁边按钮可一键展开或折叠全部文件夹，拖动中间分隔线可调整文件树宽度。右键点击文件夹可在该目录中新建笔记或文件夹。</p>
             </section>
             <section>
               <p className="font-medium text-foreground">编辑与自动保存</p>

--- a/apps/electron/src/renderer/components/vault/vault-sidebar-layout.ts
+++ b/apps/electron/src/renderer/components/vault/vault-sidebar-layout.ts
@@ -1,0 +1,9 @@
+export const VAULT_SIDEBAR_COLLAPSED_WIDTH = 36
+
+export function getVaultSidebarDisplayWidth(expandedWidth: number, collapsed: boolean): number {
+  return collapsed ? VAULT_SIDEBAR_COLLAPSED_WIDTH : expandedWidth
+}
+
+export function getVaultSidebarToggleLabel(collapsed: boolean): string {
+  return collapsed ? '展开 Vault 文件目录' : '收起 Vault 文件目录'
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.19.16",
+      "version": "0.19.17",
       "dependencies": {
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",


### PR DESCRIPTION
## 概述

为 Proma 的 Vault/Obsidian 页面增加文件目录侧栏折叠能力，让用户在阅读或编辑长文档时可以释放更多横向空间，同时保留快速恢复入口。

## 改动

- `apps/electron/src/renderer/components/vault/VaultView.tsx`
  - 在原有“全部展开/折叠文件树”按钮左侧新增向左三角，用于折叠整个文件目录。
  - 折叠后保留 36px 靠边恢复区域和向右三角，并移除折叠态竖向分隔线。
  - 展开后恢复用户调整过的侧栏宽度，并保持文件夹原有展开状态。
  - 折叠态隐藏 resize handle，避免误触。
  - 使用 `aria-controls`、`aria-expanded`、唯一 DOM ID 和明确标签完善辅助功能。
  - 在两个互斥按钮切换后主动交接键盘焦点，使 Enter/Space 可以连续完成折叠与展开。
  - 更新 Vault 内置帮助文案。
- `apps/electron/src/renderer/components/vault/vault-sidebar-layout.ts`
  - 集中定义 36px 折叠宽度、展示宽度计算及无障碍文案。
- `apps/electron/package.json`、`bun.lock`
  - 将 Electron 应用版本从 `0.19.16` 升级至 `0.19.17` 并同步 lockfile。

## 测试方法

1. 打开 Vault/Obsidian 页面，确认向左三角位于“全部展开/折叠”按钮左侧。
2. 点击向左三角，确认文件目录折叠为靠边的窄恢复区域，右侧分隔线消失，并显示向右三角。
3. 点击向右三角，确认目录恢复，原侧栏宽度及文件夹展开状态保持不变。
4. 使用 Tab 聚焦向左三角并按 Enter，确认焦点自动转移到向右三角；再次按 Enter 可直接展开。
5. 分别检查独立 Vault 页面和 Agent 右侧嵌入式 Vault 页面。

## 验证

- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`
- `git diff --check`

以上检查均已通过。Renderer build 仅保留仓库既有的大 chunk warning。

## 备注

- 未新增依赖、IPC、持久化字段或平台专用逻辑。
- 折叠切换没有动画、滤镜或额外合成层，不引入持续 GPU/compositor 压力。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
