### PR TITLE
fix(agent): 修复 Skill 改名后的消息标签显示【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.32",
+  "version": "0.19.33",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/workspace-watcher-utils.ts
+++ b/apps/electron/src/main/lib/workspace-watcher-utils.ts
@@ -38,3 +38,14 @@ export function shouldNotifyForWatchFilename(filename: string | Buffer | null): 
   const normalizedFilename = normalizeWatchFilename(filename)
   return normalizedFilename !== null && (!isHighNoisePath(normalizedFilename) || isGitDiffStatePath(normalizedFilename))
 }
+
+/** 输入相对 agent-workspaces 根目录；仅工作区顶层能力目录触发能力通知。 */
+export function classifyWorkspaceWatchFilename(filename: string | Buffer | null): 'capabilities' | 'files' | null {
+  const normalized = normalizeWatchFilename(filename)
+  if (!normalized || !shouldNotifyForWatchFilename(normalized)) return null
+  const parts = normalized.split('/').filter(Boolean)
+  if (parts.length === 2 && parts[1] === 'config.json') return null
+  if ((parts.length === 2 && parts[1] === 'mcp.json')
+    || parts[1] === 'skills' || parts[1] === 'skills-inactive') return 'capabilities'
+  return 'files'
+}

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -3,7 +3,7 @@
  *
  * 使用 fs.watch 递归监听 ~/.proma/agent-workspaces/ 目录，
  * 根据变化的文件路径区分事件类型：
- * - mcp.json / skills/ 变化 → 推送 CAPABILITIES_CHANGED（侧边栏刷新）
+ * - mcp.json / skills/ / skills-inactive/ 变化 → 推送 CAPABILITIES_CHANGED（侧边栏刷新）
  * - 其他文件变化 → 推送 WORKSPACE_FILES_CHANGED（文件浏览器刷新）
  *
  * 同时支持监听附加目录（外部路径），变化时统一推送 WORKSPACE_FILES_CHANGED。
@@ -19,7 +19,7 @@ import { AGENT_IPC_CHANNELS } from '@proma/shared'
 import { getAgentWorkspacesDir } from './config-paths'
 import { listAgentSessions } from './agent-session-manager'
 import { invalidateGitDiffCache } from './git-diff-service'
-import { isHighNoisePath, normalizeWatchFilename, shouldNotifyForWatchFilename } from './workspace-watcher-utils'
+import { classifyWorkspaceWatchFilename, isHighNoisePath, normalizeWatchFilename, shouldNotifyForWatchFilename } from './workspace-watcher-utils'
 
 /** debounce 延迟（ms） */
 const DEBOUNCE_MS = 300
@@ -222,20 +222,10 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
       if (shouldNotifyForWatchFilename(normalizedFilename)) {
         invalidateGitDiffCache(join(watchDir, normalizedFilename))
       }
-      if (isHighNoisePath(normalizedFilename) && !shouldNotifyForWatchFilename(normalizedFilename)) return
+      const changeType = classifyWorkspaceWatchFilename(normalizedFilename)
+      if (!changeType) return
 
