### PR TITLE
feat(browser): add default browser open button

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.23",
+  "version": "0.19.24",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
+++ b/apps/electron/src/renderer/components/browser/BrowserPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import type { BrowserViewState } from '@proma/shared'
-import { ChevronLeft, ChevronRight, LoaderCircle, RotateCw, ShieldAlert, Square } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Globe, LoaderCircle, RotateCw, ShieldAlert, Square } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils'
 import { browserPendingNavigationMapAtom } from '@/atoms/browser-atoms'
 import { BrowserSlot } from './BrowserSlot'
 import { shouldReuseInitialBrowserTab } from './agent-browser-link-utils'
+import { resolveExternalBrowserUrl } from './browser-external-url'
 
 /** 加号菜单最多 7 项；为原生 WebContentsView 预留完整菜单及安全间距。 */
 const ADD_TAB_MENU_CLEARANCE_PX = 256
@@ -60,6 +61,14 @@ export function BrowserPanel({ sessionId, tabId, state, isAddTabMenuOpen = false
     if (!value || typeof navigateBrowser !== 'function') return
     try { await navigateBrowser({ sessionId, tabId, url: value }) } catch (error) { console.error('[受管浏览器] 导航失败:', error) }
   }, [sessionId, tabId, url])
+
+  const openInDefaultBrowser = React.useCallback(() => {
+    const externalUrl = resolveExternalBrowserUrl(url)
+    if (!externalUrl) return
+    void window.electronAPI.openExternal(externalUrl).catch((error) => {
+      console.error('[受管浏览器] 在默认浏览器中打开失败:', error)
+    })
+  }, [url])
 
   const closeBrowser = React.useCallback(async () => {
     try {
@@ -116,6 +125,7 @@ export function BrowserPanel({ sessionId, tabId, state, isAddTabMenuOpen = false
   // 外层右侧 Tab 会先更新 UI，再异步激活 controller 中的原生标签；激活完成前禁用
   // 依赖 controller.activeTabId 的历史操作，导航则始终显式携带当前 tabId。
   const isControllerTabActive = state?.activeTabId === tabId
+  const externalBrowserUrl = resolveExternalBrowserUrl(url)
   const isBackgroundRun = state?.executionSource === 'automation' || state?.executionSource === 'delegation'
   return (
     <div className="flex h-full min-w-0 flex-col overflow-hidden border-l border-border/80 bg-content-area titlebar-no-drag">
@@ -126,6 +136,22 @@ export function BrowserPanel({ sessionId, tabId, state, isAddTabMenuOpen = false
         <form className="flex-1 min-w-0" onSubmit={(event) => { event.preventDefault(); if (!riskBlocked) void navigate() }}>
           <Input disabled={riskBlocked || !isControllerTabActive} value={url} onChange={(event) => setUrl(event.target.value)} placeholder="输入网址或搜索内容" className="h-7 bg-background/70 text-xs text-muted-foreground/70" aria-label="浏览器地址" />
         </form>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-8 shrink-0 rounded-lg text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground"
+              disabled={riskBlocked || !isControllerTabActive || !externalBrowserUrl}
+              onClick={openInDefaultBrowser}
+              aria-label="通过默认浏览器打开"
+            >
+              <Globe className="size-[18px]" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>通过默认浏览器打开</TooltipContent>
+        </Tooltip>
         {state?.loading && <LoaderCircle className="size-3.5 text-muted-foreground animate-spin" />}
         {isBackgroundRun && (
           <Tooltip><TooltipTrigger asChild><Button variant="ghost" size="icon" className="size-7 text-amber-600 hover:text-amber-700" onClick={() => void stopBackgroundRun()} aria-label="停止当前后台 Agent"><Square className="size-3.5 fill-current" /></Button></TooltipTrigger><TooltipContent>停止当前{state?.executionSource === 'automation' ? '自动任务' : '委派'}运行</TooltipContent></Tooltip>

--- a/apps/electron/src/renderer/components/browser/browser-external-url.ts
+++ b/apps/electron/src/renderer/components/browser/browser-external-url.ts
@@ -1,0 +1,15 @@
+/**
+ * 将地址栏内容限定为可安全交给系统默认浏览器的 HTTP(S) 地址。
+ * 搜索词、内部页面和其他协议仍留在受管浏览器内处理。
+ */
+export function resolveExternalBrowserUrl(input: string): string | null {
+  const value = input.trim()
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+  } catch {
+    return null
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.19.23",
+      "version": "0.19.24",
       "dependencies": {
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",


### PR DESCRIPTION
## 摘要
- 在受管浏览器地址栏右侧增加 Globe 图标按钮。
- 通过 Tooltip 提示“通过默认浏览器打开”。
- 复用既有 `openExternal` IPC，在系统默认浏览器中打开当前 HTTP(S) 地址。
- 对搜索词、内部页面和非 HTTP(S) 协议禁用按钮。

## 验证
- `bun test apps/electron/src/renderer/components/browser/browser-external-url.test.ts`（提交前通过；按需求已移除测试文件）
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/shared' typecheck`
- `bun run build:renderer`
- `git diff --check`

## 性能影响
低风险：按钮只在用户点击时触发一次既有 IPC，不新增持续订阅、定时器、IPC listener 或 WebContentsView 布局更新。地址栏输入仅触发该组件原有的交互级更新。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
