### PR TITLE
fix(files): stabilize initial file panel loading

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.24",
+  "version": "0.19.25",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -869,39 +869,42 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
 
   // 获取当前 session 的工作路径（文件浏览器需要）
   React.useEffect(() => {
+    let disposed = false
+
     if (!currentWorkspaceId) {
       setSessionPathMap((prev) => {
+        if (!prev.has(sessionId)) return prev
         const map = new Map(prev)
         map.delete(sessionId)
         return map
       })
-      return
+      return () => { disposed = true }
     }
 
+    // IPC 请求不可取消，用 effect 生命周期阻止旧工作区请求覆盖当前路径。
+    // 不在请求开始时清空已有路径，避免正常挂载时文件面板出现空窗。
     window.electronAPI
       .getAgentSessionPath(currentWorkspaceId, sessionId)
       .then((path) => {
-        if (path) {
-          setSessionPathMap((prev) => {
-            const map = new Map(prev)
-            map.set(sessionId, path)
-            return map
-          })
-        } else {
-          setSessionPathMap((prev) => {
-            const map = new Map(prev)
-            map.delete(sessionId)
-            return map
-          })
-        }
+        if (disposed) return
+        setSessionPathMap((prev) => {
+          const map = new Map(prev)
+          if (path) map.set(sessionId, path)
+          else map.delete(sessionId)
+          return map
+        })
       })
       .catch(() => {
+        if (disposed) return
         setSessionPathMap((prev) => {
+          if (!prev.has(sessionId)) return prev
           const map = new Map(prev)
           map.delete(sessionId)
           return map
         })
       })
+
+    return () => { disposed = true }
   }, [sessionId, currentWorkspaceId, setSessionPathMap])
 
   // 获取工作区共享文件目录路径（@ 引用时需要搜索）

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -59,6 +59,7 @@ import {
 } from './tree-row-layout'
 import { setFilePanelDragData, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 import { getFileBrowserRootsFromKey, getFileBrowserRootsKey } from './file-browser-roots'
+import { isCurrentFileBrowserLoadRequest, shouldShowFileBrowserEmptyState } from './file-browser-load-state'
 import type { FileBrowserRoot, FileScope } from './file-browser-roots'
 
 export type { FileBrowserRoot, FileScope } from './file-browser-roots'
@@ -143,9 +144,22 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
     () => getFileBrowserRootsFromKey(rootsKey, rootPath),
     [rootPath, rootsKey],
   )
+  // 使用实际生效的 roots（包含 rootPath 兼容入口）作为加载代次签名，避免
+  // rootPath 变化时仍复用旧的 `[]` 输入签名。
+  const effectiveRootsKey = getFileBrowserRootsKey(browserRoots)
+  // SidePanel 在路径 IPC 返回前会传入空 roots；没有任何 root 参数的独立实例
+  // 则仍沿用原来的“目录为空”语义。
+  const hasExplicitRootSource = rootPath !== undefined || roots !== undefined
+  const currentRootsKeyRef = React.useRef(effectiveRootsKey)
+  currentRootsKeyRef.current = effectiveRootsKey
   const [entries, setEntries] = React.useState<ScopedFileEntry[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const [errorRootsKey, setErrorRootsKey] = React.useState<string | null>(null)
+  // 记录 entries 对应的最后一次成功根目录。相同根目录的后台刷新不清除此值，
+  // 这样已确认的空态不会因 watcher 触发 loading 而上下跳动。
+  const [loadedRootsKey, setLoadedRootsKey] = React.useState<string | null>(null)
+  const loadRequestIdRef = React.useRef(0)
   const filesVersion = useAtomValue(workspaceFilesVersionAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const expandedStateKey = React.useMemo(
@@ -208,29 +222,57 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
 
   /** 加载并合并所有可见根目录。 */
   const loadRoot = React.useCallback(async () => {
+    const requestId = ++loadRequestIdRef.current
+    const requestRootsKey = effectiveRootsKey
+    const isCurrentRequest = (): boolean => (
+      isCurrentFileBrowserLoadRequest(requestId, loadRequestIdRef.current)
+      && currentRootsKeyRef.current === requestRootsKey
+    )
+
     if (browserRoots.length === 0) {
+      // 没有可用根目录通常表示路径仍在异步解析，不能把它当成“已确认的空目录”。
+      // 只有未传入任何 root 参数的独立实例才把空 roots 视为稳定空目录。
+      if (!isCurrentRequest()) return
       setEntries([])
+      setError(null)
+      setErrorRootsKey(null)
+      setLoadedRootsKey(hasExplicitRootSource ? null : requestRootsKey)
+      setLoading(false)
       return
     }
+
+    // 不清除 loadedRootsKey：同一根目录的 watcher 刷新应保留既有树和空态。
     setLoading(true)
     setError(null)
+    setErrorRootsKey(null)
     try {
       const groups = await Promise.all(browserRoots.map(async (root) => {
         const items = await window.electronAPI.listDirectory(root.path, access)
         return items.map((entry): ScopedFileEntry => ({ ...entry, scope: root.scope, rootPath: root.path }))
       }))
+      if (!isCurrentRequest()) return
       setEntries(sortEntries(groups.flat()))
+      setLoadedRootsKey(requestRootsKey)
     } catch (err) {
+      if (!isCurrentRequest()) return
       const msg = err instanceof Error ? err.message : '加载失败'
       setError(msg)
+      setErrorRootsKey(requestRootsKey)
       setEntries([])
+      setLoadedRootsKey(null)
     } finally {
-      setLoading(false)
+      if (isCurrentRequest()) {
+        setLoading(false)
+      }
     }
-  }, [browserRoots, access])
+  }, [access, browserRoots, effectiveRootsKey, hasExplicitRootSource])
 
   React.useEffect(() => {
-    loadRoot()
+    void loadRoot()
+    return () => {
+      // IPC 请求无法取消；卸载或根目录切换时让其结果失效。
+      loadRequestIdRef.current += 1
+    }
   }, [loadRoot, filesVersion])
 
   /** 选中项 */
@@ -382,17 +424,26 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
     return parts.length > 2 ? `.../${parts.slice(-2).join('/')}` : primaryRoot
   }, [browserRoots])
 
