### PR TITLE
fix(skills): 保持自动保存后的编辑与资源状态【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.36",
+  "version": "0.19.37",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -9,6 +9,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, mkdirSync, statSync, lstatSync, openSync, readSync, closeSync, realpathSync } from 'node:fs'
 import { cp as cpAsync, readFile as readFileAsync, realpath as realpathAsync, writeFile as writeFileAsync } from 'node:fs/promises'
 import type { Dirent } from 'node:fs'
+import { writeExistingSkillFile } from './skill-file-write'
 import { rmSyncWithRetry, renameIfDestinationAbsentWithRetry, renameWithRetry } from './fs-retry'
 import { getLocalProjectRootStatus } from './project-root-health'
 import { writeJsonFileAtomic, readJsonFileSafe, writeTextFileAtomic } from './safe-file'
@@ -1777,17 +1778,8 @@ export function writeSkillFile(workspaceSlug: string, skillSlug: string, relativ
     throw new Error(`内容过大（${(byteLen / 1024 / 1024).toFixed(2)} MB），超过 10 MB 限制`)
   }
 
-  if (existsSync(abs) && statSync(abs).isDirectory()) {
-    throw new Error(`目标是目录，无法写入文件内容: ${relativePath}`)
-  }
-
-  // 自动创建父目录
-  const parent = dirname(abs)
-  if (!existsSync(parent)) {
-    mkdirSync(parent, { recursive: true })
-  }
-
-  writeFileSync(abs, content, 'utf-8')
+  // 资源创建由 createSkillEntry 负责；编辑保存不能重建已删除/重命名的旧路径。
+  writeExistingSkillFile(abs, content)
   console.log(`[Agent 工作区] 已更新 Skill 子文件: ${workspaceSlug}/${skillSlug}/${relativePath}`)
 }
 

