### PR TITLE
fix(markdown): restore preview find interactions

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -1049,6 +1049,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     cachedScrollPosition,
     restoredScrollKey,
     scrollKey,
+    editorReady: liveMarkdownReadyKey === scrollKey,
   })
 
   const invalidatePendingPreviewScrollRestore = React.useCallback(() => {
@@ -1824,6 +1825,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           rootRef={scrollContainerRef}
           contentKey={findContentKey}
           unsupportedReason={isPdf ? '暂不支持 PDF 搜索' : undefined}
+          markdownEditorRef={isMarkdown ? markdownEditorRef : undefined}
           onOpenChange={setFindOpen}
         />
         <MarkdownToc

--- a/apps/electron/src/renderer/components/diff/PreviewFindBar.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewFindBar.tsx
@@ -1,20 +1,19 @@
 import * as React from 'react'
 import { ChevronDown, ChevronUp, Search, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import type { LiveMarkdownEditorHandle, LiveMarkdownFindOptions } from '@/components/markdown/LiveMarkdownEditor'
 
 interface PreviewFindBarProps {
   open: boolean
   rootRef: React.RefObject<HTMLElement>
   contentKey: string
   unsupportedReason?: string
+  /** Markdown 预览由 CodeMirror 管理，必须由其 StateField 绘制高亮而非改写 DOM。 */
+  markdownEditorRef?: React.RefObject<LiveMarkdownEditorHandle>
   onOpenChange: (open: boolean) => void
 }
 
-interface FindOptions {
-  caseSensitive: boolean
-  wholeWord: boolean
-  regex: boolean
-}
+type FindOptions = LiveMarkdownFindOptions
 
 const MATCH_SELECTOR = 'mark[data-proma-find-match]'
 const SHADOW_STYLE_ID = 'proma-find-highlight-style'
@@ -192,7 +191,7 @@ function setActiveMatch(marks: HTMLElement[], activeIndex: number): void {
   })
 }
 
-export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, onOpenChange }: PreviewFindBarProps): React.ReactElement | null {
+export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, markdownEditorRef, onOpenChange }: PreviewFindBarProps): React.ReactElement | null {
   const [query, setQuery] = React.useState('')
   const [caseSensitive, setCaseSensitive] = React.useState(false)
   const [wholeWord, setWholeWord] = React.useState(false)
@@ -229,15 +228,19 @@ export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, o
   }), [caseSensitive, wholeWord, regex])
 
   const clearMarks = React.useCallback(() => {
-    withObserverPaused(() => {
-      const root = rootRef.current
-      if (root) cleanupHighlights(root)
-    })
+    if (markdownEditorRef) {
+      markdownEditorRef.current?.clearFindMatches()
+    } else {
+      withObserverPaused(() => {
+        const root = rootRef.current
+        if (root) cleanupHighlights(root)
+      })
+    }
     marksRef.current = []
     activeIndexRef.current = -1
     setMatchCount(0)
     setActiveIndex(-1)
-  }, [rootRef, withObserverPaused])
+  }, [markdownEditorRef, rootRef, withObserverPaused])
 
   const runSearch = React.useCallback(() => {
     const root = rootRef.current
@@ -253,6 +256,17 @@ export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, o
     setRegexInvalid(options.regex && matcher === null)
     if (!matcher) {
       clearMarks()
+      return
+    }
+
+    if (markdownEditorRef) {
+      const requestedActiveIndex = activeIndexRef.current >= 0 ? activeIndexRef.current : 0
+      const nextMatchCount = markdownEditorRef.current?.setFindMatches(trimmed, options, requestedActiveIndex) ?? 0
+      const nextActiveIndex = nextMatchCount === 0 ? -1 : Math.min(requestedActiveIndex, nextMatchCount - 1)
+      marksRef.current = []
+      activeIndexRef.current = nextActiveIndex
+      setMatchCount(nextMatchCount)
+      setActiveIndex(nextActiveIndex)
       return
     }
 
@@ -272,7 +286,7 @@ export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, o
     activeIndexRef.current = nextActiveIndex
     setMatchCount(marks.length)
     setActiveIndex(nextActiveIndex)
-  }, [clearMarks, open, options, query, rootRef, unsupportedReason, withObserverPaused])
+  }, [clearMarks, markdownEditorRef, open, options, query, rootRef, unsupportedReason, withObserverPaused])
 
   React.useEffect(() => {
     if (!open) {
@@ -287,7 +301,19 @@ export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, o
   }, [open, runSearch, clearMarks, contentKey, unsupportedReason])
 
   React.useEffect(() => {
-    if (!open || unsupportedReason) return
+    if (!open || !markdownEditorRef) return
+    const editor = markdownEditorRef.current
+    if (!editor) return
+    return editor.subscribeToFindUpdates(({ matchCount: nextMatchCount, activeIndex: nextActiveIndex }) => {
+      marksRef.current = []
+      activeIndexRef.current = nextActiveIndex
+      setMatchCount(nextMatchCount)
+      setActiveIndex(nextActiveIndex)
+    })
+  }, [markdownEditorRef, open])
+
+  React.useEffect(() => {
+    if (!open || unsupportedReason || markdownEditorRef) return
     const root = rootRef.current
     if (!root) return
 
@@ -303,7 +329,7 @@ export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, o
       observerRef.current = null
       window.clearTimeout(timer)
     }
-  }, [open, rootRef, runSearch, unsupportedReason])
+  }, [markdownEditorRef, open, rootRef, runSearch, unsupportedReason])
 
   React.useEffect(() => {
     if (!open) return
@@ -312,10 +338,14 @@ export function PreviewFindBar({ open, rootRef, contentKey, unsupportedReason, o
   }, [open])
 
   React.useEffect(() => {
-    if (activeIndex < 0 || activeIndex >= marksRef.current.length) return
+    if (activeIndex < 0 || activeIndex >= matchCount) return
     activeIndexRef.current = activeIndex
+    if (markdownEditorRef) {
+      markdownEditorRef.current?.setActiveFindMatch(activeIndex)
+      return
+    }
     withObserverPaused(() => setActiveMatch(marksRef.current, activeIndex))
-  }, [activeIndex, matchCount, withObserverPaused])
+  }, [activeIndex, markdownEditorRef, matchCount, withObserverPaused])
 
   React.useEffect(() => {
     return () => clearMarks()

--- a/apps/electron/src/renderer/components/diff/markdown-scroll-restore.ts
+++ b/apps/electron/src/renderer/components/diff/markdown-scroll-restore.ts
@@ -6,6 +6,8 @@ export interface MarkdownScrollRestoreMaskOptions {
   cachedScrollPosition: MarkdownScrollPosition | undefined
   restoredScrollKey: string | null
   scrollKey: string
+  /** ink-mde 已挂载时，后续任意 React 重渲染都不应重新遮罩正文。 */
+  editorReady: boolean
 }
 
 /** 异步恢复仍属于当前导航时才允许它回写滚动位置。 */
@@ -23,10 +25,12 @@ export function shouldMaskMarkdownForScrollRestore({
   cachedScrollPosition,
   restoredScrollKey,
   scrollKey,
+  editorReady,
 }: MarkdownScrollRestoreMaskOptions): boolean {
   return Boolean(
     isMarkdown
       && !loading
+      && !editorReady
       && cachedScrollPosition
       && (cachedScrollPosition.top > 0 || cachedScrollPosition.left > 0)
       && restoredScrollKey !== scrollKey,

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownEditor.tsx
@@ -4,7 +4,14 @@ import { Prec, RangeSetBuilder, StateEffect, StateField, type EditorState, type 
 import { Decoration, EditorView, ViewPlugin, keymap, type DecorationSet } from '@codemirror/view'
 import ink, { type Instance } from 'ink-mde'
 import { cn } from '@/lib/utils'
-import { createLiveMarkdownBlockPreview, type ResolveLiveMarkdownImageSrc, type SaveLiveMarkdownPastedImage, type ChangeLiveMarkdownProperties } from './LiveMarkdownPreview'
+import {
+  createLiveMarkdownBlockPreview,
+  createLiveMarkdownFindController,
+  type ResolveLiveMarkdownImageSrc,
+  type SaveLiveMarkdownPastedImage,
+  type ChangeLiveMarkdownProperties,
+  type LiveMarkdownFindOptions,
+} from './LiveMarkdownPreview'
 import {
   shouldRebuildMarkdownHeadingDecorations,
   shouldRebuildMarkdownSyntaxDecorations,
@@ -13,13 +20,52 @@ export type { ChangeLiveMarkdownProperties } from './LiveMarkdownPreview'
 export type { LiveMarkdownPropertyEntry } from './live-markdown-frontmatter'
 import type { LiveMarkdownPropertyEntry } from './live-markdown-frontmatter'
 
+export type { LiveMarkdownFindOptions } from './LiveMarkdownPreview'
+
 export interface LiveMarkdownEditorHandle {
   focus: () => void
   insert: (text: string) => void
   scrollToPosition: (position: number) => void
+  /** 在 CodeMirror 的状态层渲染查找高亮，避免改写受控编辑器 DOM。 */
+  setFindMatches: (query: string, options: LiveMarkdownFindOptions, activeIndex: number) => number
+  setActiveFindMatch: (activeIndex: number) => void
+  clearFindMatches: () => void
+  subscribeToFindUpdates: (listener: (update: { matchCount: number; activeIndex: number }) => void) => () => void
   getPositionAtViewportY: (viewportY: number) => number | null
   getHost: () => HTMLDivElement | null
   getView: () => EditorView | null
+}
+
+interface LiveMarkdownFindMatch {
+  from: number
+  to: number
+}
+
+export function findLiveMarkdownMatches(
+  documentText: string,
+  query: string,
+  options: LiveMarkdownFindOptions,
+): LiveMarkdownFindMatch[] {
+  if (!query) return []
+
+  try {
+    const source = options.regex ? query : query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const wrappedSource = options.wholeWord ? `\\b(?:${source})\\b` : source
+    const matcher = new RegExp(wrappedSource, `g${options.caseSensitive ? '' : 'i'}`)
+    const matches: LiveMarkdownFindMatch[] = []
+    let match = matcher.exec(documentText)
+    while (match) {
+      if (match[0].length === 0) {
+        matcher.lastIndex += 1
+      } else {
+        matches.push({ from: match.index, to: match.index + match[0].length })
+      }
+      match = matcher.exec(documentText)
+    }
+    return matches
+  } catch {
+    return []
+  }
 }
 
 /** CodeMirror 选区的文本与可用于浮层定位的视口坐标。 */
@@ -57,6 +103,47 @@ interface MeasureView {
 }
 
 const markdownSyntaxFocusEffect = StateEffect.define<boolean>()
+const liveMarkdownFindMatchesEffect = StateEffect.define<{
+  matches: readonly LiveMarkdownFindMatch[]
+  activeIndex: number
+}>()
+
+type LiveMarkdownFindState = {
+  decorations: DecorationSet
+  matches: readonly LiveMarkdownFindMatch[]
+}
+
+function buildLiveMarkdownFindDecorations(matches: readonly LiveMarkdownFindMatch[], activeIndex: number): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>()
+  matches.forEach((match, index) => {
+    builder.add(match.from, match.to, Decoration.mark({
+      class: index === activeIndex ? 'live-markdown-find-match live-markdown-find-match-active' : 'live-markdown-find-match',
+    }))
+  })
+  return builder.finish()
+}
+
+const liveMarkdownFindMatchesField = StateField.define<LiveMarkdownFindState>({
+  create: () => ({ decorations: Decoration.none, matches: [] }),
+  update: (value, transaction) => {
+    const effect = transaction.effects.find((item) => item.is(liveMarkdownFindMatchesEffect))
+    if (effect) {
+      return {
+        decorations: buildLiveMarkdownFindDecorations(effect.value.matches, effect.value.activeIndex),
+        matches: effect.value.matches,
+      }
+    }
+    return {
+      decorations: value.decorations.map(transaction.changes),
+      matches: value.matches.map((match) => ({
+        from: transaction.changes.mapPos(match.from),
+        to: transaction.changes.mapPos(match.to, 1),
+      })),
+    }
+  },
+  provide: (field) => EditorView.decorations.from(field, (value) => value.decorations),
+})
+
 const markdownSyntaxMarkerNames = new Set([
   'CodeMark',
   'EmphasisMark',
@@ -243,6 +330,9 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
   const viewRef = React.useRef<EditorView | null>(null)
   const instanceRef = React.useRef<Instance | null>(null)
   const valueRef = React.useRef(value)
+  const findControllerRef = React.useRef(createLiveMarkdownFindController())
+  const findQueryRef = React.useRef<{ query: string; options: LiveMarkdownFindOptions; activeIndex: number } | null>(null)
+  const findUpdateListenersRef = React.useRef(new Set<(update: { matchCount: number; activeIndex: number }) => void>())
   const onChangeRef = React.useRef(onChange)
   const onSaveRef = React.useRef(onSave)
   const onCancelRef = React.useRef(onCancel)
@@ -264,6 +354,27 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
     onChangePropertiesRef.current?.(entries, documentValue)
   }, [])
 
+  const applyFindMatches = React.useCallback((query: string, options: LiveMarkdownFindOptions, activeIndex: number, scrollIntoView: boolean): number => {
+    const view = viewRef.current
+    if (!view) return 0
+    const matches = findLiveMarkdownMatches(view.state.doc.toString(), query, options)
+    const nextActiveIndex = matches.length === 0 ? -1 : Math.max(0, Math.min(activeIndex, matches.length - 1))
+    findQueryRef.current = { query, options, activeIndex: nextActiveIndex }
+    findControllerRef.current.setState({
+      query,
+      options,
+      activeMatchFrom: nextActiveIndex >= 0 ? matches[nextActiveIndex]!.from : null,
+    })
+    const findEffect = liveMarkdownFindMatchesEffect.of({ matches, activeIndex: nextActiveIndex })
+    view.dispatch({
+      effects: scrollIntoView && nextActiveIndex >= 0
+        ? [findEffect, EditorView.scrollIntoView(matches[nextActiveIndex]!.from, { y: 'center', yMargin: 24 })]
+        : findEffect,
+    })
+    findUpdateListenersRef.current.forEach((listener) => listener({ matchCount: matches.length, activeIndex: nextActiveIndex }))
+    return matches.length
+  }, [])
+
   React.useImperativeHandle(ref, () => ({
     focus: () => instanceRef.current?.focus(),
     insert: (text) => instanceRef.current?.insert(text),
@@ -272,6 +383,43 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
       if (!view) return
       const safePosition = Math.max(0, Math.min(position, view.state.doc.length))
       view.dispatch({ effects: EditorView.scrollIntoView(safePosition, { y: 'start', yMargin: 8 }) })
+    },
+    setFindMatches: (query, options, activeIndex) => applyFindMatches(query, options, activeIndex, true),
+    setActiveFindMatch: (activeIndex) => {
+      const view = viewRef.current
+      if (!view) return
+      const { matches } = view.state.field(liveMarkdownFindMatchesField)
+      if (matches.length === 0) return
+      const nextActiveIndex = Math.max(0, Math.min(activeIndex, matches.length - 1))
+      const findState = findControllerRef.current.getState()
+      findQueryRef.current = { query: findState.query, options: findState.options, activeIndex: nextActiveIndex }
+      findControllerRef.current.setState({
+        ...findState,
+        activeMatchFrom: matches[nextActiveIndex]!.from,
+      })
+      view.dispatch({
+        effects: [
+          liveMarkdownFindMatchesEffect.of({ matches, activeIndex: nextActiveIndex }),
+          EditorView.scrollIntoView(matches[nextActiveIndex]!.from, { y: 'center', yMargin: 24 }),
+        ],
+      })
+      findUpdateListenersRef.current.forEach((listener) => listener({ matchCount: matches.length, activeIndex: nextActiveIndex }))
+    },
+    clearFindMatches: () => {
+      const view = viewRef.current
+      if (!view) return
+      findQueryRef.current = null
+      findControllerRef.current.setState({
+        query: '',
+        options: { caseSensitive: false, wholeWord: false, regex: false },
+        activeMatchFrom: null,
+      })
+      view.dispatch({ effects: liveMarkdownFindMatchesEffect.of({ matches: [], activeIndex: -1 }) })
+      findUpdateListenersRef.current.forEach((listener) => listener({ matchCount: 0, activeIndex: -1 }))
+    },
+    subscribeToFindUpdates: (listener) => {
+      findUpdateListenersRef.current.add(listener)
+      return () => findUpdateListenersRef.current.delete(listener)
     },
     getPositionAtViewportY: (viewportY) => {
       const view = viewRef.current
@@ -317,9 +465,11 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
           },
         }])),
         markdownHeadingMarkers,
+        liveMarkdownFindMatchesField,
         ViewPlugin.define((view) => {
           viewRef.current = view
           let selectionFrame = 0
+          let findRefreshFrame = 0
           const reportSelection = (): void => {
             selectionFrame = 0
             const range = view.state.selection.main
@@ -356,16 +506,28 @@ export const LiveMarkdownEditor = React.forwardRef<LiveMarkdownEditorHandle, Liv
               if (update.selectionSet && update.view.hasFocus && !isPointerSelection) {
                 scheduleSelectionReport()
               }
+              // 搜索栏打开期间，文档编辑必须重算匹配集合。延迟到本次 CodeMirror
+              // update 完成后 dispatch，避免在 ViewPlugin.update 内嵌套事务。
+              if (update.docChanged && findQueryRef.current && !findRefreshFrame) {
+                findRefreshFrame = requestAnimationFrame(() => {
+                  findRefreshFrame = 0
+                  const currentFind = findQueryRef.current
+                  if (currentFind && viewRef.current === view) {
+                    applyFindMatches(currentFind.query, currentFind.options, currentFind.activeIndex, false)
+                  }
+                })
+              }
             },
             destroy: () => {
               view.dom.removeEventListener('mouseup', scheduleSelectionReport)
               if (selectionFrame) cancelAnimationFrame(selectionFrame)
+              if (findRefreshFrame) cancelAnimationFrame(findRefreshFrame)
               if (viewRef.current === view) viewRef.current = null
             },
           }
         }),
         ...markdownSyntaxVisibility,
-        createLiveMarkdownBlockPreview(resolveImageSrc, savePastedImage, onChangePropertiesProxy, enableProperties),
+        createLiveMarkdownBlockPreview(resolveImageSrc, savePastedImage, onChangePropertiesProxy, enableProperties, findControllerRef.current),
         ...extensions,
       ].map((extension) => ({ type: 'default' as const, value: extension })),
       search: false,

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownPreview.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownPreview.tsx
@@ -29,6 +29,47 @@ export type SaveLiveMarkdownPastedImage = (file: File) => Promise<string | null>
 export type { LiveMarkdownPropertyEntry } from './live-markdown-frontmatter'
 export type ChangeLiveMarkdownProperties = (entries: LiveMarkdownPropertyEntry[], documentValue?: string) => void
 
+export interface LiveMarkdownFindOptions {
+  caseSensitive: boolean
+  wholeWord: boolean
+  regex: boolean
+}
+
+export interface LiveMarkdownFindState {
+  query: string
+  options: LiveMarkdownFindOptions
+  activeMatchFrom: number | null
+}
+
+export interface LiveMarkdownFindController {
+  getState: () => LiveMarkdownFindState
+  setState: (state: LiveMarkdownFindState) => void
+  subscribe: (listener: () => void) => () => void
+}
+
+const EMPTY_LIVE_MARKDOWN_FIND_STATE: LiveMarkdownFindState = {
+  query: '',
+  options: { caseSensitive: false, wholeWord: false, regex: false },
+  activeMatchFrom: null,
+}
+
+/** 让替换型表格 widget 响应查找状态，无需直接改写 React 管理的 DOM。 */
+export function createLiveMarkdownFindController(): LiveMarkdownFindController {
+  let state = EMPTY_LIVE_MARKDOWN_FIND_STATE
+  const listeners = new Set<() => void>()
+  return {
+    getState: () => state,
+    setState: (nextState) => {
+      state = nextState
+      listeners.forEach((listener) => listener())
+    },
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  }
+}
+
 interface PreviewBlock {
   kind: PreviewKind
   from: number
@@ -178,6 +219,18 @@ function sameLines(left: Set<number>, right: Set<number>): boolean {
   return left.size === right.size && [...left].every((line) => right.has(line))
 }
 
+/** 仅识别原生滚动条 gutter，图表画布本身的点击仍应进入源码编辑。 */
+export function isMermaidScrollbarPointer(event: MouseEvent, target: HTMLElement): boolean {
+  const scroller = target.closest<HTMLElement>('.mermaid-block-scroll')
+  if (!scroller) return false
+  const verticalScrollbarWidth = scroller.offsetWidth - scroller.clientWidth
+  const horizontalScrollbarHeight = scroller.offsetHeight - scroller.clientHeight
+  const rect = scroller.getBoundingClientRect()
+  const inVerticalScrollbar = verticalScrollbarWidth > 0 && event.clientX >= rect.right - verticalScrollbarWidth
+  const inHorizontalScrollbar = horizontalScrollbarHeight > 0 && event.clientY >= rect.bottom - horizontalScrollbarHeight
+  return inVerticalScrollbar || inHorizontalScrollbar
+}
+
 abstract class LiveMarkdownBlockWidget extends WidgetType {
   private observer: ResizeObserver | null = null
 
@@ -232,6 +285,8 @@ class TableWidget extends LiveMarkdownBlockWidget {
     private readonly table: LiveMarkdownTable,
     private readonly from: number,
     private readonly to: number,
+    private readonly findController?: LiveMarkdownFindController,
+    private readonly source?: string,
   ) { super() }
 
   override eq(other: TableWidget): boolean {
@@ -252,6 +307,9 @@ class TableWidget extends LiveMarkdownBlockWidget {
         table={this.table}
         readOnly={view.state.readOnly}
         onMeasure={onMeasure}
+        findController={this.findController}
+        sourceRange={{ from: this.from, to: this.to }}
+        source={this.source}
         onCommit={(nextTable, focusCell) => {
           if (view.state.readOnly) return
           const nextSource = serializeLiveMarkdownTable(nextTable)
@@ -423,6 +481,7 @@ class MermaidWidget extends LiveMarkdownBlockWidget {
     const wrapper = document.createElement('div')
     wrapper.className = 'vault-mermaid-block'
     wrapper.dataset.liveMarkdownBlockFrom = String(this.from)
+    wrapper.dataset.liveMarkdownBlockKind = 'mermaid'
     this.root = createRoot(wrapper)
     this.root.render(<MermaidBlock code={this.code} />)
     this.observeSize(wrapper, view)
@@ -547,6 +606,7 @@ function buildBlocks(
   state: EditorState,
   onChangeProperties?: ChangeLiveMarkdownProperties,
   enableProperties = false,
+  findController?: LiveMarkdownFindController,
 ): PreviewBlock[] {
   const blocks: PreviewBlock[] = []
   const lines = Array.from({ length: state.doc.lines }, (_, index) => state.doc.line(index + 1).text)
@@ -612,7 +672,7 @@ function buildBlocks(
       const from = state.doc.line(number).from
       const to = state.doc.line(end).to
       const table = parseLiveMarkdownTable(state.sliceDoc(from, to))
-      if (table) blocks.push({ kind: 'table', from, to, decoration: Decoration.replace({ widget: new TableWidget(table, from, to), block: true }) })
+      if (table) blocks.push({ kind: 'table', from, to, decoration: Decoration.replace({ widget: new TableWidget(table, from, to, findController, state.sliceDoc(from, to)), block: true }) })
       number = end
     }
   }
@@ -660,13 +720,14 @@ export function createLiveMarkdownBlockPreview(
   savePastedImage?: SaveLiveMarkdownPastedImage,
   onChangeProperties?: ChangeLiveMarkdownProperties,
   enableProperties = false,
+  findController?: LiveMarkdownFindController,
 ): Extension {
   return [
   liveMarkdownShikiHighlight,
   StateField.define<PreviewState>({
     create: (state) => {
       const lines = activeLines(state)
-      const blocks = buildBlocks(state, onChangeProperties, enableProperties)
+      const blocks = buildBlocks(state, onChangeProperties, enableProperties, findController)
       return {
         activeLines: lines,
         blocks,
@@ -675,7 +736,7 @@ export function createLiveMarkdownBlockPreview(
     },
     update: (value, transaction) => {
       const lines = activeLines(transaction.state)
-      const blocks = transaction.docChanged ? buildBlocks(transaction.state, onChangeProperties, enableProperties) : value.blocks
+      const blocks = transaction.docChanged ? buildBlocks(transaction.state, onChangeProperties, enableProperties, findController) : value.blocks
       if (!transaction.docChanged && sameLines(lines, value.activeLines)) return value
       return {
         activeLines: lines,
@@ -705,6 +766,8 @@ export function createLiveMarkdownBlockPreview(
       const inlineMath = target?.closest<HTMLElement>('[data-live-markdown-inline-from]')
       if (!block && !inlineMath) return false
       if (block?.dataset.liveMarkdownBlockKind === 'table') return true
+      // Mermaid 容器自身提供横纵滚动；只保留滚动条拖动，图表内容点击仍可进入源码。
+      if (block?.dataset.liveMarkdownBlockKind === 'mermaid' && target && isMermaidScrollbarPointer(event, target)) return true
       // CodeBlock 的复制按钮必须在外层选区切换之前收到完整 click 序列。
       // 否则 mousedown 会把预览切回源码并卸载按钮，导致 click 永远无法触发。
       // `.cm-content` 本身就是 contenteditable；把它纳入排除条件会让所有

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownTableEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownTableEditor.tsx
@@ -7,6 +7,7 @@ import {
   shouldCommitLiveMarkdownTableCell,
   updateLiveMarkdownTableCell,
 } from './live-markdown-table'
+import type { LiveMarkdownFindController, LiveMarkdownFindOptions, LiveMarkdownFindState } from './LiveMarkdownPreview'
 
 const { useEffect, useRef, useState } = React
 
@@ -21,10 +22,64 @@ interface LiveMarkdownTableEditorProps {
   autoFocusCell?: LiveMarkdownTableCell | null
   onCommit: (table: LiveMarkdownTable, focusCell?: LiveMarkdownTableCell) => void
   onMeasure: () => void
+  findController?: LiveMarkdownFindController
+  sourceRange?: { from: number; to: number }
+  /** 原始 GFM 表格源码，用于将当前搜索结果精确映射回单元格。 */
+  source?: string
+}
+
+const EMPTY_FIND_STATE: LiveMarkdownFindState = {
+  query: '',
+  options: { caseSensitive: false, wholeWord: false, regex: false },
+  activeMatchFrom: null,
+}
+
+export function doesLiveMarkdownTableCellMatch(value: string, query: string, options: LiveMarkdownFindOptions): boolean {
+  if (!query) return false
+  try {
+    const source = options.regex ? query : query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const wrappedSource = options.wholeWord ? `\\b(?:${source})\\b` : source
+    return new RegExp(wrappedSource, options.caseSensitive ? '' : 'i').test(value)
+  } catch {
+    return false
+  }
 }
 
 function cellValue(table: LiveMarkdownTable, { row, column }: LiveMarkdownTableCell): string {
   return row === 0 ? table.header[column] ?? '' : table.rows[row - 1]?.[column] ?? ''
+}
+
+export function findLiveMarkdownTableCellSourceRange(source: string | undefined, sourceRange: { from: number; to: number } | undefined, cell: LiveMarkdownTableCell): { from: number; to: number } | null {
+  if (!source || !sourceRange) return null
+  // row=0 为表头；body 的第一个 row 需要跳过分隔行。
+  const lineIndex = cell.row === 0 ? 0 : cell.row + 1
+  const lines = source.split('\n')
+  const line = lines[lineIndex]
+  if (line === undefined) return null
+  const lineOffset = sourceRange.from + lines.slice(0, lineIndex).reduce((offset, current) => offset + current.length + 1, 0)
+  const cells: Array<{ from: number; to: number }> = []
+  let start = line.startsWith('|') ? 1 : 0
+  let escaped = false
+  for (let index = start; index <= line.length; index += 1) {
+    const char = line[index]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+    if (char === '|' || index === line.length) {
+      let from = start
+      let to = index
+      while (from < to && /\s/.test(line[from] ?? '')) from += 1
+      while (to > from && /\s/.test(line[to - 1] ?? '')) to -= 1
+      cells.push({ from: lineOffset + from, to: lineOffset + to })
+      start = index + 1
+    }
+  }
+  return cells[cell.column] ?? null
 }
 
 function renderInlineMath(value: string): React.ReactNode[] {
@@ -69,8 +124,12 @@ export function LiveMarkdownTableEditor({
   autoFocusCell = null,
   onCommit,
   onMeasure,
+  findController,
+  sourceRange,
+  source,
 }: LiveMarkdownTableEditorProps): React.ReactElement {
   const [activeCell, setActiveCell] = useState<LiveMarkdownTableCell | null>(autoFocusCell)
+  const [findState, setFindState] = useState<LiveMarkdownFindState>(() => findController?.getState() ?? EMPTY_FIND_STATE)
   const [draft, setDraft] = useState(() => autoFocusCell ? cellValue(table, autoFocusCell) : '')
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -79,6 +138,15 @@ export function LiveMarkdownTableEditor({
     setActiveCell(autoFocusCell)
     setDraft(cellValue(table, autoFocusCell))
   }, [autoFocusCell, table])
+
+  useEffect(() => {
+    if (!findController) {
+      setFindState(EMPTY_FIND_STATE)
+      return
+    }
+    setFindState(findController.getState())
+    return findController.subscribe(() => setFindState(findController.getState()))
+  }, [findController])
 
   useEffect(() => {
     if (!activeCell) return
@@ -135,11 +203,23 @@ export function LiveMarkdownTableEditor({
     const cell = { row, column }
     const value = cellValue(table, cell)
     const isActive = activeCell?.row === row && activeCell.column === column
+    const matchesFind = doesLiveMarkdownTableCellMatch(value, findState.query, findState.options)
+    const sourceCellRange = findLiveMarkdownTableCellSourceRange(source, sourceRange, cell)
+    const hasActiveFindMatch = matchesFind
+      && sourceCellRange !== null
+      && findState.activeMatchFrom !== null
+      && findState.activeMatchFrom >= sourceCellRange.from
+      && findState.activeMatchFrom < sourceCellRange.to
     const Cell = header ? 'th' : 'td'
     const ariaLabel = `${header ? '表头' : '单元格'} ${row + 1}，${column + 1}`
+    const className = [
+      isActive && 'is-editing',
+      matchesFind && 'live-markdown-table-find-match',
+      hasActiveFindMatch && 'live-markdown-table-find-match-active',
+    ].filter(Boolean).join(' ') || undefined
 
     return (
-      <Cell key={column} className={isActive ? 'is-editing' : undefined}>
+      <Cell key={column} className={className}>
         {isActive ? (
           <input
             ref={inputRef}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2410,6 +2410,16 @@
 .vault-ink-mde .vault-markdown-syntax-hidden * {
   display: none !important;
 }
+/* CodeMirror 状态层的查找装饰，避免预览搜索直接改写 .cm-content 的受控 DOM。 */
+.live-markdown-editor .live-markdown-find-match {
+  background: rgb(250 204 21 / 0.48);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+.live-markdown-editor .live-markdown-find-match-active {
+  background: rgb(249 115 22 / 0.72);
+  box-shadow: 0 0 0 1px rgb(249 115 22 / 0.55);
+}
 .vault-ink-mde .cm-editor.cm-focused,
 .vault-ink-mde .cm-editor:focus-visible,
 .vault-ink-mde .cm-content:focus-visible {
@@ -2630,6 +2640,14 @@
 .vault-ink-mde .vault-markdown-table td,
 .live-markdown-table-editor td {
   color: hsl(var(--foreground) / 0.88);
+}
+/* 替换型表格不承载 CodeMirror 的文本装饰，单元格自行响应预览查找状态。 */
+.live-markdown-table-editor .live-markdown-table-find-match {
+  background: rgb(250 204 21 / 0.48);
+}
+.live-markdown-table-editor .live-markdown-table-find-match-active {
+  background: rgb(249 115 22 / 0.72);
+  box-shadow: inset 0 0 0 1px rgb(249 115 22 / 0.55);
 }
 .live-markdown-table-editor-root {
   display: block;


### PR DESCRIPTION
## 概要
- 将 Markdown 预览查找迁移到 CodeMirror 状态装饰，恢复匹配高亮和前后跳转。
- 让替换型表格参与查找，并修复拖选导致的预览空白。
- 修复 Mermaid 滚动条拖动时错误回退源码。

## 验证
- `bun run --filter='@proma/electron' typecheck`

## 性能
- 查找仅在关键词变化或编辑器文档变更后的下一帧重新计算；长文档中的高频词或宽泛正则仍需在 Electron 中做人工交互验证。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)