### PR TITLE
feat(agent): preview plan document during approval

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -920,8 +920,8 @@ function buildPromaProductToolDefinitions(sdk: PiSdk, canUseTool: PiAgentQueryOp
     sdk.defineTool({
       name: 'EnterPlanMode',
       label: '进入计划模式',
-      description: '进入 Proma 计划模式。进入后只能调研、整理计划，并等待用户批准后再执行写操作。',
-      promptSnippet: '进入计划模式，先调研并输出计划，再等待用户确认。',
+      description: '进入 Proma 计划模式。进入后只能调研、整理计划；将完整计划写入会话 plan/ 目录，并等待用户批准后再执行写操作。',
+      promptSnippet: '进入计划模式，先调研，将完整计划写入 plan Markdown 文档，再等待用户确认。',
       parameters: Type.Object({
         reason: Type.Optional(Type.String({ description: '进入计划模式的原因。' })),
       }),
@@ -932,10 +932,11 @@ function buildPromaProductToolDefinitions(sdk: PiSdk, canUseTool: PiAgentQueryOp
     sdk.defineTool({
       name: 'ExitPlanMode',
       label: '提交计划审批',
-      description: '向用户提交计划并请求批准。用户批准后才能退出计划模式并继续执行。',
-      promptSnippet: '提交计划审批，等待用户批准后继续执行。',
+      description: '向用户提交计划并请求批准。应传入 planFile 以便用户在右侧只读预览完整 Markdown 计划；用户批准后才能退出计划模式并继续执行。',
+      promptSnippet: '提交计划审批：附上已写入 plan/ 目录的 Markdown 计划文件，等待用户批准后继续执行。',
       parameters: Type.Object({
         plan: Type.Optional(Type.String({ description: '计划正文或摘要。' })),
+        planFile: Type.String({ description: '当前会话 plan/ 目录内、待审批的 Markdown 计划文件绝对路径（必填）。' }),
         allowedPrompts: Type.Optional(Type.Array(Type.Object({
           tool: Type.String({ description: '批准后可执行的工具，通常为 Bash。' }),
           prompt: Type.String({ description: '批准后可执行的命令或操作描述。' }),

--- a/apps/electron/src/main/lib/agent-exit-plan-service.ts
+++ b/apps/electron/src/main/lib/agent-exit-plan-service.ts
@@ -3,18 +3,21 @@
  *
  * 核心职责：
  * - 拦截 ExitPlanMode 工具调用
- * - 解析 allowedPrompts，发送到渲染进程展示审批 UI
+ * - 解析 allowedPrompts 和经校验的计划文档，发送到渲染进程展示审批 UI
  * - 等待用户选择（批准/拒绝/反馈），返回对应 PermissionResult
  * - 根据用户选择切换权限模式
  *
  * 复用 AskUserService 的 Promise + Map 异步等待模式。
  */
 
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
+import { lstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
+import { basename, extname, isAbsolute, relative, resolve, sep } from 'node:path'
 import type {
   ExitPlanModeRequest,
   ExitPlanModeResponse,
   ExitPlanAllowedPrompt,
+  ExitPlanDocument,
   PromaPermissionMode,
 } from '@proma/shared'
 
@@ -34,6 +37,8 @@ interface PendingExitPlan {
   resolve: (result: ExitPlanPermissionResult) => void
   request: ExitPlanModeRequest
   toolInput: Record<string, unknown>
+  /** 审批前复核路径归属与内容版本，防止符号链接或文件替换绕过初始校验。 */
+  planDirectory?: string
 }
 
 /** ExitPlanMode 审批结果回调（通知编排层切换权限模式） */
@@ -47,6 +52,8 @@ export interface ExitPlanModeCallbacks {
  *
  * 单例模式，管理所有会话的 ExitPlanMode 请求。
  */
+const MAX_PLAN_DOCUMENT_BYTES = 1024 * 1024
+
 export class AgentExitPlanService {
   /** 待处理的请求 Map（requestId → PendingExitPlan） */
   private pendingRequests = new Map<string, PendingExitPlan>()
@@ -54,28 +61,42 @@ export class AgentExitPlanService {
   /**
    * 处理 ExitPlanMode 工具调用
    *
-   * 解析 allowedPrompts，发送到渲染进程，阻塞等待用户选择。
+   * 解析 allowedPrompts 与计划 Markdown 工件，发送到渲染进程，阻塞等待用户选择。
    */
   handleExitPlanMode(
     sessionId: string,
     input: Record<string, unknown>,
     signal: AbortSignal,
     sendToRenderer: (request: ExitPlanModeRequest) => void,
+    options?: { planDirectory?: string },
   ): Promise<ExitPlanPermissionResult> {
     console.log(`[ExitPlanService] handleExitPlanMode 开始: sessionId=${sessionId}, signal.aborted=${signal.aborted}`)
     const allowedPrompts = this.parseAllowedPrompts(input)
+    const planDocument = this.resolvePlanDocument(input.planFile, options?.planDirectory)
+    if (!planDocument) {
+      return Promise.resolve({
+        behavior: 'deny' as const,
+        message: '提交计划审批前必须提供当前会话 plan/ 目录内、大小不超过 1 MB 的 Markdown 计划文件',
+      })
+    }
 
     const request: ExitPlanModeRequest = {
       requestId: randomUUID(),
       sessionId,
       toolInput: input,
       allowedPrompts,
+      planDocument,
     }
 
     sendToRenderer(request)
 
     return new Promise<ExitPlanPermissionResult>((resolve) => {
-      this.pendingRequests.set(request.requestId, { resolve, request, toolInput: input })
+      this.pendingRequests.set(request.requestId, {
+        resolve,
+        request,
+        toolInput: input,
+        planDirectory: options?.planDirectory,
+      })
 
       signal.addEventListener('abort', () => {
         if (this.pendingRequests.has(request.requestId)) {
@@ -101,6 +122,13 @@ export class AgentExitPlanService {
 
     switch (response.action) {
       case 'approve_bypass': {
+        if (pending.request.planDocument && !this.isPlanDocumentCurrent(pending.request.planDocument, pending.planDirectory)) {
+          pending.resolve({
+            behavior: 'deny' as const,
+            message: '计划文档在审批期间已变更，请重新提交计划审批',
+          })
+          return { sessionId, targetMode: null }
+        }
         // 批准 + 切换到完全自动模式
         pending.resolve({
           behavior: 'allow' as const,
@@ -152,6 +180,50 @@ export class AgentExitPlanService {
         this.pendingRequests.delete(requestId)
       }
     }
+  }
+
+  /**
+   * 计划文档必须是当前会话 plan/ 目录内的真实 Markdown 常规文件。
+   * 使用 realpath 同时阻止 `..` 与符号链接逃逸；缺失、越界或超限时直接拒绝审批。
+   */
+  private resolvePlanDocument(value: unknown, planDirectory: string | undefined): ExitPlanDocument | undefined {
+    if (typeof value !== 'string' || !value.trim() || !isAbsolute(value.trim()) || !planDirectory) return undefined
+
+    try {
+      const planDirectoryStat = lstatSync(planDirectory)
+      if (planDirectoryStat.isSymbolicLink() || !planDirectoryStat.isDirectory()) return undefined
+      const resolvedPlanDirectory = realpathSync(planDirectory)
+      const candidatePath = resolve(value.trim())
+      const candidateStat = lstatSync(candidatePath)
+      if (candidateStat.isSymbolicLink() || !candidateStat.isFile()) return undefined
+      const resolvedFilePath = realpathSync(candidatePath)
+      const relativePath = relative(resolvedPlanDirectory, resolvedFilePath)
+      const isInsidePlanDirectory = relativePath.length > 0
+        && !relativePath.startsWith(`..${sep}`)
+        && relativePath !== '..'
+        && !isAbsolute(relativePath)
+
+      if (!isInsidePlanDirectory || extname(resolvedFilePath).toLowerCase() !== '.md' || !lstatSync(resolvedFilePath).isFile()) {
+        return undefined
+      }
+      const fileSize = statSync(resolvedFilePath).size
+      if (fileSize > MAX_PLAN_DOCUMENT_BYTES) return undefined
+
+      return {
+        filePath: resolvedFilePath,
+        displayName: basename(resolvedFilePath),
+        contentHash: createHash('sha256').update(readFileSync(resolvedFilePath)).digest('hex'),
+      }
+    } catch (error) {
+      console.warn('[ExitPlanService] 忽略无效计划文档:', error)
+      return undefined
+    }
+  }
+
+  /** 批准前重新验证文档位置和哈希，确保用户批准的是提交时的同一版本。 */
+  private isPlanDocumentCurrent(document: ExitPlanDocument, planDirectory: string | undefined): boolean {
+    const current = this.resolvePlanDocument(document.filePath, planDirectory)
+    return current?.filePath === document.filePath && current.contentHash === document.contentHash
   }
 
   /**

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -15,6 +15,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
+import { mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
@@ -49,7 +50,7 @@ import { getAdapter, fetchTitle } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
-import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, removeSDKErrorMessage, updateSDKUserMessageSkillActivations, rewindPiAgentSession, resolveAgentCwd, getActiveWorktreePath, getAgentCwdMode, getSessionWorkbenchLayout } from './agent-session-manager'
+import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, removeSDKErrorMessage, updateSDKUserMessageSkillActivations, rewindPiAgentSession, resolveAgentCwd, getActiveWorktreePath, getAgentCwdMode, getSessionWorkbenchLayout, resolveSessionWorkbenchContextDir } from './agent-session-manager'
 import { getAgentWorkspace, getProjectFilesPath, getWorkspaceMcpConfig, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles, getWorkspaceAgentsMdPath, readWorkspaceAgentsMd, getWorkspaceMemoryGuidance, isWorkspaceProjectKnowledgeMaintenanceApproved } from './agent-workspace-manager'
 import { getLocalProjectRootStatus } from './project-root-health'
 import { getMcpApiKeyEnvironment, getMcpOAuthHeaders } from './mcp-oauth-service'
@@ -67,6 +68,7 @@ import { resolvePlanningDeletionPermission } from './planning-permission-policy'
 import { askUserService } from './agent-ask-user-service'
 import { exitPlanService, type ExitPlanPermissionResult } from './agent-exit-plan-service'
 import { validateToolInput } from './agent-tool-input-validator'
+import { isSessionPlanMarkdownPath } from './agent-plan-file-policy'
 import { estimateTokenCount, WRITE_CONTENT_TOKEN_THRESHOLD } from './agent-tool-token-estimator'
 import { buildPiBuiltinTools } from './adapters/pi-builtin-tools'
 import { getAgentVaultRoots, getVaultUserContext } from './vault-service'
@@ -1142,6 +1144,29 @@ export class AgentOrchestrator {
       const getPermissionMode = (): PromaPermissionMode =>
         this.sessionPermissionModes.get(sessionId) ?? initialPermissionMode
 
+      // 计划工件只允许来自当前会话的工作台 plan/ 目录；ExitPlanMode 服务会做 realpath + 哈希复核。
+      const sessionPlanDirectory = (() => {
+        const sessionContextDirectory = resolveSessionWorkbenchContextDir(
+          workspace,
+          sessionId,
+          getSessionWorkbenchLayout(sessionMeta),
+        )
+        return sessionContextDirectory ? join(sessionContextDirectory, 'plan') : undefined
+      })()
+      // 计划目录由 Proma 创建，确保后续路径策略不需要为首次写入放宽符号链接校验。
+      // 运行中切换到 Plan 模式时，也会在首次写入前调用此函数。
+      const ensureSessionPlanDirectory = (): boolean => {
+        if (!sessionPlanDirectory) return false
+        try {
+          mkdirSync(sessionPlanDirectory, { recursive: true })
+          return true
+        } catch (error) {
+          console.warn(`[Agent 编排] 创建计划目录失败: ${sessionPlanDirectory}`, error)
+          return false
+        }
+      }
+      if (initialPermissionMode === 'plan') ensureSessionPlanDirectory()
+
       // ExitPlanMode 拦截器：plan 模式下走 UI 审批流程
       const handleExitPlanMode = (toolInput: Record<string, unknown>, signal: AbortSignal): Promise<ExitPlanPermissionResult> => {
         return exitPlanService.handleExitPlanMode(
@@ -1151,6 +1176,7 @@ export class AgentOrchestrator {
           (request: ExitPlanModeRequest) => {
             this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'exit_plan_mode_request', request } })
           },
+          { planDirectory: sessionPlanDirectory },
         )
       }
 
@@ -1299,6 +1325,7 @@ export class AgentOrchestrator {
 
         // EnterPlanMode：标记进入状态，通知渲染进程
         if (toolName === 'EnterPlanMode') {
+          ensureSessionPlanDirectory()
           planModeEntered = true
           emitPlanModeChanged(true, 'tool')
           this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'enter_plan_mode', sessionId } })
@@ -1389,16 +1416,17 @@ export class AgentOrchestrator {
             return { behavior: 'allow' as const, updatedInput: input }
 
           case 'plan': {
-            // Plan 模式：只允许只读工具 + Write/Edit 任意 .md 文件（计划文档）
+            // Plan 模式：只允许只读工具，以及当前会话 plan/ 目录中的 Markdown 计划文档。
             if (PLAN_MODE_ALLOWED_TOOLS.has(toolName)) {
               return { behavior: 'allow' as const, updatedInput: input }
             }
-            // 允许 Write/Edit 到任意 .md 文件（计划文档一定是 markdown；非 .md 仍被拒）
+            // 计划文档必须位于会话私有 plan/ 目录，避免以 Markdown 名义修改项目或用户文档。
             if (toolName === 'Write' || toolName === 'Edit') {
               const filePath = typeof input.file_path === 'string' ? input.file_path : ''
-              if (filePath.toLowerCase().endsWith('.md')) {
+              if (ensureSessionPlanDirectory() && isSessionPlanMarkdownPath(filePath, sessionPlanDirectory)) {
                 return { behavior: 'allow' as const, updatedInput: input }
               }
+              return { behavior: 'deny' as const, message: '计划模式下只能在当前会话的 plan/ 目录中写入 Markdown 计划文档，请在计划审批通过后再修改其他文件' }
             }
             // Bash 工具：只读命令（find、grep、cat 等）允许执行，写操作拒绝
             if (toolName === 'Bash') {

--- a/apps/electron/src/main/lib/agent-plan-file-policy.ts
+++ b/apps/electron/src/main/lib/agent-plan-file-policy.ts
@@ -1,0 +1,42 @@
+import { existsSync, lstatSync, realpathSync } from 'node:fs'
+import { dirname, extname, isAbsolute, relative, resolve, sep } from 'node:path'
+
+function isPathInside(root: string, candidate: string, allowRoot = false): boolean {
+  const relativePath = relative(root, candidate)
+  return (allowRoot && relativePath.length === 0)
+    || (relativePath.length > 0
+      && relativePath !== '..'
+      && !relativePath.startsWith(`..${sep}`)
+      && !isAbsolute(relativePath))
+}
+
+/**
+ * Plan 模式的 Markdown 写入必须明确指向当前会话的 plan/ 目录。
+ *
+ * 相对路径由底层工具按 Agent cwd 解析，不能可靠地映射到计划目录，因此一律拒绝。
+ * 已存在文件及其父目录同时以 realpath 复核，并拒绝任何符号链接，避免写入逃逸到项目或用户文件。
+ */
+export function isSessionPlanMarkdownPath(filePath: string, planDirectory: string | undefined): boolean {
+  if (!planDirectory || !isAbsolute(filePath) || extname(filePath).toLowerCase() !== '.md') return false
+
+  try {
+    if (!existsSync(planDirectory) || lstatSync(planDirectory).isSymbolicLink()) return false
+    const declaredPlanDirectory = resolve(planDirectory)
+    const resolvedPlanDirectory = realpathSync(declaredPlanDirectory)
+    const resolvedFilePath = resolve(filePath)
+    if (!isPathInside(declaredPlanDirectory, resolvedFilePath)) return false
+
+    if (existsSync(resolvedFilePath)) {
+      const fileStat = lstatSync(resolvedFilePath)
+      if (fileStat.isSymbolicLink() || !fileStat.isFile()) return false
+      return isPathInside(resolvedPlanDirectory, realpathSync(resolvedFilePath))
+    }
+
+    // 新文件只能创建在既有、非符号链接的 plan/ 子目录中；不允许隐式穿过符号链接父目录。
+    const parentDirectory = dirname(resolvedFilePath)
+    if (!existsSync(parentDirectory) || lstatSync(parentDirectory).isSymbolicLink()) return false
+    return isPathInside(resolvedPlanDirectory, realpathSync(parentDirectory), true)
+  } catch {
+    return false
+  }
+}

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -177,9 +177,9 @@ ${agentsMaintenanceRequirement}
       : undefined,
     ctx.permissionMode === 'plan'
       ? `## 计划模式
-只调研和规划。计划写入 \`${sessionContextDir}/plan/\`；先展示摘要并等待用户批准，再退出计划模式和执行。`
+只调研和规划。将完整计划写入 \`${sessionContextDir}/plan/\`（如 \`${sessionContextDir}/plan/my-plan.md\`）；调用 \`ExitPlanMode\` 时传入该文件的绝对 \`planFile\` 路径。先展示摘要并等待用户批准，再退出计划模式和执行。`
       : `## 计划模式
-进入计划模式时，计划文件写入 \`${sessionContextDir}/plan/\`（如 \`${sessionContextDir}/plan/my-plan.md\`），不要写到项目根。`,
+进入计划模式时，将完整计划写入 \`${sessionContextDir}/plan/\`（如 \`${sessionContextDir}/plan/my-plan.md\`），不要写到项目根；调用 \`ExitPlanMode\` 审批时传入该文件的绝对 \`planFile\` 路径，以便在右侧只读预览。`,
     buildGitAttributionPromptSection(isGitAttributionEnabled(getSettings().gitAttributionEnabled)),
     `## 回复
 - 一切呈现给用户的内容——对话回复、交付文档、代码与提交信息——必须语意连贯、易于阅读：句子完整，前后逻辑衔接，结构清晰可快速扫读。

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -19,6 +19,7 @@ import {
   FileText,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useOpenPreview } from '@/components/diff/preview-opener'
 import { allPendingExitPlanRequestsAtom, agentStreamingStatesAtom } from '@/atoms/agent-atoms'
 import type { ExitPlanModeAction, ExitPlanAllowedPrompt } from '@proma/shared'
 
@@ -62,6 +63,7 @@ interface ExitPlanModeBannerProps {
 export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): React.ReactElement | null {
   const [allRequests, setAllRequests] = useAtom(allPendingExitPlanRequestsAtom)
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
+  const openPreview = useOpenPreview()
   const requests = allRequests.get(sessionId) ?? []
   const [focusedIdx, setFocusedIdx] = React.useState(0)
   const [showFeedback, setShowFeedback] = React.useState(false)
@@ -112,6 +114,15 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
   handleActionRef.current = handleAction
 
   /** 关闭计划审批 & 终止 Agent */
+  const handleOpenPlanDocument = React.useCallback((): void => {
+    if (!request?.planDocument) return
+    openPreview(sessionId, {
+      filePath: request.planDocument.filePath,
+      previewOnly: true,
+      readOnly: true,
+    })
+  }, [openPreview, request?.planDocument, sessionId])
+
   const handleDismiss = (): void => {
     setStreamingStates((prev) => {
       const current = prev.get(sessionId)
@@ -198,6 +209,17 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
         <div className="flex items-center gap-2 mb-1">
           <FileText className="size-4 text-primary" />
           <span className="text-sm font-medium text-foreground flex-1">Agent 计划待审批</span>
+          {request.planDocument && (
+            <button
+              type="button"
+              className="flex h-7 items-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+              onClick={handleOpenPlanDocument}
+              title={`在右侧查看 ${request.planDocument.displayName}`}
+            >
+              <FileText className="size-3.5" />
+              查看计划
+            </button>
+          )}
           <button
             type="button"
             className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"

--- a/apps/electron/src/renderer/components/diff/preview-opener.ts
+++ b/apps/electron/src/renderer/components/diff/preview-opener.ts
@@ -31,40 +31,49 @@ export interface OpenPreviewOptions {
   mode?: 'tab' | 'split'
 }
 
+/**
+ * 在指定会话的右侧工作区中打开并聚焦文件预览。
+ *
+ * 供 React Hook 和 IPC 事件处理器共同复用，保证计划审批等外部事件不会绕过预览 Tab 的状态约定。
+ */
+export function openPreviewInStore(store: JotaiStore, sessionId: string, file: PreviewFile): void {
+  const previewId = getPreviewFileId(file)
+  store.set(previewFilesMapAtom, (prev) => {
+    const next = new Map(prev)
+    const files = next.get(sessionId) ?? []
+    // 同一预览身份再次打开时保留 Tab 顺序，但采用最新权限、根目录与解析上下文。
+    // 否则先以只读/Skill 上下文打开后会永久复用过期元数据。
+    const existingIndex = files.findIndex((item) => getPreviewFileId(item) === previewId)
+    next.set(sessionId, existingIndex === -1
+      ? [...files, file]
+      : files.map((item, index) => index === existingIndex ? file : item))
+    return next
+  })
+  store.set(previewFileMapAtom, (prev) => {
+    const next = new Map(prev)
+    next.set(sessionId, file)
+    return next
+  })
+  store.set(previewPanelOpenMapAtom, (prev) => {
+    const next = new Map(prev)
+    next.set(sessionId, true)
+    return next
+  })
+  // 所有入口都复用同一右侧工作区，并以会话为粒度隔离预览状态。
+  store.set(agentSidePanelOpenAtomFamily(sessionId), true)
+  store.set(agentDiffPanelTabAtom, (prev) => {
+    const next = new Map(prev)
+    next.set(sessionId, getPreviewSidePanelTab(previewId))
+    return next
+  })
+}
+
 export function useOpenPreview() {
   const store = useStore()
 
   return React.useCallback(
     (sessionId: string, file: PreviewFile, _options?: OpenPreviewOptions) => {
-      const previewId = getPreviewFileId(file)
-      store.set(previewFilesMapAtom, (prev) => {
-        const next = new Map(prev)
-        const files = next.get(sessionId) ?? []
-        // 同一预览身份再次打开时保留 Tab 顺序，但采用最新权限、根目录与解析上下文。
-        // 否则先以只读/Skill 上下文打开后会永久复用过期元数据。
-        const existingIndex = files.findIndex((item) => getPreviewFileId(item) === previewId)
-        next.set(sessionId, existingIndex === -1
-          ? [...files, file]
-          : files.map((item, index) => index === existingIndex ? file : item))
-        return next
-      })
-      store.set(previewFileMapAtom, (prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, file)
-        return next
-      })
-      store.set(previewPanelOpenMapAtom, (prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, true)
-        return next
-      })
-      // 所有入口都复用同一右侧工作区，并以会话为粒度隔离预览状态。
-      store.set(agentSidePanelOpenAtomFamily(sessionId), true)
-      store.set(agentDiffPanelTabAtom, (prev) => {
-        const next = new Map(prev)
-        next.set(sessionId, getPreviewSidePanelTab(previewId))
-        return next
-      })
+      openPreviewInStore(store, sessionId, file)
     },
     [store],
   )

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -100,6 +100,7 @@ import { detectIsWindows } from '@/lib/platform'
 import { arePathsEqual, getInactiveSessionFileChangePaths, getSessionFileChangeKind, getOwnedSessionWatcherPaths, removeSessionFileChange, upsertSessionFileChange, type SessionFileChange } from '@/lib/session-file-changes'
 import { rememberStopGenerationTarget } from '@/lib/stop-generation-target'
 import { doesWorkspaceChangeAffectPreview } from '@/components/diff/preview-open-path'
+import { openPreviewInStore } from '@/components/diff/preview-opener'
 import { removeQueuedMessage, createQueuedAgentStreamState, createAgentQueuedMessage } from '@/lib/agent-message-queue'
 import { createAgentStreamEventBatcher } from '@/lib/agent-stream-event-batcher'
 import { getChangedWorkspaceComponentFromSdkMessage, shouldRevealChangedWorkspaceComponentImmediately } from '@/lib/agent-component-activation'
@@ -918,6 +919,64 @@ export function useGlobalAgentListeners(): void {
       })
     }
 
+    const openPlanDocumentPreview = (sessionId: string, planDocument: NonNullable<import('@proma/shared').ExitPlanModeRequest['planDocument']>): void => {
+      const planPreview: PreviewFile = {
+        filePath: planDocument.filePath,
+        previewOnly: true,
+        readOnly: true,
+      }
+      openPreviewInStore(store, sessionId, planPreview)
+      // 同一路径在反馈后重新提交时必须绕过旧内容缓存，确保审批页重读本次哈希对应的文件版本。
+      bumpPreviewContentRefresh(sessionId, planPreview)
+    }
+
+    // pending 快照与实时事件可以乱序抵达。保留有限的已解决 ID，避免迟到快照复活已处理横幅。
+    const resolvedExitPlanRequestIds = new Set<string>()
+    const markExitPlanRequestResolved = (requestId: string): void => {
+      resolvedExitPlanRequestIds.add(requestId)
+      if (resolvedExitPlanRequestIds.size > 256) {
+        const oldest = resolvedExitPlanRequestIds.values().next().value
+        if (oldest) resolvedExitPlanRequestIds.delete(oldest)
+      }
+      store.set(allPendingExitPlanRequestsAtom, (prev) => {
+        let changed = false
+        const next = new Map(prev)
+        for (const [sessionId, requests] of prev) {
+          const remaining = requests.filter((request) => request.requestId !== requestId)
+          if (remaining.length === requests.length) continue
+          changed = true
+          if (remaining.length > 0) next.set(sessionId, remaining)
+          else next.delete(sessionId)
+        }
+        return changed ? next : prev
+      })
+    }
+
+    const queueExitPlanRequest = (request: import('@proma/shared').ExitPlanModeRequest): boolean => {
+      if (resolvedExitPlanRequestIds.has(request.requestId)) return false
+      let inserted = false
+      store.set(allPendingExitPlanRequestsAtom, (prev) => {
+        const current = prev.get(request.sessionId) ?? []
+        if (current.some((item) => item.requestId === request.requestId)) return prev
+        inserted = true
+        const map = new Map(prev)
+        map.set(request.sessionId, [...current, request])
+        return map
+      })
+      return inserted
+    }
+
+    // renderer 重载后，主进程仍保留未决审批；恢复横幅时同步重建只读计划预览。
+    void window.electronAPI.getPendingRequests()
+      .then(({ exitPlans }) => {
+        for (const request of exitPlans) {
+          if (queueExitPlanRequest(request) && request.planDocument) {
+            openPlanDocumentPreview(request.sessionId, request.planDocument)
+          }
+        }
+      })
+      .catch((error) => console.warn('[GlobalAgentListeners] 恢复待处理审批请求失败', error))
+
     const refreshAffectedPreviews = (filePaths: readonly string[]): void => {
       if (filePaths.length === 0) return
       const previewsBySession = store.get(previewFilesMapAtom)
@@ -1550,13 +1609,11 @@ export function useGlobalAgentListeners(): void {
               return map
             })
           } else if (event.type === 'exit_plan_mode_request') {
-            // ExitPlanMode 请求入队
-            store.set(allPendingExitPlanRequestsAtom, (prev) => {
-              const map = new Map(prev)
-              const current = map.get(sessionId) ?? []
-              map.set(sessionId, [...current, event.request])
-              return map
-            })
+            // 计划文件已由主进程限定在当前会话 plan/ 目录。审批到达时自动以只读 Markdown 打开；
+            // 不切换主会话，因此后台会话不会抢走用户的当前工作。
+            if (queueExitPlanRequest(event.request) && event.request.planDocument) {
+              openPlanDocumentPreview(sessionId, event.request.planDocument)
+            }
             // 退出 Plan 模式指示状态
             store.set(agentPlanModeSessionsAtom, (prev: Set<string>) => {
               if (!prev.has(sessionId)) return prev
@@ -1571,6 +1628,8 @@ export function useGlobalAgentListeners(): void {
               'Agent 已完成计划，等待你的审批',
               'exitPlanMode'
             )
+          } else if (event.type === 'exit_plan_mode_resolved') {
+            markExitPlanRequestResolved(event.requestId)
           } else if (event.type === 'enter_plan_mode') {
             // 进入 Plan 模式
             store.set(agentPlanModeSessionsAtom, (prev: Set<string>) =>

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1627,6 +1627,16 @@ export interface ExitPlanAllowedPrompt {
   prompt: string
 }
 
+/** 经主进程校验的计划 Markdown 工件，用于审批时的只读预览。 */
+export interface ExitPlanDocument {
+  /** 计划文件的规范化绝对路径；必须位于当前会话的 plan/ 目录。 */
+  filePath: string
+  /** 供右侧预览 Tab 展示的文件名。 */
+  displayName: string
+  /** 提交审批时的内容哈希；批准前若文件变化则要求重新提交。 */
+  contentHash: string
+}
+
 /** ExitPlanMode 请求（主进程 → 渲染进程） */
 export interface ExitPlanModeRequest {
   /** 请求唯一 ID */
@@ -1637,6 +1647,8 @@ export interface ExitPlanModeRequest {
   toolInput: Record<string, unknown>
   /** 解析后的 allowedPrompts 列表 */
   allowedPrompts: ExitPlanAllowedPrompt[]
+  /** 本次待审批的计划文档；未提供或校验失败时省略。 */
+  planDocument?: ExitPlanDocument
 }
 
 /** ExitPlanMode 用户选择行为 */


### PR DESCRIPTION
## Summary
- Open the submitted session plan Markdown in a right-side, read-only preview when approval is requested.
- Require and validate the plan artifact, including real-path, hash, size, and symlink checks before approval can grant bypass mode.
- Restrict Plan-mode Markdown writes to the session plan directory and restore pending approval previews after renderer reloads.

## Validation
- `bun run typecheck`
- `bun run electron:build`
- Dedicated test files removed at maintainer request.

## Performance
- Low risk: preview and cache refresh happen once per approval or pending-request recovery, not on streamed events.
- Main-process hashing is capped at 1 MB; no new persistent timer or IPC listener is introduced.
- Electron/Chromium manual interaction profiling was not run; remaining risk is limited to the one-time right-panel render for a 1 MB Markdown document.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)