### PR TITLE
fix: adapt Gemini 3 thinking levels

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -285,7 +285,9 @@ function applyPiModelCapabilityOverrides(model: PiCatalogModel | undefined): PiC
   if (!model) return model
 
   const normalizedId = model.id.trim().toLowerCase()
-  const geminiCapability = model.provider === 'google' ? getGeminiModelCapability(normalizedId) : undefined
+  // Pi catalog also exposes Google-protocol Gemini through OpenCode Go. The API
+  // contract—not the catalog provider name—determines whether Google thinking levels apply.
+  const geminiCapability = model.api === 'google-generative-ai' ? getGeminiModelCapability(normalizedId) : undefined
   const requiresMinimalThinkingExclusion = geminiCapability && !geminiCapability.thinkingLevels.includes('minimal')
   const input: PiCatalogModel['input'] = supportsPiNativeImageInput(model.id) && !model.input.includes('image')
     ? [...model.input, 'image']

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -12,6 +12,7 @@ import {
   extractZhipuCodingTeamApiToken,
   inferContextWindow,
   inferCodexAlignedGPT5ContextWindow,
+  getGeminiModelCapability,
   resolveReasoningCapability,
   resolveReasoningProfile,
   type CodexOAuthCredentials,
@@ -281,8 +282,20 @@ export function supportsPiNativeImageInput(modelId: string | undefined): boolean
 }
 
 function applyPiModelCapabilityOverrides(model: PiCatalogModel | undefined): PiCatalogModel | undefined {
-  if (!model || !supportsPiNativeImageInput(model.id) || model.input.includes('image')) return model
-  return { ...model, input: [...model.input, 'image'] }
+  if (!model) return model
+
+  const normalizedId = model.id.trim().toLowerCase()
+  const geminiCapability = model.provider === 'google' ? getGeminiModelCapability(normalizedId) : undefined
+  const requiresMinimalThinkingExclusion = geminiCapability && !geminiCapability.thinkingLevels.includes('minimal')
+  const input: PiCatalogModel['input'] = supportsPiNativeImageInput(model.id) && !model.input.includes('image')
+    ? [...model.input, 'image']
+    : model.input
+  const thinkingLevelMap = requiresMinimalThinkingExclusion
+    ? { ...model.thinkingLevelMap, minimal: null }
+    : model.thinkingLevelMap
+
+  if (input === model.input && thinkingLevelMap === model.thinkingLevelMap) return model
+  return { ...model, input, ...(thinkingLevelMap ? { thinkingLevelMap } : {}) }
 }
 
 const CODEX_MODEL_PATCHES: PiCatalogModelPatch[] = [

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -197,7 +197,7 @@ export async function sendMessage(
   const {
     conversationId, userMessage, channelId,
     modelId, systemMessage, contextLength, contextDividers, attachments,
-    thinkingEnabled, enabledToolIds,
+    thinkingEnabled, thinkingLevel, enabledToolIds,
   } = input
 
   // 1. 查找渠道
@@ -332,6 +332,7 @@ export async function sendMessage(
         attachments,
         readImageAttachments: getImageAttachmentData,
         thinkingEnabled,
+        thinkingLevel,
         tools,
         continuationMessages: continuationMessages.length > 0 ? continuationMessages : undefined,
       })
@@ -408,6 +409,7 @@ export async function sendMessage(
         attachments,
         readImageAttachments: getImageAttachmentData,
         thinkingEnabled,
+        thinkingLevel,
         // 不传 tools，强制模型生成文本回复而非继续调用工具
         continuationMessages,
       })

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -8,7 +8,7 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { atomFamily } from 'jotai-family'
-import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
+import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel, GeminiThinkingLevel } from '@proma/shared'
 import type { QuotedSelection } from './preview-atoms'
 
 /** 全局渠道列表缓存（启动时加载一次，设置变更时刷新） */
@@ -178,6 +178,12 @@ export const thinkingEnabledAtom = atomWithStorage<boolean>(
   false,
 )
 
+/** Gemini 3 Chat 思考深度（模型不支持时由 adapter 安全归一化）。 */
+export const thinkingLevelAtom = atomWithStorage<GeminiThinkingLevel>(
+  'proma-thinking-level',
+  'medium',
+)
+
 /** 当前对话的上下文分隔线 */
 export const contextDividersAtom = atom<string[]>([])
 
