### PR TITLE
fix(electron): package Pi runtime esbuild dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,12 @@ jobs:
         run: bun run electron:build
         working-directory: .
 
+      - name: 准备运行时依赖
+        shell: bash
+        run: |
+          bun run --filter='@proma/electron' sync:runtime-deps
+          bun run --filter='@proma/electron' rebuild:node-pty
+
       # 打包并发布到 GitHub Releases
       - name: 打包并发布 (macOS)
         env:
@@ -148,6 +154,12 @@ jobs:
       - name: 构建 Electron 应用
         run: bun run electron:build
         working-directory: .
+
+      - name: 准备运行时依赖
+        shell: bash
+        run: |
+          bun run --filter='@proma/electron' sync:runtime-deps
+          bun run --filter='@proma/electron' rebuild:node-pty
 
       # 打包并发布到 GitHub Releases
       - name: 打包并发布 (macOS x64)
@@ -341,6 +353,7 @@ jobs:
         run: bun run electron:build
 
       - name: 准备运行时依赖
+        shell: bash
         run: |
           bun run --filter='@proma/electron' sync:runtime-deps
           bun run --filter='@proma/electron' rebuild:node-pty
@@ -379,6 +392,12 @@ jobs:
       - name: 构建 Electron 应用
         run: bun run electron:build
         working-directory: .
+
+      - name: 准备运行时依赖
+        shell: bash
+        run: |
+          bun run --filter='@proma/electron' sync:runtime-deps
+          bun run --filter='@proma/electron' rebuild:node-pty
 
       - name: 打包并发布 (Windows)
         env:

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -25,8 +25,8 @@ asarUnpack:
   - "node_modules/@napi-rs/**"
   - "node_modules/@earendil-works/pi-tui/native/**"
   # Pi 0.85 的 chord 会在运行时加载 esbuild；其平台二进制必须位于 ASAR 外。
-  - "node_modules/esbuild/**"
-  - "node_modules/@esbuild/**"
+  - "**/node_modules/esbuild/**"
+  - "**/node_modules/@esbuild/**"
   - "node_modules/sharp/**"
   - "node_modules/@img/**"
   # node-pty 的 platform-native .node 与 ConPTY helper 不能留在 asar 内。

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -24,6 +24,9 @@ asarUnpack:
   - "node_modules/@mariozechner/**"
   - "node_modules/@napi-rs/**"
   - "node_modules/@earendil-works/pi-tui/native/**"
+  # Pi 0.85 的 chord 会在运行时加载 esbuild；其平台二进制必须位于 ASAR 外。
+  - "node_modules/esbuild/**"
+  - "node_modules/@esbuild/**"
   - "node_modules/sharp/**"
   - "node_modules/@img/**"
   # node-pty 的 platform-native .node 与 ConPTY helper 不能留在 asar 内。
@@ -49,10 +52,8 @@ files:
   - "!node_modules/electron/**"
   - "!node_modules/electron-builder/**"
   - "!node_modules/electronmon/**"
-  - "!node_modules/esbuild/**"
   - "!node_modules/@electron/**"
   - "!node_modules/@electron-builder/**"
-  - "!node_modules/@esbuild/**"
   # 排除 Pi SDK 纯演示/文档/sourcemap 内容，保留运行时必需文件。
   - "!node_modules/@earendil-works/*/examples/**"
   - "!node_modules/@earendil-works/*/docs/**"

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.30",
+  "version": "0.19.31",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {


### PR DESCRIPTION
## Summary
- keep `esbuild` and its platform-specific `@esbuild` binary in packaged Electron apps
- unpack both packages because Pi 0.85 loads `chord` at runtime and `chord` depends on an executable esbuild binary

## Validation
- `git diff --check`
- parsed `apps/electron/electron-builder.yml` with Ruby YAML
- verified the equivalent macOS package imports `@earendil-works/pi-coding-agent` successfully after this configuration change

Fixes the packaged-only Agent startup failure where Pi initialization throws `ERR_MODULE_NOT_FOUND: Cannot find package 'esbuild'`.\n\nMade with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)