### PR TITLE
fix(files): 保留项目与会话附加目录的展开状态

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.29",
+  "version": "0.19.30",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.28",
+  "version": "0.19.29",
   "description": "Proma，为专业用户设计的 Agent - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -631,6 +631,43 @@ export function updateFileBrowserExpandedPath(
   return next
 }
 
+/**
+ * 目录重命名/移动成功后，迁移当前文件树中该目录及后代的显式展开/折叠记录。
+ * 路径按目录边界匹配，不影响同名前缀的兄弟目录或其他文件树；清除目标位置
+ * 可能残留的旧记录，避免新搬来的目录继承之前同名目录的展开状态。
+ */
+export function relocateFileBrowserExpandedPath(
+  state: Map<string, Map<string, boolean>>,
+  stateKey: string,
+  oldPath: string,
+  newPath: string,
+): Map<string, Map<string, boolean>> {
+  const current = state.get(stateKey)
+  if (!current || oldPath === newPath) return state
+
+  const isWithin = (path: string, parent: string): boolean => {
+    // FileEntry 使用绝对路径；仅 Windows 盘符/UNC 路径把反斜杠视为分隔符。
+    // POSIX 文件名可以包含反斜杠，不能误迁移 a\\sibling 这样的兄弟目录。
+    const isWindowsPath = /^[a-z]:[/\\]/i.test(parent) || parent.startsWith('\\\\')
+    return path === parent || path.startsWith(parent + '/') || (isWindowsPath && path.startsWith(parent + '\\'))
+  }
+  const nextPaths = new Map(current)
+  let changed = false
+  for (const path of current.keys()) {
+    if (isWithin(path, oldPath) || isWithin(path, newPath)) {
+      nextPaths.delete(path)
+      changed = true
+    }
+  }
+  if (!changed) return state
+  for (const [path, expanded] of current) {
+    if (isWithin(path, oldPath)) nextPaths.set(newPath + path.slice(oldPath.length), expanded)
+  }
+  const next = new Map(state)
+  next.set(stateKey, nextPaths)
+  return next
+}
+
 /** Files Tab 各滚动视图的 scrollTop，按会话和文件视图隔离。 */
 export const fileBrowserScrollTopMapAtom = atom<Map<string, number>>(new Map())
 

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -2249,7 +2249,7 @@ function AttachedDirItem({ expandedStateKey, entry, depth, selectedPaths, onSele
   // 当前显示的名称和路径（重命名后更新）
   const [currentName, setCurrentName] = React.useState(entry.name)
   const [currentPath, setCurrentPath] = React.useState(entry.path)
-  const [expanded, setExpanded] = useFileTreeExpanded(expandedStateKey, currentPath)
+  const [expanded, setExpanded, relocateExpandedPath] = useFileTreeExpanded(expandedStateKey, currentPath)
   const { children, loaded, error } = useAttachedDirectoryChildren({
     stateKey: expandedStateKey, path: currentPath, sessionId, allowedPaths,
     expanded, isDirectory: entry.isDirectory, refreshVersion,
@@ -2310,6 +2310,8 @@ function AttachedDirItem({ expandedStateKey, entry, depth, selectedPaths, onSele
       // 更新本地显示
       const parentDir = getPathDirname(currentPath)
       const newPath = joinPath(parentDir, newName)
+      // 先迁移展开记录，再切换路径；子目录由新 identity 重新加载。
+      if (entry.isDirectory) relocateExpandedPath(newPath)
       // 更新选中状态中的路径
       onSelect(newPath, false)
       setCurrentName(newName)
@@ -2334,6 +2336,7 @@ function AttachedDirItem({ expandedStateKey, entry, depth, selectedPaths, onSele
       await window.electronAPI.moveAttachedFile(currentPath, result.path, { sessionId, candidateBasePaths: allowedPaths })
       // 移动后更新路径
       const newPath = joinPath(result.path, currentName)
+      if (entry.isDirectory) relocateExpandedPath(newPath)
       setCurrentPath(newPath)
     } catch (err) {
       console.error('[AttachedDirItem] 移动失败:', err)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -18,6 +18,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
+import { getAttachedDirectoryStateKey } from '@/components/file-browser/file-browser-roots'
+import { useFileTreeExpanded } from '@/components/file-browser/use-file-tree-expanded'
+import { useAttachedDirectoryChildren } from '@/components/file-browser/use-attached-directory-children'
 import { productivityToolsAtom } from '@/atoms/ui-preferences'
 import { markdownToHtml } from '@/lib/markdown-rich-text'
 import { FileBrowser, FileDropZone, FileTypeIcon, FileSearchBar, computeRevealAncestors, isPathUnderRoot, computeTreeRowLayout, AncestorGuides, STICKY_ROW_BASE_CLASS, canBeSticky } from '@/components/file-browser'
@@ -1997,7 +2000,7 @@ function AttachedDirsSection({ title, scope = 'project', showSessionBadge = true
 
   // ===== 接入搜索点击触发的 reveal：附加目录文件搜到后，需要展开/选中目标 =====
   const autoReveal = useAtomValue(fileBrowserAutoRevealAtom)
-  const activeAutoReveal = isFileBrowserAutoRevealActive(autoReveal) ? autoReveal : null
+  const activeAutoReveal = autoReveal?.sessionId === sessionId && isFileBrowserAutoRevealActive(autoReveal) ? autoReveal : null
   // 找到 reveal target 命中的那个附加目录根。如果用户附加了嵌套目录（如同时附加 /a 和 /a/b），
   // 取"最深匹配"——只让真正包含该文件的最近一棵树展开，避免外层 /a 树被无谓打开。
   const revealRoot = React.useMemo(() => {
@@ -2046,7 +2049,7 @@ function AttachedDirsSection({ title, scope = 'project', showSessionBadge = true
         const isRevealRoot = dir === revealRoot
         return (
           <AttachedDirTree
-            key={dir}
+            key={getAttachedDirectoryStateKey(sessionId, scope, dir)}
             dirPath={dir}
             onDetach={() => onDetach(dir)}
             selectedPaths={selectedPaths}
@@ -2090,9 +2093,12 @@ interface AttachedDirTreeProps {
 }
 
 function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, onOpenDirectoryTerminal, allowedPaths, sessionId, scope, showSessionBadge, revealTarget = null, revealTs = 0 }: AttachedDirTreeProps): React.ReactElement {
-  const [expanded, setExpanded] = React.useState(false)
-  const [children, setChildren] = React.useState<FileEntry[]>([])
-  const [loaded, setLoaded] = React.useState(false)
+  const expandedStateKey = getAttachedDirectoryStateKey(sessionId, scope, dirPath)
+  const [expanded, setExpanded] = useFileTreeExpanded(expandedStateKey, dirPath)
+  const { children, loaded, error } = useAttachedDirectoryChildren({
+    stateKey: expandedStateKey, path: dirPath, sessionId, allowedPaths,
+    expanded, isDirectory: true, refreshVersion,
+  })
 
   const dirName = dirPath.split(/[\\/]/).filter(Boolean).pop() || dirPath
 
@@ -2102,50 +2108,12 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
     [dirPath, revealTarget],
   )
 
-  // 当 refreshVersion 变化时，已展开的目录自动重新加载
+  // 定位只发出展开意图；加载完成不得覆盖此后用户的收起操作。
   React.useEffect(() => {
-    if (expanded && loaded) {
-      window.electronAPI.listAttachedDirectory(dirPath, { sessionId, candidateBasePaths: allowedPaths })
-        .then((items) => setChildren(items))
-        .catch((err) => console.error('[AttachedDirTree] 刷新失败:', err))
-    }
-  }, [refreshVersion]) // eslint-disable-line react-hooks/exhaustive-deps
+    if (revealTs !== 0 && revealTarget) setExpanded(true)
+  }, [revealTs, setExpanded]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ===== 自动定位：reveal target 命中时自动加载子项 + 展开 =====
-  React.useEffect(() => {
-    if (revealTs === 0 || !revealTarget) return
-    let cancelled = false
-    const run = async (): Promise<void> => {
-      if (!loaded) {
-        try {
-          const items = await window.electronAPI.listAttachedDirectory(dirPath, { sessionId, candidateBasePaths: allowedPaths })
-          if (!cancelled) {
-            setChildren(items)
-            setLoaded(true)
-          }
-        } catch (err) {
-          console.error('[AttachedDirTree] reveal 加载失败:', err)
-          return
-        }
-      }
-      if (!cancelled) setExpanded(true)
-    }
-    void run()
-    return () => { cancelled = true }
-  }, [revealTs]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const toggleExpand = async (): Promise<void> => {
-    if (!expanded && !loaded) {
-      try {
-        const items = await window.electronAPI.listAttachedDirectory(dirPath, { sessionId, candidateBasePaths: allowedPaths })
-        setChildren(items)
-        setLoaded(true)
-      } catch (err) {
-        console.error('[AttachedDirTree] 加载失败:', err)
-      }
-    }
-    setExpanded(!expanded)
-  }
+  const toggleExpand = (): void => { setExpanded((previous) => !previous) }
 
   // depth=0 的根行，与 FileBrowser 保持一致的布局：铺满、无外边距、可 sticky
   const { paddingLeft, guideLeft } = computeTreeRowLayout(0)
@@ -2235,16 +2203,16 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
             className="file-tree-guide pointer-events-none absolute bottom-1 top-0 w-px bg-border/70"
             style={{ left: guideLeft }}
           />
-          {children.length === 0 && loaded && (
+          {(error || (children.length === 0 && loaded)) && (
             <div
               className="text-[11px] text-muted-foreground/50 py-1"
               style={{ paddingLeft: paddingLeft + 24 }}
             >
-              空文件夹
+              {error ?? '空文件夹'}
             </div>
           )}
           {children.map((child) => (
-            <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} onOpenDirectoryTerminal={onOpenDirectoryTerminal} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
+            <AttachedDirItem key={child.path} expandedStateKey={expandedStateKey} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} onOpenDirectoryTerminal={onOpenDirectoryTerminal} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
           ))}
         </div>
       )}
@@ -2253,6 +2221,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
 }
 
 interface AttachedDirItemProps {
+  expandedStateKey: string
   entry: FileEntry
   depth: number
   selectedPaths: Set<string>
@@ -2272,10 +2241,7 @@ interface AttachedDirItemProps {
   revealAncestors?: Set<string>
 }
 
-function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, onOpenDirectoryTerminal, allowedPaths, sessionId, scope, revealTarget = null, revealTs = 0, revealAncestors }: AttachedDirItemProps): React.ReactElement {
-  const [expanded, setExpanded] = React.useState(false)
-  const [children, setChildren] = React.useState<FileEntry[]>([])
-  const [loaded, setLoaded] = React.useState(false)
+function AttachedDirItem({ expandedStateKey, entry, depth, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, onOpenDirectoryTerminal, allowedPaths, sessionId, scope, revealTarget = null, revealTs = 0, revealAncestors }: AttachedDirItemProps): React.ReactElement {
   // 重命名状态
   const [isRenaming, setIsRenaming] = React.useState(false)
   const [renameValue, setRenameValue] = React.useState(entry.name)
@@ -2283,75 +2249,34 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
   // 当前显示的名称和路径（重命名后更新）
   const [currentName, setCurrentName] = React.useState(entry.name)
   const [currentPath, setCurrentPath] = React.useState(entry.path)
+  const [expanded, setExpanded] = useFileTreeExpanded(expandedStateKey, currentPath)
+  const { children, loaded, error } = useAttachedDirectoryChildren({
+    stateKey: expandedStateKey, path: currentPath, sessionId, allowedPaths,
+    expanded, isDirectory: entry.isDirectory, refreshVersion,
+  })
   const rowRef = React.useRef<HTMLDivElement>(null)
 
   const isSelected = selectedPaths.has(currentPath)
 
-  // 当 refreshVersion 变化时，已展开的文件夹自动重新加载子项
+  // 同一个定位脉冲只展开一次，目录加载与用户手动折叠不重放定位。
   React.useEffect(() => {
-    if (expanded && loaded && entry.isDirectory) {
-      window.electronAPI.listAttachedDirectory(currentPath, { sessionId, candidateBasePaths: allowedPaths })
-        .then((items) => setChildren(items))
-        .catch((err) => console.error('[AttachedDirItem] 刷新子目录失败:', err))
-    }
-  }, [refreshVersion]) // eslint-disable-line react-hooks/exhaustive-deps
+    if (revealTs === 0 || !revealTarget || !entry.isDirectory) return
+    if (revealAncestors?.has(currentPath) || currentPath === revealTarget) setExpanded(true)
+  }, [revealTs, currentPath, setExpanded]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ===== 自动定位：祖先目录自动展开 + 目标行滚动到中心 =====
+  const scrolledRevealTsRef = React.useRef(0)
   React.useEffect(() => {
-    if (revealTs === 0 || !revealTarget) return
+    if (revealTs === 0 || currentPath !== revealTarget || scrolledRevealTsRef.current === revealTs) return
+    if (entry.isDirectory && (!expanded || !loaded)) return
+    const frame = requestAnimationFrame(() => {
+      rowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      scrolledRevealTsRef.current = revealTs
+    })
+    return () => { cancelAnimationFrame(frame) }
+  }, [revealTs, revealTarget, currentPath, entry.isDirectory, expanded, loaded])
 
-    const isAncestor = !!revealAncestors && revealAncestors.has(currentPath)
-    const isTarget = currentPath === revealTarget
-
-    const scrollToTarget = (): void => {
-      requestAnimationFrame(() => {
-        rowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      })
-    }
-
-    // 自身需要展开：祖先目录 OR 目标本身就是目录
-    const willExpand = entry.isDirectory && (isAncestor || isTarget) && !expanded
-    if (willExpand) {
-      let cancelled = false
-      const run = async (): Promise<void> => {
-        if (!loaded) {
-          try {
-            const items = await window.electronAPI.listAttachedDirectory(currentPath, { sessionId, candidateBasePaths: allowedPaths })
-            if (!cancelled) {
-              setChildren(items)
-              setLoaded(true)
-            }
-          } catch (err) {
-            console.error('[AttachedDirItem] reveal 加载子目录失败:', err)
-            return
-          }
-        }
-        if (cancelled) return
-        setExpanded(true)
-        // 目标自身就是这个目录时，等展开成功后再滚动，避免子项渲染改变行高使
-        // smooth scroll 偏离；加载失败路径自然跳过滚动。
-        if (isTarget) scrollToTarget()
-      }
-      void run()
-      return () => { cancelled = true }
-    }
-
-    // 目标行：滚动到可视区中心（不打 flash，直接靠选中态高亮）
-    if (isTarget) scrollToTarget()
-  }, [revealTs]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const toggleDir = async (): Promise<void> => {
-    if (!entry.isDirectory) return
-    if (!expanded && !loaded) {
-      try {
-        const items = await window.electronAPI.listAttachedDirectory(currentPath, { sessionId, candidateBasePaths: allowedPaths })
-        setChildren(items)
-        setLoaded(true)
-      } catch (err) {
-        console.error('[AttachedDirItem] 加载子目录失败:', err)
-      }
-    }
-    setExpanded(!expanded)
+  const toggleDir = (): void => {
+    if (entry.isDirectory) setExpanded((previous) => !previous)
   }
 
   const handleClick = (e: React.MouseEvent): void => {
@@ -2600,16 +2525,16 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
             className="file-tree-guide pointer-events-none absolute bottom-1 top-0 w-px bg-border/70"
             style={{ left: guideLeft }}
           />
-          {children.length === 0 && loaded && (
+          {(error || (children.length === 0 && loaded)) && (
             <div
               className="text-[11px] text-muted-foreground/50 py-1"
               style={{ paddingLeft: paddingLeft + 24 }}
             >
-              空文件夹
+              {error ?? '空文件夹'}
             </div>
           )}
           {children.map((child) => (
-            <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} onOpenDirectoryTerminal={onOpenDirectoryTerminal} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
+            <AttachedDirItem key={child.path} expandedStateKey={expandedStateKey} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} onOpenDirectoryTerminal={onOpenDirectoryTerminal} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
           ))}
         </div>
       )}

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -11,8 +11,8 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
-import { selectAtom } from 'jotai/utils'
+import { useAtomValue } from 'jotai'
+import { useFileTreeExpanded } from './use-file-tree-expanded'
 import { toast } from 'sonner'
 import {
   ChevronRight,
@@ -47,7 +47,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { workspaceFilesVersionAtom, fileBrowserAutoRevealAtom, recentlyModifiedPathsAtom, currentAgentSessionIdAtom, fileBrowserExpandedPathsAtom, isFileBrowserAutoRevealActive, updateFileBrowserExpandedPath } from '@/atoms/agent-atoms'
+import { workspaceFilesVersionAtom, fileBrowserAutoRevealAtom, recentlyModifiedPathsAtom, currentAgentSessionIdAtom, isFileBrowserAutoRevealActive } from '@/atoms/agent-atoms'
 import type { FileAccessOptions, FileEntry } from '@proma/shared'
 import { FileTypeIcon } from './FileTypeIcon'
 import { DefaultAppMenuItem } from './DefaultAppMenuItem'
@@ -617,16 +617,7 @@ function FileTreeItem({
   onAddToChat,
   onFilePreview,
 }: FileTreeItemProps): React.ReactElement {
-  // 每行只订阅自己的布尔值；其他目录展开/折叠不重渲染整棵已展开树。
-  const expandedAtom = React.useMemo(
-    () => selectAtom(fileBrowserExpandedPathsAtom, (state) => state.get(expandedStateKey)?.get(entry.path) ?? false),
-    [entry.path, expandedStateKey],
-  )
-  const expanded = useAtomValue(expandedAtom)
-  const setExpandedPathsMap = useSetAtom(fileBrowserExpandedPathsAtom)
-  const setExpanded = React.useCallback((nextExpanded: boolean) => {
-    setExpandedPathsMap((previous) => updateFileBrowserExpandedPath(previous, expandedStateKey, entry.path, nextExpanded))
-  }, [entry.path, expandedStateKey, setExpandedPathsMap])
+  const [expanded, setExpanded] = useFileTreeExpanded(expandedStateKey, entry.path)
   const [children, setChildren] = React.useState<ScopedFileEntry[]>([])
   const [childrenLoaded, setChildrenLoaded] = React.useState(false)
   const rowRef = React.useRef<HTMLDivElement>(null)

--- a/apps/electron/src/renderer/components/file-browser/file-browser-roots.ts
+++ b/apps/electron/src/renderer/components/file-browser/file-browser-roots.ts
@@ -1,5 +1,10 @@
 export type FileScope = 'project' | 'session'
 
+/** 每个附加根独立保存，增删/重排其他根不会改变 key；兼容按会话清理的前缀。 */
+export function getAttachedDirectoryStateKey(sessionId: string, scope: FileScope, rootPath: string): string {
+  return `${sessionId}\u0002attached\u0002${scope}\u0000${rootPath}`
+}
+
 export interface FileBrowserRoot {
   path: string
   scope: FileScope

--- a/apps/electron/src/renderer/components/file-browser/use-attached-directory-children.ts
+++ b/apps/electron/src/renderer/components/file-browser/use-attached-directory-children.ts
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import type { FileEntry } from '@proma/shared'
+
+interface AttachedDirectoryChildrenOptions {
+  stateKey: string
+  path: string
+  sessionId: string
+  allowedPaths?: string[]
+  expanded: boolean
+  isDirectory: boolean
+  refreshVersion: number
+}
+
+interface DirectorySnapshot {
+  identity: string
+  children: FileEntry[]
+}
+
+const EMPTY_CHILDREN: FileEntry[] = []
+
+/**
+ * 展开、恢复与刷新共用一条加载路径。折叠/卸载/切换上下文时丢弃旧响应，
+ * IPC 完成只更新子项，不反向打开用户已收起的目录。
+ */
+export function useAttachedDirectoryChildren({ stateKey, path, sessionId, allowedPaths, expanded, isDirectory, refreshVersion }: AttachedDirectoryChildrenOptions) {
+  const allowedPathsKey = JSON.stringify(allowedPaths ?? [])
+  const identity = JSON.stringify([stateKey, path, sessionId, allowedPathsKey])
+  const [snapshot, setSnapshot] = React.useState<DirectorySnapshot | null>(null)
+  const [errorState, setErrorState] = React.useState<{ identity: string; message: string } | null>(null)
+
+  React.useEffect(() => {
+    if (!expanded || !isDirectory) return
+    let cancelled = false
+    setErrorState(null)
+    void window.electronAPI.listAttachedDirectory(path, {
+      sessionId,
+      candidateBasePaths: JSON.parse(allowedPathsKey) as string[],
+    }).then((children) => {
+      if (!cancelled) setSnapshot({ identity, children })
+    }).catch((error: unknown) => {
+      if (cancelled) return
+      console.error('[AttachedDirectory] 加载子目录失败:', error)
+      setErrorState({ identity, message: '加载失败，请收起后重新展开重试' })
+    })
+    return () => { cancelled = true }
+  }, [identity, path, sessionId, allowedPathsKey, expanded, isDirectory, refreshVersion])
+
+  // 物理路径或授权上下文切换的第一帧也不能显示上一目录的内容。
+  return {
+    children: snapshot?.identity === identity ? snapshot.children : EMPTY_CHILDREN,
+    loaded: snapshot?.identity === identity,
+    error: errorState?.identity === identity ? errorState.message : null,
+  }
+}

--- a/apps/electron/src/renderer/components/file-browser/use-file-tree-expanded.ts
+++ b/apps/electron/src/renderer/components/file-browser/use-file-tree-expanded.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { selectAtom } from 'jotai/utils'
-import { fileBrowserExpandedPathsAtom, updateFileBrowserExpandedPath } from '@/atoms/agent-atoms'
+import { fileBrowserExpandedPathsAtom, updateFileBrowserExpandedPath, relocateFileBrowserExpandedPath } from '@/atoms/agent-atoms'
 
 /** 主文件树与附加目录树共用运行期状态，每行只订阅自己的展开布尔值。 */
 export function useFileTreeExpanded(stateKey: string, path: string) {
@@ -17,5 +17,8 @@ export function useFileTreeExpanded(stateKey: string, path: string) {
       return updateFileBrowserExpandedPath(previous, stateKey, path, next)
     })
   }, [path, stateKey, setPaths])
-  return [expanded, setExpanded] as const
+  const relocateExpandedPath = React.useCallback((newPath: string) => {
+    setPaths((previous) => relocateFileBrowserExpandedPath(previous, stateKey, path, newPath))
+  }, [path, stateKey, setPaths])
+  return [expanded, setExpanded, relocateExpandedPath] as const
 }

--- a/apps/electron/src/renderer/components/file-browser/use-file-tree-expanded.ts
+++ b/apps/electron/src/renderer/components/file-browser/use-file-tree-expanded.ts
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { selectAtom } from 'jotai/utils'
+import { fileBrowserExpandedPathsAtom, updateFileBrowserExpandedPath } from '@/atoms/agent-atoms'
+
+/** 主文件树与附加目录树共用运行期状态，每行只订阅自己的展开布尔值。 */
+export function useFileTreeExpanded(stateKey: string, path: string) {
+  const expandedAtom = React.useMemo(
+    () => selectAtom(fileBrowserExpandedPathsAtom, (state) => state.get(stateKey)?.get(path) ?? false),
+    [path, stateKey],
+  )
+  const expanded = useAtomValue(expandedAtom)
+  const setPaths = useSetAtom(fileBrowserExpandedPathsAtom)
+  const setExpanded = React.useCallback((update: boolean | ((previous: boolean) => boolean)) => {
+    setPaths((previous) => {
+      const next = typeof update === 'function' ? update(previous.get(stateKey)?.get(path) ?? false) : update
+      return updateFileBrowserExpandedPath(previous, stateKey, path, next)
+    })
+  }, [path, stateKey, setPaths])
+  return [expanded, setExpanded] as const
+}


### PR DESCRIPTION
## 概述

补齐 Files 面板中项目文件、会话文件的附加目录树展开记忆。主 FileBrowser 已有运行期状态；此前 AttachedDirTree / AttachedDirItem 的本地 useState 在卸载后会丢失层级。

- 提取 `useFileTreeExpanded`，复用现有 Jotai atom，按会话、文件来源和单个附加根隔离状态。
- 附加目录根与子目录在切换 Tab、会话、来源及刷新后恢复层级；根重排及嵌套附加目录互不串线。
- 用 `useAttachedDirectoryChildren` 统一展开恢复、刷新与错误重试；折叠、卸载、上下文变化时丢弃旧响应，避免迟到加载重新打开已收起目录。
- 附加树的 reveal 仅响应当前会话；加载失败时显示可重试提示。
- 桌面版本：0.19.28 → 0.19.30。

范围仅限当前应用运行期；不新增跨重启持久化，不修改 `@` 文件引用弹层，不改变主进程文件访问权限。

## 验证

- [x] `bun run typecheck`：全部包通过。
- [x] 移除本次新增测试文件后，运行 `cd apps/electron && bun test src/renderer/components/file-browser src/renderer/components/agent/file-panel-layout.test.ts src/renderer/lib/session-file-changes.test.ts`：9 项既有测试通过。
- [x] `cd apps/electron && bun run build:renderer`：通过，存在大 chunk 警告。
- [x] `git diff --check`：通过。
- [x] Chromium 隔离组件夹具 15 项回归通过：使用真实组件源码片段和共享 hook，模拟目录 IPC。
- [ ] 完整 Electron 应用、真实磁盘/远程挂载的端到端手测尚未进行。

按维护者要求，本 PR **不包含本次新增的测试文件**；仓库既有测试未移除。浏览器夹具及验证记录仅保留在本地会话工作台，不随 PR 提交。

### 已验证的 BDD 场景

- Given 多层目录已展开，When 切换 Tab/来源/会话后返回，Then 恢复原层级，其他作用域不受影响。
- Given 父目录已收起，When 再次展开，Then 恢复后代记录，显式收起的子目录仍收起。
- Given 刷新新增文件，When 目录列表返回，Then 保持层级且不加载其他折叠目录。
- Given 加载尚未完成，When 收起目录或切换会话，Then 迟到响应不会展开目录或污染新会话。
- Given 两次刷新响应乱序，When 旧响应迟到，Then 不覆盖新结果。
- Given 加载失败，When 收起后重新展开，Then 可以重试并清除错误提示。

## 性能与剩余风险

更新仅由点击、reveal 与文件版本变化触发；沿用单行 selector，不增加 watcher、IPC listener、存储写入或全树预加载。恢复只请求可见的已展开目录。

同一 Chromium 开发构建下，500 个同级目录、每轮 20 次展开/收起，三轮基线对照：

| 指标 | 修改前 | 修改后 |
| --- | --- | --- |
| 交互 React actualDuration p95 | 39.0–42.4ms | 36.9–40.2ms |
| 点击至内容出现后双 RAF p95 | 83.1–99.1ms | 84.1–84.4ms |
| 每轮目录 IPC | 21 | 21 |

未观察到一致的交互性能退化，但样本有限，不作为性能改善结论。双 RAF 是观测代理，不等同于精确 input-to-paint；两版大列表仍有 long task，本次未扩展到虚拟列表重构。500 目录恢复测试仅请求根和已展开子目录，共 2 次 IPC。

目录重命名/移动成功后，在当前附加根作用域迁移目录及后代展开记录；不跨独立附加根同步状态。失效状态沿用现有会话生命周期清理机制。

## 独立审核修复

- P2：重命名后自动收起。已在 `1ad2e8b7` 修复，移动操作同步处理；保留后代显式收起状态，并清除目标旧记录。
- P3：路径迁移须区分 POSIX 与 Windows。仅盘符/UNC 绝对路径接受反斜杠分隔，不误处理 POSIX 反斜杠文件名。
- 独立子会话最终复核结论：**可合并，P2/P3 均已收敛，未发现新的明确问题**。这是本地协作审核，不代表 GitHub 平台的正式 approval。
- 额外 10 项纯函数检查通过：路径边界、Windows/UNC、POSIX 反斜杠、显式 false、目标旧记录和其他树隔离。
- Chromium 新增 3 项验证通过：通过真实组件菜单重命名后保留层级、移动后在目标父目录恢复、重命名失败不修改状态。仍使用模拟 IPC，完整 Electron/真实磁盘 E2E 未进行。
- 路径迁移仅在重命名/移动成功时遍历当前根的状态，不增加常态 IPC。大量已展开目录恢复可能触发主进程同步枚举，仍需真实负载测量。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)

