### PR TITLE
fix(sidebar): unify context menu styles

### DIFF
--- a/apps/electron/src/renderer/components/ui/context-menu.tsx
+++ b/apps/electron/src/renderer/components/ui/context-menu.tsx
@@ -3,6 +3,13 @@ import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import {
+  menuAnimationClassName,
+  menuItemClassName,
+  menuSeparatorClassName,
+  menuSubTriggerClassName,
+  menuSurfaceClassName,
+} from "@/components/ui/menu-styles"
 
 const ContextMenu = ContextMenuPrimitive.Root
 
@@ -25,7 +32,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      menuSubTriggerClassName,
       inset && "pl-8",
       className
     )}
@@ -44,7 +51,9 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+      menuSurfaceClassName,
+      menuAnimationClassName,
+      "origin-[--radix-context-menu-content-transform-origin]",
       className
     )}
     {...props}
@@ -60,7 +69,9 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+        menuSurfaceClassName,
+        menuAnimationClassName,
+        "max-h-[--radix-context-menu-content-available-height] overflow-y-auto overflow-x-hidden origin-[--radix-context-menu-content-transform-origin]",
         className
       )}
       {...props}
@@ -78,7 +89,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      menuItemClassName,
       inset && "pl-8",
       className
     )}
@@ -157,7 +168,7 @@ const ContextMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    className={cn(menuSeparatorClassName, className)}
     {...props}
   />
 ))

--- a/apps/electron/src/renderer/components/ui/dropdown-menu.tsx
+++ b/apps/electron/src/renderer/components/ui/dropdown-menu.tsx
@@ -3,6 +3,13 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import {
+  menuAnimationClassName,
+  menuItemClassName,
+  menuSeparatorClassName,
+  menuSubTriggerClassName,
+  menuSurfaceClassName,
+} from "@/components/ui/menu-styles"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -25,7 +32,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      menuSubTriggerClassName,
       inset && "pl-8",
       className
     )}
@@ -45,8 +52,9 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border/50 bg-popover p-1 text-popover-foreground shadow-lg",
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      menuSurfaceClassName,
+      menuAnimationClassName,
+      "origin-[--radix-dropdown-menu-content-transform-origin]",
       className
     )}
     {...props}
@@ -64,8 +72,9 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-lg border border-border/50 bg-popover p-1 text-popover-foreground shadow-lg",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        menuSurfaceClassName,
+        menuAnimationClassName,
+        "max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overflow-x-hidden origin-[--radix-dropdown-menu-content-transform-origin]",
         className
       )}
       {...props}
@@ -83,8 +92,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      // 项内圆角与高亮态升级：rounded-md 跟容器更协调，focus 态用 accent/70 透明叠加更轻盈
-      "relative flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none transition-colors duration-100 focus:bg-accent/70 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      menuItemClassName,
       inset && "pl-8",
       className
     )}
@@ -163,7 +171,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn(menuSeparatorClassName, className)}
     {...props}
   />
 ))

--- a/apps/electron/src/renderer/components/ui/menu-styles.ts
+++ b/apps/electron/src/renderer/components/ui/menu-styles.ts
@@ -1,0 +1,13 @@
+export const menuSurfaceClassName =
+  "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border/50 bg-popover p-1 text-popover-foreground shadow-lg"
+
+export const menuAnimationClassName =
+  "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+
+export const menuItemClassName =
+  "relative flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none transition-colors duration-100 focus:bg-accent/70 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:pointer-events-none [&>svg]:size-4 [&>svg]:shrink-0"
+
+export const menuSubTriggerClassName =
+  "flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none transition-colors duration-100 focus:bg-accent/70 focus:text-accent-foreground data-[state=open]:bg-accent/70 data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+
+export const menuSeparatorClassName = "-mx-1 my-1 h-px bg-muted"


### PR DESCRIPTION
## Summary
- Unify ContextMenu and DropdownMenu surface, item, submenu, separator, and icon alignment styles.
- Reuse shared menu style tokens so left-sidebar right-click and three-dot menus render consistently.

## Validation
- `git diff --check` passed.
- Shared-style assertions passed.
- Isolated TypeScript compilation of the new style module passed.
- Full Electron typecheck remains blocked by the worktree dependency state and existing unrelated errors; no errors were reported from the changed menu files.

## Performance
- No new state, event, IPC, timer, or render path. CSS class sharing only; negligible runtime impact.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)