### PR TITLE
feat(agent): 单一委派观察 Tab 与未查看完成状态【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.17",
+  "version": "0.19.18",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -5584,6 +5584,14 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  ipcMain.handle(
+    IPC_CHANNELS.WINDOW_IS_FOCUSED,
+    async (event) => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      return win && !win.isDestroyed() ? win.isFocused() : false
+    }
+  )
+
   // ===== 任务 / 日程（Planning）=====
 
   const isPlanningTitle = (value: unknown): value is string =>

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -294,6 +294,8 @@ export interface ElectronAPI {
   windowClose: () => Promise<void>
   /** 窗口是否处于最大化状态 */
   windowIsMaximized: () => Promise<boolean>
+  /** 宿主 BrowserWindow 是否处于前台（焦点可位于原生 WebContentsView） */
+  windowIsFocused: () => Promise<boolean>
   /** 订阅窗口最大化/还原事件 */
   onWindowResize: (callback: () => void) => () => void
 
@@ -1502,6 +1504,10 @@ const electronAPI: ElectronAPI = {
 
   windowIsMaximized: () => {
     return ipcRenderer.invoke(IPC_CHANNELS.WINDOW_IS_MAXIMIZED)
+  },
+
+  windowIsFocused: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.WINDOW_IS_FOCUSED)
   },
 
   onWindowResize: (callback: () => void) => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -671,9 +671,9 @@ export function getDelegationTabLabel(title: string | null | undefined): string 
   return title?.trim() || '委派任务'
 }
 
-export type AgentSidePanelBaseTab = 'files' | 'changes' | 'chat' | 'temporary-agent' | WorkspaceComponentTab
+export type AgentSidePanelBaseTab = 'files' | 'changes' | 'chat' | 'temporary-agent' | 'delegation' | WorkspaceComponentTab
 /** 工作区组件、每个 Pi 探索分支、协作子 Agent、浏览器网页和文件预览都处于右侧工作区顶栏。 */
-export type AgentSidePanelTab = AgentSidePanelBaseTab | `exploration:${string}` | `delegation:${string}` | `browser:${string}` | `preview:${string}` | `terminal:${string}`
+export type AgentSidePanelTab = AgentSidePanelBaseTab | `exploration:${string}` | `browser:${string}` | `preview:${string}` | `terminal:${string}`
 
 /** 用户主动进入这些项目级能力时，Agent 后续的改动提示不得抢走当前视图。 */
 export function isUserPriorityWorkspaceComponentTab(
@@ -702,19 +702,11 @@ export function getExplorationSidePanelTab(branchSessionId: string): AgentSidePa
   return `exploration:${branchSessionId}`
 }
 
-/** 已在右侧打开的协作子 Agent：key 为父会话 ID，value 为子会话 ID 列表。 */
-export const agentSideDelegationMapAtom = atom<Map<string, string[]>>(new Map())
+/** 右侧当前观察的协作子 Agent：key 为父会话 ID，value 为唯一子会话 ID。 */
+export const agentSideDelegationMapAtom = atom<Map<string, string>>(new Map())
 
