### PR TITLE
fix(sidebar): 并排模式切换子会话时显示引导提示【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.17",
+  "version": "0.19.18",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -57,6 +57,7 @@ import {
   agentSidePanelOpenMapAtom,
   agentSidePanelOpenAtomFamily,
   agentSideDelegationMapAtom,
+  agentSidePanelSplitMapAtom,
   getDelegationSidePanelTab,
   openWorkspaceComponentAtom,
   agentStreamingStatesAtom,
@@ -1812,6 +1813,11 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     if (selectedSession?.sourceDelegationId && selectedSession.parentSessionId) {
       const parentSession = agentSessions.find((session) => session.id === selectedSession.parentSessionId)
       if (parentSession) {
+        if (store.get(agentSidePanelSplitMapAtom).has(parentSession.id)) {
+          toast.info('请先退出并排模式，再切换子会话', {
+            id: 'split-delegation-sidebar-navigation',
+          })
+        }
         openSession('agent', parentSession.id, parentSession.title)
         store.set(agentSideDelegationMapAtom, (previous) => {
           const openChildIds = previous.get(parentSession.id) ?? []


### PR DESCRIPTION
## 概述

右侧工作区处于并排模式时，从左侧会话树点击协作子会话可能因焦点切换而无法直接在右侧定位。本 PR 不调整现有并排布局或焦点逻辑，仅在这一场景显示简洁的单行提示，明确告知用户应先退出并排模式再切换子会话。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 点击委派子会话时检查其父会话是否存在右侧并排状态；若存在，显示「请先退出并排模式，再切换子会话」。Toast 使用固定 ID，避免连续点击造成提示堆叠；原有导航逻辑保持不变。
- `apps/electron/package.json` — 按 Electron 应用改动规范将 patch 版本从 `0.19.17` 更新为 `0.19.18`。

## 测试方法

1. 打开一个包含协作子会话的父 Agent 会话。
2. 将右侧工作区中的两个 Tab 设置为并排显示。
3. 从左侧会话树点击该父会话下的子会话。
4. 确认右上角只显示单行 Toast：「请先退出并排模式，再切换子会话」。
5. 连续重复点击，确认 Toast 不会堆叠。
6. 退出并排模式后再次点击子会话，确认不再显示该提示，并继续沿用原有导航行为。

## 验证

- `bun run --filter='@proma/electron' typecheck`：通过。
- `git diff --check`：通过。
- `bun test`：450 个通过、4 个失败。失败项来自当前本地 Electron/代理测试环境（Electron named export、代理 dispatcher、Electron binary），与本次只涉及 LeftSidebar Toast 的改动路径无关。

## 备注

- 本 PR 刻意不修复或重构焦点抢占逻辑，只提供产品引导。
- 运行 Bun 标准 lockfile 更新后 `bun.lock` 无变化，因此未手动修改生成文件。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