-      const pathParts = normalizedFilename.split('/').filter(Boolean)
-
-      // 仅忽略工作区顶层 config.json；会话目录内同名文件仍属于用户文件。
-      if (pathParts.length === 2 && pathParts[1] === 'config.json') {
-        return
-      }
-
-      const isCapabilitiesChange =
-        normalizedFilename.endsWith('/mcp.json') ||
-        normalizedFilename.includes('/skills/')
-
-      if (isCapabilitiesChange) {
+      if (changeType === 'capabilities') {
         // MCP/Skills 变化 → 通知侧边栏刷新
         if (capabilitiesTimer) clearTimeout(capabilitiesTimer)
         capabilitiesTimer = setTimeout(() => {

--- a/apps/electron/src/renderer/atoms/skill-mention-atoms.ts
+++ b/apps/electron/src/renderer/atoms/skill-mention-atoms.ts
@@ -1,0 +1,52 @@
+import { atom } from 'jotai'
+import { atomFamily } from 'jotai-family'
+import { selectAtom, unwrap } from 'jotai/utils'
+import { workspaceCapabilitiesVersionAtom } from './agent-atoms'
+import { EMPTY_SKILL_MENTION_NAMES } from '../lib/skill-mention-name'
+
+/** 仅展示使用全量 Skill 列表；不改变 Agent 的启用能力范围。 */
+export const skillMentionNamesAtomFamily = atomFamily((workspaceSlug: string | null) => atom(async (get): Promise<ReadonlyMap<string, string>> => {
+  get(workspaceCapabilitiesVersionAtom)
+  if (!workspaceSlug) return EMPTY_SKILL_MENTION_NAMES
+
+  try {
+    const skills = await window.electronAPI.getWorkspaceSkills(workspaceSlug)
+    return new Map(skills.map((skill) => [skill.slug, skill.name.trim() || skill.slug]))
+  } catch {
+    // 读取失败和删除均回退 slug；后续能力通知可重新读取恢复。
+    return EMPTY_SKILL_MENTION_NAMES
+  }
+}))
+
+function equalNames(previous: ReadonlyMap<string, string>, next: ReadonlyMap<string, string>): boolean {
+  return previous.size === next.size && [...next].every(([slug, name]) => previous.get(slug) === name)
+}
+
+/** 每个工作区独立保留待决前值；相同映射不扇出 Context 更新，也不触发 Suspense。 */
+export const skillMentionNamesDisplayAtomFamily = atomFamily((workspaceSlug: string | null) => {
+  const stableNames = selectAtom(
+    unwrap(skillMentionNamesAtomFamily(workspaceSlug), (previous) => previous ?? EMPTY_SKILL_MENTION_NAMES),
+    (names) => names,
+    equalNames,
+  )
+  // writable 包装仅用于 onMount 生命周期；值仍由异步读取派生。
+  const displayAtom = atom((get) => get(stableNames), () => {})
+  let mounts = 0
+  let retired = false
+  displayAtom.onMount = () => {
+    mounts++
+    return () => {
+      mounts--
+      // 跨 store 共用 family；最后一个订阅者卸载才清理。微任务兼容 StrictMode 重挂载。
+      queueMicrotask(() => {
+        if (mounts !== 0 || retired) return
+        // 消费者可能仍持有淘汰前的 atom，再次卸载时不能删除同 slug 的新实例。
+        retired = true
+        if (skillMentionNamesDisplayAtomFamily(workspaceSlug) !== displayAtom) return
+        skillMentionNamesDisplayAtomFamily.remove(workspaceSlug)
+        skillMentionNamesAtomFamily.remove(workspaceSlug)
+      })
+    }
+  }
+  return displayAtom
+})

--- a/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSkillMentionNames } from './SkillMentionNamesProvider'
 import { CalendarDays, Clock3, CornerDownLeft, FileText, GripVertical, ListTodo, MessageSquareText, Paperclip, Quote, Server, Sparkles, Trash2, Undo2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -174,11 +175,12 @@ const QUEUED_REFERENCE_STYLES = {
 } as const
 
 function QueuedMessagePreview({ text }: { text: string }): React.ReactElement {
+  const skillNames = useSkillMentionNames()
   if (!text) return <div className="line-clamp-2">仅附件</div>
 
   return (
     <div className="line-clamp-2 whitespace-pre-wrap">
-      {getQueuedMessageDisplayParts(text).map((part, index) => {
+      {getQueuedMessageDisplayParts(text, skillNames).map((part, index) => {
         if (part.type === 'text') return <React.Fragment key={index}>{part.value}</React.Fragment>
 
         const { icon: Icon, className } = QUEUED_REFERENCE_STYLES[part.referenceType]

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -21,6 +21,7 @@ import { CornerDownLeft, Square, Settings, X, Copy, Check, Brain, Sparkles, List
 import { AgentMessages, type AgentHistoryQuoteNavigationRequest } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { AgentMessageQueue } from './AgentMessageQueue'
+import { SkillMentionNamesProvider } from './SkillMentionNamesProvider'
 import { ContextUsageBadge } from './ContextUsageBadge'
 import { PermissionBanner } from './PermissionBanner'
 import { PermissionModeSelector } from './PermissionModeSelector'
@@ -2971,7 +2972,7 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
   )
 
   return (
-    <>
+    <SkillMentionNamesProvider workspaceSlug={workspaceSlug}>
       <div
         className="flex h-full min-h-0 flex-1 min-w-0 flex-col overflow-hidden"
         onFocusCapture={markStopShortcutTarget}
@@ -3212,6 +3213,6 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
-    </>
+    </SkillMentionNamesProvider>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SkillMentionNamesProvider.tsx
+++ b/apps/electron/src/renderer/components/agent/SkillMentionNamesProvider.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { useAtomValue } from 'jotai'
+import { skillMentionNamesDisplayAtomFamily } from '@/atoms/skill-mention-atoms'
+import { EMPTY_SKILL_MENTION_NAMES } from '@/lib/skill-mention-name'
+
+const SkillMentionNamesContext = React.createContext(EMPTY_SKILL_MENTION_NAMES)
+
+/** 使用所属会话的工作区，而非全局当前工作区，兼容临时/嵌入式 Agent。 */
+export function SkillMentionNamesProvider({ workspaceSlug, children }: {
+  workspaceSlug: string | null
+  children: React.ReactNode
+}): React.ReactElement {
+  const names = useAtomValue(skillMentionNamesDisplayAtomFamily(workspaceSlug))
+  return (
+    <SkillMentionNamesContext.Provider value={names}>
+      {children}
+    </SkillMentionNamesContext.Provider>
+  )
+}
+
+export function useSkillMentionNames(): ReadonlyMap<string, string> {
+  return React.useContext(SkillMentionNamesContext)
+}

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -42,6 +42,8 @@ import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isImageFilePath, isRelativeFilePath } from './file-path-chip'
 import { buildAgentHistoryQuoteLabel, parseAgentHistoryQuoteMention } from '@/lib/quoted-selection'
 import { createMentionPattern } from '@/lib/mention-patterns'
+import { resolveSkillMentionName } from '@/lib/skill-mention-name'
+import { useSkillMentionNames } from '@/components/agent/SkillMentionNamesProvider'
 import { useAgentBrowserLink } from '@/components/browser/AgentBrowserLinkProvider'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
@@ -339,6 +341,12 @@ export function normalizeNamedReferenceDelimiters(markdown: string): string {
   }).join('\n')
 }
 
+/** 只有 Skill 标签订阅名称；文件、MCP 等引用不随 Skill 改名重渲染。 */
+function SkillMentionLabel({ slug }: { slug: string }): React.ReactElement {
+  const names = useSkillMentionNames()
+  return <>{resolveSkillMentionName(slug, names)}</>
+}
+
 function MentionChip({ type, value }: { type: MentionType; value: string }): React.ReactElement {
   const style = MENTION_STYLES[type]
   const Icon = style.icon
@@ -402,7 +410,7 @@ function MentionChip({ type, value }: { type: MentionType; value: string }): Rea
       title={type === 'file' || isNamedReference ? (label || referenceId) : undefined}
     >
       <Icon className="size-3 inline shrink-0" />
-      {display}
+      {type === 'skill' ? <SkillMentionLabel slug={decoded} /> : display}
     </span>
   )
 }
@@ -760,16 +768,22 @@ export const UserMessageContent = React.memo(
     const [shouldCollapse, setShouldCollapse] = React.useState(false)
     const contentRef = React.useRef<HTMLDivElement>(null)
 
-    // 检测内容是否超过阈值行数
+    // 观察内部自然高度而非带 max-height 的外壳，避免折叠动画触发测量反馈。
+    // 名称异步更新与容器宽度变化都可能改变换行；不需要订阅全局名称 Context。
     React.useEffect(() => {
-      if (!contentRef.current) return
-
       const element = contentRef.current
-      const lineHeight = parseFloat(getComputedStyle(element).lineHeight)
-      const maxHeight = lineHeight * COLLAPSE_LINE_THRESHOLD
+      const content = element?.firstElementChild
+      if (!element || !content) return
 
-      // scrollHeight 超过最大高度 + 容差时折叠
-      setShouldCollapse(element.scrollHeight > maxHeight + 10)
+      const measure = (): void => {
+        const lineHeight = parseFloat(getComputedStyle(element).lineHeight)
+        const maxHeight = lineHeight * COLLAPSE_LINE_THRESHOLD
+        setShouldCollapse(element.scrollHeight > maxHeight + 10)
+      }
+      measure()
+      const observer = new ResizeObserver(measure)
+      observer.observe(content)
+      return () => observer.disconnect()
     }, [children])
 
     const toggleExpand = React.useCallback(() => {

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -1,3 +1,4 @@
+import { resolveSkillMentionName, EMPTY_SKILL_MENTION_NAMES } from './skill-mention-name'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
@@ -227,7 +228,10 @@ function decodeReferenceLabel(value: string): string {
  * 将排队消息中的文件、Skill、MCP、会话、历史引用和规划协议转换为展示片段。
  * `item.text` 仍完整保留，发送时继续通过 parseQueuedMessageMentions 提取原始 ID。
  */
-export function getQueuedMessageDisplayParts(text: string): QueuedMessageDisplayPart[] {
+export function getQueuedMessageDisplayParts(
+  text: string,
+  skillNames: ReadonlyMap<string, string> = EMPTY_SKILL_MENTION_NAMES,
+): QueuedMessageDisplayPart[] {
   const parts: QueuedMessageDisplayPart[] = []
   let lastIndex = 0
 
@@ -295,7 +299,9 @@ export function getQueuedMessageDisplayParts(text: string): QueuedMessageDisplay
             ? `Todo ${id.slice(0, 8)}`
             : referenceType === 'calendar_event'
               ? `日程 ${id.slice(0, 8)}`
-              : decodedId
+              : referenceType === 'skill'
+                ? resolveSkillMentionName(decodedId, skillNames)
+                : decodedId
 
     parts.push({ type: 'reference', referenceType, id, label })
     lastIndex = match.index + match[0].length

--- a/apps/electron/src/renderer/lib/skill-mention-name.ts
+++ b/apps/electron/src/renderer/lib/skill-mention-name.ts
@@ -1,0 +1,9 @@
+export const EMPTY_SKILL_MENTION_NAMES: ReadonlyMap<string, string> = new Map()
+
+/** slug 保持调用身份不变，当前名称仅用于展示；Skill 删除或不可读时回退 slug。 */
+export function resolveSkillMentionName(
+  slug: string,
+  names: ReadonlyMap<string, string> = EMPTY_SKILL_MENTION_NAMES,
+): string {
+  return names.get(slug) || slug
+}


### PR DESCRIPTION
## 概述

修复 Skill 改名后，用户历史消息和待发送队列的 Skill 标签仍显示目录 slug（例如 `pull-proma`），而非当前名称的问题。消息仍保存并调用 `/skill:<slug>`，只在展示层按会话所属工作区解析名称，不改写历史消息或扩大禁用 Skill 的可调用范围。

本分支从提交时最新 upstream main `347fcb48a0f82583a445cc7eefbc8864c8bde5e0` 创建。共 10 个文件，新增 137 行、删除 29 行。

## 改动

- `apps/electron/src/renderer/atoms/skill-mention-atoms.ts`：复用现有 `getWorkspaceSkills()` 全量列表（含启用与禁用项）生成名称映射；按工作区隔离异步状态。同工作区等待刷新时保留前值，映射相同时保持引用稳定；读取失败/实际删除回退 slug，最后订阅者卸载后清理缓存，并防止旧实例误删新实例。
- `apps/electron/src/renderer/components/agent/SkillMentionNamesProvider.tsx`：向会话子树提供名称映射，无额外 DOM 容器。
- `apps/electron/src/renderer/components/agent/AgentView.tsx`：使用所属会话的 workspaceSlug 接入 Provider。
- `apps/electron/src/renderer/components/ai-elements/message.tsx`：仅 Skill 标签订阅名称 Context，其他引用不随名称更新；增加局部 ResizeObserver 观察 Markdown 自然内容，尝试在名称长度/容器宽度变化时更新折叠测量，卸载时清理观察器。**此布局部分尚未验收通过，见备注。**
- `apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx`：队列预览读取当前 Skill 名称。
- `apps/electron/src/renderer/lib/agent-message-queue.ts`：仅展示函数接收可选名称映射，发送解析与引用 ID 保持不变。
- `apps/electron/src/renderer/lib/skill-mention-name.ts`：封装名称查找与 slug 回退。
- `apps/electron/src/main/lib/workspace-watcher-utils.ts`：按工作区顶层路径分类，包含 `skills/`、`skills-inactive/` 的文件和目录变更，避免项目内同名目录误触发能力通知。
- `apps/electron/src/main/lib/workspace-watcher.ts`：接入上述分类，保留原有防抖和噪声过滤。
- `apps/electron/package.json`：版本 `0.19.32` → `0.19.33`，无新增依赖。

## 已执行验证

在最新 main 基线的新分支上重新执行：

- `bun run typecheck`：全仓通过。
- 现有 `mention-patterns.test.ts`、`agent-message-queue.test.ts`、`markdown-rich-text.test.ts`、`workspace-watcher.test.ts`：**40 pass / 0 fail，95 个断言**。
- `bun run --filter='@proma/electron' build:renderer`：通过；存在大 chunk 提示。
- `git diff --check`：通过。

用户明确要求移除本轮新增测试：两个新增 Skill 测试文件和 watcher 测试追加已移除，仓库原有测试保留。此前针对新增实现运行的专项测试仅为开发阶段证据，**不随此 PR 交付，也不代表当前 40 项原有测试覆盖了全部新增行为**。

## 测试方法（待手动验收）

1. 发送含 Skill 引用的用户消息，并在运行中的会话排队同类消息；修改 Skill 名称并保存，确认历史和队列分别显示新名称，实际调用仍为原 slug。
2. 禁用 Skill，再修改名称；历史显示应更新，但 Skill 仍不可调用。删除 Skill 时标签回退 slug。
3. 在两个工作区建立同 slug、不同名称的 Skill，切换会话并模拟慢响应，确认名称不串用。连续改名时旧响应不应覆盖最新名称。
4. 无关 MCP 配置更新时，名称不应闪回 slug；读取失败后再次刷新可恢复。
5. 长消息/长 Skill 名称、窄窗口下检查折叠按钮、展开保持与滚动位置；本项目前未验收通过。
6. 验证真实 fs.watch → IPC → renderer 更新链路，检查顶层禁用目录和项目内同名目录的事件分类。

## 备注与已知验证缺口

- 已经过独立 Agent 审核，并修复所发现的 active-only 数据源和测试假阳性问题。标题“已审核 PR”表示经过审核流程，**不表示最终版本无缺陷或运行时全部验收通过**。
- **动态折叠验证未通过：**临时浏览器 fixture 在名称变长后未找到预期折叠按钮，尚未区分测试环境与实现原因。ResizeObserver 实现仍包含在本 PR，需重点复核，不能将此项视为已修复验证完成。
- 临时浏览器检查只提供部分名称更新、DOM 保持与待决保值证据，不等同于完整 Electron 验收；无随 PR 交付的可复现挂载测试。
- 未进行真实文件监听端到端验收、GPU/Compositor profiling 或长期内存压力测试。无新增 blur、动画或图层提升属性，但名称变化可能引发布局/绘制，长历史仍需测量。
- 未安装/替换运行中的应用，本 PR 不自动合并。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