--- a/apps/electron/src/main/lib/skill-file-write.ts
+++ b/apps/electron/src/main/lib/skill-file-write.ts
@@ -1,0 +1,14 @@
+import { openSync, closeSync, fstatSync, ftruncateSync, writeFileSync } from 'node:fs'
+
+/** 编辑已有资源，不允许保存时重建被外部删除/重命名的旧路径。 */
+export function writeExistingSkillFile(path: string, content: string): void {
+  // r+ 不带 O_CREAT；即使 renderer 核验后发生删除，也不会意外重建路径。
+  const fd = openSync(path, 'r+')
+  try {
+    if (!fstatSync(fd).isFile()) throw new Error('目标不是文件，无法保存 Skill 资源')
+    writeFileSync(fd, content, 'utf-8')
+    ftruncateSync(fd, Buffer.byteLength(content, 'utf-8'))
+  } finally {
+    closeSync(fd)
+  }
+}

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx
@@ -21,7 +21,7 @@ import { extractSkillBody, rebuildSkillMd } from './skillMdUtils'
 export interface SkillDetailViewProps {
   skill: SkillMeta
   workspaceSlug: string
-  /** 外部能力变更后由数据层递增，用于重新读取 SKILL.md。 */
+  /** 外部能力变更后由数据层递增，用于重新读取 SKILL.md 和静默刷新资源树。 */
   contentVersion: number
   isBuiltin: boolean
   updating: boolean
@@ -58,6 +58,8 @@ export function SkillDetailView({
   const skillSlugRef = React.useRef(skill.slug)
   const loadRequestRef = React.useRef(0)
   const saveRequestRef = React.useRef(0)
+  // 写入开始和完成都会使此前发起的读取失效，避免 watcher 的旧快照回滚正文。
+  const writeRevisionRef = React.useRef(0)
   const saveInFlightRef = React.useRef(false)
   const flushPendingRef = React.useRef(false)
   const failedSnapshotRef = React.useRef<{ name: string; description: string; body: string } | null>(null)
@@ -107,10 +109,17 @@ export function SkillDetailView({
 
   React.useEffect(() => {
     const requestId = ++loadRequestRef.current
-    setLoadingContent(true)
+    const writeRevision = writeRevisionRef.current
+    let cancelled = false
+    const isCurrentRead = (): boolean => !cancelled
+      && loadRequestRef.current === requestId
+      && writeRevisionRef.current === writeRevision
+    // 同一文档的 watcher 刷新不能卸载滚动容器和 CodeMirror，否则会丢失
+    // 滚动位置、焦点、选区及撤销历史。仅首次读取使用阻塞式加载占位。
+    if (contentRef.current === null) setLoadingContent(true)
     window.electronAPI.readSkillContent(workspaceSlug, skill.slug)
       .then((text) => {
-        if (loadRequestRef.current !== requestId) return
+        if (!isCurrentRead()) return
         const externalBody = extractSkillBody(text)
         contentRef.current = text
         setContent(text)
@@ -121,14 +130,14 @@ export function SkillDetailView({
         }
       })
       .catch((err) => {
-        if (loadRequestRef.current !== requestId) return
+        if (!isCurrentRead()) return
+        // 后台读取失败不清空已加载内容，让当前草稿仍然可以继续编辑和保存。
         console.error('[SkillDetail] 加载内容失败:', err)
-        contentRef.current = null
-        setContent(null)
       })
       .finally(() => {
-        if (loadRequestRef.current === requestId) setLoadingContent(false)
+        if (!cancelled && loadRequestRef.current === requestId) setLoadingContent(false)
       })
+    return () => { cancelled = true }
   }, [contentVersion, skill.slug, workspaceSlug, updateDraft])
 
   const saveDraft = React.useCallback((): void => {
@@ -157,10 +166,12 @@ export function SkillDetailView({
 
     // 700ms 防抖后串行写入，避免快速连续输入造成写入乱序。
     saveInFlightRef.current = true
+    ++writeRevisionRef.current
     if (mountedRef.current) setSaving(true)
     void window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, nextContent)
       .then(() => {
         if (saveRequestRef.current !== requestId) return
+        ++writeRevisionRef.current
         contentRef.current = nextContent
         savedRef.current = snapshot
         failedSnapshotRef.current = null
@@ -362,6 +373,7 @@ export function SkillDetailView({
                 <SkillFilesPanel
                   workspaceSlug={workspaceSlug}
                   skillSlug={skill.slug}
+                  contentVersion={contentVersion}
                   onFileCountChange={setFileCount}
                 />
               </div>

--- a/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
@@ -29,6 +29,8 @@ import { cn } from '@/lib/utils'
 interface SkillFilesPanelProps {
   workspaceSlug: string
   skillSlug: string
+  /** watcher 通知；同一 Skill 只静默刷新资源树，不重置编辑状态。 */
+  contentVersion?: number
   /** 文件总数（不含目录）变化时通知父组件，用于 Tab 徽章 */
   onFileCountChange?: (count: number) => void
 }
@@ -51,7 +53,13 @@ function countTree(nodes: SkillFileNode[]): { files: number; dirs: number } {
   return { files, dirs }
 }
 
-export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }: SkillFilesPanelProps): React.ReactElement {
+function hasFile(nodes: SkillFileNode[], path: string): boolean {
+  return nodes.some((node) => node.type === 'file'
+    ? node.relativePath === path
+    : hasFile(node.children ?? [], path))
+}
+
+export function SkillFilesPanel({ workspaceSlug, skillSlug, contentVersion = 0, onFileCountChange }: SkillFilesPanelProps): React.ReactElement {
   const [tree, setTree] = React.useState<SkillFileNode[]>([])
   const [loading, setLoading] = React.useState(true)
   const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
@@ -62,6 +70,16 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
   const [editing, setEditing] = React.useState(false)
   const [editText, setEditText] = React.useState('')
   const [saving, setSaving] = React.useState(false)
+  const [missingFile, setMissingFile] = React.useState(false)
+  const [treeError, setTreeError] = React.useState(false)
+  const scopeRef = React.useRef(0)
+  const treeRequestRef = React.useRef(0)
+  const fileRequestRef = React.useRef(0)
+  const treeLoadedRef = React.useRef(false)
+  const selectedRef = React.useRef(selected)
+  selectedRef.current = selected
+  const missingFileRef = React.useRef(missingFile)
+  missingFileRef.current = missingFile
 
   const [creating, setCreating] = React.useState<{ type: 'file' | 'directory'; parent: string } | null>(null)
   const [createName, setCreateName] = React.useState('')
@@ -74,47 +92,106 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
     onFileCountChangeRef.current = onFileCountChange
   }, [onFileCountChange])
 
-  const refreshTree = React.useCallback(async (): Promise<void> => {
+  // 身份变化才重置状态；普通 watcher 通知不能卸载树、编辑器或清除草稿。
+  React.useEffect(() => {
+    ++scopeRef.current
+    treeLoadedRef.current = false
+    setTree([])
     setLoading(true)
-    try {
-      const nodes = await window.electronAPI.listSkillFiles(workspaceSlug, skillSlug)
-      setTree(nodes)
-      onFileCountChangeRef.current?.(countTree(nodes).files)
-    } catch (err) {
-      console.error('[SkillFiles] 加载文件树失败:', err)
-      toast.error('加载文件树失败')
-    } finally {
-      setLoading(false)
+    setTreeError(false)
+    setSelected(null)
+    selectedRef.current = null
+    setFileContent(null)
+    setLoadingFile(false)
+    setEditing(false)
+    setEditText('')
+    setSaving(false)
+    setMissingFile(false)
+    missingFileRef.current = false
+    setExpanded(new Set())
+    setCreating(null)
+    setCreateName('')
+    setRenaming(null)
+    setRenameValue('')
+    onFileCountChangeRef.current?.(0)
+    return () => {
+      ++scopeRef.current
+      ++treeRequestRef.current
+      ++fileRequestRef.current
     }
   }, [workspaceSlug, skillSlug])
 
+  const markMissing = React.useCallback((): void => {
+    // 保留已加载内容/草稿；路径重新出现也不能自动解除锁定，须显式重新打开。
+    missingFileRef.current = true
+    setMissingFile(true)
+    ++fileRequestRef.current
+    setLoadingFile(false)
+  }, [])
+
+  const refreshTree = React.useCallback(async (): Promise<void> => {
+    const scope = scopeRef.current
+    const request = ++treeRequestRef.current
+    const isCurrent = (): boolean => scope === scopeRef.current && request === treeRequestRef.current
+    if (!treeLoadedRef.current) setLoading(true)
+    try {
+      const nodes = await window.electronAPI.listSkillFiles(workspaceSlug, skillSlug)
+      if (!isCurrent()) return
+      treeLoadedRef.current = true
+      setTree(nodes)
+      setTreeError(false)
+      onFileCountChangeRef.current?.(countTree(nodes).files)
+      if (selectedRef.current && !hasFile(nodes, selectedRef.current)) markMissing()
+    } catch (err) {
+      if (!isCurrent()) return
+      console.error('[SkillFiles] 加载文件树失败:', err)
+      setTreeError(true)
+      toast.error('加载文件树失败')
+    } finally {
+      if (isCurrent()) setLoading(false)
+    }
+  }, [workspaceSlug, skillSlug, markMissing])
+
   React.useEffect(() => {
     void refreshTree()
-    setSelected(null)
-    setFileContent(null)
-    setEditing(false)
-    setExpanded(new Set())
-  }, [refreshTree])
+    return () => { ++treeRequestRef.current }
+  }, [refreshTree, contentVersion])
 
   const openFile = React.useCallback(
     async (relativePath: string): Promise<void> => {
+      if (saving) return
+      if (editing && editText !== (fileContent?.content ?? '')
+        && !window.confirm('当前文件有未保存的修改，确认放弃并打开文件？')) return
+      const scope = scopeRef.current
+      const request = ++fileRequestRef.current
+      const isCurrent = (): boolean => scope === scopeRef.current && request === fileRequestRef.current
+      selectedRef.current = relativePath
       setSelected(relativePath)
+      setMissingFile(false)
+      missingFileRef.current = false
       setEditing(false)
+      setFileContent(null)
       setLoadingFile(true)
       try {
         const result = await window.electronAPI.readSkillFile(workspaceSlug, skillSlug, relativePath)
+        if (!isCurrent()) return
         setFileContent(result)
         setEditText(result.content ?? '')
       } catch (err) {
+        if (!isCurrent()) return
         console.error('[SkillFiles] 读取文件失败:', err)
         toast.error(err instanceof Error ? err.message : '读取文件失败')
         setFileContent(null)
       } finally {
-        setLoadingFile(false)
+        if (isCurrent()) setLoadingFile(false)
       }
     },
-    [workspaceSlug, skillSlug],
+    [workspaceSlug, skillSlug, saving, editing, editText, fileContent],
   )
+
+  // 创建操作可能跨过一轮编辑；完成后必须使用最新草稿状态判断是否可切换。
+  const openFileRef = React.useRef(openFile)
+  openFileRef.current = openFile
 
   const toggleExpand = (path: string): void => {
     setExpanded((prev) => {
@@ -126,19 +203,33 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
   }
 
   const saveFile = async (): Promise<void> => {
-    if (!fileContent) return
+    if (!fileContent || saving || missingFileRef.current) return
+    const scope = scopeRef.current
+    const request = fileRequestRef.current
+    const isCurrent = (): boolean => scope === scopeRef.current && request === fileRequestRef.current
+    const snapshot = editText
     setSaving(true)
     try {
-      await window.electronAPI.writeSkillFile(workspaceSlug, skillSlug, fileContent.relativePath, editText)
-      setFileContent({ ...fileContent, content: editText, size: new Blob([editText]).size })
+      // 先核验以给出明确失效提示；主进程也拒绝创建缺失路径，封住核验后的删除竞态。
+      const nodes = await window.electronAPI.listSkillFiles(workspaceSlug, skillSlug)
+      if (!isCurrent() || missingFileRef.current) return
+      if (!hasFile(nodes, fileContent.relativePath)) {
+        markMissing()
+        void refreshTree()
+        return
+      }
+      await window.electronAPI.writeSkillFile(workspaceSlug, skillSlug, fileContent.relativePath, snapshot)
+      if (!isCurrent() || missingFileRef.current) return
+      setFileContent({ ...fileContent, content: snapshot, size: new Blob([snapshot]).size })
       setEditing(false)
       toast.success('已保存')
       void refreshTree()
     } catch (err) {
+      if (!isCurrent()) return
       console.error('[SkillFiles] 保存文件失败:', err)
       toast.error(err instanceof Error ? err.message : '保存失败')
     } finally {
-      setSaving(false)
+      if (scope === scopeRef.current) setSaving(false)
     }
   }
 
@@ -160,14 +251,19 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
       return
     }
     const relativePath = creating.parent ? `${creating.parent}/${name}` : name
+    if (saving) return
+    const scope = scopeRef.current
     try {
       await window.electronAPI.createSkillEntry(workspaceSlug, skillSlug, relativePath, creating.type)
+      if (scope !== scopeRef.current) return
       toast.success(`已创建${creating.type === 'directory' ? '目录' : '文件'}: ${name}`)
       setCreating(null)
       setCreateName('')
       await refreshTree()
-      if (creating.type === 'file') void openFile(relativePath)
+      if (scope !== scopeRef.current) return
+      if (creating.type === 'file') void openFileRef.current(relativePath)
     } catch (err) {
+      if (scope !== scopeRef.current) return
       console.error('[SkillFiles] 创建失败:', err)
       toast.error(err instanceof Error ? err.message : '创建失败')
     }
@@ -176,16 +272,16 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
   const deleteEntry = async (node: SkillFileNode): Promise<void> => {
     const label = node.type === 'directory' ? '目录及其内容' : '文件'
     if (!window.confirm(`确认删除${label} "${node.relativePath}"？此操作不可撤销。`)) return
+    if (saving) return
+    const scope = scopeRef.current
     try {
       await window.electronAPI.deleteSkillEntry(workspaceSlug, skillSlug, node.relativePath)
+      if (scope !== scopeRef.current) return
       toast.success('已删除')
-      if (selected === node.relativePath || (node.type === 'directory' && selected?.startsWith(node.relativePath + '/'))) {
-        setSelected(null)
-        setFileContent(null)
-        setEditing(false)
-      }
+      if (selectedRef.current === node.relativePath || selectedRef.current?.startsWith(node.relativePath + '/')) markMissing()
       void refreshTree()
     } catch (err) {
+      if (scope !== scopeRef.current) return
       console.error('[SkillFiles] 删除失败:', err)
       toast.error(err instanceof Error ? err.message : '删除失败')
     }
@@ -208,16 +304,17 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
     }
     const parentParts = node.relativePath.split('/').slice(0, -1)
     const newRel = parentParts.length ? `${parentParts.join('/')}/${newName}` : newName
+    if (saving) return
+    const scope = scopeRef.current
     try {
       await window.electronAPI.renameSkillEntry(workspaceSlug, skillSlug, node.relativePath, newRel)
+      if (scope !== scopeRef.current) return
       toast.success('已重命名')
-      if (selected === node.relativePath) {
-        setSelected(newRel)
-        if (fileContent) setFileContent({ ...fileContent, relativePath: newRel })
-      }
+      if (selectedRef.current === node.relativePath || selectedRef.current?.startsWith(node.relativePath + '/')) markMissing()
       setRenaming(null)
       void refreshTree()
     } catch (err) {
+      if (scope !== scopeRef.current) return
       console.error('[SkillFiles] 重命名失败:', err)
       toast.error(err instanceof Error ? err.message : '重命名失败')
     }
@@ -262,6 +359,7 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
         </div>
       </div>
 
+      {treeError && <div role="alert" className="px-1 pb-2 text-xs text-destructive">资源列表刷新失败，已保留当前内容。请重试刷新。</div>}
       <SettingsCard divided={false} className="flex-1 min-h-0">
         <div className="grid grid-cols-[minmax(220px,1fr)_2fr] h-full min-h-[420px]">
           {/* Tree */}
@@ -309,6 +407,9 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
 
           {/* Editor */}
           <div className="flex flex-col min-w-0">
+            {missingFile && <div role="alert" className="p-3 text-xs text-destructive">
+              文件已被删除或重命名：{selected}。已保留当前内容和草稿，请先复制备份；保存已禁用，重新打开现有文件后才能保存。
+            </div>}
             {!selected ? (
               <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground p-6 text-center">
                 从左侧选择文件以查看或编辑
@@ -338,7 +439,7 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
                       {formatSize(fileContent.size)}
                     </span>
                     {!editing ? (
-                      <Button size="sm" variant="ghost" onClick={() => setEditing(true)} className="h-7">
+                      <Button size="sm" variant="ghost" onClick={() => setEditing(true)} disabled={missingFile} className="h-7">
                         <Pencil size={12} /> 编辑
                       </Button>
                     ) : (
@@ -347,6 +448,7 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
                           size="sm"
                           variant="ghost"
                           onClick={() => {
+                            if (missingFile && !window.confirm('文件已失效，确认放弃保留的草稿？')) return
                             setEditText(fileContent.content ?? '')
                             setEditing(false)
                           }}
@@ -355,7 +457,7 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
                         >
                           <X size={12} /> 取消
                         </Button>
-                        <Button size="sm" onClick={() => void saveFile()} disabled={saving} className="h-7">
+                        <Button size="sm" onClick={() => void saveFile()} disabled={saving || missingFile} className="h-7">
                           <Save size={12} /> {saving ? '保存中...' : '保存'}
                         </Button>
                       </>
@@ -365,6 +467,7 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
                 {editing ? (
                   <textarea
                     value={editText}
+                    readOnly={saving}
                     onChange={(e) => setEditText(e.target.value)}
                     className="flex-1 bg-transparent text-xs font-mono resize-none p-3 focus:outline-none border-0"
                     spellCheck={false}


### PR DESCRIPTION
## 概述
修复 Skills 详情在自动保存或外部文件变更触发 watcher 刷新时，正文编辑器被卸载重建、滚动位置回到顶部的问题；同时让已打开的资源文件 Tab 能在后台刷新时更新文件树，并保护用户正在编辑的资源草稿。

## 改动
- `apps/electron/src/renderer/components/agent-skills/SkillDetailView.tsx` — 将首次加载与同一 Skill 的后台刷新分离；后台重读不再显示加载占位或卸载 CodeMirror，读取失败保留当前内容；通过写入版本屏障丢弃会回滚已保存内容的迟到读取结果；将刷新版本传给资源文件面板。
- `apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx` — 响应资源文件后台刷新，保持展开目录、当前选中项和未保存草稿；外部删除或重命名当前文件时保留草稿并阻止继续写入旧路径；处理异步读取、刷新与保存的乱序完成。
- `apps/electron/src/main/lib/agent-workspace-manager.ts` — 资源文件保存改为仅写入仍存在的文件，不再在编辑保存期间重新创建已被外部删除或重命名的旧路径。
- `apps/electron/src/main/lib/skill-file-write.ts` — 新增仅覆盖既有普通文件的底层写入封装，并安全截断较短的新内容。
- `apps/electron/package.json` — 将 Electron 包版本从上游 `0.19.36` 递增到 `0.19.37`。

## 测试方法
1. 运行 `bun run typecheck`，确认 monorepo 类型检查通过。
2. 运行 `bun test apps/electron/src/renderer/components/agent-skills apps/electron/src/main/lib/workspace-watcher.test.ts`，确认相关既有测试通过。
3. 运行 `bun run --cwd apps/electron build:renderer`，确认 renderer 可构建。
4. 手动打开一篇较长的 Skill，在中下部连续编辑并等待自动保存：确认滚动位置、光标和撤销历史不重置。
5. 打开资源文件 Tab，通过其他进程新增、删除或重命名资源文件：确认列表刷新，未保存草稿不会被覆盖或写回已失效路径。

## 备注
- 根据提交前要求，本 PR 不包含新增测试文件；已完成的本地验证未作为文件提交。
- renderer 构建会报告现有大 chunk 提示，但构建成功。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
