### PR TITLE
fix(sidebar): 修复折叠态会话 Rail 即时切换【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.26",
+  "version": "0.19.27",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.27",
+  "version": "0.19.28",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -39,5 +39,7 @@ export interface SettingsSessionNavigation {
   type: TabType
   sessionId: string
   title: string
+  /** 导航经设置脏表单确认并真正执行后提交的调用方 intent。 */
+  onOpened?: () => void
 }
 export const settingsPendingSessionNavigationAtom = atom<SettingsSessionNavigation | null>(null)

--- a/apps/electron/src/renderer/components/agent/CollapsedDelegatedSessionsPopover.tsx
+++ b/apps/electron/src/renderer/components/agent/CollapsedDelegatedSessionsPopover.tsx
@@ -1,0 +1,145 @@
+/**
+ * 折叠态主会话的委派子会话快速查看面板。
+ * 鼠标悬浮主会话时展示所有子会话；键盘用 ArrowRight 打开。
+ *
+ * 整块入口只有一个点击语义：切到主会话。右下角的 delegation 角标是纯装饰，
+ * 不拦指针也没有 hover 特效，hover 展开已经足够揭示子会话的存在。
+ *
+ * 开合与焦点策略统一由 useHoverPopover 提供：入口与弹层是同一个 hover 表面，
+ * 离开后留出宽限期再关闭；子会话项先执行导航再收起弹层，保证点击一定生效。
+ */
+
+import * as React from 'react'
+import { GitBranch } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import type { AgentSessionMeta } from '@proma/shared'
+import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
+import {
+  getDelegatedChildSessionStatus,
+  getDelegationStatusIconClass,
+} from '@/lib/agent-session-list'
+import {
+  HOVER_POPOVER_CONTENT_CLASS,
+  composeEventHandlers,
+  useHoverPopover,
+} from '@/hooks/useHoverPopover'
+
+type TriggerElement = React.ReactElement<{
+  onClick?: React.MouseEventHandler
+  onKeyDown?: React.KeyboardEventHandler
+  'aria-expanded'?: boolean
+  'aria-controls'?: string
+  'aria-keyshortcuts'?: string
+}>
+
+interface CollapsedDelegatedSessionsPopoverProps {
+  parentTitle: string
+  childSessions: AgentSessionMeta[]
+  activeSessionId: string | null
+  activeDelegationSessionId: string | null
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>
+  /** Rail 同时只允许一个子会话面板展开，因此开合状态由 Rail 持有。 */
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (session: AgentSessionMeta) => void
+  children: React.ReactNode
+}
+
+export function CollapsedDelegatedSessionsPopover({
+  parentTitle,
+  childSessions,
+  activeSessionId,
+  activeDelegationSessionId,
+  agentIndicatorMap,
+  open,
+  onOpenChange,
+  onSelect,
+  children,
+}: CollapsedDelegatedSessionsPopoverProps): React.ReactElement {
+  const contentId = React.useId()
+  const anchorRef = React.useRef<HTMLSpanElement | null>(null)
+  const popover = useHoverPopover({ open, onOpenChange })
+
+  const child = React.Children.only(children) as TriggerElement
+  const parentButton = React.cloneElement(child, {
+    // 整块只有一个点击语义：切到主会话，并收起子会话面板。
+    onClick: composeEventHandlers(child.props.onClick, popover.close),
+    // hover 对键盘与触摸不可用，保留一个不与导航冲突的展开快捷键。
+    onKeyDown: composeEventHandlers(child.props.onKeyDown, (event) => {
+      if (event.key !== 'ArrowRight' || childSessions.length === 0) return
+      event.preventDefault()
+      popover.openByKeyboard()
+    }),
+    'aria-expanded': popover.open,
+    'aria-controls': popover.open ? contentId : undefined,
+    'aria-keyshortcuts': 'ArrowRight',
+  })
+
+  return (
+    <Popover open={popover.open} onOpenChange={popover.onOpenChange}>
+      <PopoverAnchor asChild>
+        <span ref={anchorRef} className="relative inline-flex size-10" {...popover.hoverProps}>
+          {parentButton}
+          {/* 纯装饰角标：不拦指针、不可聚焦、无 hover 特效，点击直接穿透到主会话按钮。 */}
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -bottom-0.5 -right-0.5 z-10 flex size-5 items-center justify-center text-foreground/45"
+          >
+            <GitBranch size={11} />
+          </span>
+        </span>
+      </PopoverAnchor>
+      <PopoverContent
+        id={contentId}
+        side="right"
+        align="start"
+        sideOffset={8}
+        aria-label={`「${parentTitle}」的子会话`}
+        className={cn('w-64 p-1.5', HOVER_POPOVER_CONTENT_CLASS)}
+        {...popover.hoverProps}
+        {...popover.contentFocusProps}
+        onCloseAutoFocus={(event) => {
+          popover.contentFocusProps.onCloseAutoFocus(event)
+          if (event.defaultPrevented) return
+          // 没有独立 trigger 按钮，Radix 无处归还焦点：显式送回主会话按钮。
+          event.preventDefault()
+          anchorRef.current?.querySelector('button')?.focus()
+        }}
+      >
+        {childSessions.length > 0 ? (
+          <div className="flex max-h-[320px] flex-col gap-0.5 overflow-y-auto scrollbar-thin">
+            {childSessions.map((session) => {
+              const status = getDelegatedChildSessionStatus(session, agentIndicatorMap)
+              const active = session.id === activeSessionId
+                || (session.parentSessionId === activeSessionId && session.id === activeDelegationSessionId)
+              return (
+                <button
+                  key={session.id}
+                  type="button"
+                  aria-current={active ? 'page' : undefined}
+                  onClick={() => {
+                    // 先导航再收起：关闭动作不能抢在导航之前卸载当前列表项。
+                    onSelect(session)
+                    popover.close()
+                  }}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    active
+                      ? 'bg-accent/70 text-accent-foreground'
+                      : 'text-foreground/75 hover:bg-foreground/[0.06] hover:text-foreground',
+                  )}
+                >
+                  <GitBranch className={cn('size-3.5 shrink-0', getDelegationStatusIconClass(status))} />
+                  <span className="min-w-0 flex-1 truncate">{session.title || '未命名子会话'}</span>
+                </button>
+              )
+            })}
+          </div>
+        ) : (
+          <div className="px-2 py-2 text-[12px] text-foreground/40">暂无子会话</div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/CollapsedSessionRail.tsx
+++ b/apps/electron/src/renderer/components/agent/CollapsedSessionRail.tsx
@@ -1,0 +1,213 @@
+/**
+ * CollapsedSessionRail — 折叠态侧栏的会话入口列表。
+ *
+ * 排序与切换行为与上游 Rail 完全一致：置顶只由传入的 items 决定，点击后选中态、
+ * 首字母与顺序在同一次提交内一起生效，不做任何导航延后。仅当 delegated child
+ * Popover 正在打开时固定当时可见根 id，避免实时状态排序卸载或移动它的 Anchor。
+ * 面板关闭后立即恢复动态顺序。
+ *
+ * 子会话面板的开合状态住在本组件内。不要把它提回 LeftSidebar：那个组件有几十个
+ * atom 订阅和大型 useMemo，一次 hover 或面板开合会让整棵侧栏在 paint 前重渲染，
+ * 点击切换会出现明显延迟。
+ */
+
+import * as React from 'react'
+import { Clock, GitBranch } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  SessionMiniMapPopover,
+  useSessionMiniMapHover,
+  type SessionMiniMapType,
+} from '@/components/session-preview/SessionMiniMapPopover'
+import { CollapsedDelegatedSessionsPopover } from '@/components/agent/CollapsedDelegatedSessionsPopover'
+import {
+  getCollapsedAgentRailVisibleItems,
+  getEffectiveCollapsedRailPopoverId,
+} from '@/lib/collapsed-agent-rail'
+import type { AgentSessionMeta } from '@proma/shared'
+import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
+
+export interface RailRecentItem {
+  id: string
+  title: string
+  type: SessionMiniMapType
+  initial: string
+  active: boolean
+  status: SessionIndicatorStatus
+  pinned: boolean
+  workspaceName?: string
+  isAutomation?: boolean
+  isDelegation?: boolean
+  childSessions?: AgentSessionMeta[]
+}
+
+const RAIL_STATUS_CLASS: Record<SessionIndicatorStatus, string> = {
+  idle: 'hidden',
+  running: 'border-blue-500 animate-pulse',
+  blocked: 'border-orange-500',
+  completed: 'border-emerald-500',
+}
+
+function getRailItemChildCount(item: RailRecentItem): number {
+  return item.childSessions?.length ?? 0
+}
+
+function RailRecentButton({
+  item,
+  onSelect,
+  onSelectChild,
+  activeSessionId,
+  activeDelegationSessionId,
+  agentIndicatorMap,
+  open,
+  onOpenChange,
+  miniMapDisabled,
+}: {
+  item: RailRecentItem
+  onSelect: (item: RailRecentItem) => void
+  onSelectChild: (session: AgentSessionMeta) => void
+  activeSessionId: string | null
+  activeDelegationSessionId: string | null
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  miniMapDisabled?: boolean
+}): React.ReactElement {
+  const hasChildren = getRailItemChildCount(item) > 0
+  const preview = useSessionMiniMapHover(600, miniMapDisabled || hasChildren)
+  const button = (
+    <button
+      ref={preview.setAnchorRef}
+      type="button"
+      aria-label={`打开${item.type === 'agent' ? 'Agent 会话' : 'Chat 对话'}：${item.title}`}
+      onClick={() => onSelect(item)}
+      onMouseEnter={preview.handleMouseEnter}
+      onMouseLeave={preview.handleMouseLeave}
+      className={cn(
+        'relative size-10 flex items-center justify-center overflow-hidden rounded-[12px] transition-colors titlebar-no-drag focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        item.active
+          ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          : 'text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/80'
+      )}
+    >
+      <span
+        className={cn(
+          'absolute inset-y-0 left-0 w-0 border-l-[3px] rounded-l-[12px] pointer-events-none',
+          RAIL_STATUS_CLASS[item.status]
+        )}
+      />
+      {item.isAutomation
+        ? <Clock size={14} className="text-foreground/40" />
+        : item.isDelegation
+          ? <GitBranch size={14} className="text-foreground/40" />
+          : <span className="text-[13px] font-semibold leading-none">{item.initial}</span>
+      }
+    </button>
+  )
+
+  return (
+    <>
+      {item.type === 'agent' && hasChildren ? (
+        <CollapsedDelegatedSessionsPopover
+          parentTitle={item.title}
+          childSessions={item.childSessions ?? []}
+          activeSessionId={activeSessionId}
+          activeDelegationSessionId={activeDelegationSessionId}
+          agentIndicatorMap={agentIndicatorMap}
+          open={open}
+          onOpenChange={onOpenChange}
+          onSelect={onSelectChild}
+        >
+          {button}
+        </CollapsedDelegatedSessionsPopover>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>{button}</TooltipTrigger>
+          <TooltipContent side="right">{item.type === 'agent' ? 'Agent' : 'Chat'} · {item.title}</TooltipContent>
+        </Tooltip>
+      )}
+      <SessionMiniMapPopover
+        target={{
+          type: item.type,
+          sessionId: item.id,
+          title: item.title,
+          workspaceName: item.workspaceName,
+        }}
+        anchorRef={preview.anchorRef}
+        open={preview.isOpen}
+        isLeaving={preview.isLeaving}
+        onMouseEnter={preview.handlePanelMouseEnter}
+        onMouseLeave={preview.handlePanelMouseLeave}
+      />
+    </>
+  )
+}
+
+export function CollapsedSessionRail({
+  items,
+  activeSessionId,
+  activeDelegationSessionId,
+  agentIndicatorMap,
+  miniMapDisabled,
+  onSelect,
+  onSelectChild,
+}: {
+  items: RailRecentItem[]
+  activeSessionId: string | null
+  activeDelegationSessionId: string | null
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>
+  miniMapDisabled?: boolean
+  onSelect: (item: RailRecentItem) => void
+  onSelectChild: (session: AgentSessionMeta) => void
+}): React.ReactElement {
+  const [openPopoverId, setOpenPopoverId] = React.useState<string | null>(null)
+  const [openSnapshotIds, setOpenSnapshotIds] = React.useState<string[] | null>(null)
+
+  const popoverItemIds = React.useMemo(
+    () => items.filter((item) => getRailItemChildCount(item) > 0).map((item) => item.id),
+    [items],
+  )
+  const effectiveOpenPopoverId = getEffectiveCollapsedRailPopoverId(openPopoverId, popoverItemIds)
+  const visibleItems = getCollapsedAgentRailVisibleItems(
+    items,
+    effectiveOpenPopoverId,
+    openSnapshotIds,
+  )
+
+  React.useLayoutEffect(() => {
+    if (openPopoverId !== null && effectiveOpenPopoverId === null) {
+      setOpenPopoverId(null)
+      setOpenSnapshotIds(null)
+    }
+  }, [effectiveOpenPopoverId, openPopoverId])
+
+  return (
+    <div className="mt-2 flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin">
+      <div className="flex flex-col items-center gap-0.5 pb-2">
+        {visibleItems.map((item) => (
+          <RailRecentButton
+            key={`${item.type}-${item.id}`}
+            item={item}
+            agentIndicatorMap={agentIndicatorMap}
+            activeSessionId={activeSessionId}
+            activeDelegationSessionId={activeDelegationSessionId}
+            open={effectiveOpenPopoverId === item.id}
+            onOpenChange={(nextOpen) => {
+              if (nextOpen) {
+                setOpenSnapshotIds(visibleItems.map((candidate) => candidate.id))
+                setOpenPopoverId(item.id)
+                return
+              }
+              setOpenPopoverId((current) => (current === item.id ? null : current))
+              setOpenSnapshotIds(null)
+            }}
+            miniMapDisabled={miniMapDisabled}
+            onSelect={onSelect}
+            onSelectChild={onSelectChild}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/CollapsedSessionRail.tsx
+++ b/apps/electron/src/renderer/components/agent/CollapsedSessionRail.tsx
@@ -24,6 +24,8 @@ import { CollapsedDelegatedSessionsPopover } from '@/components/agent/CollapsedD
 import {
   getCollapsedAgentRailVisibleItems,
   getEffectiveCollapsedRailPopoverId,
+  reduceCollapsedRailPopoverState,
+  type CollapsedRailPopoverState,
 } from '@/lib/collapsed-agent-rail'
 import type { AgentSessionMeta } from '@proma/shared'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -161,8 +163,12 @@ export function CollapsedSessionRail({
   onSelect: (item: RailRecentItem) => void
   onSelectChild: (session: AgentSessionMeta) => void
 }): React.ReactElement {
-  const [openPopoverId, setOpenPopoverId] = React.useState<string | null>(null)
-  const [openSnapshotIds, setOpenSnapshotIds] = React.useState<string[] | null>(null)
+  // ID 与快照必须一起提交；旧面板的延迟关闭不能清理新面板的快照。
+  const [popoverState, setPopoverState] = React.useState<CollapsedRailPopoverState>({
+    openPopoverId: null,
+    snapshotIds: null,
+  })
+  const { openPopoverId, snapshotIds: openSnapshotIds } = popoverState
 
   const popoverItemIds = React.useMemo(
     () => items.filter((item) => getRailItemChildCount(item) > 0).map((item) => item.id),
@@ -177,8 +183,9 @@ export function CollapsedSessionRail({
 
   React.useLayoutEffect(() => {
     if (openPopoverId !== null && effectiveOpenPopoverId === null) {
-      setOpenPopoverId(null)
-      setOpenSnapshotIds(null)
+      setPopoverState((current) => reduceCollapsedRailPopoverState(current, {
+        type: 'close', id: openPopoverId,
+      }))
     }
   }, [effectiveOpenPopoverId, openPopoverId])
 
@@ -194,13 +201,10 @@ export function CollapsedSessionRail({
             activeDelegationSessionId={activeDelegationSessionId}
             open={effectiveOpenPopoverId === item.id}
             onOpenChange={(nextOpen) => {
-              if (nextOpen) {
-                setOpenSnapshotIds(visibleItems.map((candidate) => candidate.id))
-                setOpenPopoverId(item.id)
-                return
-              }
-              setOpenPopoverId((current) => (current === item.id ? null : current))
-              setOpenSnapshotIds(null)
+              setPopoverState((current) => reduceCollapsedRailPopoverState(current, nextOpen
+                ? { type: 'open', id: item.id, snapshotIds: visibleItems.map((candidate) => candidate.id) }
+                : { type: 'close', id: item.id },
+              ))
             }}
             miniMapDisabled={miniMapDisabled}
             onSelect={onSelect}

--- a/apps/electron/src/renderer/components/agent/CollapsedToolsPopover.tsx
+++ b/apps/electron/src/renderer/components/agent/CollapsedToolsPopover.tsx
@@ -1,0 +1,92 @@
+/**
+ * 折叠态侧栏的工作区工具入口，支持 hover、点击、触摸和键盘。
+ *
+ * 与子会话面板共用 useHoverPopover：入口与弹层视作同一 hover 表面，离开后留
+ * 宽限期再关闭；工具项先执行动作再收起弹层。
+ */
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  HOVER_POPOVER_CONTENT_CLASS,
+  composeEventHandlers,
+  useHoverPopover,
+} from '@/hooks/useHoverPopover'
+
+type TriggerElement = React.ReactElement<{
+  onMouseEnter?: React.MouseEventHandler
+  onMouseLeave?: React.MouseEventHandler
+  onPointerDown?: React.PointerEventHandler
+  onKeyDown?: React.KeyboardEventHandler
+}>
+
+export interface CollapsedToolItem {
+  label: string
+  icon: React.ReactNode
+  active?: boolean
+  badge?: string
+  showUpdate?: boolean
+  onClick: () => void
+}
+
+export function CollapsedToolsPopover({
+  children,
+  items,
+}: {
+  children: React.ReactNode
+  items: CollapsedToolItem[]
+}): React.ReactElement {
+  const popover = useHoverPopover()
+
+  const child = React.Children.only(children) as TriggerElement
+  const trigger = React.cloneElement(child, {
+    onMouseEnter: composeEventHandlers(child.props.onMouseEnter, popover.hoverProps.onMouseEnter),
+    onMouseLeave: composeEventHandlers(child.props.onMouseLeave, popover.hoverProps.onMouseLeave),
+    onPointerDown: composeEventHandlers(child.props.onPointerDown, popover.manualTriggerProps.onPointerDown),
+    onKeyDown: composeEventHandlers(child.props.onKeyDown, popover.manualTriggerProps.onKeyDown),
+  })
+
+  return (
+    <Popover open={popover.open} onOpenChange={popover.onOpenChange}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className={cn('w-48 p-1.5', HOVER_POPOVER_CONTENT_CLASS)}
+        {...popover.hoverProps}
+        {...popover.contentFocusProps}
+      >
+        <div className="flex flex-col gap-0.5">
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              aria-current={item.active ? 'page' : undefined}
+              onClick={() => {
+                // 先执行工具动作再收起，避免关闭时提前卸载当前按钮。
+                item.onClick()
+                popover.close()
+              }}
+              className={cn(
+                'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                item.active
+                  ? 'bg-accent/70 text-accent-foreground'
+                  : 'text-foreground/70 hover:bg-foreground/[0.06] hover:text-foreground',
+              )}
+            >
+              <span className="flex size-4 shrink-0 items-center justify-center">{item.icon}</span>
+              <span className="min-w-0 flex-1 truncate">{item.label}</span>
+              {item.badge && (
+                <span className="rounded-full bg-primary px-1.5 text-[10px] font-medium leading-4 text-primary-foreground tabular-nums">
+                  {item.badge}
+                </span>
+              )}
+              {item.showUpdate && <span className="size-2 shrink-0 rounded-full bg-blue-500" />}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -105,6 +105,8 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { productivityToolsAtom, sessionHoverPreviewEnabledAtom } from '@/atoms/ui-preferences'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
+import { CollapsedToolsPopover, type CollapsedToolItem } from '@/components/agent/CollapsedToolsPopover'
+import { CollapsedSessionRail, type RailRecentItem } from '@/components/agent/CollapsedSessionRail'
 import { ObsidianIcon } from '@/components/obsidian/obsidian-brand'
 import { VirtualSidebarList, type VirtualSidebarRow } from '@/components/ui/virtual-sidebar-list'
 import { LocalProjectBadge } from '@/components/agent/LocalProjectBadge'
@@ -120,8 +122,17 @@ import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-regi
 import { rememberStopGenerationTarget } from '@/lib/stop-generation-target'
 import { markSessionCompletionViewed } from '@/lib/agent-completion-presence'
 import {
+  buildAgentSessionTrees,
+  getCollapsedAgentRailTreeStatus,
+  getCollapsedAgentRailTrees,
+  isDelegatedChildSession,
+  sortDelegatedChildSessions,
+  type AgentSessionTreeItem,
+} from '@/lib/collapsed-agent-rail'
+import {
   collectAgentSessionTreeIds,
   countSettledDelegatedChildren,
+  getAgentSessionTreeIndicatorStatus,
   getDelegatedChildSessionStatus,
   getDelegationStatusIconClass,
   groupArchivedAgentSessionsByProject,
@@ -321,11 +332,6 @@ interface AgentProjectGroup {
   sessions: AgentSessionMeta[]
 }
 
-interface AgentSessionTreeItem {
-  session: AgentSessionMeta
-  childSessions: AgentSessionMeta[]
-}
-
 /** 合成「自动任务」虚拟项目组的工作区 ID（不对应真实 workspace，仅用于聚合自动任务会话） */
 const AUTOMATION_GROUP_ID = '__automations__'
 /** 供合成组复用 AgentProjectGroupItem 时填充无意义的 workspace 专属回调 */
@@ -395,13 +401,6 @@ function groupByDate<T extends { updatedAt: number }>(items: T[]): Array<{ label
   if (yesterday.length > 0) groups.push({ label: '昨天', items: yesterday })
   if (earlier.length > 0) groups.push({ label: '更早', items: earlier })
   return groups
-}
-
-const RAIL_STATUS_CLASS: Record<SessionIndicatorStatus, string> = {
-  idle: 'hidden',
-  running: 'border-blue-500 animate-pulse',
-  blocked: 'border-orange-500',
-  completed: 'border-emerald-500',
 }
 
 const SIDEBAR_DRAG_STRIP_HEIGHT = {
@@ -484,49 +483,6 @@ function isHiddenAutomationSession(session: AgentSessionMeta): boolean {
   return !!session.sourceAutomationId && !session.pinned
 }
 
-function isDelegatedChildSession(session: AgentSessionMeta): boolean {
-  return !!session.parentSessionId && !!session.sourceDelegationId
-}
-
-function sortDelegatedChildSessions(
-  sessions: readonly AgentSessionMeta[],
-  agentIndicatorMap?: ReadonlyMap<string, SessionIndicatorStatus>,
-): AgentSessionMeta[] {
-  const priority = (session: AgentSessionMeta): number => Number(
-    agentIndicatorMap && ACTIVE_SESSION_STATUSES.has(getDelegatedChildSessionStatus(session, agentIndicatorMap)),
-  )
-  return [...sessions].sort((a, b) => priority(b) - priority(a) || b.updatedAt - a.updatedAt)
-}
-
-function buildAgentSessionTrees(
-  sessions: AgentSessionMeta[],
-  agentIndicatorMap?: ReadonlyMap<string, SessionIndicatorStatus>,
-): AgentSessionTreeItem[] {
-  const sessionIds = new Set(sessions.map((session) => session.id))
-  const childrenByParentId = new Map<string, AgentSessionMeta[]>()
-  const roots: AgentSessionMeta[] = []
-
-  for (const session of sessions) {
-    if (
-      isDelegatedChildSession(session)
-      && session.parentSessionId
-      && sessionIds.has(session.parentSessionId)
-    ) {
-      const children = childrenByParentId.get(session.parentSessionId) ?? []
-      children.push(session)
-      childrenByParentId.set(session.parentSessionId, children)
-      continue
-    }
-
-    roots.push(session)
-  }
-
-  return roots.map((session) => ({
-    session,
-    childSessions: sortDelegatedChildSessions(childrenByParentId.get(session.id) ?? [], agentIndicatorMap),
-  }))
-}
-
 function getDelegatedChildStatus(
   session: AgentSessionMeta,
   agentIndicatorMap: Map<string, SessionIndicatorStatus>,
@@ -538,15 +494,7 @@ function getSessionTreeStatus(
   item: AgentSessionTreeItem,
   agentIndicatorMap: Map<string, SessionIndicatorStatus>,
 ): SessionIndicatorStatus {
-  const statuses = [
-    agentIndicatorMap.get(item.session.id) ?? 'idle',
-    ...item.childSessions.map((session) => getDelegatedChildStatus(session, agentIndicatorMap)),
-  ]
-
-  if (statuses.includes('blocked')) return 'blocked'
-  if (statuses.includes('running')) return 'running'
-  if (statuses.includes('completed')) return 'completed'
-  return 'idle'
+  return getAgentSessionTreeIndicatorStatus(item.session, item.childSessions, agentIndicatorMap)
 }
 
 function treeContainsSessionId(item: AgentSessionTreeItem, sessionId: string | null): boolean {
@@ -619,83 +567,6 @@ function getArchivedDelegatedChildren(
     && !child.isDraft
     && !draftSessionIds.has(child.id)
   ))
-}
-
-interface RailRecentItem {
-  id: string
-  title: string
-  type: SessionMiniMapType
-  initial: string
-  active: boolean
-  status: SessionIndicatorStatus
-  pinned: boolean
-  workspaceName?: string
-  isAutomation?: boolean
-  isDelegation?: boolean
-}
-
-function RailRecentButton({
-  item,
-  onSelect,
-  miniMapDisabled,
-}: {
-  item: RailRecentItem
-  onSelect: (item: RailRecentItem) => void
-  miniMapDisabled?: boolean
-}): React.ReactElement {
-  const preview = useSessionMiniMapHover(600, miniMapDisabled)
-
-  return (
-    <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            ref={preview.setAnchorRef}
-            type="button"
-            aria-label={`打开${item.type === 'agent' ? 'Agent 会话' : 'Chat 对话'}：${item.title}`}
-            onClick={() => onSelect(item)}
-            onMouseEnter={preview.handleMouseEnter}
-            onMouseLeave={preview.handleMouseLeave}
-            className={cn(
-              'relative size-10 flex items-center justify-center overflow-hidden rounded-[12px] transition-colors titlebar-no-drag',
-              item.active
-                ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-                : 'text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/80'
-            )}
-          >
-            <span
-              className={cn(
-                'absolute inset-y-0 left-0 w-0 border-l-[3px] rounded-l-[12px] pointer-events-none',
-                RAIL_STATUS_CLASS[item.status]
-              )}
-            />
-            {item.isAutomation
-              ? <Clock size={14} className="text-foreground/40" />
-              : item.isDelegation
-                ? <GitBranch size={14} className="text-foreground/40" />
-                : <span className="text-[13px] font-semibold leading-none">{item.initial}</span>
-            }
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right">
-          {item.type === 'agent' ? 'Agent' : 'Chat'} · {item.title}
-        </TooltipContent>
-      </Tooltip>
-      <SessionMiniMapPopover
-        target={{
-          type: item.type,
-          sessionId: item.id,
-          title: item.title,
-          workspaceName: item.workspaceName,
-        }}
-        anchorRef={preview.anchorRef}
-        open={preview.isOpen}
-        isLeaving={preview.isLeaving}
-        onMouseEnter={preview.handlePanelMouseEnter}
-        onMouseLeave={preview.handlePanelMouseLeave}
-      />
-    </>
-  )
 }
 
 function SidebarWindowDragStrip({ height }: { height: number }): React.ReactElement {
@@ -1844,44 +1715,50 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     if (selectedSession?.sourceDelegationId && selectedSession.parentSessionId) {
       const parentSession = agentSessions.find((session) => session.id === selectedSession.parentSessionId)
       if (parentSession) {
-        if (store.get(agentSidePanelSplitMapAtom).has(parentSession.id)) {
-          toast.info('请先退出并排模式，再切换子会话', {
-            id: 'split-delegation-sidebar-navigation',
-          })
-        }
-        openSession('agent', parentSession.id, parentSession.title)
-        store.set(agentSideDelegationMapAtom, (previous) => (
-          selectDelegatedSession(previous, parentSession.id, selectedSession.id)
-        ))
-        store.set(agentSidePanelOpenAtomFamily(parentSession.id), true)
-        rememberStopGenerationTarget({ kind: 'agent', sessionId: selectedSession.id })
-        setUnviewedDelegatedCompleted((prev) => (
-          markSessionCompletionViewed(prev, selectedSession.id)
-        ))
-        store.set(agentDiffPanelTabAtom, (previous) => {
-          const next = new Map(previous)
-          next.set(parentSession.id, getDelegationSidePanelTab())
-          return next
+        openSession('agent', parentSession.id, parentSession.title, {
+          onOpened: () => {
+            if (store.get(agentSidePanelSplitMapAtom).has(parentSession.id)) {
+              toast.info('请先退出并排模式，再切换子会话', {
+                id: 'split-delegation-sidebar-navigation',
+              })
+            }
+            store.set(agentSideDelegationMapAtom, (previous) => (
+              selectDelegatedSession(previous, parentSession.id, selectedSession.id)
+            ))
+            store.set(agentSidePanelOpenAtomFamily(parentSession.id), true)
+            rememberStopGenerationTarget({ kind: 'agent', sessionId: selectedSession.id })
+            setUnviewedDelegatedCompleted((prev) => (
+              markSessionCompletionViewed(prev, selectedSession.id)
+            ))
+            store.set(agentDiffPanelTabAtom, (previous) => {
+              const next = new Map(previous)
+              next.set(parentSession.id, getDelegationSidePanelTab())
+              return next
+            })
+            setActiveView('conversations')
+            setUnviewedCompleted((prev: Set<string>) => {
+              if (!prev.has(id)) return prev
+              const next = new Set(prev)
+              next.delete(id)
+              return next
+            })
+          },
         })
+        return
+      }
+    }
+
+    openSession('agent', id, title, {
+      onOpened: () => {
         setActiveView('conversations')
+        // 清除该会话的"已完成未查看"标记
         setUnviewedCompleted((prev: Set<string>) => {
           if (!prev.has(id)) return prev
           const next = new Set(prev)
           next.delete(id)
           return next
         })
-        return
-      }
-    }
-
-    openSession('agent', id, title)
-    setActiveView('conversations')
-    // 清除该会话的"已完成未查看"标记
-    setUnviewedCompleted((prev: Set<string>) => {
-      if (!prev.has(id)) return prev
-      const next = new Set(prev)
-      next.delete(id)
-      return next
+      },
     })
   }, [agentSessions, openSession, setActiveView, setUnviewedCompleted, setUnviewedDelegatedCompleted, store])
 
@@ -2433,7 +2310,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setViewMode,
   ])
 
-  const railRecentItems = React.useMemo(() => {
+  const railRecentItems = React.useMemo<RailRecentItem[]>(() => {
     if (mode === 'chat') {
       return conversations
         .filter((c) => !c.archived && !draftSessionIds.has(c.id))
@@ -2459,43 +2336,40 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         }))
     }
 
-    return agentSessions
-      .filter((session) =>
-        !session.archived
-        && !session.isDraft
-        && !draftSessionIds.has(session.id)
-        && (!currentWorkspaceId || session.workspaceId === currentWorkspaceId)
-        // 自动任务会话不出现在收起态 Rail，与展开态列表保持一致
-        && !isHiddenAutomationSession(session)
-      )
-      .sort((a, b) => {
-        const statusA = agentIndicatorMap.get(a.id) ?? (unviewedCompletedSessionIds.has(a.id) ? 'completed' : 'idle')
-        const statusB = agentIndicatorMap.get(b.id) ?? (unviewedCompletedSessionIds.has(b.id) ? 'completed' : 'idle')
-        const priority = (session: AgentSessionMeta, status: SessionIndicatorStatus): number => {
-          if (session.id === activeSessionId) return 0
-          if (status === 'blocked') return 1
-          if (status === 'running') return 2
-          if (session.pinned) return 3
-          if (status === 'completed') return 4
-          return 5
-        }
-        const priorityDelta = priority(a, statusA) - priority(b, statusB)
-        if (priorityDelta !== 0) return priorityDelta
-        return b.updatedAt - a.updatedAt
-      })
-      .slice(0, 5)
-      .map((session) => ({
-        id: session.id,
-        title: session.title,
-        type: 'agent' as const,
-        initial: getRailInitial(session.title),
-        active: session.id === activeSessionId,
-        status: agentIndicatorMap.get(session.id) ?? (unviewedCompletedSessionIds.has(session.id) ? 'completed' as const : 'idle' as const),
-        pinned: !!session.pinned,
-        workspaceName: session.workspaceId ? workspaceNameMap.get(session.workspaceId) : undefined,
-        isAutomation: !!session.sourceAutomationId,
-        isDelegation: !!session.sourceDelegationId,
-      }))
+    const eligibleSessions = agentSessions.filter((session) => (
+      !session.archived
+      && !session.isDraft
+      && !draftSessionIds.has(session.id)
+      // 自动任务会话不出现在收起态 Rail，与展开态列表保持一致
+      && !isHiddenAutomationSession(session)
+    ))
+    const railTrees = getCollapsedAgentRailTrees({
+      sessions: eligibleSessions,
+      workspaceId: currentWorkspaceId,
+      activeSessionId,
+      agentIndicatorMap,
+      unviewedCompletedSessionIds,
+      // CollapsedSessionRail 自己截取 5 个可见根；Popover 打开后它需要完整候选集，
+      // 才能用快照 id 取回可能已被动态排序挤出前五的 Anchor。
+      limit: Number.POSITIVE_INFINITY,
+    })
+
+    return railTrees.map((tree) => ({
+      id: tree.session.id,
+      title: tree.session.title,
+      type: 'agent' as const,
+      initial: getRailInitial(tree.session.title),
+      active: tree.session.id === activeSessionId,
+      // 色条与展开态行共用会话树聚合状态：父会话空闲时也跟随子会话的运行/阻塞/完成态。
+      status: getCollapsedAgentRailTreeStatus(tree, agentIndicatorMap, unviewedCompletedSessionIds),
+      pinned: !!tree.session.pinned,
+      workspaceName: tree.session.workspaceId ? workspaceNameMap.get(tree.session.workspaceId) : undefined,
+      isAutomation: !!tree.session.sourceAutomationId,
+      // 正常 child 收纳进父 Popover；仅父不在当前 workspace 的 moved/orphan child
+      // 复用展开态策略成为可达根条目，并以 delegation 图标区分。
+      isDelegation: isDelegatedChildSession(tree.session),
+      childSessions: tree.childSessions,
+    }))
   }, [
     mode,
     conversations,
@@ -2508,6 +2382,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     unviewedCompletedSessionIds,
     workspaceNameMap,
   ])
+
+  const handleSelectRailChild = React.useCallback((session: AgentSessionMeta): void => {
+    handleSelectAgentSession(session.id, session.title)
+  }, [handleSelectAgentSession])
 
   // 删除确认弹窗（collapsed/expanded 共享）
   const deleteDialog = (
@@ -3254,6 +3132,47 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       isWorkspaceComponentActive(component as WorkspaceComponentTab),
     );
 
+    const collapsedToolItems: CollapsedToolItem[] = [
+      ...(productivityTools.todosEnabled ? [{
+        label: "Todo",
+        icon: <ListTodo size={16} />,
+        active: isWorkspaceComponentActive("todos"),
+        onClick: () => handleOpenPlanningComponent("todos"),
+      }] : []),
+      ...(productivityTools.calendarEnabled ? [{
+        label: "日程",
+        icon: <CalendarDays size={16} />,
+        active: isWorkspaceComponentActive("calendar"),
+        onClick: () => handleOpenPlanningComponent("calendar"),
+      }] : []),
+      ...(productivityTools.obsidianEnabled ? [{
+        label: "Obsidian",
+        icon: <ObsidianIcon size={16} />,
+        active: isWorkspaceComponentActive("vault"),
+        onClick: handleOpenVault,
+      }] : []),
+      ...(mode === "agent" ? [{
+        label: "项目记忆",
+        icon: <Brain size={16} />,
+        active: isWorkspaceComponentActive("memory"),
+        onClick: () => handleOpenCapabilityComponent("memory"),
+      }] : []),
+      {
+        label: "定时任务",
+        icon: <Clock size={16} />,
+        active: isWorkspaceComponentActive("automations"),
+        badge: automationCount > 0 ? formatAutomationCount(automationCount) : undefined,
+        onClick: () => handleOpenPlanningComponent("automations"),
+      },
+      ...(mode === "agent" ? [{
+        label: "MCP/Skills",
+        icon: <Blocks size={16} />,
+        active: isWorkspaceComponentActive("skills") || isWorkspaceComponentActive("mcp"),
+        showUpdate: (capabilities?.skills.filter((skill) => skill.hasUpdate).length ?? 0) > 0,
+        onClick: handleOpenMcpSkillsComponents,
+      }] : []),
+    ];
+
     return (
       <div
         ref={sidebarRootRef}
@@ -3396,128 +3315,49 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
             </TooltipTrigger>
             <TooltipContent side="right">搜索</TooltipContent>
           </Tooltip>
+          <CollapsedToolsPopover items={collapsedToolItems}>
+            <button
+              type="button"
+              aria-label="工作区工具"
+              className="group relative flex size-10 items-center justify-center p-1 titlebar-no-drag focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span
+                className={cn(
+                  "flex size-8 items-center justify-center rounded-[10px] text-foreground/45 transition-[background-color,color,box-shadow] duration-150 group-hover:bg-foreground/[0.06] group-hover:text-foreground/75",
+                  hasActiveCollapsedTool && "bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]",
+                )}
+              >
+                <Blocks size={16} />
+              </span>
+              {hasActiveCollapsedTool && (
+                <span className="absolute right-1 top-1 size-1.5 rounded-full bg-primary" />
+              )}
+            </button>
+          </CollapsedToolsPopover>
+
+          <div className="my-1 h-px w-6 bg-border/70" />
         </div>
 
         {/* 会话列表不再和 Todo、日程、Skills 等次级入口抢占垂直空间。 */}
-        <div className="mt-2 flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin">
-          <div className="flex flex-col items-center gap-0.5 pb-2">
-            {railRecentItems.map((item) => (
-              <RailRecentButton
-                key={`${item.type}-${item.id}`}
-                item={item}
-                miniMapDisabled={!sessionHoverPreviewEnabled}
-                onSelect={(selected) => {
-                  if (selected.type === "agent") {
-                    handleSelectAgentSession(selected.id, selected.title);
-                  } else {
-                    handleSelectConversation(selected.id, selected.title);
-                  }
-                }}
-              />
-            ))}
-          </div>
-        </div>
+        {/* Rail 的面板开合与顺序冻结都在组件内部，hover 不会重渲染整个侧栏。 */}
+        <CollapsedSessionRail
+          items={railRecentItems}
+          activeSessionId={activeSessionId}
+          activeDelegationSessionId={activeDelegationSessionId}
+          agentIndicatorMap={agentIndicatorMap}
+          miniMapDisabled={!sessionHoverPreviewEnabled}
+          onSelectChild={handleSelectRailChild}
+          onSelect={(selected) => {
+            if (selected.type === "agent") {
+              handleSelectAgentSession(selected.id, selected.title);
+            } else {
+              handleSelectConversation(selected.id, selected.title);
+            }
+          }}
+        />
 
-        {/* 次级工作区工具收纳至底部菜单，始终可达且不挤压会话入口。 */}
-        <div className="flex flex-col items-center gap-0.5 border-t border-border/50 py-2">
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="更多工作区工具"
-                    className="group relative flex size-10 items-center justify-center p-1 titlebar-no-drag"
-                  >
-                    <span
-                      className={cn(
-                        "flex size-8 items-center justify-center rounded-[10px] text-foreground/45 transition-[background-color,color] duration-150 group-hover:bg-foreground/[0.06] group-hover:text-foreground/75",
-                        hasActiveCollapsedTool &&
-                          "bg-primary/10 text-foreground",
-                      )}
-                    >
-                      <MoreHorizontal size={17} />
-                    </span>
-                    {hasActiveCollapsedTool && (
-                      <span className="absolute right-1 top-1 size-1.5 rounded-full bg-primary" />
-                    )}
-                  </button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent side="right">更多工作区工具</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent side="right" align="end" className="min-w-40">
-              {productivityTools.todosEnabled && (
-                <DropdownMenuItem
-                  aria-current={isWorkspaceComponentActive("todos") ? "page" : undefined}
-                  className={cn(isWorkspaceComponentActive("todos") && "bg-accent/70 text-accent-foreground")}
-                  onSelect={() => handleOpenPlanningComponent("todos")}
-                >
-                  <ListTodo />
-                  Todo
-                </DropdownMenuItem>
-              )}
-              {productivityTools.calendarEnabled && (
-                <DropdownMenuItem
-                  aria-current={isWorkspaceComponentActive("calendar") ? "page" : undefined}
-                  className={cn(isWorkspaceComponentActive("calendar") && "bg-accent/70 text-accent-foreground")}
-                  onSelect={() => handleOpenPlanningComponent("calendar")}
-                >
-                  <CalendarDays />
-                  日程
-                </DropdownMenuItem>
-              )}
-              {productivityTools.obsidianEnabled && (
-                <DropdownMenuItem
-                  aria-current={isWorkspaceComponentActive("vault") ? "page" : undefined}
-                  className={cn(isWorkspaceComponentActive("vault") && "bg-accent/70 text-accent-foreground")}
-                  onSelect={handleOpenVault}
-                >
-                  <ObsidianIcon size={16} />
-                  Obsidian
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem
-                aria-current={isWorkspaceComponentActive("automations") ? "page" : undefined}
-                className={cn(isWorkspaceComponentActive("automations") && "bg-accent/70 text-accent-foreground")}
-                onSelect={() => handleOpenPlanningComponent("automations")}
-              >
-                <Clock />
-                定时任务
-                {automationCount > 0 && (
-                  <span className="ml-auto rounded-full bg-primary px-1.5 text-[10px] font-medium leading-4 text-primary-foreground tabular-nums">
-                    {formatAutomationCount(automationCount)}
-                  </span>
-                )}
-              </DropdownMenuItem>
-              {mode === "agent" && (
-                <>
-                  <DropdownMenuItem
-                    aria-current={isWorkspaceComponentActive("skills") || isWorkspaceComponentActive("mcp") ? "page" : undefined}
-                    className={cn((isWorkspaceComponentActive("skills") || isWorkspaceComponentActive("mcp")) && "bg-accent/70 text-accent-foreground")}
-                    onSelect={handleOpenMcpSkillsComponents}
-                  >
-                    <Blocks />
-                    MCP/Skills
-                    {(capabilities?.skills.filter((skill) => skill.hasUpdate)
-                      .length ?? 0) > 0 && (
-                      <span className="ml-auto size-2 rounded-full bg-blue-500" />
-                    )}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    aria-current={isWorkspaceComponentActive("memory") ? "page" : undefined}
-                    className={cn(isWorkspaceComponentActive("memory") && "bg-accent/70 text-accent-foreground")}
-                    onSelect={() => handleOpenCapabilityComponent("memory")}
-                  >
-                    <Brain />
-                    项目记忆
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
+        {/* 底部只保留全局状态与账户入口，工作区工具统一从搜索下方进入。 */}
+        <div className="flex flex-col items-center gap-0.5 py-2">
           {hasUpdate && (
             <SidebarUpdateButton
               status={updateStatus}

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -191,7 +191,10 @@ export function SettingsPanel({
         pendingAction.navigation.type,
         pendingAction.navigation.sessionId,
         pendingAction.navigation.title,
-        { bypassSettingsGuard: true },
+        {
+          bypassSettingsGuard: true,
+          onOpened: pendingAction.navigation.onOpened,
+        },
       )
     } else {
       onClose?.()

--- a/apps/electron/src/renderer/hooks/useHoverPopover.ts
+++ b/apps/electron/src/renderer/hooks/useHoverPopover.ts
@@ -1,0 +1,160 @@
+/**
+ * useHoverPopover — 折叠态侧栏弹层共用的 hover / 点击 / 键盘开合控制。
+ *
+ * 折叠态入口只有 40px，鼠标从入口移动到弹层必然经过两者之间的空隙，也可能
+ * 短暂落在侧栏容器上。因此关闭一律走宽限期：进入入口或弹层任一表面立即取消
+ * 关闭，离开后延迟 HOVER_POPOVER_CLOSE_DELAY 才真正关闭。
+ *
+ * 不要改成「离开即关闭 + relatedTarget 命中判定」：Portal 弹层斜向移动时
+ * relatedTarget 会落在侧栏滚动容器上，弹层在鼠标到达列表前就消失，列表项因此
+ * 完全点不到。同理，列表项的关闭必须发生在自身 onClick 里（先执行动作再收起），
+ * 不能放在弹层的 onClickCapture 上抢在业务处理之前卸载内容。
+ */
+
+import * as React from 'react'
+
+export const HOVER_POPOVER_CLOSE_DELAY = 150
+
+/**
+ * side="right" + sideOffset={8} 弹层的共用样式：
+ * - before 伪元素把 8px 间距纳入弹层命中区，鼠标横穿时不会离开 hover 表面；
+ * - 退场动画期间不再拦截指针，避免正在淡出的弹层吃掉下一次点击。
+ */
+export const HOVER_POPOVER_CONTENT_CLASS
+  = "relative before:absolute before:-left-2 before:top-0 before:h-full before:w-2 before:content-[''] data-[state=closed]:pointer-events-none"
+
+export type HoverPopoverOpenReason = 'hover' | 'pointer' | 'keyboard'
+
+export interface UseHoverPopoverOptions {
+  /** 受控开合；省略时由 hook 自己维护状态。 */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  closeDelay?: number
+}
+
+export interface HoverPopoverController {
+  open: boolean
+  /** 传给 Radix Popover 的 onOpenChange，同时取消待执行的延迟关闭。 */
+  onOpenChange: (open: boolean) => void
+  /** 入口与弹层内容共用的一组 hover 属性，两个表面视作同一个 hover 区域。 */
+  hoverProps: {
+    onMouseEnter: () => void
+    onMouseLeave: () => void
+  }
+  /** 触控与键盘 affordance：记录打开原因，用于决定是否抢焦点。 */
+  manualTriggerProps: {
+    onPointerDown: () => void
+    onKeyDown: (event: React.KeyboardEvent) => void
+  }
+  /** 弹层内容的焦点属性：hover 打开时不抢焦点，键盘打开时正常归还焦点。 */
+  contentFocusProps: {
+    onOpenAutoFocus: (event: Event) => void
+    onCloseAutoFocus: (event: Event) => void
+    onFocusCapture: () => void
+  }
+  /** 执行完列表项动作后立即收起弹层。 */
+  close: () => void
+  /**
+   * 以键盘意图打开弹层：打开后焦点进入内容，Escape 可归还焦点。
+   * 供没有独立 trigger 按钮、只靠 hover 展示的弹层保留键盘可达性。
+   */
+  openByKeyboard: () => void
+}
+
+export function composeEventHandlers<E extends React.SyntheticEvent>(
+  first: ((event: E) => void) | undefined,
+  second: (event: E) => void,
+): (event: E) => void {
+  return (event) => {
+    first?.(event)
+    second(event)
+  }
+}
+
+export function useHoverPopover(options: UseHoverPopoverOptions = {}): HoverPopoverController {
+  const { open: controlledOpen, onOpenChange, closeDelay = HOVER_POPOVER_CLOSE_DELAY } = options
+
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false)
+  const open = controlledOpen ?? uncontrolledOpen
+
+  // 受控与否在组件生命周期内固定；用 ref 读取可让回调保持稳定身份。
+  const isControlledRef = React.useRef(controlledOpen !== undefined)
+  const onOpenChangeRef = React.useRef(onOpenChange)
+  const openRef = React.useRef(open)
+  const closeTimerRef = React.useRef<number | null>(null)
+  const openReasonRef = React.useRef<HoverPopoverOpenReason>('pointer')
+  const focusWasInsideRef = React.useRef(false)
+
+  React.useEffect(() => {
+    onOpenChangeRef.current = onOpenChange
+    openRef.current = open
+  })
+
+  const cancelScheduledClose = React.useCallback((): void => {
+    if (closeTimerRef.current == null) return
+    window.clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = null
+  }, [])
+
+  const commitOpen = React.useCallback((next: boolean): void => {
+    cancelScheduledClose()
+    openRef.current = next
+    if (!isControlledRef.current) setUncontrolledOpen(next)
+    onOpenChangeRef.current?.(next)
+  }, [cancelScheduledClose])
+
+  const scheduleClose = React.useCallback((): void => {
+    cancelScheduledClose()
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null
+      commitOpen(false)
+    }, closeDelay)
+  }, [cancelScheduledClose, closeDelay, commitOpen])
+
+  React.useEffect(() => cancelScheduledClose, [cancelScheduledClose])
+
+  const handleHoverEnter = React.useCallback((): void => {
+    if (!openRef.current) openReasonRef.current = 'hover'
+    commitOpen(true)
+  }, [commitOpen])
+
+  const close = React.useCallback((): void => {
+    commitOpen(false)
+  }, [commitOpen])
+
+  const openByKeyboard = React.useCallback((): void => {
+    openReasonRef.current = 'keyboard'
+    commitOpen(true)
+  }, [commitOpen])
+
+  return {
+    open,
+    onOpenChange: commitOpen,
+    hoverProps: {
+      onMouseEnter: handleHoverEnter,
+      onMouseLeave: scheduleClose,
+    },
+    manualTriggerProps: {
+      onPointerDown: () => {
+        openReasonRef.current = 'pointer'
+      },
+      onKeyDown: (event) => {
+        if (event.key === 'Enter' || event.key === ' ') openReasonRef.current = 'keyboard'
+      },
+    },
+    contentFocusProps: {
+      onOpenAutoFocus: (event) => {
+        if (openReasonRef.current === 'hover') event.preventDefault()
+      },
+      onCloseAutoFocus: (event) => {
+        if (openReasonRef.current === 'hover' && !focusWasInsideRef.current) event.preventDefault()
+        focusWasInsideRef.current = false
+      },
+      onFocusCapture: () => {
+        focusWasInsideRef.current = true
+      },
+    },
+    close,
+    openByKeyboard,
+  }
+}

--- a/apps/electron/src/renderer/hooks/useOpenSession.ts
+++ b/apps/electron/src/renderer/hooks/useOpenSession.ts
@@ -34,6 +34,8 @@ import {
 
 interface OpenSessionOptions {
   bypassSettingsGuard?: boolean
+  /** 仅在导航实际执行后调用；设置 Guard 取消时不会调用。 */
+  onOpened?: () => void
 }
 
 type OpenSessionFn = (type: TabType, sessionId: string, title: string, options?: OpenSessionOptions) => void
@@ -59,7 +61,7 @@ export function useOpenSession(): OpenSessionFn {
   return React.useCallback(
     (type: TabType, sessionId: string, title: string, options?: OpenSessionOptions): void => {
       if (!options?.bypassSettingsGuard && settingsOpen && channelFormDirty) {
-        setPendingSessionNavigation({ type, sessionId, title })
+        setPendingSessionNavigation({ type, sessionId, title, onOpened: options?.onOpened })
         return
       }
       setSettingsOpen(false)
@@ -106,6 +108,8 @@ export function useOpenSession(): OpenSessionFn {
         setCurrentConversationId(null)
         setCurrentAgentSessionId(null)
       }
+
+      options?.onOpened?.()
     },
     [tabs, setTabs, setActiveTabId, setAutomationForm, setActiveView, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, agentSessions, setCurrentAgentWorkspaceId, setUnviewedCompleted, settingsOpen, channelFormDirty, setSettingsOpen, setPendingSessionNavigation, currentAgentSessionId],
   )

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -261,6 +261,31 @@ export function getDelegatedChildSessionStatus(
 }
 
 /**
+ * Resolve the sidebar indicator status of one parent session together with its
+ * delegated children, taking the highest priority of
+ * blocked > running > completed > idle.
+ *
+ * Expanded rows and the collapsed Rail must both call this: the parent's color
+ * code has to follow its children even while the parent itself is idle, and the
+ * two sidebar forms must never disagree about the same session tree.
+ */
+export function getAgentSessionTreeIndicatorStatus(
+  session: AgentSessionMeta,
+  childSessions: readonly AgentSessionMeta[],
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>,
+): SessionIndicatorStatus {
+  const statuses: SessionIndicatorStatus[] = [
+    agentIndicatorMap.get(session.id) ?? 'idle',
+    ...childSessions.map((child) => getDelegatedChildSessionStatus(child, agentIndicatorMap)),
+  ]
+
+  if (statuses.includes('blocked')) return 'blocked'
+  if (statuses.includes('running')) return 'running'
+  if (statuses.includes('completed')) return 'completed'
+  return 'idle'
+}
+
+/**
  * Count direct children whose current sidebar state has settled. This must use
  * the same status source as child rows so parent progress cannot disagree.
  */

--- a/apps/electron/src/renderer/lib/collapsed-agent-rail.test.ts
+++ b/apps/electron/src/renderer/lib/collapsed-agent-rail.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  reduceCollapsedRailPopoverState,
+  type CollapsedRailPopoverState,
+} from '@/lib/collapsed-agent-rail'
+
+describe('折叠态 Rail Popover 状态', () => {
+  const openState: CollapsedRailPopoverState = {
+    openPopoverId: 'parent-a',
+    snapshotIds: ['parent-a', 'parent-b'],
+  }
+
+  test('given B 已打开 when A 的延迟关闭到达 then 保留 B 的 snapshot', () => {
+    const stateAfterBOpens = reduceCollapsedRailPopoverState(openState, {
+      type: 'open',
+      id: 'parent-b',
+      snapshotIds: ['parent-b', 'parent-a'],
+    })
+
+    const result = reduceCollapsedRailPopoverState(stateAfterBOpens, {
+      type: 'close',
+      id: 'parent-a',
+    })
+
+    expect(result).toBe(stateAfterBOpens)
+    expect(result).toEqual({
+      openPopoverId: 'parent-b',
+      snapshotIds: ['parent-b', 'parent-a'],
+    })
+  })
+
+  test('given A 已打开 when A 关闭 then 清理当前面板和 snapshot', () => {
+    expect(reduceCollapsedRailPopoverState(openState, {
+      type: 'close',
+      id: 'parent-a',
+    })).toEqual({
+      openPopoverId: null,
+      snapshotIds: null,
+    })
+  })
+
+  test('given A 已打开 when B 打开 then 使用 B 的最新入口 snapshot', () => {
+    expect(reduceCollapsedRailPopoverState(openState, {
+      type: 'open',
+      id: 'parent-b',
+      snapshotIds: ['parent-b', 'parent-c'],
+    })).toEqual({
+      openPopoverId: 'parent-b',
+      snapshotIds: ['parent-b', 'parent-c'],
+    })
+  })
+})

--- a/apps/electron/src/renderer/lib/collapsed-agent-rail.ts
+++ b/apps/electron/src/renderer/lib/collapsed-agent-rail.ts
@@ -10,12 +10,33 @@ export interface AgentSessionTreeItem {
   childSessions: AgentSessionMeta[]
 }
 
+export interface CollapsedRailPopoverState {
+  openPopoverId: string | null
+  snapshotIds: string[] | null
+}
+
 /** 目标条目已不在可见集合或已没有子会话时，残留的展开状态一律失效。 */
 export function getEffectiveCollapsedRailPopoverId(
   openPopoverId: string | null,
   validPopoverItemIds: readonly string[],
 ): string | null {
   return openPopoverId && validPopoverItemIds.includes(openPopoverId) ? openPopoverId : null
+}
+
+/**
+ * 处理 Rail Popover 状态。关闭事件必须携带来源 ID，过期的延迟关闭不能影响新面板。
+ */
+export function reduceCollapsedRailPopoverState(
+  state: CollapsedRailPopoverState,
+  event:
+    | { type: 'open'; id: string; snapshotIds: readonly string[] }
+    | { type: 'close'; id: string },
+): CollapsedRailPopoverState {
+  if (event.type === 'open') {
+    return { openPopoverId: event.id, snapshotIds: [...event.snapshotIds] }
+  }
+  if (state.openPopoverId !== event.id) return state
+  return { openPopoverId: null, snapshotIds: null }
 }
 
 /**

--- a/apps/electron/src/renderer/lib/collapsed-agent-rail.ts
+++ b/apps/electron/src/renderer/lib/collapsed-agent-rail.ts
@@ -1,0 +1,179 @@
+import type { AgentSessionMeta } from '@proma/shared'
+import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
+import {
+  getAgentSessionTreeIndicatorStatus,
+  getDelegatedChildSessionStatus,
+} from '@/lib/agent-session-list'
+
+export interface AgentSessionTreeItem {
+  session: AgentSessionMeta
+  childSessions: AgentSessionMeta[]
+}
+
+/** 目标条目已不在可见集合或已没有子会话时，残留的展开状态一律失效。 */
+export function getEffectiveCollapsedRailPopoverId(
+  openPopoverId: string | null,
+  validPopoverItemIds: readonly string[],
+): string | null {
+  return openPopoverId && validPopoverItemIds.includes(openPopoverId) ? openPopoverId : null
+}
+
+/**
+ * 计算 Rail 的根条目。Popover 打开期间使用打开时捕获的根 id 顺序，
+ * 但条目对象仍从最新 items 读取，因此标题、状态和 childSessions 会继续更新。
+ */
+export function getCollapsedAgentRailVisibleItems<T extends { id: string }>(
+  items: readonly T[],
+  openPopoverId: string | null,
+  openSnapshotIds: readonly string[] | null,
+  limit = 5,
+): T[] {
+  if (openPopoverId === null || openSnapshotIds === null) return items.slice(0, limit)
+
+  const itemsById = new Map(items.map((item) => [item.id, item]))
+  const result = openSnapshotIds
+    .slice(0, limit)
+    .flatMap((id) => {
+      const item = itemsById.get(id)
+      return item ? [item] : []
+    })
+  const includedIds = new Set(result.map((item) => item.id))
+
+  // 防御性兜底：即使打开事件与一次更新交错，也不让仍然有效的 open parent
+  // 因快照尚未写入而丢失锚点。
+  const openItem = itemsById.get(openPopoverId)
+  if (openItem && !includedIds.has(openPopoverId)) {
+    if (result.length >= limit) includedIds.delete(result.pop()!.id)
+    result.push(openItem)
+    includedIds.add(openPopoverId)
+  }
+
+  // 快照中的其他条目被删除时，用最新动态顺序补足空位，但不移动仍存在的 Anchor。
+  for (const item of items) {
+    if (result.length >= limit) break
+    if (includedIds.has(item.id)) continue
+    result.push(item)
+    includedIds.add(item.id)
+  }
+  return result
+}
+
+export function isDelegatedChildSession(session: AgentSessionMeta): boolean {
+  return !!session.parentSessionId && !!session.sourceDelegationId
+}
+
+export function sortDelegatedChildSessions(
+  sessions: readonly AgentSessionMeta[],
+  agentIndicatorMap?: ReadonlyMap<string, SessionIndicatorStatus>,
+): AgentSessionMeta[] {
+  const priority = (session: AgentSessionMeta): number => Number(
+    agentIndicatorMap && ['blocked', 'running', 'completed'].includes(getDelegatedChildSessionStatus(session, agentIndicatorMap)),
+  )
+  return [...sessions].sort((a, b) => priority(b) - priority(a) || b.updatedAt - a.updatedAt)
+}
+
+export function buildAgentSessionTrees(
+  sessions: readonly AgentSessionMeta[],
+  agentIndicatorMap?: ReadonlyMap<string, SessionIndicatorStatus>,
+): AgentSessionTreeItem[] {
+  const sessionIds = new Set(sessions.map((session) => session.id))
+  const childrenByParentId = new Map<string, AgentSessionMeta[]>()
+  const roots: AgentSessionMeta[] = []
+
+  for (const session of sessions) {
+    if (
+      isDelegatedChildSession(session)
+      && session.parentSessionId
+      && sessionIds.has(session.parentSessionId)
+    ) {
+      const children = childrenByParentId.get(session.parentSessionId) ?? []
+      children.push(session)
+      childrenByParentId.set(session.parentSessionId, children)
+      continue
+    }
+
+    // 与展开态项目分组保持一致：父会话不在当前集合中的 moved/orphan child
+    // 作为该项目的根条目保留，避免因历史或迁移中间态变得不可达。
+    roots.push(session)
+  }
+
+  return roots.map((session) => ({
+    session,
+    childSessions: sortDelegatedChildSessions(childrenByParentId.get(session.id) ?? [], agentIndicatorMap),
+  }))
+}
+
+export function buildWorkspaceAgentSessionTrees(
+  sessions: readonly AgentSessionMeta[],
+  workspaceId: string | null,
+  agentIndicatorMap?: ReadonlyMap<string, SessionIndicatorStatus>,
+): AgentSessionTreeItem[] {
+  const workspaceSessions = workspaceId
+    ? sessions.filter((session) => session.workspaceId === workspaceId)
+    : sessions
+  return buildAgentSessionTrees(workspaceSessions, agentIndicatorMap)
+}
+
+/**
+ * 折叠态 Rail 入口的状态：与展开态行共用会话树聚合逻辑，父会话自身空闲但子
+ * 会话在运行/阻塞/刚完成时，色条与展开态保持一致；随后才回落到「已完成未查看」。
+ */
+export function getCollapsedAgentRailTreeStatus(
+  tree: AgentSessionTreeItem,
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>,
+  unviewedCompletedSessionIds: ReadonlySet<string>,
+): SessionIndicatorStatus {
+  const status = getAgentSessionTreeIndicatorStatus(
+    tree.session,
+    tree.childSessions,
+    agentIndicatorMap,
+  )
+  if (status !== 'idle') return status
+  return unviewedCompletedSessionIds.has(tree.session.id) ? 'completed' : 'idle'
+}
+
+/**
+ * 折叠态 Rail 的可见会话树：排序与上游 Rail 完全一致（当前会话 > blocked >
+ * running > pinned > completed > idle，再按更新时间），只是把委派子会话收纳到
+ * 父条目下，并用会话树聚合状态参与排序。
+ *
+ * 排序只依赖传入的派生数据，不引入任何中间 state，因此点击后的置顶在同一次
+ * 提交内完成，不会额外触发同步重渲染。
+ */
+export function getCollapsedAgentRailTrees(input: {
+  sessions: readonly AgentSessionMeta[]
+  workspaceId: string | null
+  activeSessionId: string | null
+  agentIndicatorMap: ReadonlyMap<string, SessionIndicatorStatus>
+  unviewedCompletedSessionIds: ReadonlySet<string>
+  limit?: number
+}): AgentSessionTreeItem[] {
+  const trees = buildWorkspaceAgentSessionTrees(
+    input.sessions,
+    input.workspaceId,
+    input.agentIndicatorMap,
+  )
+
+  // 每棵树只聚合一次状态，排序比较器仅读取预计算值。
+  const decoratedTrees = trees.map((tree) => ({
+    tree,
+    status: getCollapsedAgentRailTreeStatus(tree, input.agentIndicatorMap, input.unviewedCompletedSessionIds),
+  }))
+  const priority = (session: AgentSessionMeta, status: SessionIndicatorStatus): number => {
+    if (session.id === input.activeSessionId) return 0
+    if (status === 'blocked') return 1
+    if (status === 'running') return 2
+    if (session.pinned) return 3
+    if (status === 'completed') return 4
+    return 5
+  }
+
+  return decoratedTrees
+    .sort((a, b) => {
+      const priorityDelta = priority(a.tree.session, a.status) - priority(b.tree.session, b.status)
+      if (priorityDelta !== 0) return priorityDelta
+      return b.tree.session.updatedAt - a.tree.session.updatedAt
+    })
+    .slice(0, input.limit ?? 5)
+    .map(({ tree }) => tree)
+}


### PR DESCRIPTION
## 概述
修复折叠态 Agent Rail 的会话切换体验，使点击后的 active 状态、会话首字母/图标和 Rail 排序直接跟随 `activeSessionId` 在同一次 React 更新中生效，不再延迟到鼠标离开 Rail。与此同时保留委派子会话的 hover 面板、父会话适配导航和状态色聚合，并修复 Popover 打开期间 Rail 实时排序导致 Anchor 跳位或父入口掉出前五的问题。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 移除会导致整棵侧栏同步二次渲染的 Rail 中间排序状态和冻结逻辑；排序直接使用 `activeSessionId`，并把 Rail 交互交给独立组件。
- `apps/electron/src/renderer/components/agent/CollapsedSessionRail.tsx` — 新增折叠态会话 Rail，局部管理 delegated Popover 的开合与可见入口快照，避免 Popover 打开时 Anchor 因实时状态变化跳位或掉出前五。
- `apps/electron/src/renderer/components/agent/CollapsedDelegatedSessionsPopover.tsx` — 统一 hover 宽限、Portal 间隙命中、键盘 `ArrowRight`、焦点回收和子会话点击顺序；右下角 delegation 图标改为纯装饰，整块入口统一切换父会话。
- `apps/electron/src/renderer/components/agent/CollapsedToolsPopover.tsx` — 复用统一 hover Popover 控制器，工具动作先执行再关闭面板。
- `apps/electron/src/renderer/hooks/useHoverPopover.ts` — 新增共享的 hover / timer / controlled state / keyboard / focus 管理逻辑，并在卸载时清理延迟关闭 timer。
- `apps/electron/src/renderer/lib/collapsed-agent-rail.ts` — 新增会话树构建、状态聚合、动态排序和 Popover 打开期间可见条目稳定化逻辑。
- `apps/electron/src/renderer/lib/agent-session-list.ts` — 抽取父会话与委派子会话的统一状态聚合逻辑，保证展开态和折叠态色条一致。
- `apps/electron/src/renderer/hooks/useOpenSession.ts`、`apps/electron/src/renderer/atoms/settings-tab.ts`、`apps/electron/src/renderer/components/settings/SettingsPanel.tsx` — 传递只在导航真正执行后触发的 `onOpened` 回调，避免 Settings dirty guard 取消后提前提交导航副作用。
- `apps/electron/package.json` — patch 版本更新至 `0.19.27`。

## 测试方法
1. `git diff --check`。
2. 对相关 Rail 纯函数测试已在开发 worktree 中验证通过；按用户要求，提交前删除了该 PR 新增的测试文件，因此本 PR 不包含新增测试代码。
3. `cd apps/electron && bunx tsc --noEmit`。
4. 手动验证折叠态父会话、委派子会话、右下角装饰图标、hover 面板、`ArrowRight` 和 Settings dirty guard 导航路径。

## 备注
- 本 PR 基于最新 `origin/main`（`bbf577a8`，v0.19.26）创建，当前 Electron patch 版本为 `0.19.27`。
- 完整 Electron DevTools Performance/Layers/GPU profile 尚未执行；Popover 面积较小且没有新增 backdrop blur、filter blur、will-change 或无限动画，但建议在多子会话和 software fallback 环境中补充验证。
- 提交前按要求移除了 `collapsed-agent-rail.test.ts`，因此测试新增量为 0 行。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)