+  const visibleEntries = loadedRootsKey === effectiveRootsKey ? entries : []
+  const visibleError = errorRootsKey === effectiveRootsKey ? error : null
+
   const fileTree = (
     <div className={cn('file-tree-guide-scope', embedded ? 'py-0' : 'py-1')} onClick={handleBackgroundClick}>
-      {error && (
-        <div className="px-3 py-2 text-xs text-destructive">{error}</div>
+      {visibleError && (
+        <div className="px-3 py-2 text-xs text-destructive">{visibleError}</div>
       )}
-      {!error && entries.length === 0 && !loading && !hideEmpty && (
+      {!shouldShowFileBrowserEmptyState({
+        currentRootsKey: effectiveRootsKey,
+        loadedRootsKey,
+        entryCount: visibleEntries.length,
+        hasError: Boolean(visibleError),
+        hideEmpty,
+      }) ? null : (
         <div className="px-3 py-4 text-xs text-muted-foreground text-center">
           目录为空
         </div>
       )}
-      {entries.map((entry) => (
+      {visibleEntries.map((entry) => (
         <FileTreeItem
           key={entry.path}
           entry={entry}

--- a/apps/electron/src/renderer/components/file-browser/file-browser-load-state.ts
+++ b/apps/electron/src/renderer/components/file-browser/file-browser-load-state.ts
@@ -1,0 +1,40 @@
+/**
+ * FileBrowser 异步根目录加载的纯状态判断。
+ *
+ * 请求无法由 IPC 取消，因此渲染层以单调递增的代次拒绝过期结果；
+ * 空态只在当前根目录至少成功加载一次后展示，后台刷新期间保持已确认的空态。
+ */
+
+export interface FileBrowserEmptyStateInput {
+  /** 当前 FileBrowser 实际消费的根目录稳定签名。 */
+  currentRootsKey: string
+  /** 最近一次成功完成目录读取的根目录签名。 */
+  loadedRootsKey: string | null
+  entryCount: number
+  hasError: boolean
+  hideEmpty: boolean | undefined
+}
+
+/** 只有仍属于最新加载代次的异步结果才能写回文件树状态。 */
+export function isCurrentFileBrowserLoadRequest(requestId: number, latestRequestId: number): boolean {
+  return requestId === latestRequestId
+}
+
+/**
+ * 判断是否展示“目录为空”。
+ *
+ * 不以 loading 为条件：已确认为空的目录在 watcher 触发后台刷新时应保持稳定，
+ * 避免“目录为空”文案和下方上传区反复出现、消失而造成面板闪烁。
+ */
+export function shouldShowFileBrowserEmptyState({
+  currentRootsKey,
+  loadedRootsKey,
+  entryCount,
+  hasError,
+  hideEmpty,
+}: FileBrowserEmptyStateInput): boolean {
+  return !hasError
+    && !hideEmpty
+    && entryCount === 0
+    && loadedRootsKey === currentRootsKey
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.19.24",
+      "version": "0.19.25",
       "dependencies": {
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",


### PR DESCRIPTION
## Summary
- 修复新项目首次进入时文件面板空态布局闪烁
- 忽略过期的异步目录读取结果，避免旧 roots 覆盖当前文件树
- 在路径解析完成前不误显示“目录为空”，并保留已确认空目录的稳定空态
- 为 session 工作路径请求增加 effect 生命周期保护

## Issue
Closes #1961

## Validation
- `bun run --filter @proma/electron typecheck`
- 相关既有测试：10 pass / 0 fail
- `bun run electron:build`
- `git diff --check`

## Performance
低风险：仅在 renderer 侧增加请求代次和 roots key 判断，不增加 watcher、IPC listener、timer 或依赖；watcher 触发的刷新仍沿用现有路径，并避免过期结果造成额外布局抖动。已完成 Electron 构建验证；Windows 11 实机回归尚未执行。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)