### PR TITLE
fix: align startup branding copy

### DIFF
--- a/apps/electron/resources/startup-splash/index.html
+++ b/apps/electron/resources/startup-splash/index.html
@@ -43,7 +43,7 @@
       <p class="slogan">让协作自然发生，让想法流动成形</p>
       <div class="progress"></div>
       <p class="title">正在启动 Proma</p>
-      <p class="tagline">LOCAL-FIRST AI AGENT</p>
+      <p class="tagline">FOR PROFESSIONALS</p>
     </main>
   </body>
 </html>

--- a/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
@@ -781,7 +781,7 @@ export function OnboardingView({ onComplete, initialStep = 'welcome' }: Onboardi
               欢迎使用 Proma
             </h1>
             <p className="mt-3 text-base leading-relaxed text-neutral-500 md:text-lg">
-              为专业的用户打造的通用 Agent
+              为专业用户打造的通用 Agent
             </p>
 
             {/* 主操作 */}


### PR DESCRIPTION
## Summary\n- align the native startup splash tagline with the Onboarding brand message\n- refine the Onboarding subtitle to the final professional-user wording\n\n## Validation\n- bun run typecheck\n- git diff --check\n- verified all prior Local-first and onboarding copy values are replaced in the target views\n\nPerformance impact: none; static HTML/JSX copy-only change with no runtime or rendering-path behavior changes.\n\nMade with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)