### PR TITLE
Fix redundant MCP tool labels

### DIFF
--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -38,6 +38,9 @@ export function shouldShowToolKindLabel(
   kindLabel: string,
   phraseLabel: string,
 ): boolean {
+  // MCP 工具的语义化短语已经包含完整的 "SERVER / TOOL" 名称，
+  // 再叠加 toolKindLabel 前缀会形成 "名称 · 名称 + 参数" 的重复，直接隐藏前缀。
+  if (toolName.startsWith('mcp__')) return false
   if (!hasMeaningfulToolInput(input)) return false
   if (!kindLabel.trim() || !phraseLabel.trim()) return false
   if (normalizeToolLabel(kindLabel) === normalizeToolLabel(phraseLabel)) return false


### PR DESCRIPTION
## Summary
- Remove the redundant MCP tool kind prefix from agent tool activity rows
- Keep the MCP server/tool name and parameter summary in the semantic label

## Validation
- `bun run --cwd apps/electron typecheck`
- `git diff --check`

## Performance
- Low risk: this changes only a synchronous label visibility predicate; no new render work, state, IPC, listeners, or timers.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)