-export function getDelegationSidePanelTab(childSessionId: string): AgentSidePanelTab {
-  return `delegation:${childSessionId}`
-}
-
-export function getDelegationSessionIdFromSidePanelTab(tab: AgentSidePanelTab | 'delegation'): string | null {
-  return tab.startsWith('delegation:') ? tab.slice('delegation:'.length) : null
-}
-
-export function isDelegationSidePanelTab(tab: AgentSidePanelTab | 'delegation'): tab is `delegation:${string}` {
-  return tab.startsWith('delegation:')
+export function getDelegationSidePanelTab(): AgentSidePanelTab {
+  return 'delegation'
 }
 
 export function getExplorationSessionIdFromSidePanelTab(tab: AgentSidePanelTab | 'exploration'): string | null {
@@ -1117,11 +1109,21 @@ export const agentRunningSessionIdsAtom = atom<Set<string>>((get) => {
 /** 侧边栏会话指示点状态 */
 export type SessionIndicatorStatus = 'idle' | 'running' | 'blocked' | 'completed'
 
-/** 已完成但用户尚未查看的会话 ID 集合 */
+/** 已完成但用户尚未查看的顶层会话 ID 集合。参与 Dock/Launcher 角标。 */
 export const unviewedCompletedSessionIdsAtom = atom<Set<string>>(new Set<string>())
+
+/** 刚完成但用户尚未查看的协作子会话 ID 集合。仅驱动父子会话状态颜色。 */
+export const unviewedCompletedDelegatedSessionIdsAtom = atom<Set<string>>(new Set<string>())
 
 let lastIndicatorSignature = ''
 let lastIndicatorMap = new Map<string, SessionIndicatorStatus>()
+
+/** Delegated child IDs only recompute when the session list changes, not on streaming hot paths. */
+const delegatedAgentSessionIdsAtom = atom<Set<string>>((get) => new Set(
+  get(agentSessionsAtom)
+    .filter((session) => !!session.sourceDelegationId)
+    .map((session) => session.id),
+))
 
 function getStableIndicatorMap(entries: Array<[string, SessionIndicatorStatus]>): Map<string, SessionIndicatorStatus> {
   entries.sort(([a], [b]) => a.localeCompare(b))
@@ -1148,10 +1150,12 @@ export const dockBadgeCountAtom = atom<number>((get) => {
  */
 export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorStatus>>((get) => {
   const streamStates = get(agentStreamingStatesAtom)
+  const delegatedSessionIds = get(delegatedAgentSessionIdsAtom)
   const pendingPerms = get(allPendingPermissionRequestsAtom)
   const pendingAskUser = get(allPendingAskUserRequestsAtom)
   const pendingExitPlan = get(allPendingExitPlanRequestsAtom)
   const unviewedCompleted = get(unviewedCompletedSessionIdsAtom)
+  const unviewedDelegatedCompleted = get(unviewedCompletedDelegatedSessionIdsAtom)
 
   const map = new Map<string, SessionIndicatorStatus>()
 
@@ -1165,8 +1169,10 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
     } else if (
       state.contextCompaction?.status === 'running'
       && state.contextCompaction.afterCompletedTurn === true
+      && !delegatedSessionIds.has(id)
     ) {
-      // 主任务已经交付，后续仅在整理上下文时应呈现为可验收的完成态。
+      // 顶层主任务已经交付，后续仅在整理上下文时可呈现为完成态。
+      // 委派 child 的绿色严格保留给“成功完成且未查看”，不能由 compaction 绕过。
       map.set(id, 'completed')
     } else {
       map.set(id, 'running')
@@ -1174,6 +1180,11 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
   }
 
   for (const id of unviewedCompleted) {
+    if (!map.has(id)) {
+      map.set(id, 'completed')
+    }
+  }
+  for (const id of unviewedDelegatedCompleted) {
     if (!map.has(id)) {
       map.set(id, 'completed')
     }

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -350,10 +350,19 @@ function SideAgentSessionContent({
   onView?: () => void
 }): React.ReactElement {
   const previousContentKeyRef = React.useRef<string | null>(null)
+  const onViewRef = React.useRef(onView)
+  onViewRef.current = onView
   const shouldAnimate = previousContentKeyRef.current !== null && previousContentKeyRef.current !== contentKey
 
   React.useEffect(() => {
     previousContentKeyRef.current = contentKey
+  }, [contentKey])
+
+  // A delegated child may finish while hidden, then become visible simply because its parent
+  // session is reopened. Rendering the visible content itself is a view acknowledgement; do not
+  // require a second pointer or focus event inside the child pane to clear its completion state.
+  React.useEffect(() => {
+    onViewRef.current?.()
   }, [contentKey])
 
   return (

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -45,6 +45,8 @@ import {
   agentFileChangesCurrentRunAtom,
   agentSessionComponentTabsAtomFamily,
   agentSessionStreamingStateAtomFamily,
+  agentSessionIndicatorMapAtom,
+  unviewedCompletedDelegatedSessionIdsAtom,
   isWorkspaceComponentTab,
   isUserPriorityWorkspaceComponentTab,
   sanitizeWorkspaceComponentTabs,
@@ -68,7 +70,6 @@ import {
 import {
   getBrowserSidePanelTab,
   getBrowserTabIdFromSidePanelTab,
-  getDelegationSessionIdFromSidePanelTab,
   getDelegationSidePanelTab,
   getExplorationSessionIdFromSidePanelTab,
   getExplorationSidePanelTab,
@@ -111,6 +112,8 @@ import {
   recordRightPanelTabVisit,
   removeRightPanelTabFromHistory,
 } from '@/lib/right-panel-tab-history'
+import { getDelegatedChildSessionStatus, getDelegationStatusIconClass } from '@/lib/agent-session-list'
+import { markSessionCompletionViewed } from '@/lib/agent-completion-presence'
 import { rememberStopGenerationTarget } from '@/lib/stop-generation-target'
 import { TerminalTabContent } from '@/components/tabs/TerminalTabContent'
 import { shouldShowBothFileSources } from './file-panel-layout'
@@ -337,7 +340,15 @@ function getLatestExplorationConclusion(messages: SDKMessage[], sourceMessageId:
  * 右侧嵌入 Agent 在切换时轻微淡入并横移 1px，缓和不同消息高度瞬间替换的视觉跳变。
  * 首次打开不播放，且尊重系统的减少动态效果偏好。
  */
-function SideAgentSessionContent({ contentKey, children }: { contentKey: string; children: React.ReactNode }): React.ReactElement {
+function SideAgentSessionContent({
+  contentKey,
+  children,
+  onView,
+}: {
+  contentKey: string
+  children: React.ReactNode
+  onView?: () => void
+}): React.ReactElement {
   const previousContentKeyRef = React.useRef<string | null>(null)
   const shouldAnimate = previousContentKeyRef.current !== null && previousContentKeyRef.current !== contentKey
 
@@ -352,6 +363,8 @@ function SideAgentSessionContent({ contentKey, children }: { contentKey: string;
         'min-h-0 flex-1 overflow-hidden',
         shouldAnimate && 'animate-in fade-in-0 slide-in-from-right-1 duration-150 motion-reduce:animate-none',
       )}
+      onFocusCapture={onView}
+      onPointerDownCapture={onView}
     >
       {children}
     </div>
@@ -834,14 +847,18 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const sideTemporaryAgents = sideTemporaryAgentMap.get(sessionId) ?? []
   const sideDelegationMap = useAtomValue(agentSideDelegationMapAtom)
   const setSideDelegationMap = useSetAtom(agentSideDelegationMapAtom)
-  const sideDelegationSessionIds = sideDelegationMap.get(sessionId) ?? []
+  const setUnviewedDelegatedCompleted = useSetAtom(unviewedCompletedDelegatedSessionIdsAtom)
+  const sideDelegationSessionId = sideDelegationMap.get(sessionId) ?? null
+  const agentIndicatorMap = useAtomValue(agentSessionIndicatorMapAtom)
   const terminalTabsMap = useAtomValue(agentTerminalTabsAtom)
   const setTerminalTabsMap = useSetAtom(agentTerminalTabsAtom)
   const terminalTabs = terminalTabsMap.get(sessionId) ?? []
   const activeTerminalId = getTerminalIdFromSidePanelTab(activeTab)
-  const activeDelegationSessionId = getDelegationSessionIdFromSidePanelTab(activeTab)
-  const activeDelegationSession = activeDelegationSessionId
-    ? sessions.find((item) => item.id === activeDelegationSessionId && item.parentSessionId === sessionId && !!item.sourceDelegationId) ?? null
+  const selectedDelegationSession = sideDelegationSessionId
+    ? sessions.find((item) => item.id === sideDelegationSessionId && item.parentSessionId === sessionId && !!item.sourceDelegationId) ?? null
+    : null
+  const selectedDelegationStatus = selectedDelegationSession
+    ? getDelegatedChildSessionStatus(selectedDelegationSession, agentIndicatorMap)
     : null
   const activeExplorationSessionId = getExplorationSessionIdFromSidePanelTab(activeTab)
   const activeExplorationBranch = activeExplorationSessionId
@@ -874,7 +891,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const effectiveActiveTab: AgentSidePanelTab = activeTab === 'chat' && !sideChatConversationId
     ? 'files'
     // `temporary-agent` 是旧的单分支内存状态；新状态使用 exploration:<sessionId>。
-    : activeTab === 'temporary-agent' || (activeExplorationSessionId !== null && !activeExplorationBranch) || (activeDelegationSessionId !== null && !activeDelegationSession) || (activeTerminalId !== null && !terminalTabs.some((terminal) => terminal.terminalId === activeTerminalId))
+    : activeTab === 'temporary-agent' || (activeExplorationSessionId !== null && !activeExplorationBranch) || (activeTab === 'delegation' && !selectedDelegationSession) || (activeTerminalId !== null && !terminalTabs.some((terminal) => terminal.terminalId === activeTerminalId))
       ? 'files'
       : isWorkspaceComponentTab(activeTab) && (!workspaceSlug || !workspaceComponentTabs.includes(activeTab) || !isWorkspaceComponentEnabled(activeTab))
         ? 'files'
@@ -979,18 +996,15 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     }
   }, [activeTab, returnToPreviousTabAfterClose, sessionId, setSideTemporaryAgentMap])
 
-  const handleCloseDelegationTab = React.useCallback((childSessionId: string) => {
+  const handleCloseDelegationTab = React.useCallback(() => {
     setSideDelegationMap((prev) => {
-      const openChildIds = prev.get(sessionId) ?? []
-      const remaining = openChildIds.filter((id) => id !== childSessionId)
-      if (remaining.length === openChildIds.length) return prev
+      if (!prev.has(sessionId)) return prev
       const next = new Map(prev)
-      if (remaining.length > 0) next.set(sessionId, remaining)
-      else next.delete(sessionId)
+      next.delete(sessionId)
       return next
     })
-    if (getDelegationSessionIdFromSidePanelTab(activeTab) === childSessionId) {
-      returnToPreviousTabAfterClose(getDelegationSidePanelTab(childSessionId))
+    if (activeTab === 'delegation') {
+      returnToPreviousTabAfterClose(getDelegationSidePanelTab())
     }
   }, [activeTab, returnToPreviousTabAfterClose, sessionId, setSideDelegationMap])
 
@@ -1015,24 +1029,21 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
 
   // 子 Agent 被从左侧删除后，同样移除右侧的悬空观察 Tab；不改变左侧树的现有渲染与排序。
   React.useEffect(() => {
+    if (!sideDelegationSessionId) return
     const validChildIds = new Set(sessions
       .filter((item) => item.parentSessionId === sessionId && !!item.sourceDelegationId)
       .map((item) => item.id))
-    const remaining = sideDelegationSessionIds.filter((id) => validChildIds.has(id))
-    if (remaining.length === sideDelegationSessionIds.length) return
+    if (validChildIds.has(sideDelegationSessionId)) return
     setSideDelegationMap((prev) => {
-      const current = prev.get(sessionId) ?? []
-      const nextRemaining = current.filter((id) => validChildIds.has(id))
-      if (nextRemaining.length === current.length) return prev
+      if (prev.get(sessionId) !== sideDelegationSessionId) return prev
       const next = new Map(prev)
-      if (nextRemaining.length > 0) next.set(sessionId, nextRemaining)
-      else next.delete(sessionId)
+      next.delete(sessionId)
       return next
     })
-    if (activeDelegationSessionId && !validChildIds.has(activeDelegationSessionId)) {
-      returnToPreviousTabAfterClose(getDelegationSidePanelTab(activeDelegationSessionId))
+    if (activeTab === 'delegation') {
+      returnToPreviousTabAfterClose(getDelegationSidePanelTab())
     }
-  }, [activeDelegationSessionId, returnToPreviousTabAfterClose, sessionId, sessions, setSideDelegationMap, sideDelegationSessionIds])
+  }, [activeTab, returnToPreviousTabAfterClose, sessionId, sessions, setSideDelegationMap, sideDelegationSessionId])
 
   // 浏览器状态由 MainArea 的全局订阅同步到 atom；右侧工作区只负责呈现和显式打开。
   // 这样切换文件/改动时 BrowserSlot 会正确隐藏原生 WebContentsView，而不会销毁网页会话。
@@ -1118,12 +1129,20 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     })()
   }, [publishBrowserState, sessionId])
 
+  const markDelegationSessionViewed = React.useCallback((childSessionId: string) => {
+    setUnviewedDelegatedCompleted((prev) => markSessionCompletionViewed(prev, childSessionId))
+  }, [setUnviewedDelegatedCompleted])
+
+  const handleCloseSidePanel = React.useCallback(() => {
+    // Closing the whole right workspace hides every auxiliary conversation.
+    rememberStopGenerationTarget({ kind: 'agent', sessionId })
+    setIsOpen(false)
+  }, [sessionId, setIsOpen])
+
   const handleWorkspaceTabChange = React.useCallback((tab: AgentSidePanelTab) => {
-    // 点击会话类右侧 Tab 本身即代表用户将停止目标切换到其可见会话；
-    // 否则父会话的旧交互记录会抢在当前右侧会话之前被快捷键使用。
-    const delegatedSessionId = getDelegationSessionIdFromSidePanelTab(tab)
-    if (delegatedSessionId && sideDelegationSessionIds.includes(delegatedSessionId)) {
-      rememberStopGenerationTarget({ kind: 'agent', sessionId: delegatedSessionId })
+    if (tab === 'delegation' && sideDelegationSessionId) {
+      rememberStopGenerationTarget({ kind: 'agent', sessionId: sideDelegationSessionId })
+      markDelegationSessionViewed(sideDelegationSessionId)
     } else {
       const explorationSessionId = getExplorationSessionIdFromSidePanelTab(tab)
       if (explorationSessionId && sideTemporaryAgents.some((branch) => branch.sessionId === explorationSessionId)) {
@@ -1153,7 +1172,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     if (queue.sessionId !== sessionId) return
     queue.desiredTabId = browserTabId
     flushBrowserTabSelection()
-  }, [flushBrowserTabSelection, onTabChange, previewFiles, sessionId, setPreviewFileMap, sideChatConversationId, sideDelegationSessionIds, sideTemporaryAgents, split, updateSplit])
+  }, [flushBrowserTabSelection, markDelegationSessionViewed, onTabChange, previewFiles, sessionId, setPreviewFileMap, sideChatConversationId, sideDelegationSessionId, sideTemporaryAgents, split, updateSplit])
 
   // Agent/浏览器等外部事件仍只更新兼容 activeTab；分屏时把新目标落到当前焦点 Pane。
   React.useEffect(() => {
@@ -1282,17 +1301,13 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       icon: <Split className="size-3.5" />,
       closable: true,
     })),
-    ...sideDelegationSessionIds.flatMap((childSessionId) => {
-      const child = sessions.find((item) => (
-        item.id === childSessionId && item.parentSessionId === sessionId && !!item.sourceDelegationId
-      ))
-      return child ? [{
-        id: getDelegationSidePanelTab(child.id),
-        label: getDelegationTabLabel(child.title),
-        icon: <GitBranch className="size-3.5" />,
-        closable: true,
-      }] : []
-    }),
+    ...(selectedDelegationSession && selectedDelegationStatus ? [{
+      id: getDelegationSidePanelTab(),
+      label: getDelegationTabLabel(selectedDelegationSession.title),
+      icon: <GitBranch className={cn('size-3.5', getDelegationStatusIconClass(selectedDelegationStatus))} />,
+      status: selectedDelegationStatus,
+      closable: true,
+    }] : []),
     ...(browserState?.tabs.map((tab) => ({
       id: getBrowserSidePanelTab(tab.tabId),
       label: tab.title || '新建标签页',
@@ -1301,7 +1316,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       closable: true,
       activity: showBrowserActivity && activeBrowserTabId !== tab.tabId && browserState.activeTabId === tab.tabId,
     })) ?? []),
-  ], [activeBrowserTabId, browserState, previewFiles, sessions, sessionId, showBrowserActivity, sideChatConversationId, sideDelegationSessionIds, sideTemporaryAgents, terminalTabs, workspaceComponentTabs])
+  ], [activeBrowserTabId, browserState, previewFiles, selectedDelegationSession, selectedDelegationStatus, sessions, showBrowserActivity, sideChatConversationId, sideTemporaryAgents, terminalTabs, workspaceComponentTabs])
   workspaceTabsRef.current = workspaceTabs
 
   React.useEffect(() => {
@@ -1349,8 +1364,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     if (tab === 'chat') { handleCloseChatTab(); return }
     const explorationSessionId = getExplorationSessionIdFromSidePanelTab(tab)
     if (explorationSessionId) { handleCloseExplorationTab(explorationSessionId); return }
-    const delegationSessionId = getDelegationSessionIdFromSidePanelTab(tab)
-    if (delegationSessionId) { handleCloseDelegationTab(delegationSessionId); return }
+    if (tab === 'delegation') { handleCloseDelegationTab(); return }
     const browserTabId = getBrowserTabIdFromSidePanelTab(tab)
     if (browserTabId) void handleCloseBrowserTab(browserTabId)
   }, [exitSplitInsteadOfClosingBoundTab, handleCloseBrowserTab, handleCloseChatTab, handleCloseDelegationTab, handleCloseExplorationTab, handleClosePreviewTab, returnToPreviousTabAfterClose, sessionId, setTerminalTabsMap, setWorkspaceComponentTabs])
@@ -1525,7 +1539,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     const paneExplorationBranch = paneExplorationSessionId
       ? sideTemporaryAgents.find((branch) => branch.sessionId === paneExplorationSessionId) ?? null
       : null
-    const paneDelegationSessionId = getDelegationSessionIdFromSidePanelTab(paneTab)
+    const paneDelegationSessionId = paneTab === 'delegation' ? sideDelegationSessionId : null
     const paneDelegationSession = paneDelegationSessionId
       ? sessions.find((item) => item.id === paneDelegationSessionId && item.parentSessionId === sessionId && !!item.sourceDelegationId) ?? null
       : null
@@ -1583,7 +1597,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
         <AgentView sessionId={paneExplorationBranch.sessionId} embedded />
       </SideAgentSessionContent>
     ) : paneDelegationSession ? (
-      <SideAgentSessionContent contentKey={`delegation:${paneDelegationSession.id}`}>
+      <SideAgentSessionContent
+        contentKey={`delegation:${paneDelegationSession.id}`}
+        onView={() => markDelegationSessionViewed(paneDelegationSession.id)}
+      >
         <AgentView sessionId={paneDelegationSession.id} embedded />
       </SideAgentSessionContent>
     ) : paneTab === 'todos' ? (
@@ -1783,7 +1800,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             activeTabAction={activeExplorationBranch ? (
               <ExplorationBringBackAction parentSessionId={sessionId} branch={activeExplorationBranch} sessions={sessions} />
             ) : undefined}
-            onClose={() => setIsOpen(false)}
+            onClose={handleCloseSidePanel}
           />
 
           <div ref={splitContentRef} className="relative flex min-h-0 flex-1 overflow-hidden">

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -50,7 +50,7 @@ function isExpandedWorkspaceTab(tab: string | undefined): boolean {
       || tab.startsWith('preview:')
       || tab.startsWith('terminal:')
       || tab.startsWith('exploration:')
-      || tab.startsWith('delegation:')
+      || tab === 'delegation'
     ),
   )
 }

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -39,6 +39,7 @@ import {
   currentAgentSessionIdAtom,
   agentSessionIndicatorMapAtom,
   unviewedCompletedSessionIdsAtom,
+  unviewedCompletedDelegatedSessionIdsAtom,
   agentChannelIdAtom,
   agentModelIdAtom,
   agentSessionChannelMapAtom,
@@ -57,6 +58,7 @@ import {
   agentSidePanelOpenMapAtom,
   agentSidePanelOpenAtomFamily,
   agentSideDelegationMapAtom,
+  agentSidePanelSplitMapAtom,
   getDelegationSidePanelTab,
   openWorkspaceComponentAtom,
   agentStreamingStatesAtom,
@@ -115,13 +117,19 @@ import {
 import { detectIsMac } from '@/lib/platform'
 import { ShortcutKeycaps } from '@/components/shortcuts/ShortcutKeycaps'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
+import { rememberStopGenerationTarget } from '@/lib/stop-generation-target'
+import { markSessionCompletionViewed } from '@/lib/agent-completion-presence'
 import {
   collectAgentSessionTreeIds,
   countSettledDelegatedChildren,
   getDelegatedChildSessionStatus,
+  getDelegationStatusIconClass,
   groupArchivedAgentSessionsByProject,
   isAgentSessionVisibleInTrees,
+  isDelegationObservationVisible,
+  removeDelegatedSessionSelection,
   replaceAgentSessionInFreshnessOrder,
+  selectDelegatedSession,
   sortAgentSessionsByUpdatedAtDesc,
 } from '@/lib/agent-session-list'
 import {
@@ -479,7 +487,20 @@ function isDelegatedChildSession(session: AgentSessionMeta): boolean {
   return !!session.parentSessionId && !!session.sourceDelegationId
 }
 
-function buildAgentSessionTrees(sessions: AgentSessionMeta[]): AgentSessionTreeItem[] {
+function sortDelegatedChildSessions(
+  sessions: readonly AgentSessionMeta[],
+  agentIndicatorMap?: ReadonlyMap<string, SessionIndicatorStatus>,
+): AgentSessionMeta[] {
+  const priority = (session: AgentSessionMeta): number => Number(
+    agentIndicatorMap && ACTIVE_SESSION_STATUSES.has(getDelegatedChildSessionStatus(session, agentIndicatorMap)),
+  )
+  return [...sessions].sort((a, b) => priority(b) - priority(a) || b.updatedAt - a.updatedAt)
+}
+
+function buildAgentSessionTrees(
+  sessions: AgentSessionMeta[],
+  agentIndicatorMap?: ReadonlyMap<string, SessionIndicatorStatus>,
+): AgentSessionTreeItem[] {
   const sessionIds = new Set(sessions.map((session) => session.id))
   const childrenByParentId = new Map<string, AgentSessionMeta[]>()
   const roots: AgentSessionMeta[] = []
@@ -501,7 +522,7 @@ function buildAgentSessionTrees(sessions: AgentSessionMeta[]): AgentSessionTreeI
 
   return roots.map((session) => ({
     session,
-    childSessions: childrenByParentId.get(session.id) ?? [],
+    childSessions: sortDelegatedChildSessions(childrenByParentId.get(session.id) ?? [], agentIndicatorMap),
   }))
 }
 
@@ -768,7 +789,24 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
   const [archivedAgentSessionCount, setArchivedAgentSessionCount] = React.useState(0)
   const [currentAgentSessionId, setCurrentAgentSessionId] = useAtom(currentAgentSessionIdAtom)
-  const activeRightWorkspaceTab = useAtomValue(agentDiffPanelTabAtom).get(currentAgentSessionId ?? '')
+  const sideDelegationMap = useAtomValue(agentSideDelegationMapAtom)
+  const diffPanelTabMap = useAtomValue(agentDiffPanelTabAtom)
+  const sidePanelSplitMap = useAtomValue(agentSidePanelSplitMapAtom)
+  const sidePanelOpenMap = useAtomValue(agentSidePanelOpenMapAtom)
+  const activeParentSessionId = currentAgentSessionId ?? ''
+  const activeRightWorkspaceTab = diffPanelTabMap.get(activeParentSessionId)
+  const activeRightWorkspaceSplit = sidePanelSplitMap.get(activeParentSessionId) ?? null
+  const isActiveSidePanelOpen = activeParentSessionId
+    ? sidePanelOpenMap[activeParentSessionId] ?? true
+    : false
+  const isDelegationVisible = isDelegationObservationVisible(
+    isActiveSidePanelOpen,
+    activeRightWorkspaceTab,
+    activeRightWorkspaceSplit,
+  )
+  const activeDelegationSessionId = isDelegationVisible
+    ? sideDelegationMap.get(activeParentSessionId) ?? null
+    : null
   const isWorkspaceComponentActive = React.useCallback(
     (component: WorkspaceComponentTab): boolean => activeRightWorkspaceTab === component,
     [activeRightWorkspaceTab],
@@ -776,6 +814,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const agentIndicatorMap = useAtomValue(agentSessionIndicatorMapAtom)
   const unviewedCompletedSessionIds = useAtomValue(unviewedCompletedSessionIdsAtom)
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
+  const setUnviewedDelegatedCompleted = useSetAtom(unviewedCompletedDelegatedSessionIdsAtom)
   const agentChannelId = useAtomValue(agentChannelIdAtom)
   const agentModelId = useAtomValue(agentModelIdAtom)
   const setSessionChannelMap = useSetAtom(agentSessionChannelMapAtom)
@@ -922,19 +961,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       }
       return changed ? map : prev
     })
-    store.set(agentSideDelegationMapAtom, (prev) => {
-      let changed = false
-      const next = new Map(prev)
-      if (next.delete(id)) changed = true
-      for (const [parentSessionId, childSessionIds] of next) {
-        const remaining = childSessionIds.filter((childSessionId) => childSessionId !== id)
-        if (remaining.length === childSessionIds.length) continue
-        changed = true
-        if (remaining.length > 0) next.set(parentSessionId, remaining)
-        else next.delete(parentSessionId)
-      }
-      return changed ? next : prev
-    })
+    store.set(agentSideDelegationMapAtom, (prev) => removeDelegatedSessionSelection(prev, id))
+    setUnviewedDelegatedCompleted((prev) => markSessionCompletionViewed(prev, id))
     setDiffPanelTab(deleteKey)
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)
@@ -1047,14 +1075,17 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const pinnedAgentSessionTrees = React.useMemo<AgentSessionTreeItem[]>(
     () => pinnedAgentSessions.map((session) => ({
       session,
-      childSessions: getDirectDelegatedChildren(agentSessions, session.id).filter((child) => (
-        !child.archived
-        && !child.isDraft
-        && !draftSessionIds.has(child.id)
-        && !isHiddenAutomationSession(child)
-      )),
+      childSessions: sortDelegatedChildSessions(
+        getDirectDelegatedChildren(agentSessions, session.id).filter((child) => (
+          !child.archived
+          && !child.isDraft
+          && !draftSessionIds.has(child.id)
+          && !isHiddenAutomationSession(child)
+        )),
+        agentIndicatorMap,
+      ),
     })),
-    [agentSessions, draftSessionIds, pinnedAgentSessions],
+    [agentIndicatorMap, agentSessions, draftSessionIds, pinnedAgentSessions],
   )
 
   /** 对话按日期分组（根据 viewMode 过滤归档状态，排除 draft） */
@@ -1813,17 +1844,17 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       const parentSession = agentSessions.find((session) => session.id === selectedSession.parentSessionId)
       if (parentSession) {
         openSession('agent', parentSession.id, parentSession.title)
-        store.set(agentSideDelegationMapAtom, (previous) => {
-          const openChildIds = previous.get(parentSession.id) ?? []
-          if (openChildIds.includes(selectedSession.id)) return previous
-          const next = new Map(previous)
-          next.set(parentSession.id, [...openChildIds, selectedSession.id])
-          return next
-        })
+        store.set(agentSideDelegationMapAtom, (previous) => (
+          selectDelegatedSession(previous, parentSession.id, selectedSession.id)
+        ))
         store.set(agentSidePanelOpenAtomFamily(parentSession.id), true)
+        rememberStopGenerationTarget({ kind: 'agent', sessionId: selectedSession.id })
+        setUnviewedDelegatedCompleted((prev) => (
+          markSessionCompletionViewed(prev, selectedSession.id)
+        ))
         store.set(agentDiffPanelTabAtom, (previous) => {
           const next = new Map(previous)
-          next.set(parentSession.id, getDelegationSidePanelTab(selectedSession.id))
+          next.set(parentSession.id, getDelegationSidePanelTab())
           return next
         })
         setActiveView('conversations')
@@ -1846,7 +1877,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       next.delete(id)
       return next
     })
-  }, [agentSessions, openSession, setActiveView, setUnviewedCompleted, store])
+  }, [agentSessions, openSession, setActiveView, setUnviewedCompleted, setUnviewedDelegatedCompleted, store])
 
   const clearQuickSwitchHints = React.useCallback((): void => {
     for (const row of quickSwitchHintRowsRef.current) {
@@ -2839,15 +2870,19 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           ),
         })
         if (expandedChildren) {
-          for (const childSession of item.childSessions) {
+          for (const [childIndex, childSession] of item.childSessions.entries()) {
             rows.push({
               id: `agent-archived-child-${childSession.id}`,
-              estimateSize: 34,
+              estimateSize: childIndex === 0 ? 36 : 34,
               content: (
-                <div className="ml-6 border-l border-foreground/10 pl-2 pr-3">
+                <div className={cn(
+                  'ml-6 border-l border-foreground/10 pl-2 pr-3',
+                  childIndex === 0 && 'pt-0.5',
+                )}>
                   <DelegatedChildSessionItem
                     session={childSession}
                     activeSessionId={activeSessionId}
+                    activeDelegationSessionId={activeDelegationSessionId}
                     agentIndicatorMap={agentIndicatorMap}
                     relativeTimeNow={relativeTimeNow}
                     workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
@@ -2867,7 +2902,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       }
     }
     return rows
-  }, [activeSessionId, agentIndicatorMap, archivedAgentSessionProjectGroups, collapsedDelegationParentIds, currentWorkspaceId, expandedArchivedProjectIds, expandedDelegationParentIds, handleAgentRename, handleRequestDelete, handleRequestMove, handleSelectAgentSession, handleToggleArchiveAgent, handleToggleArchivedProject, handleToggleDelegationParent, handleTogglePinAgent, handleToggleStarAgent, relativeTimeNow, sessionHoverPreviewEnabled, workspaceNameMap])
+  }, [activeDelegationSessionId, activeSessionId, agentIndicatorMap, archivedAgentSessionProjectGroups, collapsedDelegationParentIds, currentWorkspaceId, expandedArchivedProjectIds, expandedDelegationParentIds, handleAgentRename, handleRequestDelete, handleRequestMove, handleSelectAgentSession, handleToggleArchiveAgent, handleToggleArchivedProject, handleToggleDelegationParent, handleTogglePinAgent, handleToggleStarAgent, relativeTimeNow, sessionHoverPreviewEnabled, workspaceNameMap])
 
   const agentActiveVirtualRows = React.useMemo<VirtualSidebarRow[]>(() => {
     if (viewMode !== 'active') return []
@@ -2927,13 +2962,16 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       })
 
       if (childCount > 0 && expandedChildren) {
-        for (const childSession of item.childSessions) {
+        for (const [childIndex, childSession] of item.childSessions.entries()) {
           rows.push({
             id: `agent-child-${childSession.id}`,
-            estimateSize: 34,
+            estimateSize: childIndex === 0 ? 36 : 34,
             content: (
               <div
-                className="ml-7 border-l border-foreground/10 pl-2"
+                className={cn(
+                  'ml-7 border-l border-foreground/10 pl-2',
+                  childIndex === 0 && 'pt-0.5',
+                )}
                 onDragOver={projectWorkspaceId ? (event) => handleProjectDragOver(event, projectWorkspaceId) : undefined}
                 onDragLeave={projectWorkspaceId ? handleProjectDragLeave : undefined}
                 onDrop={projectWorkspaceId ? (event) => handleProjectDrop(event, projectWorkspaceId) : undefined}
@@ -2941,6 +2979,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                 <DelegatedChildSessionItem
                   session={childSession}
                   activeSessionId={activeSessionId}
+                  activeDelegationSessionId={activeDelegationSessionId}
                   agentIndicatorMap={agentIndicatorMap}
                   relativeTimeNow={relativeTimeNow}
                   workspaceName={isAutomationGroup && childSession.workspaceId ? workspaceNameMapForRow?.get(childSession.workspaceId) : undefined}
@@ -3059,6 +3098,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               extraCount={extraCount}
               collapsed={collapsed}
               activeSessionId={activeSessionId}
+              activeDelegationSessionId={activeDelegationSessionId}
               agentIndicatorMap={agentIndicatorMap}
               expandedDelegationParentIds={expandedDelegationParentIds}
               collapsedDelegationParentIds={collapsedDelegationParentIds}
@@ -3149,6 +3189,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
     return rows
   }, [
+    activeDelegationSessionId,
     activeSessionId,
     agentIndicatorMap,
     collapsedDelegationParentIds,
@@ -4206,13 +4247,6 @@ const SESSION_ACCENT_INDICATOR_CLASS: Record<SessionLeftAccent, string> = {
   green: 'bg-green-500',
 }
 
-const DELEGATION_STATUS_ICON_CLASS: Record<SessionIndicatorStatus, string> = {
-  idle: 'text-foreground/40',
-  running: 'text-blue-500',
-  blocked: 'text-orange-500',
-  completed: 'text-green-500',
-}
-
 function getSessionLeftAccent(status: SessionIndicatorStatus): SessionLeftAccent | undefined {
   if (status === 'blocked') return 'orange'
   if (status === 'running') return 'blue'
@@ -4419,7 +4453,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                   <Clock size={11} className="flex-shrink-0 text-foreground/40" />
                 )}
                 {session.sourceDelegationId && (
-                  <GitBranch size={11} className={cn('flex-shrink-0', DELEGATION_STATUS_ICON_CLASS[indicatorStatus])} />
+                  <GitBranch size={11} className={cn('flex-shrink-0', getDelegationStatusIconClass(indicatorStatus))} />
                 )}
                 <span
                   className="truncate"
@@ -4547,6 +4581,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 interface DelegatedChildSessionItemProps {
   session: AgentSessionMeta
   activeSessionId: string | null
+  activeDelegationSessionId: string | null
   agentIndicatorMap: Map<string, SessionIndicatorStatus>
   relativeTimeNow: number
   workspaceName?: string
@@ -4562,6 +4597,7 @@ interface DelegatedChildSessionItemProps {
 const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem({
   session,
   activeSessionId,
+  activeDelegationSessionId,
   agentIndicatorMap,
   relativeTimeNow,
   workspaceName,
@@ -4575,11 +4611,13 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
 }: DelegatedChildSessionItemProps): React.ReactElement {
   const sessionHoverPreviewEnabled = useAtomValue(sessionHoverPreviewEnabledAtom)
   const status = getDelegatedChildStatus(session, agentIndicatorMap)
+  const highlighted = session.id === activeSessionId
+    || (session.parentSessionId === activeSessionId && session.id === activeDelegationSessionId)
 
   return (
     <AgentSessionItem
       session={session}
-      active={session.id === activeSessionId}
+      active={highlighted}
       indicatorStatus={status}
       disableMiniMap={!sessionHoverPreviewEnabled}
       relativeTimeNow={relativeTimeNow}
@@ -4618,7 +4656,7 @@ function getVisibleAgentProjectSessions({
   previousActiveIds?: ReadonlySet<string>
 }): VisibleAgentProjectSessions {
   const recentCutoff = relativeTimeNow - PROJECT_SESSION_RECENT_WINDOW_MS
-  const treeItems = buildAgentSessionTrees(group.sessions)
+  const treeItems = buildAgentSessionTrees(group.sessions, agentIndicatorMap)
   const activeSessions = treeItems
     .filter((item) => (
       ACTIVE_SESSION_STATUSES.has(getSessionTreeStatus(item, agentIndicatorMap))
@@ -4668,6 +4706,7 @@ interface AgentProjectGroupItemProps {
   /** 用户已点击"显示更多"额外展开的会话数量（基于 collapsedSessions 之上累加） */
   extraCount: number
   activeSessionId: string | null
+  activeDelegationSessionId: string | null
   agentIndicatorMap: Map<string, SessionIndicatorStatus>
   expandedDelegationParentIds: Set<string>
   collapsedDelegationParentIds: Set<string>
@@ -4710,6 +4749,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   collapsed,
   extraCount,
   activeSessionId,
+  activeDelegationSessionId,
   agentIndicatorMap,
   expandedDelegationParentIds,
   collapsedDelegationParentIds,
@@ -5037,6 +5077,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                             key={childSession.id}
                             session={childSession}
                             activeSessionId={activeSessionId}
+                            activeDelegationSessionId={activeDelegationSessionId}
                             agentIndicatorMap={agentIndicatorMap}
                             relativeTimeNow={relativeTimeNow}
                             workspaceName={isAutomationGroup && childSession.workspaceId ? workspaceNameMap?.get(childSession.workspaceId) : undefined}

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -25,8 +25,9 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
-import type { AgentSidePanelTab, WorkspaceComponentTab } from '@/atoms/agent-atoms'
+import type { AgentSidePanelTab, SessionIndicatorStatus, WorkspaceComponentTab } from '@/atoms/agent-atoms'
 import { groupRightWorkspaceTabs, type RightWorkspacePane } from '@/lib/right-workspace-split'
+import { getDelegationStatusIconClass } from '@/lib/agent-session-list'
 import type { ProductivityToolsSettings } from '@/types/settings'
 
 export interface RightWorkspaceTabDragState {
@@ -41,6 +42,7 @@ export interface WorkspacePanelTab {
   icon: React.ReactNode
   closable?: boolean
   activity?: boolean
+  status?: SessionIndicatorStatus
 }
 
 interface DiffPanelTabBarProps {
@@ -356,7 +358,12 @@ export function DiffPanelTabBar({
                   {tab.activity || (isChangesTab && unseenChanges && !selected) ? (
                     <span className="size-1.5 shrink-0 rounded-full bg-primary" aria-label="有未查看更新" />
                   ) : (
-                    <span className={cn('shrink-0', selected ? 'text-foreground' : 'text-muted-foreground/80')}>{tab.icon}</span>
+                    <span className={cn(
+                      'shrink-0',
+                      tab.status
+                        ? getDelegationStatusIconClass(tab.status)
+                        : selected ? 'text-foreground' : 'text-muted-foreground/80',
+                    )}>{tab.icon}</span>
                   )}
                   <span className="truncate">{tab.label}</span>
                 </button>

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -36,6 +36,8 @@ import {
   agentWorkspacesAtom,
   agentAttachedFilesMapAtom,
   agentDiffPanelTabAtom,
+  agentSideDelegationMapAtom,
+  agentSidePanelSplitMapAtom,
   currentSessionSidePanelOpenAtom,
   isWorkspaceComponentTab,
 } from '@/atoms/agent-atoms'
@@ -56,6 +58,7 @@ import {
   updateShortcutOverrides,
 } from '@/lib/shortcut-registry'
 import { getFileParentPath } from '@/lib/file-utils'
+import { isDelegationObservationVisible } from '@/lib/agent-session-list'
 import { getLastInteractedStopTarget, resolveStopGenerationTarget } from '@/lib/stop-generation-target'
 import { CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT } from '@/lib/right-workspace-events'
 import {
@@ -86,7 +89,11 @@ export function GlobalShortcuts(): null {
   const activeTabId = useAtomValue(activeTabIdAtom)
   const activeTab = useAtomValue(activeTabAtom)
   const activeAgentSidePanelTab = useAtomValue(agentDiffPanelTabAtom).get(activeTab?.type === 'agent' ? activeTab.sessionId : '')
+  const activeAgentSessionId = activeTab?.type === 'agent' ? activeTab.sessionId : ''
+  const activeDelegationSessionId = useAtomValue(agentSideDelegationMapAtom).get(activeAgentSessionId) ?? null
+  const activeAgentSidePanelSplit = useAtomValue(agentSidePanelSplitMapAtom).get(activeAgentSessionId) ?? null
   const isActiveAgentSidePanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
 
   // 统一关闭逻辑：与 TabBar.handleClose 共用
   // 含 Agent 子进程 stop + 流式中的确认对话框（修复 Issue #357）
@@ -137,7 +144,7 @@ export function GlobalShortcuts(): null {
       if (
         isActiveAgentSidePanelOpen
         && activeAgentSidePanelTab
-        && (isWorkspaceComponentTab(activeAgentSidePanelTab) || activeAgentSidePanelTab.startsWith('preview:') || activeAgentSidePanelTab.startsWith('browser:') || activeAgentSidePanelTab.startsWith('exploration:') || activeAgentSidePanelTab.startsWith('delegation:') || activeAgentSidePanelTab.startsWith('terminal:'))
+        && (isWorkspaceComponentTab(activeAgentSidePanelTab) || activeAgentSidePanelTab.startsWith('preview:') || activeAgentSidePanelTab.startsWith('browser:') || activeAgentSidePanelTab.startsWith('exploration:') || activeAgentSidePanelTab === 'delegation' || activeAgentSidePanelTab.startsWith('terminal:'))
       ) {
         window.dispatchEvent(new CustomEvent(CLOSE_ACTIVE_RIGHT_WORKSPACE_TAB_EVENT, {
           detail: { sessionId: activeTab.sessionId },
@@ -219,16 +226,33 @@ export function GlobalShortcuts(): null {
     }, []),
   )
 
-  // Cmd+Shift+Backspace → 停止光标所在、或最近点击过的 Chat / Agent。
-  // 父会话与右侧委派子会话可能同时挂载，因此事件必须带目标，不能广播给全部视图。
+  // Cmd+Shift+Backspace → 停止最近交互的会话。只有 delegated child 需要额外校验，
+  // 因为右侧观察槽会保留挂载状态并替换内容；其他会话沿用原有交互目标语义。
   useShortcut(
     'stop-generation',
     useCallback(() => {
-      const target = getLastInteractedStopTarget()
-        ?? resolveStopGenerationTarget(activeTab, activeAgentSidePanelTab)
-      if (!target) return
-      window.dispatchEvent(new CustomEvent('proma:stop-generation', { detail: target }))
-    }, [activeAgentSidePanelTab, activeTab]),
+      const lastTarget = getLastInteractedStopTarget()
+      const lastTargetIsDelegated = lastTarget?.kind === 'agent'
+        && agentSessions.some((session) => session.id === lastTarget.sessionId && !!session.sourceDelegationId)
+      const delegatedTargetVisible = lastTargetIsDelegated
+        && lastTarget.sessionId === activeDelegationSessionId
+        && activeTab?.type === 'agent'
+        && isDelegationObservationVisible(
+          isActiveAgentSidePanelOpen,
+          activeAgentSidePanelTab,
+          activeAgentSidePanelSplit,
+        )
+      const target = lastTarget && (!lastTargetIsDelegated || delegatedTargetVisible)
+        ? lastTarget
+        : resolveStopGenerationTarget(
+            activeTab,
+            isActiveAgentSidePanelOpen ? activeAgentSidePanelTab : undefined,
+            activeDelegationSessionId ? { type: 'agent', sessionId: activeDelegationSessionId } : null,
+          )
+      if (target) {
+        window.dispatchEvent(new CustomEvent('proma:stop-generation', { detail: target }))
+      }
+    }, [activeAgentSidePanelSplit, activeAgentSidePanelTab, activeDelegationSessionId, activeTab, agentSessions, isActiveAgentSidePanelOpen]),
   )
 
   // ===== 快速任务窗口 → 创建会话并自动发送 =====

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -44,6 +44,7 @@ import {
   workspaceAttachedDirectoriesMapAtom,
   workspaceAttachedFilesMapAtom,
   unviewedCompletedSessionIdsAtom,
+  unviewedCompletedDelegatedSessionIdsAtom,
   agentSessionPathMapAtom,
   agentDiffRefreshVersionAtom,
   agentDiffPanelTabAtom,
@@ -53,6 +54,7 @@ import {
   agentSidePanelOpenAtomFamily,
   revealChangedWorkspaceComponentAtom,
   agentSideDelegationMapAtom,
+  agentSidePanelSplitMapAtom,
   getDelegationSidePanelTab,
   askUserDraftsAtom,
 } from '@/atoms/agent-atoms'
@@ -85,14 +87,18 @@ import {
   shouldActivateExternalAgentRun,
   shouldRevealDelegatedSession,
 } from '@/lib/external-agent-run'
-import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
+import { upsertAgentSession, mergeFetchedAgentSessions, selectDelegatedSession } from '@/lib/agent-session-list'
 import {
   getAgentCompletionMarkers,
+  getDelegatedCompletionAttention,
+  markSessionCompletionUnviewed,
+  markSessionCompletionViewed,
   notifyAgentCompletion,
 } from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { detectIsWindows } from '@/lib/platform'
 import { arePathsEqual, getInactiveSessionFileChangePaths, getSessionFileChangeKind, getOwnedSessionWatcherPaths, removeSessionFileChange, upsertSessionFileChange, type SessionFileChange } from '@/lib/session-file-changes'
+import { rememberStopGenerationTarget } from '@/lib/stop-generation-target'
 import { doesWorkspaceChangeAffectPreview } from '@/components/diff/preview-open-path'
 import { removeQueuedMessage, createQueuedAgentStreamState, createAgentQueuedMessage } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
@@ -576,6 +582,20 @@ export function useGlobalAgentListeners(): void {
   const store = useStore()
 
   useEffect(() => {
+    const clearCompletionAttention = (sessionId: string): void => {
+      store.set(unviewedCompletedSessionIdsAtom, (prev) => markSessionCompletionViewed(prev, sessionId))
+      store.set(unviewedCompletedDelegatedSessionIdsAtom, (prev) => markSessionCompletionViewed(prev, sessionId))
+    }
+
+    /** 新一轮启动时立即把 delegated child 提升到所属父会话的子列表首位。 */
+    const promoteDelegatedSessionForRunStart = (sessionId: string, startedAt: number): void => {
+      store.set(agentSessionsAtom, (prev) => {
+        const session = prev.find((item) => item.id === sessionId)
+        if (!session?.parentSessionId || !session.sourceDelegationId || session.updatedAt > startedAt) return prev
+        return upsertAgentSession(prev, { ...session, updatedAt: startedAt })
+      })
+    }
+
     /** 正在执行的写工具；写入前的文件存在性用于区分新建和编辑。 */
     const pendingWriteTools = new Map<string, {
       path: string
@@ -592,22 +612,25 @@ export function useGlobalAgentListeners(): void {
         // 主进程在启动 deferred run 前先发送 started 投影。这里必须先建立完整的
         // 当前 run 状态，否则首个 SDK/tool 事件到达前会被当成空闲；后续事件只能
         // 隐式创建一个没有 startedAt 的状态，导致续跑的运行计时和 run 边界丢失。
+        let acceptedRunStart = false
         store.set(agentStreamingStatesAtom, (prev) => {
           const current = prev.get(status.sessionId)
           if (
             current?.runGeneration != null
             && status.runGeneration != null
-            && current.runGeneration > status.runGeneration
+            && current.runGeneration >= status.runGeneration
           ) return prev
-          // 旧 IPC 事件降级为 startedAt 比较；不让迟到队列状态覆盖较新的 run。
-          if (status.runGeneration == null && current?.startedAt != null && current.startedAt > status.startedAt) return prev
+          // 旧 IPC 事件降级为 startedAt 比较；不让迟到或重复队列状态覆盖当前 run。
+          if (status.runGeneration == null && current?.startedAt != null && current.startedAt >= status.startedAt) return prev
           const map = new Map(prev)
           map.set(status.sessionId, {
             ...createQueuedAgentStreamState(current, status.startedAt),
             ...(status.runGeneration != null ? { runGeneration: status.runGeneration } : {}),
           })
+          acceptedRunStart = true
           return map
         })
+        if (acceptedRunStart) promoteDelegatedSessionForRunStart(status.sessionId, status.startedAt)
         store.set(agentSessionMessageQueueAtom, (prev) => {
           const current = prev.get(status.sessionId) ?? []
           const next = removeQueuedMessage(current, status.messageId)
@@ -706,7 +729,16 @@ export function useGlobalAgentListeners(): void {
           createdAt: event.startedAt,
           updatedAt: event.startedAt,
         }
-        store.set(agentSessionsAtom, (prev) => upsertAgentSession(prev, upserted))
+        const duplicateRunStart = currentStreamState?.runGeneration != null && event.runGeneration != null
+          ? currentStreamState.runGeneration === event.runGeneration
+          : currentStreamState?.startedAt === event.startedAt
+        const knownSession = store.get(agentSessionsAtom).some((item) => item.id === event.sessionId)
+        if (!duplicateRunStart || !knownSession) {
+          store.set(agentSessionsAtom, (prev) => upsertAgentSession(prev, knownSession
+            ? upserted
+            : { ...upserted, updatedAt: Math.max(upserted.updatedAt, event.startedAt) }))
+        }
+        if (!duplicateRunStart) promoteDelegatedSessionForRunStart(event.sessionId, event.startedAt)
         const activationModelId = activation.modelId
         if (activationModelId) {
           store.set(agentSessionModelMapAtom, (prev) => {
@@ -715,12 +747,7 @@ export function useGlobalAgentListeners(): void {
             return map
           })
         }
-        store.set(unviewedCompletedSessionIdsAtom, (prev) => {
-          if (!prev.has(event.sessionId)) return prev
-          const next = new Set(prev)
-          next.delete(event.sessionId)
-          return next
-        })
+        clearCompletionAttention(event.sessionId)
         store.set(agentStreamingStatesAtom, (prev) => {
           const map = new Map(prev)
           map.set(event.sessionId, activation.streamState)
@@ -734,19 +761,18 @@ export function useGlobalAgentListeners(): void {
           && upserted.parentSessionId
           && shouldRevealDelegatedSession(upserted.parentSessionId, store.get(activeSessionIdAtom))
         ) {
-          store.set(agentSideDelegationMapAtom, (previous) => {
-            const openChildIds = previous.get(upserted.parentSessionId!) ?? []
-            if (openChildIds.includes(upserted.id)) return previous
-            const next = new Map(previous)
-            next.set(upserted.parentSessionId!, [...openChildIds, upserted.id])
-            return next
-          })
+          store.set(agentSideDelegationMapAtom, (previous) => (
+            selectDelegatedSession(previous, upserted.parentSessionId!, upserted.id)
+          ))
           store.set(agentSidePanelOpenAtomFamily(upserted.parentSessionId), true)
           store.set(agentDiffPanelTabAtom, (previous) => {
             const next = new Map(previous)
-            next.set(upserted.parentSessionId!, getDelegationSidePanelTab(upserted.id))
+            next.set(upserted.parentSessionId!, getDelegationSidePanelTab())
             return next
           })
+          // The UI has actively replaced the right observation slot with this child. Keep the
+          // global stop shortcut aligned even though no AgentView pointer event has fired yet.
+          rememberStopGenerationTarget({ kind: 'agent', sessionId: upserted.id })
         }
       }
 
@@ -1110,6 +1136,7 @@ export function useGlobalAgentListeners(): void {
           // 队列 run 会先通过独立 IPC 发送 started 投影，但该投影可能在窗口
           // 重载或跨 renderer 路由时丢失。run_started 是同一轮的第二个权威启动信号，
           // 必须在首个 SDK/tool 事件之前恢复 running、startedAt 和正常的 live UI。
+          let acceptedRunStart = false
           store.set(agentStreamingStatesAtom, (prev) => {
             const current = prev.get(sessionId)
             if (
@@ -1130,14 +1157,11 @@ export function useGlobalAgentListeners(): void {
               ...createQueuedAgentStreamState(current, runStartedEvent.startedAt),
               ...(runStartedEvent.runGeneration != null ? { runGeneration: runStartedEvent.runGeneration } : {}),
             })
+            acceptedRunStart = true
             return map
           })
-          store.set(unviewedCompletedSessionIdsAtom, (prev) => {
-            if (!prev.has(sessionId)) return prev
-            const next = new Set(prev)
-            next.delete(sessionId)
-            return next
-          })
+          if (acceptedRunStart) promoteDelegatedSessionForRunStart(sessionId, runStartedEvent.startedAt)
+          clearCompletionAttention(sessionId)
         }
 
         // 自动任务会话被用户接管（毕业）：向用户提示，后续定时运行将新建独立会话
@@ -1318,12 +1342,7 @@ export function useGlobalAgentListeners(): void {
           if (event.type !== 'prompt_suggestion') {
             const prevState = store.get(agentSessionStreamingStateAtomFamily(sessionId))
             if (!prevState || !prevState.running) {
-              store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
-                if (!prev.has(sessionId)) return prev
-                const next = new Set(prev)
-                next.delete(sessionId)
-                return next
-              })
+              clearCompletionAttention(sessionId)
             }
           }
 
@@ -1666,7 +1685,60 @@ export function useGlobalAgentListeners(): void {
           return map
         })
 
-        // 只有未激活会话才进入"未查看完成"，避免当前页面完成时出现额外未读提醒。
+        const completionParentSessionId = completionSession?.parentSessionId
+        if (data.triggeredBy === 'delegation' || completionSession?.sourceDelegationId) {
+          // Snapshot renderer layout before resolving native BrowserWindow focus asynchronously.
+          const completionPresence = {
+            activeSessionId: store.get(activeSessionIdAtom),
+            selectedDelegationSessionId: completionParentSessionId
+              ? store.get(agentSideDelegationMapAtom).get(completionParentSessionId) ?? null
+              : null,
+            activeSidePanelTab: completionParentSessionId
+              ? store.get(agentDiffPanelTabAtom).get(completionParentSessionId)
+              : undefined,
+            split: completionParentSessionId
+              ? store.get(agentSidePanelSplitMapAtom).get(completionParentSessionId) ?? null
+              : null,
+            sidePanelOpen: completionParentSessionId
+              ? store.get(agentSidePanelOpenAtomFamily(completionParentSessionId))
+              : false,
+          }
+          const updateDelegatedAttention = (windowHasFocus: boolean): void => {
+            // Do not let an old async completion overwrite a newer run's cleared state.
+            if (!isTerminalEventForCurrentRun(
+              store.get(agentSessionStreamingStateAtomFamily(data.sessionId)),
+              data,
+            )) return
+            const attention = getDelegatedCompletionAttention({
+              completion: data,
+              session: completionSession,
+              hasStreamError,
+              ...completionPresence,
+              windowHasFocus,
+            })
+            if (!attention) return
+            store.set(unviewedCompletedDelegatedSessionIdsAtom, (prev: Set<string>) => (
+              attention === 'unviewed'
+                ? markSessionCompletionUnviewed(prev, data.sessionId)
+                : markSessionCompletionViewed(prev, data.sessionId)
+            ))
+          }
+
+          if (document.hasFocus()) {
+            updateDelegatedAttention(true)
+          } else {
+            const getWindowIsFocused = (window.electronAPI as Partial<typeof window.electronAPI>).windowIsFocused
+            if (typeof getWindowIsFocused === 'function') {
+              void getWindowIsFocused()
+                .then(updateDelegatedAttention)
+                .catch(() => updateDelegatedAttention(false))
+            } else {
+              updateDelegatedAttention(false)
+            }
+          }
+        }
+
+        // 只有未激活的顶层会话才进入全局“未查看完成”；协作子会话使用独立集合，不计入 Dock。
         const currentSessionId = store.get(currentAgentSessionIdAtom)
         const completionMarkers = getAgentCompletionMarkers({
           tabs: store.get(tabsAtom),
@@ -1677,11 +1749,9 @@ export function useGlobalAgentListeners(): void {
           documentHasFocus: document.hasFocus(),
         })
         if (completionMarkers.markUnviewedCompleted && !backgroundTasksPending) {
-          store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
-            const next = new Set(prev)
-            next.add(data.sessionId)
-            return next
-          })
+          store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => (
+            markSessionCompletionUnviewed(prev, data.sessionId)
+          ))
         } else if (!backgroundTasksPending) {
           // 当前聚焦会话已在主应用可见；同步确认，避免灵动岛把这次完成继续当未读。
           void window.electronAPI.agentIsland.markSessionViewed(data.sessionId).catch(console.error)

--- a/apps/electron/src/renderer/lib/agent-completion-presence.ts
+++ b/apps/electron/src/renderer/lib/agent-completion-presence.ts
@@ -1,5 +1,6 @@
 import type { AgentSessionMeta, AgentStreamCompletePayload } from '@proma/shared'
 import type { TabItem } from '@/atoms/tab-atoms'
+import { isDelegationObservationVisible } from '@/lib/agent-session-list'
 
 export interface AgentCompletionPresenceInput {
   tabs: TabItem[]
@@ -18,7 +19,7 @@ export interface AgentCompletionMarkers {
 
 export interface AgentCompletionNotificationInput {
   completion: AgentStreamCompletePayload
-  session?: Pick<AgentSessionMeta, 'sourceDelegationId'>
+  session?: Pick<AgentSessionMeta, 'sourceDelegationId' | 'parentSessionId'>
 }
 
 export interface NotifyAgentCompletionInput extends AgentCompletionNotificationInput {
@@ -34,6 +35,73 @@ export function shouldNotifyAgentCompletion({
   return completion.triggeredBy !== 'delegation' && !session?.sourceDelegationId
 }
 
+export function markSessionCompletionUnviewed(
+  sessionIds: Set<string>,
+  sessionId: string,
+): Set<string> {
+  if (sessionIds.has(sessionId)) return sessionIds
+  const next = new Set(sessionIds)
+  next.add(sessionId)
+  return next
+}
+
+export function markSessionCompletionViewed(
+  sessionIds: Set<string>,
+  sessionId: string,
+): Set<string> {
+  if (!sessionIds.has(sessionId)) return sessionIds
+  const next = new Set(sessionIds)
+  next.delete(sessionId)
+  return next
+}
+
+export function isSuccessfulAgentCompletion(
+  completion: AgentStreamCompletePayload,
+  hasStreamError: boolean,
+): boolean {
+  return !completion.stoppedByUser &&
+    !hasStreamError &&
+    (!completion.resultSubtype || completion.resultSubtype === 'success')
+}
+
+export type DelegatedCompletionAttention = 'viewed' | 'unviewed' | null
+
+interface DelegatedCompletionAttentionInput extends AgentCompletionNotificationInput {
+  hasStreamError: boolean
+  activeSessionId: string | null
+  selectedDelegationSessionId: string | null
+  activeSidePanelTab: string | undefined
+  split: { leftTab: string; rightTab: string } | null
+  sidePanelOpen: boolean
+  windowHasFocus: boolean
+}
+
+/** Resolve delegated completion to one attention transition; null means no state change. */
+export function getDelegatedCompletionAttention({
+  completion,
+  session,
+  hasStreamError,
+  activeSessionId,
+  selectedDelegationSessionId,
+  activeSidePanelTab,
+  split,
+  sidePanelOpen,
+  windowHasFocus,
+}: DelegatedCompletionAttentionInput): DelegatedCompletionAttention {
+  if (completion.triggeredBy !== 'delegation' && !session?.sourceDelegationId) return null
+
+  const visible = !!session?.parentSessionId
+    && windowHasFocus
+    && activeSessionId === session.parentSessionId
+    && selectedDelegationSessionId === completion.sessionId
+    && isDelegationObservationVisible(sidePanelOpen, activeSidePanelTab, split)
+  if (visible) return 'viewed'
+
+  return !completion.backgroundTasksPending && isSuccessfulAgentCompletion(completion, hasStreamError)
+    ? 'unviewed'
+    : null
+}
+
 /** 仅在真正成功且无需等待后台任务时调用完成通知 callback */
 export function notifyAgentCompletion({
   completion,
@@ -41,12 +109,8 @@ export function notifyAgentCompletion({
   hasStreamError,
   notify,
 }: NotifyAgentCompletionInput): void {
-  const isSuccessfulCompletion = !completion.stoppedByUser &&
-    !hasStreamError &&
-    (!completion.resultSubtype || completion.resultSubtype === 'success')
-
   if (!completion.backgroundTasksPending &&
-    isSuccessfulCompletion &&
+    isSuccessfulAgentCompletion(completion, hasStreamError) &&
     shouldNotifyAgentCompletion({ completion, session })) {
     notify()
   }

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -6,6 +6,18 @@ interface AgentSessionTreeLike {
   childSessions: readonly Pick<AgentSessionMeta, 'id'>[]
 }
 
+const DELEGATION_STATUS_ICON_CLASS: Readonly<Record<SessionIndicatorStatus, string>> = {
+  idle: 'text-foreground/40',
+  running: 'text-blue-500',
+  blocked: 'text-orange-500',
+  completed: 'text-green-500',
+}
+
+/** Keep delegated-session status colors identical wherever its GitBranch icon is rendered. */
+export function getDelegationStatusIconClass(status: SessionIndicatorStatus): string {
+  return DELEGATION_STATUS_ICON_CLASS[status]
+}
+
 /** 按最近更新时间排序 Agent 会话，保持与主进程 listAgentSessions 一致。 */
 export function sortAgentSessionsByUpdatedAtDesc(
   sessions: readonly AgentSessionMeta[],
@@ -193,6 +205,46 @@ export function isAgentSessionVisibleInTrees(
 ): boolean {
   if (!sessionId) return false
   return collectAgentSessionTreeIds(items).has(sessionId)
+}
+
+/** The stable delegation observation slot is visible in a single pane or either split pane. */
+export function isDelegationObservationVisible(
+  sidePanelOpen: boolean,
+  activeSidePanelTab: string | undefined,
+  split: { leftTab: string; rightTab: string } | null,
+): boolean {
+  if (!sidePanelOpen) return false
+  return split
+    ? split.leftTab === 'delegation' || split.rightTab === 'delegation'
+    : activeSidePanelTab === 'delegation'
+}
+
+/** Replace the delegated child shown in one parent's single observation slot. */
+export function selectDelegatedSession(
+  selections: Map<string, string>,
+  parentSessionId: string,
+  childSessionId: string,
+): Map<string, string> {
+  if (selections.get(parentSessionId) === childSessionId) return selections
+  const next = new Map(selections)
+  next.set(parentSessionId, childSessionId)
+  return next
+}
+
+/** Remove a deleted parent or child from the delegated-session observation slots. */
+export function removeDelegatedSessionSelection(
+  selections: Map<string, string>,
+  sessionId: string,
+): Map<string, string> {
+  let changed = false
+  const next = new Map(selections)
+  if (next.delete(sessionId)) changed = true
+  for (const [parentSessionId, childSessionId] of next) {
+    if (childSessionId !== sessionId) continue
+    next.delete(parentSessionId)
+    changed = true
+  }
+  return changed ? next : selections
 }
 
 /**

--- a/apps/electron/src/renderer/lib/stop-generation-target.ts
+++ b/apps/electron/src/renderer/lib/stop-generation-target.ts
@@ -29,6 +29,11 @@ export function clearStopGenerationTarget(target: StopGenerationTarget): void {
   }
 }
 
+interface DelegationSelectionLike {
+  type: string
+  sessionId: string
+}
+
 /**
  * Resolves a fallback target when the user has not yet focused or clicked a
  * conversation view in this window.
@@ -36,12 +41,14 @@ export function clearStopGenerationTarget(target: StopGenerationTarget): void {
 export function resolveStopGenerationTarget(
   activeTab: SessionTabLike | null,
   activeAgentSidePanelTab: string | undefined,
+  activeDelegation: DelegationSelectionLike | null = null,
 ): StopGenerationTarget | null {
   if (!activeTab) return null
 
   if (activeTab.type === 'agent') {
-    const delegatedChildSessionId = activeAgentSidePanelTab?.startsWith('delegation:')
-      ? activeAgentSidePanelTab.slice('delegation:'.length)
+    const delegatedChildSessionId = activeAgentSidePanelTab === 'delegation'
+      && activeDelegation?.type === 'agent'
+      ? activeDelegation.sessionId
       : null
 
     return {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -429,6 +429,8 @@ export const IPC_CHANNELS = {
   WINDOW_CLOSE: 'window:close',
   /** 窗口是否最大化 */
   WINDOW_IS_MAXIMIZED: 'window:is-maximized',
+  /** 宿主 BrowserWindow 是否处于前台（包含焦点位于 WebContentsView 的情况） */
+  WINDOW_IS_FOCUSED: 'window:is-focused',
   /** 在系统剪贴板中写入纯文本 */
   WRITE_CLIPBOARD_TEXT: 'clipboard:write-text',
   /** 截图导出：将 HTML 渲染为 PNG 图片 */


### PR DESCRIPTION
## 概述

将父 Agent 会话右侧的多个委派子会话 Tab 收敛为一个稳定的 `delegation` 观察槽。切换子会话时仅替换槽内内容，保持 Tab 身份与分屏位置，不中断、停止或删除任何子 Agent。同时统一左右两侧的真实标题与 `GitBranch` 状态色，并将绿色定义为“刚成功完成、当前不可见且尚未查看”的注意力状态，避免历史完成、可见完成或上下文压缩造成误报。

在保持上述语义与生命周期保护不变的前提下，核心瘦身一度从 `+556/-163`（净增 `+393`）收敛到净增 `+278`；随后补入“delegated child 新一轮开始即在所属 parent 内置顶”的新增验收语义，最终为 `+489/-171`（净增 `+318`），仍比原实现减少 75 行、约 19.1%。瘦身主要移除了 stop target 的重复可见性枚举、分散的 completion 决策和单用途 helper。

## 改动

- `apps/electron/src/renderer/atoms/agent-atoms.ts` — 将父子观察关系从 `Map<parentId, childId[]>` 收敛为 `Map<parentId, childId>`；新增委派完成未查看集合；保持 Dock 角标只统计顶层会话；避免 post-turn compaction 将委派 child 错误标绿。
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 使用稳定 `delegation` Tab 渲染当前选中 child；支持单 Pane 与 Split Pane；同步标题、状态颜色、查看语义、关闭/删除清理和 stop target。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 仅高亮右侧真实可见的 child；Split 任一 Pane 显示 delegation 时均保持高亮，关闭右栏后取消；增加父会话与第一个 child 之间的 2px 间距；running / blocked child 在所属 parent 内按本轮 freshness 置顶。
- `apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx` — 为工作区 Tab 增加状态色契约，使左右 `GitBranch` 使用一致的 idle/running/blocked/completed 颜色。
- `apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx` 与 `apps/electron/src/renderer/lib/stop-generation-target.ts` — 全局停止快捷键只保留仍可见的历史 target；单 Pane 隐藏 child 时回退父会话，Split 另一 Pane 仍显示 child 时保留 child。
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` 与 `apps/electron/src/renderer/lib/agent-completion-presence.ts` — 以完成瞬间的窗口、父会话、右栏开关、观察槽和 Split 布局判断 child 是否可见；可见完成立即视为已查看，隐藏成功完成才标绿；异步焦点查询带 run generation 保护，避免污染下一轮运行。
- `apps/electron/src/main/ipc.ts`、`apps/electron/src/preload/index.ts` 与 `packages/shared/src/types/runtime.ts` — 新增 `window:is-focused` IPC，通过宿主 `BrowserWindow.isFocused()` 覆盖原生 `WebContentsView` 获得焦点时 `document.hasFocus()` 失真的场景。
- `apps/electron/package.json` 与 `packages/shared/package.json` — 分别递增版本至 `0.19.18` 与 `0.1.68`。

## 测试方法

1. 运行 `bun test apps/electron/src/renderer`，确认现有 107 个 renderer 测试全部通过。
2. 运行 `bun run --cwd apps/electron typecheck` 与 `bun run --cwd packages/shared typecheck`。
3. 运行 `bun run --cwd apps/electron build:renderer`，确认 production renderer 构建成功。
4. 手工启动开发版 Electron，验证 child A → B 只替换同一个右侧 Tab，且两者执行均不中断。
5. 验证 running 为蓝色、blocked 为橙色、历史完成为灰色；隐藏成功完成变绿，已可见完成保持灰色，窗口失焦完成变绿。
6. 验证 Split 任一 Pane 显示 child 时左栏保持高亮，关闭观察 Tab/右栏不会停止 child；停止快捷键命中当前仍可见的最近交互会话。
7. 依次启动 child A、child B，确认每个 child 在进入 running 时立即移动到所属 parent 的子列表首位；A 较晚完成时不得挤下仍在运行的 B，重复或陈旧 start 不再次重排。

## 备注

- 已完成同模型只读终审，并针对 stop target、Split 高亮、原生 Browser 焦点和 post-turn compaction 四项发现完成修复与复验；瘦身及 child 运行置顶补丁的独立只读复核最终均无 Blocker / High / Medium。
- 保留 ErlichLiu 补充的“隐藏完成后首次真正渲染即确认已查看”修复，并将 callback 固定为仅在 mount / child 内容切换时触发，避免失焦完成后的普通重渲染误清绿色。
- 未引入新的 blur、backdrop filter、mask、持续动画或合成层；新增焦点 IPC 仅在委派完成且 renderer 未持有焦点时调用一次，不属于高频渲染路径。
- PR 不新增测试文件；删除新增测试文件后，现有 107 个 renderer 测试、类型检查和生产构建均通过。真实 Electron 窗口的完整手工 E2E 建议在合并前按上述步骤复核。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)


