### PR TITLE
fix(context): align Astra window with GPT-5.6

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -59,8 +59,8 @@ const VOLCENGINE_GLM_MAX_TOKENS = 128_000
 const GLM_53_FAMILY_MAX_TOKENS = 131_072
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api'
 const CODEX_MAX_TOKENS = 128_000
-// GPT-6 Astra 按 1M 上下文声明，与 Proma 共享上下文推断保持一致。
-const CODEX_GPT_6_ASTRA_CONTEXT_WINDOW = 1_000_000
+// GPT-6 Astra 与 GPT-5.6 系列统一按 372K 上下文注册。
+const CODEX_GPT_6_ASTRA_CONTEXT_WINDOW = CODEX_GPT_56_CONTEXT_WINDOW
 /**
  * 将 Codex 已标记的 GPT-5.x 上下文窗口外推到同名第三方模型。
  *

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -36,7 +36,7 @@ export function inferCodexAlignedGPT5ContextWindow(modelId: string | undefined):
     case 'gpt-5.6-sol':
     case 'gpt-5.6-terra':
     case 'gpt-5.6-luna': return CODEX_GPT_56_CONTEXT_WINDOW
-    case 'gpt-6-astra': return ONE_MILLION_CONTEXT_WINDOW
+    case 'gpt-6-astra': return CODEX_GPT_56_CONTEXT_WINDOW
     default: return undefined
   }
 }


### PR DESCRIPTION
## Summary

- Align GPT-6 Astra context-window inference and Codex runtime registration with the GPT-5.6 baseline of 372K.

## Validation

- Passed `git diff --check` and confirmed no remaining Astra-specific 1M assignment.
- `bun run typecheck` was attempted but could not run because this fresh worktree has no installed dependencies (`tsc: command not found`).

## Performance impact

- No UI, IPC, renderer, or high-frequency update path changed; configuration-only adjustment.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)