@@ -291,6 +297,9 @@ export const conversationContextLengthAtom = atom<Map<string, ContextLengthValue
 
 /** 每个对话的思考模式 */
 export const conversationThinkingEnabledAtom = atom<Map<string, boolean>>(new Map())
+
+/** 每个对话的 Gemini 3 思考深度。 */
+export const conversationThinkingLevelAtom = atom<Map<string, GeminiThinkingLevel>>(new Map())
 
 /** 每个对话的并排模式 */
 export const conversationParallelModeAtom = atom<Map<string, boolean>>(new Map())

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -14,11 +14,12 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { CornerDownLeft, Square, Brain, Paperclip } from 'lucide-react'
+import { CornerDownLeft, Square, Paperclip } from 'lucide-react'
 import { ModelSelector } from './ModelSelector'
 import { ClearContextButton } from './ClearContextButton'
 import { ContextSettingsPopover } from './ContextSettingsPopover'
 import { ToolSelectorPopover } from './ToolSelectorPopover'
+import { ChatThinkingPopover } from './ChatThinkingPopover'
 import { AttachmentPreviewItem } from './AttachmentPreviewItem'
 import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
@@ -47,7 +48,6 @@ import {
 import type { PendingAttachment } from '@/atoms/chat-atoms'
 import {
   useConversationModel,
-  useConversationThinkingEnabled,
 } from '@/hooks/useConversationSettings'
 import { cn } from '@/lib/utils'
 import { fileToBase64, formatFileNames } from '@/lib/file-utils'
@@ -111,7 +111,6 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   }, [conversationId, setDraftsMap, setDraftSyncVersions])
 
   const [selectedModel] = useConversationModel()
-  const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
   const setPendingAttachments = onSetPendingAttachments
   const [isDragOver, setIsDragOver] = React.useState(false)
   const chatVoiceInputId = React.useId()
