### PR TITLE
fix(changes): 清理已删除文件在本会话文件变更中的残留记录

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -7,7 +7,7 @@
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app, clipboard, nativeImage } from 'electron'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { existsSync, realpathSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
-import { writeFile } from 'node:fs/promises'
+import { realpath, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { createHash } from 'node:crypto'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, AGENT_ISLAND_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, VAULT_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare, TERMINAL_IPC_CHANNELS } from '@proma/shared'
@@ -535,6 +535,28 @@ function isPathAllowed(filePath: string, options?: FileAccessOptions): boolean {
   // 保留 realpath 校验以拒绝不存在的目标，但不再按会话附件重复收窄范围。
   if (options?.unrestricted) return true
   return getAuthorizedRoots(options).some((root) => isUnderRoot(resolved, root))
+}
+
+async function getResolvedAuthorizedRoots(options?: FileAccessOptions): Promise<string[]> {
+  const roots = getAuthorizedRoots(options)
+  return Promise.all(roots.map(async (root) => {
+    try {
+      return await realpath(resolve(root))
+    } catch {
+      return resolve(root)
+    }
+  }))
+}
+
+function isResolvedPathAllowed(resolvedPath: string, resolvedRoots: readonly string[]): boolean {
+  return resolvedRoots.some((root) => {
+    const relativePath = relative(root, resolvedPath)
+    return relativePath === '' || (
+      relativePath !== '..'
+      && !relativePath.startsWith(`..${sep}`)
+      && !isAbsolute(relativePath)
+    )
+  })
 }
 
 function normalizeFileAccessOptions(value?: FileAccessOptions | string[]): FileAccessOptions | undefined {
@@ -4133,22 +4155,37 @@ export function registerIpcHandlers(): void {
   )
 
   // 批量检查文件是否仍存在（供渲染端清理已删除的会话文件变更记录）。
-  // 只做 statSync 不读内容；只接受绝对路径，防止借相对路径探测主进程 cwd。
+  // 只接受绝对路径；以有限并发异步执行，避免慢盘或网络路径阻塞 Electron 主进程。
   ipcMain.handle(
     'file:exists-batch',
     async (_, filePaths: unknown, access?: FileAccessOptions | string[]): Promise<string[]> => {
       if (!Array.isArray(filePaths)) return []
       const options = normalizeFileAccessOptions(access)
-      const existing: string[] = []
-      for (const rawPath of filePaths.slice(0, 1000)) {
-        if (typeof rawPath !== 'string' || rawPath.length === 0 || !isAbsolute(rawPath)) continue
-        try {
-          if (statSync(rawPath).isFile() && isPathAllowed(rawPath, options)) existing.push(rawPath)
-        } catch {
-          // 不存在或不可读：视为已删除
+      const candidates = filePaths.slice(0, 1000).filter(
+        (rawPath): rawPath is string => typeof rawPath === 'string' && rawPath.length > 0 && isAbsolute(rawPath),
+      )
+      const resolvedRoots = options?.unrestricted ? [] : await getResolvedAuthorizedRoots(options)
+      const existing = new Array<boolean>(candidates.length).fill(false)
+      let nextIndex = 0
+      const checkNext = async (): Promise<void> => {
+        while (nextIndex < candidates.length) {
+          const index = nextIndex++
+          const filePath = candidates[index]!
+          try {
+            if (!(await stat(filePath)).isFile()) continue
+            if (options?.unrestricted) {
+              existing[index] = true
+              continue
+            }
+            const resolvedPath = await realpath(filePath)
+            existing[index] = isResolvedPathAllowed(resolvedPath, resolvedRoots)
+          } catch {
+            // 不存在、不可读或不在授权路径内：视为已删除。
+          }
         }
       }
-      return existing
+      await Promise.all(Array.from({ length: Math.min(candidates.length, 32) }, checkNext))
+      return candidates.filter((_, index) => existing[index])
     },
   )
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -4132,6 +4132,26 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 批量检查文件是否仍存在（供渲染端清理已删除的会话文件变更记录）。
+  // 只做 statSync 不读内容；只接受绝对路径，防止借相对路径探测主进程 cwd。
+  ipcMain.handle(
+    'file:exists-batch',
+    async (_, filePaths: unknown, access?: FileAccessOptions | string[]): Promise<string[]> => {
+      if (!Array.isArray(filePaths)) return []
+      const options = normalizeFileAccessOptions(access)
+      const existing: string[] = []
+      for (const rawPath of filePaths.slice(0, 1000)) {
+        if (typeof rawPath !== 'string' || rawPath.length === 0 || !isAbsolute(rawPath)) continue
+        try {
+          if (statSync(rawPath).isFile() && isPathAllowed(rawPath, options)) existing.push(rawPath)
+        } catch {
+          // 不存在或不可读：视为已删除
+        }
+      }
+      return existing
+    },
+  )
+
   // 写入文本文件（供 Markdown 内联编辑使用）
   ipcMain.handle(
     'file:write-text',

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -977,6 +977,9 @@ export interface ElectronAPI {
   /** 解析文件路径并读取内容（供内联预览使用） */
   resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<import('@proma/shared').FilePreviewReadResult | null>
 
+  /** 批量检查文件是否仍存在（用于清理已删除的会话文件变更记录） */
+  filterExistingFilePaths: (filePaths: string[], access?: import('@proma/shared').FileAccessOptions) => Promise<string[]>
+
   /** 写入文本文件（供 Markdown 内联编辑使用） */
   writeTextFile: (filePath: string, content: string, access?: import('@proma/shared').FileAccessOptions) => Promise<boolean>
 
@@ -2464,6 +2467,10 @@ const electronAPI: ElectronAPI = {
 
   resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
     return ipcRenderer.invoke('file:resolve-and-read', filePath, access) as Promise<import('@proma/shared').FilePreviewReadResult | null>
+  },
+
+  filterExistingFilePaths: (filePaths: string[], access?: import('@proma/shared').FileAccessOptions) => {
+    return ipcRenderer.invoke('file:exists-batch', filePaths, access) as Promise<string[]>
   },
 
   writeTextFile: (filePath: string, content: string, access?: import('@proma/shared').FileAccessOptions) => {

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -11,10 +11,11 @@ import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
-import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom, agentSessionsAtom, workspaceGitDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentNonGitFileChangesAtom, agentSelectedWorktreeAtom, agentSessionsAtom, workspaceGitDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
 import { WorktreeSelector } from './WorktreeSelector'
-import { groupSessionFileChanges } from '@/lib/session-file-changes'
+import { groupSessionFileChanges, arePathsEqual } from '@/lib/session-file-changes'
+import { detectIsWindows } from '@/lib/platform'
 import type { SessionFileChange } from '@/lib/session-file-changes'
 import { buildDiffFileTree } from './diff-file-tree'
 import type { DiffFileTreeNode } from './diff-file-tree'
@@ -531,7 +532,50 @@ function NonGitChangesList({
   sessionId: string
   onFileClick?: (filePath: string) => void
 }): React.ReactElement {
-  const { current, earlier } = groupSessionFileChanges(changes, currentRunId)
+  const { current, earlier } = React.useMemo(
+    () => groupSessionFileChanges(changes, currentRunId),
+    [changes, currentRunId],
+  )
+  const setNonGitFileChanges = useSetAtom(agentNonGitFileChangesAtom)
+  /** 已校验过存在性的路径；组件存活期内同一路径不重复发起 IPC。 */
+  const existenceCheckedRef = React.useRef<Set<string>>(new Set())
+
+  React.useEffect(() => {
+    // 文件变更记录是 append-only 的内存流水账：会话未运行期间被删除的文件
+    // watcher 清理不到，展示前对「更早」分组批量校验存在性并剔除。
+    const pending = earlier.filter((change) => !existenceCheckedRef.current.has(change.path))
+    if (pending.length === 0) return
+    for (const change of pending) existenceCheckedRef.current.add(change.path)
+    let cancelled = false
+    void window.electronAPI
+      .filterExistingFilePaths(pending.map((change) => change.path), { sessionId, unrestricted: true })
+      .then((existingPaths) => {
+        if (cancelled) return
+        const isWindows = detectIsWindows()
+        const missing = pending.filter(
+          (change) => !existingPaths.some((existingPath) => arePathsEqual(existingPath, change.path, isWindows)),
+        )
+        if (missing.length === 0) return
+        setNonGitFileChanges((prev) => {
+          const currentChanges = prev.get(sessionId)
+          if (!currentChanges) return prev
+          const next = currentChanges.filter(
+            (change) => !missing.some((m) => arePathsEqual(m.path, change.path, isWindows)),
+          )
+          if (next.length === currentChanges.length) return prev
+          const map = new Map(prev)
+          map.set(sessionId, next)
+          return map
+        })
+      })
+      .catch(() => {
+        // 校验失败不清记录，允许下次渲染重试。
+        for (const change of pending) existenceCheckedRef.current.delete(change.path)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [earlier, sessionId, setNonGitFileChanges])
   const hasEarlierChanges = earlier.length > 0
   const title = hasEarlierChanges
     ? `本会话文件变更 · ${changes.length}`

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -92,7 +92,7 @@ import {
 } from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { detectIsWindows } from '@/lib/platform'
-import { getSessionFileChangeKind, getOwnedSessionWatcherPaths, upsertSessionFileChange } from '@/lib/session-file-changes'
+import { arePathsEqual, getSessionFileChangeKind, getOwnedSessionWatcherPaths, removeSessionFileChange, upsertSessionFileChange } from '@/lib/session-file-changes'
 import { doesWorkspaceChangeAffectPreview } from '@/components/diff/preview-open-path'
 import { removeQueuedMessage, createQueuedAgentStreamState, createAgentQueuedMessage } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
@@ -963,7 +963,18 @@ export function useGlobalAgentListeners(): void {
           for (const changedPath of uniquelyMatchingPaths) {
             // watcher 现在也会携带删除/目录路径；这些不应进入会话的文件改动记录。
             const existingFile = await window.electronAPI.resolveAndReadFile(changedPath, { sessionId, unrestricted: true })
-            if (!existingFile) continue
+            if (!existingFile) {
+              // 文件已不存在：反向清理该会话的文件改动记录，避免「先创建再删除」的
+              // 残留条目一直留在改动面板中。
+              store.set(agentNonGitFileChangesAtom, (prev) => {
+                const current = prev.get(sessionId)
+                if (!current?.some((change) => arePathsEqual(change.path, changedPath, isWindows))) return prev
+                const map = new Map(prev)
+                map.set(sessionId, removeSessionFileChange(current, changedPath, isWindows))
+                return map
+              })
+              continue
+            }
             const previewFile = await buildWrittenFilePreviewInfo(sessionId, changedPath)
             if (previewFile.previewOnly) {
               store.set(agentNonGitFileChangesAtom, (prev) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -92,7 +92,7 @@ import {
 } from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { detectIsWindows } from '@/lib/platform'
-import { arePathsEqual, getSessionFileChangeKind, getOwnedSessionWatcherPaths, removeSessionFileChange, upsertSessionFileChange } from '@/lib/session-file-changes'
+import { arePathsEqual, getInactiveSessionFileChangePaths, getSessionFileChangeKind, getOwnedSessionWatcherPaths, removeSessionFileChange, upsertSessionFileChange, type SessionFileChange } from '@/lib/session-file-changes'
 import { doesWorkspaceChangeAffectPreview } from '@/components/diff/preview-open-path'
 import { removeQueuedMessage, createQueuedAgentStreamState, createAgentQueuedMessage } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
@@ -931,6 +931,41 @@ export function useGlobalAgentListeners(): void {
         const candidateIds = [...streamingStates.entries()]
           .filter(([, state]) => state.running)
           .map(([sessionId]) => sessionId)
+        const activeSessionIds = new Set(candidateIds)
+
+        // 停止会话不会进入下方的运行中归属流程。若 watcher 明确带回该会话
+        // 已记录路径的变化，则单独确认它是否已经删除，避免面板已打开时被
+        // `existenceCheckedRef` 缓存住的历史记录永久残留。
+        const inactiveChangedPaths = getInactiveSessionFileChangePaths(
+          store.get(agentNonGitFileChangesAtom),
+          filePaths,
+          activeSessionIds,
+          isWindows,
+        )
+        if (inactiveChangedPaths.length > 0) {
+          const existingPaths = await window.electronAPI.filterExistingFilePaths(
+            inactiveChangedPaths,
+            { unrestricted: true },
+          )
+          const deletedPaths = inactiveChangedPaths.filter(
+            (path) => !existingPaths.some((existingPath) => arePathsEqual(existingPath, path, isWindows)),
+          )
+          if (deletedPaths.length > 0) {
+            store.set(agentNonGitFileChangesAtom, (previous) => {
+              let next: Map<string, SessionFileChange[]> | undefined
+              for (const [sessionId, changes] of previous) {
+                if (activeSessionIds.has(sessionId)) continue
+                const filtered = changes.filter(
+                  (change) => !deletedPaths.some((path) => arePathsEqual(change.path, path, isWindows)),
+                )
+                if (filtered.length === changes.length) continue
+                if (!next) next = new Map(previous)
+                next.set(sessionId, filtered)
+              }
+              return next ?? previous
+            })
+          }
+        }
 
         const candidates = await Promise.all(candidateIds.map(async (sessionId) => {
           const session = store.get(agentSessionsAtom).find((item) => item.id === sessionId)

--- a/apps/electron/src/renderer/lib/session-file-changes.ts
+++ b/apps/electron/src/renderer/lib/session-file-changes.ts
@@ -92,6 +92,14 @@ export function upsertSessionFileChange(
   );
 }
 
+export function removeSessionFileChange(
+  changes: readonly SessionFileChange[],
+  path: string,
+  caseInsensitive = false,
+): SessionFileChange[] {
+  return changes.filter((change) => !arePathsEqual(change.path, path, caseInsensitive));
+}
+
 export function groupSessionFileChanges(
   changes: readonly SessionFileChange[],
   currentRunId: string | undefined,

--- a/apps/electron/src/renderer/lib/session-file-changes.ts
+++ b/apps/electron/src/renderer/lib/session-file-changes.ts
@@ -100,6 +100,32 @@ export function removeSessionFileChange(
   return changes.filter((change) => !arePathsEqual(change.path, path, caseInsensitive));
 }
 
+/**
+ * Returns tracked file paths touched by a watcher event for sessions that are
+ * no longer running. Running sessions are handled by the normal watcher path,
+ * while stopped sessions need their stale records pruned explicitly.
+ */
+export function getInactiveSessionFileChangePaths(
+  changesBySession: ReadonlyMap<string, readonly SessionFileChange[]>,
+  changedPaths: readonly string[],
+  activeSessionIds: ReadonlySet<string>,
+  caseInsensitive = false,
+): string[] {
+  const matching: string[] = []
+  for (const [sessionId, changes] of changesBySession) {
+    if (activeSessionIds.has(sessionId)) continue
+    for (const change of changes) {
+      if (
+        changedPaths.some((changedPath) => arePathsEqual(change.path, changedPath, caseInsensitive))
+        && !matching.some((path) => arePathsEqual(path, change.path, caseInsensitive))
+      ) {
+        matching.push(change.path)
+      }
+    }
+  }
+  return matching
+}
+
 export function groupSessionFileChanges(
   changes: readonly SessionFileChange[],
   currentRunId: string | undefined,


### PR DESCRIPTION
## Summary

「本会话文件变更」（改动面板的非 Git 文件区）记录是 append-only 的内存流水账，只有 upsert 没有删除路径：文件先创建再删除后条目仍留在改动面板，且按 runId 分组后不断沉入「更早」分组，越积越多。

修复方式：

- **watcher 反向清理**：watcher 检测到文件已不存在时，从 `agentNonGitFileChangesAtom` 移除该会话的对应条目（此前只跳过新增，不清理旧记录）。
- **渲染前存在性过滤**：新增轻量 `file:exists-batch` 主进程 IPC（仅 `statSync`、仅绝对路径、带路径授权校验、上限 1000 条），`NonGitChangesList` 展示前对「更早」分组批量校验存在性并剔除已删除条目，兜底会话未运行期间被删除、watcher 覆盖不到的场景。每条路径在组件存活期内只校验一次（ref 去重）。
- 抽出 `removeSessionFileChange` 工具函数。

## 性能影响

低风险。更新源为事件驱动（watcher/atom），低频；watcher 清理复用已有的 `resolveAndReadFile` 调用，零新增 IPC；渲染前过滤每条路径仅一次批量 IPC，无定时器、无新增订阅、无渲染热路径改动。

## Test plan

- [x] 全仓 typecheck 通过（6 个包）
- [x] 相关单元测试通过（renderer/lib + main/lib 346 通过，4 个失败为 bun 环境无法 import electron 原生模块的既有问题，与本改动无关）
- [ ] 真实运行验证：会话中创建→删除一个非 Git 目录文件，确认改动面板不再残留该条目

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)