### PR TITLE
feat(sidebar): 项目区块支持一键折叠所有项目

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Star, Settings, Plus, CirclePlus, Trash2, Pencil, PanelLeft, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, CalendarDays, ChevronRight, ChevronDown, ChevronUp, Blocks, Brain, ListTodo, GitBranch, Download, Loader2, RotateCw, Info } from 'lucide-react'
+import { Pin, PinOff, Star, Settings, Plus, CirclePlus, Trash2, Pencil, PanelLeft, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, CalendarDays, ChevronRight, ChevronDown, ChevronUp, ChevronsDownUp, Blocks, Brain, ListTodo, GitBranch, Download, Loader2, RotateCw, Info } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -3015,6 +3015,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       }
     }
 
+    const hasExpandedProject = displayProjectGroups.some((group) => !collapsedWorkspaceIds.has(group.workspace.id))
+
     rows.push({
       id: 'agent-project-heading',
       estimateSize: 34,
@@ -3022,6 +3024,26 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         <div className="px-2 pt-2 pb-1 flex items-center justify-between">
           <span className="px-1.5 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">项目</span>
           <div className="flex items-center gap-0.5">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  disabled={!hasExpandedProject}
+                  onClick={() => {
+                    setCollapsedWorkspaceIds((prev) => {
+                      const next = new Set(prev)
+                      for (const group of displayProjectGroups) next.add(group.workspace.id)
+                      return next
+                    })
+                  }}
+                  className="size-6 flex items-center justify-center rounded-md text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/60 transition-colors titlebar-no-drag disabled:opacity-30 disabled:pointer-events-none"
+                  aria-label="折叠所有项目"
+                >
+                  <ChevronsDownUp size={13} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">折叠所有项目</TooltipContent>
+            </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button


### PR DESCRIPTION
## 功能说明

主界面左侧「项目」区块标题栏新增「一键折叠所有项目」按钮（ChevronsDownUp 图标），点击即可将当前显示的所有项目组（含「自动任务」合成组）的会话列表全部折叠。

## 实现细节

- 复用现有 `collapsedWorkspaceIds` 状态：折叠 = 将全部组 ID 加入集合，单项目点击标题展开的原有行为完全不受影响
- 智能禁用：所有项目均已折叠时按钮自动置灰，避免无效点击
- 归档视图的分组使用独立的 `expandedArchivedProjectIds` 状态，不受此按钮影响
- UI 与标题栏既有按钮（从本地文件夹创建 / 新建空白项目）风格一致，含 Tooltip 与 aria-label

## 改动范围

`apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`：+23 / -1，仅此一个文件

## 验证

typecheck 全部 6 个包通过；基于上游最新 main（bbf577a8）提交，无合并冲突。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)