### PR TITLE
fix(browser): keep usable Google pages open

### DIFF
--- a/apps/electron/src/main/lib/browser-controller.ts
+++ b/apps/electron/src/main/lib/browser-controller.ts
@@ -1180,10 +1180,41 @@ export class BrowserController {
     await withBrowserCdpTimeout(() => tab.view.webContents.loadURL(url), 'Page.navigate', timeoutMs, signal)
   }
 
-  /** 默认 Google 页面在 3 秒内未完成加载时停止旧导航，并在同一标签页加载 Bing。 */
+  private async loadUrlUntilMainFrameReady(tab: BrowserTabRecord, url: string, signal?: AbortSignal, timeoutMs = GOOGLE_DEFAULT_LOAD_TIMEOUT_MS): Promise<void> {
+    throwIfBrowserOperationAborted(signal)
+    const contents = tab.view.webContents
+    await withBrowserCdpTimeout(() => new Promise<void>((resolve, reject) => {
+      let settled = false
+      const cleanup = (): void => {
+        contents.removeListener('did-navigate', onNavigate)
+        contents.removeListener('did-fail-load', onFail)
+      }
+      const finish = (callback: () => void): void => {
+        if (settled) return
+        settled = true
+        cleanup()
+        callback()
+      }
+      const onNavigate = (): void => {
+        // did-navigate 表示主框架已收到可用文档；不等待页面的子资源加载完成。
+        finish(resolve)
+      }
+      const onFail = (event: Electron.Event, errorCode: number, description: string, _validatedURL: string, isMainFrame: boolean): void => {
+        if (!isMainFrame) return
+        finish(() => reject(new Error(`页面导航失败（${errorCode}）：${description}`)))
+      }
+      contents.on('did-navigate', onNavigate)
+      contents.on('did-fail-load', onFail)
+      void contents.loadURL(url).catch((error) => finish(() => reject(error)))
+    }), 'Page.navigate', timeoutMs, signal)
+  }
+
   private async loadUrlWithFallback(tab: BrowserTabRecord, url: string, fallbackUrl: string | undefined, signal?: AbortSignal): Promise<{ loadedUrl: string; usedFallback: boolean }> {
     try {
-      await this.loadUrl(tab, url, signal, fallbackUrl ? GOOGLE_DEFAULT_LOAD_TIMEOUT_MS : undefined)
+      // 对 Google 只需确认主框架已完成导航；首屏可用后不再等待图片、脚本等子资源。
+      // 这样“Google 已经能打开，但资源仍在加载”不会被误判为超时并跳到 Bing。
+      if (fallbackUrl) await this.loadUrlUntilMainFrameReady(tab, url, signal)
+      else await this.loadUrl(tab, url, signal)
       return { loadedUrl: url, usedFallback: false }
     } catch (error) {
       if (!fallbackUrl || !(error instanceof BrowserCdpTimeoutError)) throw error


### PR DESCRIPTION
## Summary

- Treat Google main-frame navigation as success once the usable document is available.
- Do not redirect to Bing while subresources are still loading.
- Keep Bing as a fallback only when the main frame does not navigate within 3 seconds.

## Validation

- [x] `bun run --cwd apps/electron typecheck`
- [x] `git diff --check`
- [ ] Electron runtime verification not available in this session

## Performance impact

Low risk: the fallback path now listens for main-frame navigation and cleans up temporary listeners after completion. No renderer, IPC, timer, or subscription changes beyond the existing navigation timeout.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)