### PR TITLE
fix(markdown): 改进表格多行单元格编辑和加粗渲染【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.37",
+  "version": "0.19.38",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/markdown/LiveMarkdownTableEditor.tsx
+++ b/apps/electron/src/renderer/components/markdown/LiveMarkdownTableEditor.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react'
-import { renderMarkdownMath } from '@/lib/markdown-math'
+import { liveMarkdownTableCellDraft, renderLiveMarkdownTableInline } from './live-markdown-table-inline'
 import {
   type LiveMarkdownTable,
-  isLikelyLiveMarkdownLatex,
+  liveMarkdownTableCellKeyAction,
   nextLiveMarkdownTableCell,
   shouldCommitLiveMarkdownTableCell,
   updateLiveMarkdownTableCell,
 } from './live-markdown-table'
 import type { LiveMarkdownFindController, LiveMarkdownFindOptions, LiveMarkdownFindState } from './LiveMarkdownPreview'
 
-const { useEffect, useRef, useState } = React
+const { useEffect, useLayoutEffect, useRef, useState } = React
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect
 
 export interface LiveMarkdownTableCell {
   row: number
@@ -82,37 +83,6 @@ export function findLiveMarkdownTableCellSourceRange(source: string | undefined,
   return cells[cell.column] ?? null
 }
 
-function renderInlineMath(value: string): React.ReactNode[] {
-  const parts: React.ReactNode[] = []
-  const pattern = /(^|[^\\])(?:\$([^$\n]+)\$|\\\((.+?)\\\)|\\\[([\s\S]+?)\\\]|`([^`\n]+)`)/g
-  let cursor = 0
-  let match: RegExpExecArray | null
-
-  while ((match = pattern.exec(value)) !== null) {
-    const prefix = match[1] ?? ''
-    const start = match.index
-    if (start > cursor) parts.push(value.slice(cursor, start))
-    if (prefix) parts.push(prefix)
-    const code = match[5]
-    const latex = match[2] ?? match[3] ?? match[4] ?? (code && isLikelyLiveMarkdownLatex(code) ? code : null)
-    const displayMode = Boolean(match[4])
-    if (latex !== null) {
-      parts.push(
-        <span
-          key={`${start}:${latex}`}
-          className={displayMode ? 'live-markdown-table-math is-display' : 'live-markdown-table-math'}
-          dangerouslySetInnerHTML={{ __html: renderMarkdownMath(latex, displayMode) }}
-        />,
-      )
-    } else if (code !== undefined) {
-      parts.push(<code key={`${start}:code:${code}`}>{code}</code>)
-    }
-    cursor = start + match[0].length
-  }
-  if (cursor < value.length) parts.push(value.slice(cursor))
-  return parts.length ? parts : [value]
-}
-
 /**
  * An editable GFM table embedded inside Live Markdown's CodeMirror widget.
  * It owns cell-level edit state so the surrounding document never has to
@@ -130,13 +100,14 @@ export function LiveMarkdownTableEditor({
 }: LiveMarkdownTableEditorProps): React.ReactElement {
   const [activeCell, setActiveCell] = useState<LiveMarkdownTableCell | null>(autoFocusCell)
   const [findState, setFindState] = useState<LiveMarkdownFindState>(() => findController?.getState() ?? EMPTY_FIND_STATE)
-  const [draft, setDraft] = useState(() => autoFocusCell ? cellValue(table, autoFocusCell) : '')
-  const inputRef = useRef<HTMLInputElement>(null)
+  const [draft, setDraft] = useState(() => autoFocusCell ? liveMarkdownTableCellDraft(cellValue(table, autoFocusCell)) : '')
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const minimumHeightRef = useRef(0)
 
   useEffect(() => {
     if (!autoFocusCell) return
     setActiveCell(autoFocusCell)
-    setDraft(cellValue(table, autoFocusCell))
+    setDraft(liveMarkdownTableCellDraft(cellValue(table, autoFocusCell)))
   }, [autoFocusCell, table])
 
   useEffect(() => {
@@ -155,30 +126,59 @@ export function LiveMarkdownTableEditor({
     onMeasure()
   }, [activeCell, onMeasure])
 
-  const activate = (cell: LiveMarkdownTableCell) => {
+  // 首次激活、输入和列宽变化时都重新测量，长文本无需在单行框内横向滚动。
+  useIsomorphicLayoutEffect(() => {
+    const input = inputRef.current
+    if (!input) return
+    const resize = () => {
+      input.style.height = '0px'
+      input.style.height = `${Math.max(input.scrollHeight, minimumHeightRef.current)}px`
+      onMeasure()
+    }
+    resize()
+    let width = input.getBoundingClientRect().width
+    const observer = new ResizeObserver(() => {
+      const nextWidth = input.getBoundingClientRect().width
+      if (nextWidth === width) return
+      width = nextWidth
+      minimumHeightRef.current = 0
+      resize()
+    })
+    observer.observe(input)
+    return () => observer.disconnect()
+  }, [activeCell, draft, onMeasure])
+
+  const activate = (cell: LiveMarkdownTableCell, element: HTMLButtonElement) => {
     if (readOnly) return
     if (activeCell?.row === cell.row && activeCell.column === cell.column) return
+    minimumHeightRef.current = element.getBoundingClientRect().height
     if (activeCell) {
-      const original = cellValue(table, activeCell)
+      const original = liveMarkdownTableCellDraft(cellValue(table, activeCell))
       if (shouldCommitLiveMarkdownTableCell(original, draft)) {
         onCommit(updateLiveMarkdownTableCell(table, activeCell.row, activeCell.column, draft), cell)
         return
       }
       setActiveCell(cell)
-      setDraft(cellValue(table, cell))
+      setDraft(liveMarkdownTableCellDraft(cellValue(table, cell)))
       return
     }
     setActiveCell(cell)
-    setDraft(cellValue(table, cell))
+    setDraft(liveMarkdownTableCellDraft(cellValue(table, cell)))
   }
 
   const commit = (focusCell?: LiveMarkdownTableCell) => {
     if (!activeCell) return
-    const original = cellValue(table, activeCell)
+    if (focusCell) {
+      const target = inputRef.current?.closest('table')?.querySelector<HTMLButtonElement>(
+        `[data-live-markdown-table-cell="${focusCell.row}:${focusCell.column}"]`,
+      )
+      minimumHeightRef.current = target?.getBoundingClientRect().height ?? 0
+    }
+    const original = liveMarkdownTableCellDraft(cellValue(table, activeCell))
     if (!shouldCommitLiveMarkdownTableCell(original, draft)) {
       if (focusCell) {
         setActiveCell(focusCell)
-        setDraft(cellValue(table, focusCell))
+        setDraft(liveMarkdownTableCellDraft(cellValue(table, focusCell)))
       } else {
         setActiveCell(null)
         setDraft('')
@@ -202,7 +202,7 @@ export function LiveMarkdownTableEditor({
   const renderCell = (row: number, column: number, header: boolean) => {
     const cell = { row, column }
     const value = cellValue(table, cell)
-    const isActive = activeCell?.row === row && activeCell.column === column
+    const isActive = !readOnly && activeCell?.row === row && activeCell.column === column
     const matchesFind = doesLiveMarkdownTableCellMatch(value, findState.query, findState.options)
     const sourceCellRange = findLiveMarkdownTableCellSourceRange(source, sourceRange, cell)
     const hasActiveFindMatch = matchesFind
@@ -221,10 +221,12 @@ export function LiveMarkdownTableEditor({
     return (
       <Cell key={column} className={className}>
         {isActive ? (
-          <input
+          <textarea
             ref={inputRef}
             className="live-markdown-table-input"
             aria-label={`编辑${ariaLabel}`}
+            rows={1}
+            title="Enter 保存，Shift+Enter 换行，Tab 切换单元格，Esc 取消"
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
             onBlur={(event) => {
@@ -232,20 +234,26 @@ export function LiveMarkdownTableEditor({
               commit()
             }}
             onKeyDown={(event) => {
-              if (event.key === 'Enter') {
+              const action = liveMarkdownTableCellKeyAction(
+                event.key,
+                event.shiftKey,
+                event.nativeEvent.isComposing,
+                event.keyCode,
+              )
+              if (action === 'commit') {
                 event.preventDefault()
                 commit()
-              } else if (event.key === 'Escape') {
+              } else if (action === 'cancel') {
                 event.preventDefault()
                 cancel()
-              } else if (event.key === 'Tab') {
+              } else if (action === 'next' || action === 'previous') {
                 event.preventDefault()
-                commit(nextCell(cell, event.shiftKey))
+                commit(nextCell(cell, action === 'previous'))
               }
             }}
           />
         ) : readOnly ? (
-          <span className="live-markdown-table-value">{renderInlineMath(value)}</span>
+          <span className="live-markdown-table-value" dangerouslySetInnerHTML={{ __html: renderLiveMarkdownTableInline(value) }} />
         ) : (
           <button
             type="button"
@@ -254,11 +262,14 @@ export function LiveMarkdownTableEditor({
             onMouseDown={(event) => {
               event.preventDefault()
               event.stopPropagation()
-              activate(cell)
+              activate(cell, event.currentTarget)
             }}
-            onClick={(event) => event.preventDefault()}
+            onClick={(event) => {
+              event.preventDefault()
+              if (event.detail === 0) activate(cell, event.currentTarget)
+            }}
           >
-            <span className="live-markdown-table-value">{renderInlineMath(value)}</span>
+            <span className="live-markdown-table-value" dangerouslySetInnerHTML={{ __html: renderLiveMarkdownTableInline(value) }} />
           </button>
         )}
       </Cell>

--- a/apps/electron/src/renderer/components/markdown/live-markdown-table-inline.ts
+++ b/apps/electron/src/renderer/components/markdown/live-markdown-table-inline.ts
@@ -1,0 +1,71 @@
+import MarkdownIt from 'markdown-it'
+import { renderMarkdownMath } from '@/lib/markdown-math'
+import { isLikelyLiveMarkdownLatex } from './live-markdown-table'
+
+interface TableInlineEnvironment {
+  breaks?: Array<{ from: number; to: number }>
+}
+
+// 表格单元格是编辑按钮的一部分：只渲染内联格式，不引入嵌套链接、图片或任意 HTML。
+const markdown = new MarkdownIt({ html: false, breaks: true, linkify: false })
+  .disable(['link', 'image', 'autolink'])
+
+markdown.inline.ruler.before('escape', 'table_math', (state, silent) => {
+  const remaining = state.src.slice(state.pos, state.posMax)
+  const match = remaining.match(/^(?:\$([^$\n]+)\$|\\\((.+?)\\\)|\\\[([\s\S]+?)\\\])/)
+  if (!match) return false
+  if (!silent) {
+    const token = state.push('table_math', '', 0)
+    token.content = match[1] ?? match[2] ?? match[3] ?? ''
+    token.block = Boolean(match[3])
+  }
+  state.pos += match[0].length
+  return true
+})
+
+markdown.inline.ruler.before('html_inline', 'table_break', (state, silent) => {
+  const match = state.src.slice(state.pos, state.posMax).match(/^<br\s*\/?>/i)
+  if (!match) return false
+  if (!silent) {
+    state.push('hardbreak', 'br', 0)
+    const environment = state.env as TableInlineEnvironment
+    environment.breaks?.push({ from: state.pos, to: state.pos + match[0].length })
+  }
+  state.pos += match[0].length
+  return true
+})
+
+function renderMath(latex: string, displayMode: boolean): string {
+  const html = renderMarkdownMath(latex, displayMode)
+  // 共享公式函数在异常时返回原文；此处的 HTML sink 必须将该 fallback 转义。
+  const safeHtml = html === latex ? markdown.utils.escapeHtml(latex) : html
+  return `<span class="live-markdown-table-math${displayMode ? ' is-display' : ''}">${safeHtml}</span>`
+}
+
+markdown.renderer.rules.table_math = (tokens, index) => {
+  const token = tokens[index]!
+  return renderMath(token.content, token.block)
+}
+markdown.renderer.rules.code_inline = (tokens, index) => {
+  const value = tokens[index]!.content
+  return isLikelyLiveMarkdownLatex(value)
+    ? renderMath(value, false)
+    : `<code>${markdown.utils.escapeHtml(value)}</code>`
+}
+markdown.renderer.rules.hardbreak = () => '<br>'
+markdown.renderer.rules.softbreak = () => '<br>'
+
+/** 仅转换语义换行；代码、公式、转义文本中的 <br> 保持原样，避免编辑后损坏内容。 */
+export function liveMarkdownTableCellDraft(value: string): string {
+  const breaks: NonNullable<TableInlineEnvironment['breaks']> = []
+  markdown.parseInline(value, { breaks } satisfies TableInlineEnvironment)
+  let draft = value
+  for (const { from, to } of breaks.sort((a, b) => b.from - a.from)) {
+    draft = draft.slice(0, from) + '\n' + draft.slice(to)
+  }
+  return draft.replace(/\r\n?/g, '\n')
+}
+
+export function renderLiveMarkdownTableInline(value: string): string {
+  return markdown.renderInline(value)
+}

--- a/apps/electron/src/renderer/components/markdown/live-markdown-table.ts
+++ b/apps/electron/src/renderer/components/markdown/live-markdown-table.ts
@@ -60,7 +60,7 @@ export function parseLiveMarkdownTable(source: string): LiveMarkdownTable | null
 }
 
 function escapeCell(value: string): string {
-  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>')
+  return value.replace(/\|/g, '\\|').replace(/\r\n?|\n/g, '<br>')
 }
 
 function serializeSeparator(alignment: LiveMarkdownTableAlignment): string {
@@ -89,6 +89,19 @@ export function isLikelyLiveMarkdownLatex(value: string): boolean {
   // form. Requiring braces for subscripts avoids rendering ordinary code such as
   // `file_name` and `v1_2` as math.
   return /^[A-Za-z](?:\^(?:\{[^}\n]+\}|[A-Za-z0-9+\-=()])|_\{[^}\n]+\})$/.test(trimmed)
+}
+
+export function liveMarkdownTableCellKeyAction(
+  key: string,
+  shiftKey: boolean,
+  isComposing: boolean,
+  keyCode: number,
+): 'commit' | 'cancel' | 'next' | 'previous' | 'newline' | null {
+  if (isComposing || keyCode === 229) return null
+  if (key === 'Enter') return shiftKey ? 'newline' : 'commit'
+  if (key === 'Escape') return 'cancel'
+  if (key === 'Tab') return shiftKey ? 'previous' : 'next'
+  return null
 }
 
 export function shouldCommitLiveMarkdownTableCell(currentValue: string, draft: string): boolean {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2681,28 +2681,37 @@
   outline-offset: -2px;
 }
 .live-markdown-table-editor .is-editing {
-  padding: 0.2rem 0.25rem;
   background: hsl(var(--muted) / 0.38);
 }
 .live-markdown-table-input {
+  display: block;
   box-sizing: border-box;
-  width: 100%;
+  width: calc(100% + 1.4rem);
   min-width: 0;
+  min-height: 2.35rem;
+  margin: -0.5rem -0.7rem;
+  resize: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   border: 0;
   border-radius: 0.25rem;
   background: hsl(var(--background));
   color: hsl(var(--foreground));
-  padding: 0.3rem 0.45rem;
+  padding: 0.5rem 0.7rem;
   font: inherit;
   line-height: inherit;
   outline: 2px solid hsl(var(--ring));
-  outline-offset: 0;
+  outline-offset: -2px;
 }
 .live-markdown-table-value {
   display: block;
   min-height: 1.35rem;
   overflow-wrap: anywhere;
   word-break: break-word;
+}
+.live-markdown-table-value strong {
+  font-weight: 700;
 }
 .live-markdown-table-math {
   display: inline-block;


### PR DESCRIPTION
## 概述

修复 Live Markdown 表格在编辑多行单元格时仅显示单行输入框的问题，并补齐表格单元格内的 Markdown 加粗渲染。编辑态改为覆盖完整单元格的自适应 textarea，阅读态使用受限的内联 Markdown 渲染器，同时保留现有公式、行内代码和表格查找高亮行为。

## 改动

- `apps/electron/src/renderer/components/markdown/LiveMarkdownTableEditor.tsx`
  - 将单行 `input` 替换为自动增高的 `textarea`，进入编辑时至少保持原单元格高度。
  - 支持 Enter 保存、Shift+Enter 换行、Tab/Shift+Tab 切换单元格、Escape 取消。
  - 组合输入期间忽略 Enter/Tab 等提交动作，避免中文及日文输入法误触发。
  - 在列宽变化后重新测量编辑区，并在卸载时清理 `ResizeObserver`。
  - 保留最新 `main` 加入的表格查找匹配和活动结果高亮。
- `apps/electron/src/renderer/components/markdown/live-markdown-table-inline.ts`
  - 新增受限的 `markdown-it` 内联渲染器，支持加粗、强调、代码、数学公式和无属性 `<br>`。
  - 关闭任意 HTML、链接、图片和自动链接；对代码和公式异常回退内容执行 HTML 转义。
  - 仅将语义 `<br>` 转成编辑草稿中的换行，避免破坏代码及公式的字面内容。
- `apps/electron/src/renderer/components/markdown/live-markdown-table.ts`
  - 保存时将 LF、CRLF 和孤立 CR 统一序列化为 `<br>`，防止多行内容被表格解析器误判为新行。
  - 集中定义表格单元格键盘动作及输入法组合态判断。
- `apps/electron/src/renderer/styles/globals.css`
  - 增加完整单元格编辑区的尺寸、折行和溢出样式，并明确表格内 `strong` 字重。
- `apps/electron/package.json`
  - Electron patch 版本更新至 `0.19.38`。

## 测试方法

1. 在 Live Markdown 中创建包含长文本和 `<br>` 的表格，点击单元格，确认 textarea 覆盖完整单元块且会随内容和列宽自动增高。
2. 使用 Shift+Enter 输入多行内容，再按 Enter 保存；确认 Markdown 源码使用 `<br>` 持久化，表格行列结构及相邻单元格不变。
3. 分别验证 Tab、Shift+Tab、Escape，以及中文输入法确认阶段的 Enter，不应产生错误提交或错位。
4. 在表头和普通单元格中输入 `**加粗**`，确认显示为粗体；同时验证行内代码和数学公式继续正确显示。
5. 打开预览查找，确认表格单元格匹配与当前匹配高亮仍正常。
6. 已执行并通过：
   - `bun test apps/electron/src/renderer/lib/markdown-rich-text.test.ts`（25 pass，0 fail）
   - `cd apps/electron && bun run typecheck`
   - `bun run typecheck`（全仓所有 package 通过）
   - `bun run --filter='@proma/electron' build:renderer`
   - `git diff --check`

## 备注

- 本分支基于最新 upstream `main`（`a987ec88`）创建，并已合并 `#2023` 新增的 Markdown 预览查找交互。
- 根据提交要求，本 PR 不包含此次开发过程中使用的新增回归测试文件；保留并运行了仓库现有 Markdown 测试。
- 未引入新依赖；`markdown-it` 与 KaTeX 均为 Electron 应用已有依赖。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
