### PR TITLE
Fix updater cache cleanup

### DIFF
--- a/apps/electron/src/main/lib/updater/auto-updater.ts
+++ b/apps/electron/src/main/lib/updater/auto-updater.ts
@@ -7,10 +7,12 @@
 
 import { autoUpdater } from 'electron-updater'
 import { BrowserWindow, app } from 'electron'
+import { join } from 'node:path'
 import type { UpdateStatus } from './updater-types'
 import { UPDATER_IPC_CHANNELS } from './updater-types'
 import { createIdleInstallScheduler } from './idle-install-scheduler'
 import { isNewerVersion } from './version'
+import { createUpdateCacheCleanup, getDefaultUpdaterBaseCacheDirectory, shouldDeferUpdateCacheCleanup } from './update-cache-cleanup'
 
 /** 当前更新状态 */
 let currentStatus: UpdateStatus = { status: 'idle' }
@@ -20,6 +22,9 @@ let win: BrowserWindow | null = null
 
 /** 定时检查定时器 */
 let checkInterval: ReturnType<typeof setInterval> | null = null
+
+/** 新版窗口稳定后执行的更新缓存清理定时器。 */
+let appliedUpdateCacheCleanupTimer: ReturnType<typeof setTimeout> | null = null
 
 /**
  * 已下载更新时仍会定期检查最新 Release。保留该快照可以在“更新源版本
@@ -32,6 +37,12 @@ let activeDownloadVersion: string | null = null
 
 /** 由 Agent 服务注入，覆盖所有窗口/后台 Agent 的运行状态。 */
 let hasActiveAgents = (): boolean => false