@@ -350,30 +349,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   const toolbarItems = React.useMemo<ToolbarItem[]>(() => [
     // Chat 可能与主 Agent 输入框并存；不能复用其全局 open atom，否则两个 Popover 会同时打开、互相关闭。
     { key: 'model', node: <ModelSelector excludedProviders={['openai-codex', 'xai']} /> },
-    {
-      key: 'thinking',
-      node: (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className={cn(
-                inputToolbarButtonClass,
-                thinkingEnabled && inputToolbarActiveButtonClass
-              )}
-              onClick={() => setThinkingEnabled(!thinkingEnabled)}
-            >
-              <Brain className="size-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            <p>{thinkingEnabled ? '关闭思考模式' : '开启思考模式'}</p>
-          </TooltipContent>
-        </Tooltip>
-      ),
-    },
+    { key: 'thinking', node: <ChatThinkingPopover modelId={selectedModel?.modelId} /> },
     {
       key: 'attach',
       node: (
@@ -399,7 +375,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     { key: 'tools', node: <ToolSelectorPopover /> },
     { key: 'context', node: <ContextSettingsPopover /> },
     { key: 'clear', node: <ClearContextButton onClick={onClearContext} /> },
-  ], [handleOpenFileDialog, thinkingEnabled, setThinkingEnabled, onClearContext, chatVoiceInputId])
+  ], [handleOpenFileDialog, selectedModel?.modelId, onClearContext, chatVoiceInputId])
 
   const trailingNode = streaming ? (
     <Tooltip>

--- a/apps/electron/src/renderer/components/chat/ChatThinkingPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatThinkingPopover.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import { Brain } from 'lucide-react'
+import { getGeminiModelCapability, type GeminiThinkingLevel } from '@proma/shared'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Switch } from '@/components/ui/switch'
+import { inputToolbarActiveButtonClass, inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
+import { useConversationThinkingEnabled, useConversationThinkingLevel } from '@/hooks/useConversationSettings'
+import { cn } from '@/lib/utils'
+
+const THINKING_LEVEL_LABELS: Record<GeminiThinkingLevel, string> = {
+  minimal: '最小',
+  low: '低',
+  medium: '中',
+  high: '高',
+}
+
+interface ChatThinkingPopoverProps {
+  modelId?: string
+}
+
+/**
+ * Chat 的思考设置。仅 Gemini 3 文本模型显示其官方支持的深度；其他模型仍保留原有开关。
+ * 设置只写入当前对话 atom，不订阅流式内容或增加 IPC。
+ */
+export function ChatThinkingPopover({ modelId }: ChatThinkingPopoverProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
+  const [thinkingLevel, setThinkingLevel] = useConversationThinkingLevel()
+  const capability = getGeminiModelCapability(modelId)
+  const effectiveLevel = capability?.thinkingLevels.includes(thinkingLevel)
+    ? thinkingLevel
+    : capability?.defaultThinkingLevel
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(inputToolbarButtonClass, thinkingEnabled && inputToolbarActiveButtonClass)}
+          aria-label="思考设置"
+        >
+          <Brain className="size-5" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent side="top" align="center" sideOffset={8} className="w-56 space-y-3 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium">思考模式</p>
+            <p className="text-xs text-muted-foreground">{thinkingEnabled ? '已启用' : '已关闭'}</p>
+          </div>
+          <Switch checked={thinkingEnabled} onCheckedChange={setThinkingEnabled} aria-label="启用思考模式" />
+        </div>
+        {capability && (
+          <div className="space-y-2 border-t pt-3">
+            <p className="text-xs font-medium text-muted-foreground">Gemini 思考深度</p>
+            <div className="grid grid-cols-2 gap-1">
+              {capability.thinkingLevels.map((level) => (
+                <Button
+                  key={level}
+                  type="button"
+                  variant={effectiveLevel === level ? 'secondary' : 'ghost'}
+                  size="sm"
+                  className="h-8 justify-start px-2 text-xs"
+                  disabled={!thinkingEnabled}
+                  onClick={() => setThinkingLevel(level)}
+                >
+                  {THINKING_LEVEL_LABELS[level]}
+                </Button>
+              ))}
+            </div>
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              当前模型默认：{THINKING_LEVEL_LABELS[capability.defaultThinkingLevel]}
+            </p>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -42,6 +42,7 @@ import {
   useConversationModel,
   useConversationContextLength,
   useConversationThinkingEnabled,
+  useConversationThinkingLevel,
   useConversationPromptId,
 } from '@/hooks/useConversationSettings'
 import { registerPendingTitle } from '@/hooks/useGlobalChatListeners'
@@ -108,6 +109,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   const [selectedModel, setSelectedModel] = useConversationModel()
   const [contextLength] = useConversationContextLength()
   const [thinkingEnabled] = useConversationThinkingEnabled()
+  const [thinkingLevel] = useConversationThinkingLevel()
   const [conversationPromptId] = useConversationPromptId()
 
   // ===== 全局 atoms（Map 结构，按 conversationId 读取） =====
@@ -352,6 +354,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       contextDividers: options?.contextDividersOverride ?? contextDividers,
       attachments: savedAttachments.length > 0 ? savedAttachments : undefined,
       thinkingEnabled: thinkingEnabled || undefined,
+      thinkingLevel: thinkingEnabled ? thinkingLevel : undefined,
       systemMessage: resolveSystemMessage(conversationPromptId, promptConfig, userProfile.userName),
       enabledToolIds: activeToolIds.length > 0 ? activeToolIds : undefined,
     }
@@ -406,6 +409,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     contextLength,
     contextDividers,
     thinkingEnabled,
+    thinkingLevel,
     conversationPromptId,
     promptConfig,
     userProfile.userName,

--- a/apps/electron/src/renderer/hooks/useConversationSettings.ts
+++ b/apps/electron/src/renderer/hooks/useConversationSettings.ts
@@ -12,12 +12,15 @@ import {
   selectedModelAtom,
   contextLengthAtom,
   thinkingEnabledAtom,
+  thinkingLevelAtom,
   conversationModelsAtom,
   conversationContextLengthAtom,
   conversationThinkingEnabledAtom,
+  conversationThinkingLevelAtom,
   conversationParallelModeAtom,
 } from '@/atoms/chat-atoms'
 import type { SelectedModel, ContextLengthValue } from '@/atoms/chat-atoms'
+import type { GeminiThinkingLevel } from '@proma/shared'
 import {
   selectedPromptIdAtom,
   conversationPromptIdAtom,
@@ -104,6 +107,15 @@ export function useConversationThinkingEnabled(): [boolean, (v: boolean) => void
   const defaultEnabled = useAtomValue(thinkingEnabledAtom)
   const value = useMapValue(conversationThinkingEnabledAtom, conversationId, defaultEnabled)
   const setter = useMapSetter(conversationThinkingEnabledAtom, conversationId)
+  return [value, setter]
+}
+
+/** 每个对话独立的 Gemini 3 思考深度。 */
+export function useConversationThinkingLevel(): [GeminiThinkingLevel, (v: GeminiThinkingLevel) => void] {
+  const conversationId = useConversationId()
+  const defaultLevel = useAtomValue(thinkingLevelAtom)
+  const value = useMapValue(conversationThinkingLevelAtom, conversationId, defaultLevel)
+  const setter = useMapSetter(conversationThinkingLevelAtom, conversationId)
   return [value, setter]
 }
 

--- a/apps/electron/src/renderer/hooks/useConversationSettings.ts
+++ b/apps/electron/src/renderer/hooks/useConversationSettings.ts
@@ -110,12 +110,21 @@ export function useConversationThinkingEnabled(): [boolean, (v: boolean) => void
   return [value, setter]
 }
 
-/** 每个对话独立的 Gemini 3 思考深度。 */
+/**
+ * 每个对话独立的 Gemini 3 思考深度。
+ * 用户选择也同步为持久化默认值：重启后当前及新对话保持最近选择，
+ * 同时在当前窗口内仍允许各对话独立切换。
+ */
 export function useConversationThinkingLevel(): [GeminiThinkingLevel, (v: GeminiThinkingLevel) => void] {
   const conversationId = useConversationId()
   const defaultLevel = useAtomValue(thinkingLevelAtom)
+  const setDefaultLevel = useSetAtom(thinkingLevelAtom)
   const value = useMapValue(conversationThinkingLevelAtom, conversationId, defaultLevel)
-  const setter = useMapSetter(conversationThinkingLevelAtom, conversationId)
+  const setConversationLevel = useMapSetter(conversationThinkingLevelAtom, conversationId)
+  const setter = React.useCallback((level: GeminiThinkingLevel) => {
+    setConversationLevel(level)
+    setDefaultLevel(level)
+  }, [setConversationLevel, setDefaultLevel])
   return [value, setter]
 }
 

--- a/packages/core/src/providers/google-adapter.ts
+++ b/packages/core/src/providers/google-adapter.ts
@@ -20,6 +20,7 @@ import type {
   ToolDefinition,
   ContinuationMessage,
 } from './types.ts'
+import { getGeminiModelCapability, normalizeGeminiThinkingLevel } from '@proma/shared'
 import { normalizeBaseUrl } from './url-utils.ts'
 
 // ===== Google 特有类型 =====
@@ -202,13 +203,24 @@ export class GoogleAdapter implements ProviderAdapter {
     // 构建 generationConfig
     const generationConfig: Record<string, unknown> = {}
 
-    // 思考模式配置：
-    // - 启用时：显示思考过程 + 设置 thinkingBudget 控制深度
-    // - 关闭时：不传 thinkingConfig，模型使用默认行为
+    // Gemini 3 使用 thinkingLevel 而非旧版 thinkingBudget。未知/旧模型保留预算模式，
+    // 已知 Gemini 3 文本模型则按其官方合法档位归一化，避免 3.7/3.8 收到 minimal 后 400。
     if (input.thinkingEnabled) {
-      generationConfig.thinkingConfig = {
-        includeThoughts: true,
-        thinkingBudget: 16384,
+      const geminiCapability = getGeminiModelCapability(input.modelId)
+      if (geminiCapability) {
+        const selectedLevel = normalizeGeminiThinkingLevel(
+          input.modelId,
+          input.thinkingLevel as 'minimal' | 'low' | 'medium' | 'high' | undefined,
+        )!
+        generationConfig.thinkingConfig = {
+          includeThoughts: true,
+          thinkingLevel: selectedLevel.toUpperCase(),
+        }
+      } else {
+        generationConfig.thinkingConfig = {
+          includeThoughts: true,
+          thinkingBudget: 16384,
+        }
       }
     }
 

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -6,7 +6,7 @@
  * core 层不依赖 Electron / Node fs，通过注入函数访问平台能力。
  */
 
-import type { ChatMessage, FileAttachment, ProviderType } from '@proma/shared'
+import type { AgentThinkingLevel, ChatMessage, FileAttachment, ProviderType } from '@proma/shared'
 
 // ===== 图片附件数据 =====
 
@@ -220,6 +220,8 @@ export interface StreamRequestInput {
   readImageAttachments: ImageAttachmentReader
   /** 是否启用思考模式（各适配器根据供应商 API 自行转换） */
   thinkingEnabled?: boolean
+  /** 用户选择的思考深度；适配器应按模型能力安全归一化。 */
+  thinkingLevel?: AgentThinkingLevel
   /** 工具定义列表（可选，启用 function calling） */
   tools?: ToolDefinition[]
   /** 工具续接消息（tool use 循环中，前一轮的 tool_use + tool_result） */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ProviderType } from './channel'
+import type { AgentThinkingLevel } from './agent'
 
 // ===== 附件相关 =====
 
@@ -234,6 +235,8 @@ export interface ChatSendInput {
   attachments?: FileAttachment[]
   /** 是否启用思考模式 */
   thinkingEnabled?: boolean
+  /** 用户选择的思考深度；具体模型会在 provider adapter 内安全归一化。 */
+  thinkingLevel?: AgentThinkingLevel
   /** 本次请求启用的工具 ID 列表（由前端工具选择器决定） */
   enabledToolIds?: string[]
 }

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -7,6 +7,8 @@
  * 必须共用同一份判定，避免出现"UI 显示 1M 但实际只 200K"的不一致。
  */
 
+import { getGeminiModelCapability } from './gemini-model-capabilities'
+
 /** 默认上下文窗口（无法识别模型时使用） */
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 
@@ -126,6 +128,8 @@ export function inferContextWindow(model?: string): number | undefined {
   if (!model) return undefined
   const codexAlignedWindow = inferCodexAlignedGPT5ContextWindow(model)
   if (codexAlignedWindow !== undefined) return codexAlignedWindow
+  const geminiCapability = getGeminiModelCapability(model)
+  if (geminiCapability) return geminiCapability.contextWindow
   if (supports1MContext(model)) return ONE_MILLION_CONTEXT_WINDOW
   return DEFAULT_CONTEXT_WINDOW
 }

--- a/packages/shared/src/utils/gemini-model-capabilities.ts
+++ b/packages/shared/src/utils/gemini-model-capabilities.ts
@@ -1,0 +1,97 @@
+import type { AgentThinkingLevel } from '../types/agent'
+
+export type GeminiThinkingLevel = Extract<AgentThinkingLevel, 'minimal' | 'low' | 'medium' | 'high'>
+
+export interface GeminiModelCapability {
+  contextWindow: number
+  maxOutputTokens: number
+  thinkingLevels: readonly GeminiThinkingLevel[]
+  defaultThinkingLevel: GeminiThinkingLevel
+}
+
+const ONE_MILLION = 1_000_000
+const SIXTY_FOUR_K = 65_536
+
+const ALL_LEVELS = ['minimal', 'low', 'medium', 'high'] as const satisfies readonly GeminiThinkingLevel[]
+const NO_MINIMAL_LEVELS = ['low', 'medium', 'high'] as const satisfies readonly GeminiThinkingLevel[]
+
+/**
+ * Gemini 文本模型的产品级能力表。
+ *
+ * Pi catalog 负责 Agent runtime 的协议与计费元数据；这里仅保存 Proma 必须跨
+ * Agent、Chat 和上下文展示共用的官方模型约束，避免把 Image / Live SKU 误判为 1M。
+ */
+const GEMINI_TEXT_MODEL_CAPABILITIES: Readonly<Record<string, GeminiModelCapability>> = {
+  'gemini-3-flash-preview': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: ALL_LEVELS,
+    defaultThinkingLevel: 'high',
+  },
+  'gemini-3.1-pro-preview': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: NO_MINIMAL_LEVELS,
+    defaultThinkingLevel: 'high',
+  },
+  'gemini-3.1-flash-lite': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: ALL_LEVELS,
+    defaultThinkingLevel: 'minimal',
+  },
+  'gemini-3.1-flash-lite-preview': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: ALL_LEVELS,
+    defaultThinkingLevel: 'minimal',
+  },
+  'gemini-3.5-flash': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: ALL_LEVELS,
+    defaultThinkingLevel: 'medium',
+  },
+  'gemini-3.5-flash-lite': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: ALL_LEVELS,
+    defaultThinkingLevel: 'minimal',
+  },
+  'gemini-3.6-flash': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: ALL_LEVELS,
+    defaultThinkingLevel: 'medium',
+  },
+  'gemini-3.7-flash': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: NO_MINIMAL_LEVELS,
+    defaultThinkingLevel: 'medium',
+  },
+  'gemini-3.8-flash': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: NO_MINIMAL_LEVELS,
+    defaultThinkingLevel: 'medium',
+  },
+}
+
+function normalizeGeminiModelId(modelId: string | undefined): string | undefined {
+  return modelId?.trim().toLowerCase().replace(/^models\//, '')
+}
+
+export function getGeminiModelCapability(modelId: string | undefined): GeminiModelCapability | undefined {
+  const normalized = normalizeGeminiModelId(modelId)
+  return normalized ? GEMINI_TEXT_MODEL_CAPABILITIES[normalized] : undefined
+}
+
+export function normalizeGeminiThinkingLevel(
+  modelId: string | undefined,
+  level: GeminiThinkingLevel | undefined,
+): GeminiThinkingLevel | undefined {
+  const capability = getGeminiModelCapability(modelId)
+  if (!capability) return level
+  return level && capability.thinkingLevels.includes(level) ? level : capability.defaultThinkingLevel
+}

--- a/packages/shared/src/utils/gemini-model-capabilities.ts
+++ b/packages/shared/src/utils/gemini-model-capabilities.ts
@@ -28,7 +28,21 @@ const GEMINI_TEXT_MODEL_CAPABILITIES: Readonly<Record<string, GeminiModelCapabil
     thinkingLevels: ALL_LEVELS,
     defaultThinkingLevel: 'high',
   },
