### PR TITLE
fix(feishu): preserve per-chat model route on restart

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.26",
+  "version": "0.19.27",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -97,6 +97,7 @@ import {
 
 import { redactSensitiveLogText, redactSensitiveLogValue } from './bridge-log-redaction'
 import { getFeishuApiBaseUrl, normalizeFeishuDomain } from './feishu-domain'
+import { restorePersistedFeishuBinding } from './feishu/binding-restore'
 
 // ===== 类型定义 =====
 
@@ -372,25 +373,19 @@ class FeishuBridge {
       const raw = readFileSync(bindingsPath, 'utf-8')
       const bindings = JSON.parse(raw) as FeishuChatBinding[]
       const appSettings = getSettings()
+      const routeFallback = {
+        channelId: this.botConfig.defaultChannelId ?? appSettings.agentChannelId,
+        modelId: this.botConfig.defaultModelId ?? appSettings.agentModelId,
+      }
 
       for (const b of bindings) {
         // 验证对应会话仍然存在
         const session = getAgentSessionMeta(b.sessionId)
         if (session) {
-          if (b.source === 'session-mirror' && session.archived) {
-            b.archived = true
-            b.archivedAt ??= session.updatedAt
-          }
-          // 同步最新的渠道和模型设置（用户可能已更改）
-          if (appSettings.agentChannelId) {
-            b.channelId = appSettings.agentChannelId
-          }
-          if (appSettings.agentModelId) {
-            b.modelId = appSettings.agentModelId
-          }
-          this.chatBindings.set(b.chatId, b)
-          if (!b.archived) {
-            this.sessionToChat.set(b.sessionId, b.chatId)
+          const restoredBinding = restorePersistedFeishuBinding(b, session, routeFallback)
+          this.chatBindings.set(restoredBinding.chatId, restoredBinding)
+          if (!restoredBinding.archived) {
+            this.sessionToChat.set(restoredBinding.sessionId, restoredBinding.chatId)
           }
         }
       }

--- a/apps/electron/src/main/lib/feishu/binding-restore.test.ts
+++ b/apps/electron/src/main/lib/feishu/binding-restore.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+import type { FeishuChatBinding } from '@proma/shared'
+import { restorePersistedFeishuBinding } from './binding-restore'
+
+function createBinding(overrides: Partial<FeishuChatBinding> = {}): FeishuChatBinding {
+  return {
+    chatId: 'chat-sales-coach-rc',
+    botId: 'bot-1',
+    userId: 'user-1',
+    sessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    channelId: 'sales-coach-crm-gateway-v1',
+    modelId: 'deepseek-v4-flash-vision-exp',
+    source: 'feishu',
+    createdAt: 1,
+    ...overrides,
+  }
+}
+
+describe('restorePersistedFeishuBinding', () => {
+  test('Given 聊天已用 /model 写入独立路由 When Bridge 重启 Then 不被全局默认覆盖', () => {
+    const binding = createBinding()
+
+    const restored = restorePersistedFeishuBinding(
+      binding,
+      { archived: false, updatedAt: 2 },
+      { channelId: 'global-source-channel', modelId: 'global-default-model' },
+    )
+
+    expect(restored.channelId).toBe('sales-coach-crm-gateway-v1')
+    expect(restored.modelId).toBe('deepseek-v4-flash-vision-exp')
+    expect(binding).toEqual(createBinding())
+  })
+
+  test('Given 旧绑定缺少路由字段 When Bridge 重启 Then 只补齐默认渠道和模型', () => {
+    const restored = restorePersistedFeishuBinding(
+      createBinding({ channelId: '', modelId: undefined }),
+      { archived: false, updatedAt: 2 },
+      { channelId: 'bot-default-channel', modelId: 'bot-default-model' },
+    )
+
+    expect(restored.channelId).toBe('bot-default-channel')
+    expect(restored.modelId).toBe('bot-default-model')
+  })
+
+  test('Given 镜像会话已归档 When Bridge 重启 Then 保留路由并同步归档状态', () => {
+    const restored = restorePersistedFeishuBinding(
+      createBinding({ source: 'session-mirror' }),
+      { archived: true, updatedAt: 42 },
+      { channelId: 'global-source-channel', modelId: 'global-default-model' },
+    )
+
+    expect(restored).toMatchObject({
+      channelId: 'sales-coach-crm-gateway-v1',
+      modelId: 'deepseek-v4-flash-vision-exp',
+      archived: true,
+      archivedAt: 42,
+    })
+  })
+})

--- a/apps/electron/src/main/lib/feishu/binding-restore.ts
+++ b/apps/electron/src/main/lib/feishu/binding-restore.ts
@@ -1,0 +1,34 @@
+import type { AgentSessionMeta, FeishuChatBinding } from '@proma/shared'
+
+interface FeishuBindingRouteFallback {
+  channelId?: string
+  modelId?: string
+}
+
+/**
+ * 恢复飞书聊天绑定时，已持久化的 per-chat 路由优先。
+ *
+ * Bot 或应用默认值只用于补齐旧绑定缺失的字段，不能覆盖用户通过
+ * `/model` 为某个聊天显式选择并已经写盘的渠道和模型。
+ */
+export function restorePersistedFeishuBinding(
+  binding: FeishuChatBinding,
+  session: Pick<AgentSessionMeta, 'archived' | 'updatedAt'>,
+  fallback: FeishuBindingRouteFallback,
+): FeishuChatBinding {
+  const restored = { ...binding }
+
+  if (restored.source === 'session-mirror' && session.archived) {
+    restored.archived = true
+    restored.archivedAt ??= session.updatedAt
+  }
+
+  if (!restored.channelId && fallback.channelId) {
+    restored.channelId = fallback.channelId
+  }
+  if (!restored.modelId && fallback.modelId) {
+    restored.modelId = fallback.modelId
+  }
+
+  return restored
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.19.26",
+      "version": "0.19.27",
       "dependencies": {
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",


### PR DESCRIPTION
## 问题

飞书聊天通过 /model 写盘后的独立渠道与模型，会在 Bridge 重启或系统解锁自愈时被应用全局默认值覆盖。该行为与既有 per-chat 持久化设计不一致，并会导致消息绕回错误渠道。

## 修复

- 恢复绑定时保留已持久化的 per-chat 渠道与模型
- 仅在旧绑定缺少路由字段时继承 Bot/应用默认值
- 保留 Session 镜像归档恢复语义
- Electron 版本递增到 0.19.27

## 验证

- 新增 3 个 BDD 回归案例：3/3 通过
- 飞书与绑定相关测试：11/11 通过
- Electron typecheck：通过
- Electron main build：通过
- 全仓：修复分支 434 pass / 5 baseline environment failures；未修改 v0.19.26 为 431 pass / 同样 5 failures，未新增失败