### PR TITLE
feat(pi): load whitelisted Pi extensions in managed runtime

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -146,6 +146,8 @@ export interface PiAgentQueryOptions extends AgentQueryInput {
   /** Proma 聚合的附加目录；Pi 内置工具 factory 不接收多 root 参数，编排层会把它们注入 systemPrompt。 */
   additionalDirectories?: string[]
   additionalSkillPaths?: string[]
+  /** Whitelisted Pi extension paths loaded by the managed Pi resource loader. */
+  additionalExtensionPaths?: string[]
   /** 当前用户输入显式引用的 Skill name（兼容历史 slug 已在编排层归一化） */
   skillMentions?: string[]
   /** Persisted user-message UUID for turn-scoped Skill attribution. */
@@ -1493,7 +1495,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
         cwd,
         agentDir: input.piAgentDir,
         settingsManager,
-        ...createPromaManagedResourceLoaderOptions(),
+        ...createPromaManagedResourceLoaderOptions({ additionalExtensionPaths: input.additionalExtensionPaths }),
         agentsFilesOverride: createPromaProjectInstructionFilesOverride(input.projectInstructionFiles ?? []),
         additionalSkillPaths: input.additionalSkillPaths ?? [],
         skillsOverride: createPromaSkillsOverride(input.additionalSkillPaths),

--- a/apps/electron/src/main/lib/adapters/pi-resource-loader-overrides.ts
+++ b/apps/electron/src/main/lib/adapters/pi-resource-loader-overrides.ts
@@ -11,13 +11,19 @@ export interface PromaProjectInstructionFile {
   content: string
 }
 
-export function createPromaManagedResourceLoaderOptions() {
+export function createPromaManagedResourceLoaderOptions(options?: { additionalExtensionPaths?: string[] }) {
   return {
     noContextFiles: true,
     noExtensions: true,
     noSkills: true,
     // An explicit empty source prevents Pi from discovering APPEND_SYSTEM.md.
     appendSystemPrompt: [],
+    // Whitelisted extensions only: Pi still loads explicit paths when
+    // `noExtensions` is true (resource-loader CLI/temporary path), so the
+    // managed runtime stays free of ambient user/project settings discovery.
+    ...(options?.additionalExtensionPaths?.length
+      ? { additionalExtensionPaths: options.additionalExtensionPaths }
+      : {}),
   }
 }
 


### PR DESCRIPTION
## 动机

Proma 的受管 Pi runtime 目前完全禁止加载 Pi 扩展（`noExtensions: true` 且从不传 `additionalExtensionPaths`），用户无法在 Proma 里使用任何 Pi 扩展。

典型案例：`pi-v4-anchor-all`（DeepSeek trajectory anchor）必须作为 Pi extension 才能 hook `before_provider_request` / `after_provider_response` 去改写 wire 载荷、限制工具集。MCP 只能暴露为普通工具，**无法**表达「请求改写 + 工具集限制」——所以 MCP 不是替代品。

## 改动（最小）

- `createPromaManagedResourceLoaderOptions(options?)`：可选 `additionalExtensionPaths`，只在非空时透传给 Pi `DefaultResourceLoader`。
- `pi-agent-adapter.ts`：接收 `input.additionalExtensionPaths` 并透传。

## 设计约束（保留原来的「受管 runtime 不被 ambient 污染」）

- `noExtensions: true` 保持：既不读 `~/.pi/agent/settings.json` 的用户包，也不读项目级 `.pi` 包。
- 只加载**显式白名单**传入的本地扩展路径。Pi `resource-loader` 在 `noExtensions` 下仍加载 `additionalExtensionPaths`（走 CLI/temporary 通道），所以这个改动不会重新放开 ambient 发现。

## 验证

- `bun run --filter='*' typecheck` 需在依赖安装齐全后跑（本仓库无 node_modules 时无法本地验证，改动仅是字段透传）。
- 后续可在 Proma workspace 配置中接入白名单路径后实测 extension 生命周期钩子。

Closes #1954