### PR TITLE
fix(agent): 移除会话拖拽三点提示【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.23",
+  "version": "0.19.24",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -4484,7 +4484,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
           }}
           className={cn(
             'session-quick-switch-row group relative w-full flex items-center gap-1.5 rounded-md py-1.5 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
-            !editing && 'cursor-grab active:cursor-grabbing group-hover:pl-6',
+            !editing && 'cursor-grab active:cursor-grabbing',
             active && 'agent-session-item-active',
             leftAccent
               ? SESSION_ACCENT_ROW_CLASS[leftAccent]
@@ -4501,25 +4501,6 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                 leftAccent ? SESSION_ACCENT_INDICATOR_CLASS[leftAccent] : 'bg-primary',
               )}
             />
-          )}
-          {!editing && (
-            <Tooltip delayDuration={2000}>
-              <TooltipTrigger asChild>
-                <span
-                  aria-label="拖拽会话引用"
-                  className={cn(
-                    'absolute left-1 top-1/2 z-10 inline-flex size-4 -translate-y-1/2 items-center justify-center rounded text-foreground/35 opacity-0 transition-opacity duration-150 group-hover:opacity-100',
-                    leftAccent && 'left-1.5',
-                  )}
-                  onMouseEnter={preview.closeNow}
-                >
-                  <GripVertical size={12} />
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="right" className="max-w-64">
-                支持直接拖拽会话到当前输入框，实现对会话的引用。
-              </TooltipContent>
-            </Tooltip>
           )}
           <div className="flex-1 min-w-0">
             {editing ? (

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.19.23",
+      "version": "0.19.24",
       "dependencies": {
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",


### PR DESCRIPTION
## 概述
移除 Agent 左侧会话列表中鼠标悬停时显示的三点拖拽提示，减少视觉干扰并恢复更简洁的会话行布局。该提示由 PR #1968 引入；本次只移除 GripVertical 图标、Tooltip 及其悬停时的左侧缩进，不改变会话拖拽引用功能。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 删除会话行左侧悬停显示的 `GripVertical` 拖拽图标及说明 Tooltip。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 移除仅用于给拖拽图标让位的 `group-hover:pl-6`，避免悬停时标题发生无意义位移。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 保留整行 `draggable`、`onDragStart`、`setSessionReferenceDragData` 和 `onDragEnd`，继续支持将会话拖入 Agent 输入框生成引用。
- `apps/electron/package.json` — 将桌面应用 patch 版本从 `0.19.23` 更新为 `0.19.24`。
- `bun.lock` — 同步 `@proma/electron` 版本信息。

## 测试方法
1. 运行 `bun run --filter='@proma/electron' typecheck`。
2. 运行 `git diff --check`。
3. 确认会话行仍保留整行拖拽事件链及会话引用载荷生成逻辑。
4. 手动验证悬停会话行不再显示左侧三点，同时仍可将会话拖到另一个 Agent 输入框生成引用。

## 备注
- 本次修改已通过独立子会话按 PR Analyzer 方法论进行审查。
- 当前修改不涉及 IPC、拖拽 MIME 协议、AgentView 输入框处理或跨平台 API。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)