+  'gemini-3.1-pro': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: NO_MINIMAL_LEVELS,
+    defaultThinkingLevel: 'high',
+  },
   'gemini-3.1-pro-preview': {
+    contextWindow: ONE_MILLION,
+    maxOutputTokens: SIXTY_FOUR_K,
+    thinkingLevels: NO_MINIMAL_LEVELS,
+    defaultThinkingLevel: 'high',
+  },
+  // Google catalog 在启用 custom tools 时使用此精确别名；它仍是同一文本模型，
+  // 不能误回退到旧版 thinkingBudget 或默认 200K 上下文。
+  'gemini-3.1-pro-preview-customtools': {
     contextWindow: ONE_MILLION,
     maxOutputTokens: SIXTY_FOUR_K,
     thinkingLevels: NO_MINIMAL_LEVELS,

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -29,6 +29,12 @@ export {
 } from './context-window'
 export { calculateContextUsageRatio } from './context-usage'
 export {
+  getGeminiModelCapability,
+  normalizeGeminiThinkingLevel,
+  type GeminiModelCapability,
+  type GeminiThinkingLevel,
+} from './gemini-model-capabilities'
+export {
   PI_AUTO_COMPACTION_THRESHOLD_RATIO,
   calculatePiAutoCompactionReserveTokens,
   calculatePiAutoCompactionThresholdTokens,


### PR DESCRIPTION
## Summary
- align Gemini 3 text-model context-window and valid thinking-depth metadata
- prevent Gemini 3.7/3.8 Agent sessions from exposing unsupported `minimal`
- send Google Gemini 3 `thinkingLevel` from Chat and expose per-conversation controls

## Verification
- `bun run --filter='@proma/shared' typecheck`
- `bun run --filter='@proma/core' typecheck`
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)