### PR TITLE
fix(mcp): preserve server states when deleting

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -10,7 +10,7 @@ import { existsSync, realpathSync, readFileSync, writeFileSync, mkdirSync, statS
 import { realpath, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { createHash } from 'node:crypto'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, AGENT_ISLAND_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, SLACK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, VAULT_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare, TERMINAL_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, AGENT_ISLAND_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, SLACK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, VAULT_IPC_CHANNELS, PLANNING_CONFLICT_ERROR, MAX_ATTACHMENT_SIZE, isPromaPermissionMode, normalizePathForCompare, removeMcpServerFromConfig, TERMINAL_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, WINDOWS_AGENT_ISLAND_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
@@ -2971,6 +2971,21 @@ export function registerIpcHandlers(): void {
         )
       }
     }
+  )
+
+  // Remove a single MCP from the current main-process snapshot. This must not
+  // use the full-config save flow: that flow deliberately re-validates enabled
+  // entries, which would transiently disable unrelated MCPs during deletion.
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.DELETE_MCP,
+    async (_, workspaceSlug: string, name: string): Promise<WorkspaceMcpConfig> => {
+      const current = getWorkspaceMcpConfig(workspaceSlug)
+      const config = removeMcpServerFromConfig(current, name)
+      advanceWorkspaceMcpRefreshGeneration(workspaceSlug)
+      clearWorkspaceMcpPendingValidation(workspaceSlug, name)
+      saveWorkspaceMcpConfig(workspaceSlug, config)
+      return config
+    },
   )
 
   // Atomically toggle one MCP. Any later save advances the workspace refresh

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -694,6 +694,9 @@ export interface ElectronAPI {
   /** 保存工作区 MCP 配置；显式关闭的条目会取消进行中的验证。 */
   saveWorkspaceMcpConfig: (workspaceSlug: string, config: WorkspaceMcpConfig, options?: import('@proma/shared').SaveWorkspaceMcpConfigOptions) => Promise<void>
 
+  /** 原子删除单个 MCP，保留其他条目的当前状态。 */
+  deleteWorkspaceMcp: (workspaceSlug: string, name: string) => Promise<WorkspaceMcpConfig>
+
   /** 刷新并持久化工作区 MCP 真实连接状态 */
   refreshMcpConnections: (workspaceSlug: string) => Promise<WorkspaceMcpConfig>
 
@@ -2036,6 +2039,10 @@ const electronAPI: ElectronAPI = {
 
   saveWorkspaceMcpConfig: (workspaceSlug: string, config: WorkspaceMcpConfig, options?: import('@proma/shared').SaveWorkspaceMcpConfigOptions) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SAVE_MCP_CONFIG, workspaceSlug, config, options)
+  },
+
+  deleteWorkspaceMcp: (workspaceSlug: string, name: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DELETE_MCP, workspaceSlug, name) as Promise<WorkspaceMcpConfig>
   },
 
   refreshMcpConnections: (workspaceSlug: string) => {

--- a/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
+++ b/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
@@ -341,10 +341,9 @@ export function useAgentSkillsData(workspaceId?: string): AgentSkillsData {
     const entry = mcpConfig.servers[name]
     if (entry?.isBuiltin) return
     try {
-      const newServers = { ...mcpConfig.servers }
-      delete newServers[name]
-      const newConfig: WorkspaceMcpConfig = { servers: newServers }
-      await window.electronAPI.saveWorkspaceMcpConfig(workspaceSlug, newConfig)
+      // Delete against the main-process snapshot so unrelated enabled MCPs are
+      // neither overwritten by this renderer snapshot nor re-validated.
+      const newConfig = await window.electronAPI.deleteWorkspaceMcp(workspaceSlug, name)
       setMcpConfig(newConfig)
       bumpCapabilitiesVersion((v) => v + 1)
       try {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1844,6 +1844,8 @@ export const AGENT_IPC_CHANNELS = {
   GET_MCP_CONFIG: 'agent:get-mcp-config',
   /** 保存工作区 MCP 配置 */
   SAVE_MCP_CONFIG: 'agent:save-mcp-config',
+  /** 原子删除单个 MCP，保留其他条目的当前状态。 */
+  DELETE_MCP: 'agent:delete-mcp',
   /** 刷新并持久化工作区 MCP 真实连接状态 */
   REFRESH_MCP_CONNECTIONS: 'agent:refresh-mcp-connections',
   /** 原子切换 MCP 启用状态，并在启用时条件持久化真实验证结果。 */

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -43,6 +43,7 @@ export {
   inferMcpTransportType,
   normalizeMcpTransportType,
 } from './mcp-transport'
+export { removeMcpServerFromConfig } from './mcp-config'
 export {
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_TITLE,

--- a/packages/shared/src/utils/mcp-config.ts
+++ b/packages/shared/src/utils/mcp-config.ts
@@ -1,0 +1,14 @@
+import type { WorkspaceMcpConfig } from '../types/agent'
+
+/**
+ * Removes one MCP entry without changing the configuration or enablement state
+ * of every other server.
+ */
+export function removeMcpServerFromConfig(
+  config: WorkspaceMcpConfig,
+  name: string,
+): WorkspaceMcpConfig {
+  const servers = { ...config.servers }
+  delete servers[name]
+  return { servers }
+}


### PR DESCRIPTION
## Summary
- fix MCP deletion to operate on the latest main-process configuration
- preserve enabled/disabled state of unrelated MCP servers
- avoid re-validating unrelated servers during deletion

## Issue
Closes #1993

## Validation
- `bun test ./packages/shared/src/utils/mcp-config.test.ts` passed before removing the requested test file
- `git diff --check` passed
- full typecheck remains blocked by missing worktree dependencies and unrelated baseline errors

性能影响：低风险；删除操作由完整配置保存改为单条目原子变更，减少无关 MCP 验证与状态抖动。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)