+
+/** 已安装更新包的延后清理：新版窗口稳定后才执行，避免安装链路中途删包。 */
+const APPLIED_UPDATE_CACHE_CLEANUP_DELAY_MS = 15_000
+/** Windows Defender、索引器等短暂占用缓存文件时的异步重试策略。 */
+const APPLIED_UPDATE_CACHE_CLEANUP_RETRY_DELAY_MS = 1_000
+const APPLIED_UPDATE_CACHE_CLEANUP_MAX_RETRIES = 2
 
 /**
  * 用户选择「空闲时更新」后，等待所有 Agent 结束再安装。
@@ -191,6 +202,10 @@ export function cleanupUpdater(): void {
     clearInterval(checkInterval)
     checkInterval = null
   }
+  if (appliedUpdateCacheCleanupTimer) {
+    clearTimeout(appliedUpdateCacheCleanupTimer)
+    appliedUpdateCacheCleanupTimer = null
+  }
   downloadedStatusDuringCheck = null
   activeDownloadVersion = null
   idleInstallScheduler.dispose()
@@ -203,6 +218,59 @@ export function cleanupUpdater(): void {
  */
 export function initAutoUpdater(mainWindow: BrowserWindow): void {
   configureUpdater(mainWindow)
+
+  const updateCacheCleanup = createUpdateCacheCleanup({
+    stateFilePath: join(app.getPath('userData'), 'updater-cache-state.json'),
+    baseCacheDirectory: getDefaultUpdaterBaseCacheDirectory(),
+  })
+
+  // 不在刚启动时立即删包：只有主窗口实际可展示且连续稳定 15 秒，才视为基础健康检查通过。
+  // Renderer 加载失败或进程崩溃时，保留安装包供重试与诊断；不以错误页的 did-finish-load 为健康信号。
+  let rendererFailedDuringHealthCheck = false
+  const cancelAppliedUpdateCacheCleanup = () => {
+    rendererFailedDuringHealthCheck = true
+    if (appliedUpdateCacheCleanupTimer) {
+      clearTimeout(appliedUpdateCacheCleanupTimer)
+      appliedUpdateCacheCleanupTimer = null
+    }
+  }
+  let cleanupRetryCount = 0
+  const runAppliedUpdateCacheCleanup = () => {
+    appliedUpdateCacheCleanupTimer = null
+    if (rendererFailedDuringHealthCheck || mainWindow.isDestroyed()) return
+    // pending 是 electron-updater 的共享下载目录；任何下载进行中都不能与清理并发。
+    if (shouldDeferUpdateCacheCleanup(activeDownloadVersion !== null, currentStatus.status === 'downloading')) {
+      console.log('[更新缓存] 有更新正在下载，跳过本次已安装包清理')
+      return
+    }
+    const result = updateCacheCleanup.cleanupForRunningVersion(app.getVersion())
+    if (result.status === 'skipped-unsafe') {
+      console.warn('[更新缓存] 跳过了未通过路径安全校验的缓存清理')
+    } else if (result.status === 'failed') {
+      if (cleanupRetryCount < APPLIED_UPDATE_CACHE_CLEANUP_MAX_RETRIES) {
+        cleanupRetryCount += 1
+        console.warn(`[更新缓存] 清理未完成，${APPLIED_UPDATE_CACHE_CLEANUP_RETRY_DELAY_MS / 1_000} 秒后重试（${cleanupRetryCount}/${APPLIED_UPDATE_CACHE_CLEANUP_MAX_RETRIES}）`)
+        appliedUpdateCacheCleanupTimer = setTimeout(runAppliedUpdateCacheCleanup, APPLIED_UPDATE_CACHE_CLEANUP_RETRY_DELAY_MS)
+      } else {
+        console.warn('[更新缓存] 缓存清理多次失败，将在下次启动时重试')
+      }
+    }
+  }
+  const cleanupAppliedUpdateCache = () => {
+    if (rendererFailedDuringHealthCheck || mainWindow.isDestroyed()) return
+    if (appliedUpdateCacheCleanupTimer) clearTimeout(appliedUpdateCacheCleanupTimer)
+    cleanupRetryCount = 0
+    appliedUpdateCacheCleanupTimer = setTimeout(runAppliedUpdateCacheCleanup, APPLIED_UPDATE_CACHE_CLEANUP_DELAY_MS)
+  }
+  mainWindow.webContents.on('did-fail-load', (_event, errorCode, _errorDescription, _validatedURL, isMainFrame) => {
+    if (isMainFrame && errorCode !== -3) cancelAppliedUpdateCacheCleanup()
+  })
+  mainWindow.webContents.once('render-process-gone', cancelAppliedUpdateCacheCleanup)
+  if (mainWindow.isVisible()) {
+    cleanupAppliedUpdateCache()
+  } else {
+    mainWindow.once('ready-to-show', cleanupAppliedUpdateCache)
+  }
 
   autoUpdater.logger = {
     info: (...args: unknown[]) => console.log('[更新-updater]', ...args),
@@ -263,6 +331,7 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
   autoUpdater.on('update-downloaded', (info) => {
     downloadedStatusDuringCheck = null
     activeDownloadVersion = null
+    updateCacheCleanup.recordDownloadedUpdate(info.version, info.downloadedFile)
     console.log('[更新] 下载完成:', info.version)
     setStatus({
       status: 'downloaded',
@@ -313,9 +382,14 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
 
   // 窗口关闭时清理定时器
   mainWindow.on('closed', () => {
+    cancelAppliedUpdateCacheCleanup()
     if (checkInterval) {
       clearInterval(checkInterval)
       checkInterval = null
+    }
+    if (appliedUpdateCacheCleanupTimer) {
+      clearTimeout(appliedUpdateCacheCleanupTimer)
+      appliedUpdateCacheCleanupTimer = null
     }
     downloadedStatusDuringCheck = null
     activeDownloadVersion = null

--- a/apps/electron/src/main/lib/updater/update-cache-cleanup.test.ts
+++ b/apps/electron/src/main/lib/updater/update-cache-cleanup.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { MAC_DIFFERENTIAL_CACHE_TTL_MS, createUpdateCacheCleanup, shouldDeferUpdateCacheCleanup } from './update-cache-cleanup'
+
+const tempDirectories: string[] = []
+
+function createFixture(platform: NodeJS.Platform = 'win32') {
+  const root = mkdtempSync(join(tmpdir(), 'proma-updater-cache-'))
+  tempDirectories.push(root)
+  const baseCacheDirectory = join(root, 'cache-root')
+  const cacheDirectory = join(baseCacheDirectory, 'com.proma.app-updater')
+  const pendingDirectory = join(cacheDirectory, 'pending')
+  const downloadedFile = join(pendingDirectory, 'Proma-0.20.0.exe')
+  const stateFilePath = join(root, 'user-data', 'updater-cache-state.json')
+
+  mkdirSync(pendingDirectory, { recursive: true })
+  writeFileSync(downloadedFile, 'installer')
+
+  return {
+    baseCacheDirectory,
+    cacheDirectory,
+    downloadedFile,
+    pendingDirectory,
+    platform,
+    stateFilePath,
+  }
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true })
+  }
+})
+
+describe('更新安装包缓存清理', () => {
+  test('Given 有新更新正在检查或下载 When 旧版本健康清理到期 Then 必须延后清理共享 pending 目录', () => {
+    expect(shouldDeferUpdateCacheCleanup(true, false)).toBe(true)
+    expect(shouldDeferUpdateCacheCleanup(false, true)).toBe(true)
+    expect(shouldDeferUpdateCacheCleanup(false, false)).toBe(false)
+  })
+
+  test('Given 尚未运行目标版本 When 启动 Then 保留待安装包以便重试', () => {
+    const fixture = createFixture()
+    const cleanup = createUpdateCacheCleanup(fixture)
+    cleanup.recordDownloadedUpdate('0.20.0', fixture.downloadedFile)
+
+    const result = cleanup.cleanupForRunningVersion('0.19.32')
+
+    expect(result).toEqual({ status: 'retained', deletedCount: 0 })
+    expect(existsSync(fixture.downloadedFile)).toBe(true)
+    expect(existsSync(fixture.stateFilePath)).toBe(true)
+  })
+
+  test('Given 新版本已成功启动 When 清理 Then 删除 pending 内的安装包和状态文件', () => {
+    const fixture = createFixture()
+    const cleanup = createUpdateCacheCleanup(fixture)
+    cleanup.recordDownloadedUpdate('0.20.0', fixture.downloadedFile)
+    writeFileSync(join(fixture.pendingDirectory, 'update-info.json'), '{}')
+
+    const result = cleanup.cleanupForRunningVersion('0.20.0')
+
+    expect(result).toEqual({ status: 'cleaned', deletedCount: 2 })
+    expect(existsSync(fixture.pendingDirectory)).toBe(false)
+    expect(existsSync(fixture.stateFilePath)).toBe(false)
+    expect(existsSync(`${fixture.stateFilePath}.bak`)).toBe(false)
+  })
+
+  test('Given 不属于 updater pending 目录的下载文件 When 记录 Then 拒绝创建清理状态', () => {
+    const fixture = createFixture()
+    const outsideFile = join(dirname(fixture.baseCacheDirectory), 'outside-installer.exe')
+    writeFileSync(outsideFile, 'installer')
+    const cleanup = createUpdateCacheCleanup(fixture)
+
+    expect(cleanup.recordDownloadedUpdate('0.20.0', outsideFile)).toBe(false)
+    expect(existsSync(fixture.stateFilePath)).toBe(false)
+    expect(existsSync(outsideFile)).toBe(true)
+  })
+
+  test('Given 下载路径经过软链接目录 When 记录 Then 拒绝为其建立删除状态', () => {
+    const fixture = createFixture()
+    const outsideCacheDirectory = join(dirname(fixture.baseCacheDirectory), 'outside-cache')
+    const linkedCacheDirectory = join(fixture.baseCacheDirectory, 'linked-cache')
+    const linkedPendingDirectory = join(outsideCacheDirectory, 'pending')
+    const linkedInstaller = join(linkedPendingDirectory, 'Proma-0.20.0.exe')
+    mkdirSync(linkedPendingDirectory, { recursive: true })
+    writeFileSync(linkedInstaller, 'installer')
+    symlinkSync(outsideCacheDirectory, linkedCacheDirectory)
+
+    const cleanup = createUpdateCacheCleanup(fixture)
+
+    expect(cleanup.recordDownloadedUpdate('0.20.0', join(linkedCacheDirectory, 'pending', 'Proma-0.20.0.exe'))).toBe(false)
+    expect(existsSync(fixture.stateFilePath)).toBe(false)
+    expect(existsSync(linkedInstaller)).toBe(true)
+  })
+
+  test('Given 缓存状态无法持久化 When 下载完成 Then 不抛错且保留可安装文件', () => {
+    const fixture = createFixture()
+    const cleanup = createUpdateCacheCleanup({ ...fixture, stateFilePath: join('/dev/null', 'updater-cache-state.json') })
+
+    expect(cleanup.recordDownloadedUpdate('0.20.0', fixture.downloadedFile)).toBe(false)
+    expect(existsSync(fixture.downloadedFile)).toBe(true)
+  })
+
+  test('Given pending 含不受信任目录 When 清理 Then 保留状态并拒绝递归删除', () => {
+    const fixture = createFixture()
+    const cleanup = createUpdateCacheCleanup(fixture)
+    cleanup.recordDownloadedUpdate('0.20.0', fixture.downloadedFile)
+    const unexpectedDirectory = join(fixture.pendingDirectory, 'unexpected')
+    mkdirSync(unexpectedDirectory)
+    writeFileSync(join(unexpectedDirectory, 'keep'), 'keep')
+
+    const result = cleanup.cleanupForRunningVersion('0.20.0')
+
+    expect(result.status).toBe('skipped-unsafe')
+    expect(existsSync(fixture.stateFilePath)).toBe(true)
+    expect(readFileSync(join(unexpectedDirectory, 'keep'), 'utf8')).toBe('keep')
+  })
+
+  test('Given 删除被文件系统拒绝 When 清理 Then 保留状态供下次启动重试', () => {
+    const fixture = createFixture()
+    const cleanup = createUpdateCacheCleanup(fixture)
+    cleanup.recordDownloadedUpdate('0.20.0', fixture.downloadedFile)
+    chmodSync(fixture.pendingDirectory, 0o500)
+
+    const result = cleanup.cleanupForRunningVersion('0.20.0')
+
+    chmodSync(fixture.pendingDirectory, 0o700)
+    expect(result.status).toBe('failed')
+    expect(existsSync(fixture.stateFilePath)).toBe(true)
+    expect(existsSync(fixture.downloadedFile)).toBe(true)
+  })
+
+  test('Given macOS 差分缓存过期且有新待安装更新 When 后续启动 Then 回收差分缓存但保留新安装包', () => {
+    const fixture = createFixture('darwin')
+    let now = 1_000
+    const cleanup = createUpdateCacheCleanup({ ...fixture, now: () => now })
+    cleanup.recordDownloadedUpdate('0.20.0', fixture.downloadedFile)
+    writeFileSync(join(fixture.cacheDirectory, 'update.zip'), 'differential-base')
+    writeFileSync(join(fixture.cacheDirectory, 'current.blockmap'), 'blockmap')
+    writeFileSync(join(fixture.cacheDirectory, 'unrelated-file'), 'keep')
+
+    cleanup.cleanupForRunningVersion('0.20.0')
+    mkdirSync(fixture.pendingDirectory)
+    const nextInstaller = join(fixture.pendingDirectory, 'Proma-0.21.0.zip')
+    writeFileSync(nextInstaller, 'next-installer')
+    cleanup.recordDownloadedUpdate('0.21.0', nextInstaller)
+
+    now += MAC_DIFFERENTIAL_CACHE_TTL_MS
+    const expiredResult = cleanup.cleanupForRunningVersion('0.20.0')
+
+    expect(expiredResult).toEqual({ status: 'cleaned', deletedCount: 2 })
+    expect(existsSync(join(fixture.cacheDirectory, 'update.zip'))).toBe(false)
+    expect(existsSync(join(fixture.cacheDirectory, 'current.blockmap'))).toBe(false)
+    expect(readFileSync(join(fixture.cacheDirectory, 'unrelated-file'), 'utf8')).toBe('keep')
+    expect(existsSync(nextInstaller)).toBe(true)
+    expect(existsSync(fixture.stateFilePath)).toBe(true)
+  })
+})

--- a/apps/electron/src/main/lib/updater/update-cache-cleanup.ts
+++ b/apps/electron/src/main/lib/updater/update-cache-cleanup.ts
@@ -1,0 +1,384 @@
+import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmdirSync, unlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
+import { gte, valid } from 'semver'
+import { readJsonFileSafe, writeJsonFileAtomic } from '../safe-file'
+
+/** macOS 差分更新基线的最长保留时间。 */
+export const MAC_DIFFERENTIAL_CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000
+
+const CACHE_STATE_VERSION = 2
+const PENDING_DIRECTORY_NAME = 'pending'
+const MAC_DIFFERENTIAL_CACHE_FILES = ['update.zip', 'current.blockmap'] as const
+
+interface PendingUpdateCacheState {
+  targetVersion: string
+  downloadedFile: string
+  pendingDirectory: string
+  cacheDirectory: string
+  platform: string
+  downloadedAt: number
+}
+
+interface MacDifferentialCacheState {
+  cacheDirectory: string
+  expiresAt: number
+}
+
+interface UpdateCacheState {
+  schemaVersion: typeof CACHE_STATE_VERSION
+  pendingUpdate?: PendingUpdateCacheState
+  macDifferentialCache?: MacDifferentialCacheState
+}
+
+export interface UpdateCacheCleanupResult {
+  status: 'not-needed' | 'retained' | 'cleaned' | 'skipped-unsafe' | 'failed'
+  deletedCount: number
+}
+
+/** pending 为 electron-updater 的共享目录，下载期间必须禁止任何清理。 */
+export function shouldDeferUpdateCacheCleanup(hasActiveDownload: boolean, isDownloading: boolean): boolean {
+  return hasActiveDownload || isDownloading
+}
+
+export interface UpdateCacheCleanupOptions {
+  /** Proma 自己拥有的状态文件，不写入 electron-updater 的私有状态。 */
+  stateFilePath: string
+  /** electron-updater 使用的系统级缓存根目录。 */
+  baseCacheDirectory: string
+  platform?: NodeJS.Platform
+  now?: () => number
+  log?: Pick<Console, 'info' | 'warn'>
+}
+
+/**
+ * 计算 electron-updater 的默认缓存根目录。
+ *
+ * 应只在运行平台调用；测试可通过 UpdateCacheCleanupOptions 注入固定目录。
+ */
+export function getDefaultUpdaterBaseCacheDirectory(
+  platform: NodeJS.Platform = process.platform,
+  environment: NodeJS.ProcessEnv = process.env,
+  homeDirectory = homedir(),
+): string {
+  if (platform === 'win32') {
+    return environment.LOCALAPPDATA || join(homeDirectory, 'AppData', 'Local')
+  }
+  if (platform === 'darwin') {
+    return join(homeDirectory, 'Library', 'Caches')
+  }
+  return environment.XDG_CACHE_HOME || join(homeDirectory, '.cache')
+}
+
+/**
+ * 为 electron-updater 缓存建立显式生命周期：
+ *
+ * - 待安装包只会在目标版本成功启动后删除；
+ * - macOS 的差分下载基线与待安装包状态独立持久化；
+ * - 所有删除都限制在 electron-updater 实际下载文件所在的 pending 目录；
+ * - 缓存状态是 best-effort，绝不能影响 update-downloaded 事件或安装能力。
+ */
+export function createUpdateCacheCleanup(options: UpdateCacheCleanupOptions) {
+  const platform = options.platform ?? process.platform
+  const now = options.now ?? Date.now
+  const log = options.log ?? console
+  const stateFilePath = resolve(options.stateFilePath)
+  const baseCacheDirectory = resolve(options.baseCacheDirectory)
+
+  function recordDownloadedUpdate(targetVersion: string, downloadedFile: string): boolean {
+    try {
+      const downloadedFilePath = resolve(downloadedFile)
+      const pendingDirectory = dirname(downloadedFilePath)
+      const cacheDirectory = dirname(pendingDirectory)
+
+      if (!isSafeManagedPendingDirectory(pendingDirectory, cacheDirectory, baseCacheDirectory) || !hasRegularFile(downloadedFilePath)) {
+        log.warn(`[更新缓存] 跳过记录未验证的下载路径: ${downloadedFilePath}`)
+        return false
+      }
+
+      const state = readState(stateFilePath) ?? createEmptyState()
+      state.pendingUpdate = {
+        targetVersion,
+        downloadedFile: downloadedFilePath,
+        pendingDirectory,
+        cacheDirectory,
+        platform,
+        downloadedAt: now(),
+      }
+      return persistState(state)
+    } catch (error) {
+      // updater 安装包已可用；无法记录清理元数据不应将它变成下载失败。
+      log.warn(`[更新缓存] 无法记录下载缓存状态，将跳过后续自动清理: ${String(error)}`)
+      return false
+    }
+  }
+
+  function cleanupForRunningVersion(runningVersion: string): UpdateCacheCleanupResult {
+    const state = readState(stateFilePath)
+    if (state === null) return { status: 'not-needed', deletedCount: 0 }
+
+    let deletedCount = 0
+    let didChangeState = false
+    let didSkipUnsafePath = false
+    let didFail = false
+
+    // macOS 差分缓存独立于 pending 状态处理，避免被下一次待安装更新覆盖 TTL。
+    if (state.macDifferentialCache) {
+      const macResult = cleanupExpiredMacDifferentialCache(state.macDifferentialCache)
+      deletedCount += macResult.deletedCount
+      if (macResult.status === 'cleaned') {
+        state.macDifferentialCache = undefined
+        didChangeState = true
+      } else if (macResult.status === 'skipped-unsafe') {
+        state.macDifferentialCache = undefined
+        didChangeState = true
+        didSkipUnsafePath = true
+      } else if (macResult.status === 'failed') {
+        didFail = true
+      }
+    }
+
+    if (state.pendingUpdate) {
+      const pending = state.pendingUpdate
+      if (!isSafePendingState(pending, baseCacheDirectory)) {
+        log.warn('[更新缓存] 清理状态中的 pending 路径未通过安全校验，已放弃清理')
+        state.pendingUpdate = undefined
+        didChangeState = true
+        didSkipUnsafePath = true
+      } else if (!isVersionAtLeast(runningVersion, pending.targetVersion)) {
+        // 尚未切换到目标版本时，待安装包仍可能用于重试，绝不能删除。
+      } else {
+        const removal = removePendingDirectory(pending.pendingDirectory, pending.cacheDirectory, baseCacheDirectory)
+        deletedCount += removal.deletedCount
+
+        if (removal.status === 'removed' || removal.status === 'absent') {
+          log.info(`[更新缓存] 已确认运行 v${runningVersion}，清理 ${removal.deletedCount} 个已安装更新文件`)
+          state.pendingUpdate = undefined
+          didChangeState = true
+
+          // update.zip 是 macOS 未来差分下载的唯一基线，保留一份且设置明确的失效期。
+          if (platform === 'darwin' && pending.platform === 'darwin' && hasRegularFile(join(pending.cacheDirectory, 'update.zip'))) {
+            state.macDifferentialCache = {
+              cacheDirectory: pending.cacheDirectory,
+              expiresAt: now() + MAC_DIFFERENTIAL_CACHE_TTL_MS,
+            }
+          }
+        } else if (removal.status === 'unsafe') {
+          didSkipUnsafePath = true
+        } else {
+          // 文件被 Defender / 索引器等占用时保留状态，下次启动再尝试。
+          didFail = true
+        }
+      }
+    }
+
+    if (didChangeState) {
+      if (hasStateEntries(state)) {
+        if (!persistState(state)) didFail = true
+      } else if (!removeStateFile(stateFilePath)) {
+        didFail = true
+      }
+    }
+
+    if (didSkipUnsafePath) return { status: 'skipped-unsafe', deletedCount }
+    if (didFail) return { status: 'failed', deletedCount }
+    if (deletedCount > 0 || didChangeState) return { status: 'cleaned', deletedCount }
+    return { status: 'retained', deletedCount }
+  }
+
+  function cleanupExpiredMacDifferentialCache(state: MacDifferentialCacheState): UpdateCacheCleanupResult {
+    if (platform !== 'darwin' || !isSafeManagedCacheDirectory(state.cacheDirectory, baseCacheDirectory)) {
+      return { status: 'skipped-unsafe', deletedCount: 0 }
+    }
+
+    if (!Number.isFinite(state.expiresAt) || now() < state.expiresAt) {
+      return { status: 'retained', deletedCount: 0 }
+    }
+
+    let deletedCount = 0
+    for (const fileName of MAC_DIFFERENTIAL_CACHE_FILES) {
+      const result = removeRegularFile(join(state.cacheDirectory, fileName))
+      if (result === 'removed') deletedCount += 1
+      if (result === 'failed') return { status: 'failed', deletedCount }
+    }
+    log.info(`[更新缓存] 已回收 ${deletedCount} 个过期的 macOS 差分更新缓存文件`)
+    return { status: 'cleaned', deletedCount }
+  }
+
+  function persistState(state: UpdateCacheState): boolean {
+    try {
+      mkdirSync(dirname(stateFilePath), { recursive: true })
+      writeJsonFileAtomic(stateFilePath, state)
+      return true
+    } catch (error) {
+      log.warn(`[更新缓存] 无法持久化缓存状态: ${String(error)}`)
+      return false
+    }
+  }
+
+  return { recordDownloadedUpdate, cleanupForRunningVersion }
+}
+
+function createEmptyState(): UpdateCacheState {
+  return { schemaVersion: CACHE_STATE_VERSION }
+}
+
+function hasStateEntries(state: UpdateCacheState): boolean {
+  return state.pendingUpdate !== undefined || state.macDifferentialCache !== undefined
+}
+
+function readState(filePath: string): UpdateCacheState | null {
+  const value = readJsonFileSafe<unknown>(filePath)
+  if (!isRecord(value) || value.schemaVersion !== CACHE_STATE_VERSION) return null
+
+  const state = createEmptyState()
+  if (isPendingUpdateCacheState(value.pendingUpdate)) state.pendingUpdate = value.pendingUpdate
+  if (isMacDifferentialCacheState(value.macDifferentialCache)) state.macDifferentialCache = value.macDifferentialCache
+  return hasStateEntries(state) ? state : null
+}
+
+function isPendingUpdateCacheState(value: unknown): value is PendingUpdateCacheState {
+  return (
+    isRecord(value)
+    && typeof value.targetVersion === 'string'
+    && typeof value.downloadedFile === 'string'
+    && typeof value.pendingDirectory === 'string'
+    && typeof value.cacheDirectory === 'string'
+    && typeof value.platform === 'string'
+    && typeof value.downloadedAt === 'number'
+  )
+}
+
+function isMacDifferentialCacheState(value: unknown): value is MacDifferentialCacheState {
+  return isRecord(value) && typeof value.cacheDirectory === 'string' && typeof value.expiresAt === 'number'
+}
+
+function isSafePendingState(state: PendingUpdateCacheState, baseCacheDirectory: string): boolean {
+  return (
+    isAbsolute(state.downloadedFile)
+    && isAbsolute(state.pendingDirectory)
+    && isAbsolute(state.cacheDirectory)
+    && resolve(dirname(state.downloadedFile)) === resolve(state.pendingDirectory)
+    && isSafeManagedPendingDirectory(state.pendingDirectory, state.cacheDirectory, baseCacheDirectory)
+  )
+}
+
+function isSafeManagedPendingDirectory(pendingDirectory: string, cacheDirectory: string, baseCacheDirectory: string): boolean {
+  return (
+    basename(pendingDirectory) === PENDING_DIRECTORY_NAME
+    && resolve(dirname(pendingDirectory)) === resolve(cacheDirectory)
+    && isSafeManagedCacheDirectory(cacheDirectory, baseCacheDirectory)
+    && isPlainDirectory(pendingDirectory)
+  )
+}
+
+/** 缓存目录必须是系统缓存根的直接普通子目录；拒绝软链接和 Windows junction。 */
+function isSafeManagedCacheDirectory(cacheDirectory: string, baseCacheDirectory: string): boolean {
+  if (!isAbsolute(cacheDirectory) || resolve(dirname(cacheDirectory)) !== resolve(baseCacheDirectory)) return false
+  if (!isPlainDirectory(baseCacheDirectory) || !isPlainDirectory(cacheDirectory)) return false
+
+  try {
+    const realBaseCacheDirectory = resolve(realpathSync(baseCacheDirectory))
+    return resolve(realpathSync(dirname(cacheDirectory))) === realBaseCacheDirectory
+      && resolve(dirname(realpathSync(cacheDirectory))) === realBaseCacheDirectory
+  } catch {
+    return false
+  }
+}
+
+function isVersionAtLeast(runningVersion: string, targetVersion: string): boolean {
+  const running = valid(runningVersion)
+  const target = valid(targetVersion)
+  return running !== null && target !== null && gte(running, target)
+}
+
+type PendingRemovalResult = {
+  status: 'removed' | 'absent' | 'failed' | 'unsafe'
+  deletedCount: number
+}
+
+/**
+ * 仅删除 pending 中的普通文件，目录、软链接和 junction 一律保留并下次重试。
+ * electron-updater 的安装器、web-installer package、元数据和临时文件均为普通文件。
+ */
+function removePendingDirectory(
+  pendingDirectory: string,
+  cacheDirectory: string,
+  baseCacheDirectory: string,
+): PendingRemovalResult {
+  if (!existsSync(pendingDirectory)) return { status: 'absent', deletedCount: 0 }
+  if (!isSafeManagedPendingDirectory(pendingDirectory, cacheDirectory, baseCacheDirectory)) {
+    return { status: 'unsafe', deletedCount: 0 }
+  }
+
+  let deletedCount = 0
+  try {
+    for (const entry of readdirSync(pendingDirectory)) {
+      const entryPath = join(pendingDirectory, entry)
+      if (!hasRegularFile(entryPath)) return { status: 'unsafe', deletedCount }
+      unlinkSync(entryPath)
+      deletedCount += 1
+    }
+
+    // 删除前再次验证父路径，缩小路径被替换的竞态窗口。
+    if (!isSafeManagedPendingDirectory(pendingDirectory, cacheDirectory, baseCacheDirectory)) {
+      return { status: 'unsafe', deletedCount }
+    }
+    rmdirSync(pendingDirectory)
+    return { status: 'removed', deletedCount }
+  } catch {
+    return { status: 'failed', deletedCount }
+  }
+}
+
+function isPlainDirectory(path: string): boolean {
+  try {
+    const stat = lstatSync(path)
+    return stat.isDirectory() && !stat.isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+function hasRegularFile(path: string): boolean {
+  try {
+    const stat = lstatSync(path)
+    return stat.isFile() && !stat.isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+type RegularFileRemovalResult = 'removed' | 'absent' | 'failed'
+
+function removeRegularFile(filePath: string): RegularFileRemovalResult {
+  if (!existsSync(filePath)) return 'absent'
+  if (!hasRegularFile(filePath)) return 'failed'
+  try {
+    unlinkSync(filePath)
+    return 'removed'
+  } catch {
+    return 'failed'
+  }
+}
+
+function removeStateFile(filePath: string): boolean {
+  // safe-file 会保留 .bak；状态完成后必须一并清理，避免下次读取时回退并复活旧状态。
+  let failed = false
+  for (const candidate of [filePath, `${filePath}.tmp`, `${filePath}.bak`]) {
+    try {
+      unlinkSync(candidate)
+    } catch (error) {
+      if (!isNotFoundError(error)) failed = true
+    }
+  }
+  return !failed
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}


### PR DESCRIPTION
## Summary
- Clean installed electron-updater pending packages only after the updated app reaches a stable main window.
- Keep update downloads, cleanup, retry, state persistence, and macOS differential-cache retention safe across Windows, macOS, and Linux.
- Add updater-cache lifecycle regression coverage.

## Verification
- `bun run --filter='@proma/electron' typecheck`
- `bun test apps/electron/src/main/lib/updater` (12 passing)
- `git diff --check`

## Performance
No renderer, streaming, or high-frequency IPC path changes. File work is limited to one post-startup cleanup attempt and bounded retries; update downloads always take precedence.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)