### PR TITLE
fix(agent): resolve home paths and render local images

### DIFF
--- a/apps/electron/src/main/lib/agent-file-path.ts
+++ b/apps/electron/src/main/lib/agent-file-path.ts
@@ -2,13 +2,28 @@ import { homedir } from 'node:os'
 import { isAbsolute, resolve } from 'node:path'
 
 /**
+ * 展开 shell 风格的用户目录缩写。
+ *
+ * Node 的 path API 不会处理 `~`；只识别当前用户的 `~`、`~/…` 与 `~\\…`，
+ * 不支持也不会猜测 `~other-user`。后续调用方仍须完成自身的授权校验。
+ */
+export function expandHomeDirectory(filePath: string): string {
+  if (filePath === '~') return homedir()
+  if (filePath.startsWith('~/') || filePath.startsWith('~\\')) {
+    return resolve(homedir(), ...filePath.slice(2).split(/[\\/]+/))
+  }
+  return filePath
+}
+
+/**
  * 将 Agent 工具报告的文件路径解析到该会话实际运行的 cwd。
  *
- * Write/Edit 可接受相对路径；它们相对于 Agent cwd（项目目录或活动 worktree），
- * 未归属项目的会话则与 Agent 启动逻辑一致，回退到用户主目录。
+ * 支持 shell 风格的 `~` 用户目录缩写。其他相对路径仍相对于 Agent cwd（项目目录或
+ * 活动 worktree）；未归属项目的会话则与 Agent 启动逻辑一致，回退到用户主目录。
  */
 export function resolvePathAgainstAgentCwd(filePath: string, agentCwd?: string): string {
-  return isAbsolute(filePath)
-    ? resolve(filePath)
-    : resolve(agentCwd ?? homedir(), filePath)
+  const expandedPath = expandHomeDirectory(filePath)
+  return isAbsolute(expandedPath)
+    ? resolve(expandedPath)
+    : resolve(agentCwd ?? homedir(), expandedPath)
 }

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -16,6 +16,7 @@ import AdmZip from 'adm-zip'
 import { DOMParser } from '@xmldom/xmldom'
 import type { FilePreviewReadResult, OfficePreviewResult } from '@proma/shared'
 import { getBundledOfficeCliPath } from './officecli-manager'
+import { expandHomeDirectory } from './agent-file-path'
 
 const require = createRequire(__filename)
 const PDFJS_PACKAGE = 'pdfjs-dist'
@@ -91,7 +92,8 @@ export function cleanPreviewTmpDir(): number {
  * 「猜中一个同名文件」比明确提示找不到更危险；最终授权边界由 IPC 层 realpath 校验。
  */
 export function isAbsolutePreviewPath(filePath: string): boolean {
-  return filePath.startsWith('/') || filePath.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(filePath)
+  const expandedPath = expandHomeDirectory(filePath)
+  return expandedPath.startsWith('/') || expandedPath.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(expandedPath)
 }
 
 function isWithinBasePath(candidate: string, basePath: string): boolean {
@@ -142,7 +144,7 @@ function candidatePathsForRelativeFile(filePath: string, basePaths: readonly str
 
 export function resolveTargetPath(filePath: string, basePaths?: string[]): string {
   if (filePath.includes('\0')) return ''
-  if (isAbsolutePreviewPath(filePath)) return resolve(filePath)
+  if (isAbsolutePreviewPath(filePath)) return resolve(expandHomeDirectory(filePath))
 
   const bases = basePaths?.filter(Boolean) ?? []
   const candidates = candidatePathsForRelativeFile(filePath, bases)

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -1174,7 +1174,7 @@ export const AgentMessages = React.memo(function AgentMessages({
   }, [structuralGroups])
 
   return (
-    <BasePathsProvider basePaths={messageBasePaths}>
+    <BasePathsProvider basePaths={messageBasePaths} sessionId={sessionId}>
       <AgentBrowserLinkProvider sessionId={sessionId}>
         <div ref={historySelectionRootRef} className="relative flex min-h-0 flex-1 flex-col">
       <style>{`

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip-utils.ts
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip-utils.ts
@@ -26,6 +26,7 @@ const MAX_FILE_REFERENCE_LENGTH = 4096
 const PATH_SEP_RE = /[\\/]/
 const WIN_DRIVE_RE = /^[A-Za-z]:[\\/]/
 const UNC_PATH_RE = /^\\\\/
+const HOME_DIRECTORY_RE = /^~(?:[\\/]|$)/
 
 function getExtension(filename: string): string {
   const dot = filename.lastIndexOf('.')
@@ -48,7 +49,7 @@ export function stripLineCol(filePath: string): { path: string; suffix: string }
 
 /** 与主进程 file-preview-service.ts 的绝对路径规则保持一致。 */
 export function isAbsolutePreviewPath(filePath: string): boolean {
-  return filePath.startsWith('/') || UNC_PATH_RE.test(filePath) || WIN_DRIVE_RE.test(filePath)
+  return filePath.startsWith('/') || UNC_PATH_RE.test(filePath) || WIN_DRIVE_RE.test(filePath) || HOME_DIRECTORY_RE.test(filePath)
 }
 
 export function isImageFilePath(filePath: string): boolean {

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -37,10 +37,10 @@ interface FileResolutionCacheEntry {
   resolvedPath?: string
 }
 
-/** 文件存在性缓存（模块级共享，避免重复 IPC）。key = filePath + basePaths */
+/** 文件存在性缓存（模块级共享，避免重复 IPC）。key 包含会话授权上下文。 */
 const fileExistsCache = new Map<string, FileResolutionCacheEntry>()
-function existsCacheKey(filePath: string, bases: string[]): string {
-  return `${filePath}\0${bases.join('\0')}`
+function existsCacheKey(filePath: string, bases: string[], sessionId?: string): string {
+  return `${sessionId ?? ''}\0${filePath}\0${bases.join('\0')}`
 }
 
 interface FilePathChipProps {
@@ -50,11 +50,13 @@ interface FilePathChipProps {
   basePath?: string
   /** 多个候选基础目录（如主 cwd + 附加目录），点击时由主进程依次解析 */
   basePaths?: string[]
+  /** 消息所属会话；嵌入子会话时不得回退为父会话的授权边界。 */
+  sessionId?: string
   className?: string
 }
 
 /** 文件路径芯片 — 可点击，触发文件预览 */
-export function FilePathChip({ filePath, basePath, basePaths, className }: FilePathChipProps): React.ReactElement {
+export function FilePathChip({ filePath, basePath, basePaths, sessionId, className }: FilePathChipProps): React.ReactElement {
   const trimmedPath = filePath.trim()
   const { path: cleanPath, suffix: lineColSuffix } = stripLineCol(trimmedPath)
   const filename = getFileName(cleanPath)
@@ -80,17 +82,19 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
     lineColSuffix: resolvedPath ? lineColSuffix : '',
   }), [trimmedPath, resolvedPath, lineColSuffix])
 
+  const getSessionId = React.useCallback(() => sessionId ?? store.get(currentAgentSessionIdAtom) ?? undefined, [sessionId, store])
+
   const resolveCurrentPath = React.useCallback((): Promise<void> => {
-    const key = existsCacheKey(cleanPath, candidateBases)
+    const resolvedSessionId = getSessionId()
+    const key = existsCacheKey(cleanPath, candidateBases, resolvedSessionId)
     const inFlight = resolutionRequestRef.current
     if (inFlight?.key === key) return inFlight.promise
 
     const generation = ++requestGenerationRef.current
     const bases = candidateBases.length > 0 ? candidateBases : undefined
-    const sessionId = store.get(currentAgentSessionIdAtom)
     let promise: Promise<void>
     promise = window.electronAPI.resolveFilePath(cleanPath, {
-      sessionId: sessionId ?? undefined,
+      sessionId: resolvedSessionId ?? undefined,
       candidateBasePaths: bases,
     })
       .then((resolved) => {
@@ -111,7 +115,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
       })
     resolutionRequestRef.current = { key, promise }
     return promise
-  }, [cleanPath, candidateBases, store])
+  }, [cleanPath, candidateBases, getSessionId])
 
   // IntersectionObserver 首次懒检查可使用缓存；Tooltip 打开时会绕过缓存重新解析。
   React.useEffect(() => {
@@ -122,7 +126,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
     mountedRef.current = true
     setFileStatus('idle')
     setResolvedPath(undefined)
-    const key = existsCacheKey(cleanPath, candidateBases)
+    const key = existsCacheKey(cleanPath, candidateBases, getSessionId())
     const cached = fileExistsCache.get(key)
     if (cached) {
       setFileStatus(cached.exists ? 'resolved' : 'broken')
@@ -147,22 +151,22 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
       requestGenerationRef.current += 1
       observer.disconnect()
     }
-  }, [cleanPath, candidateBases, resolveCurrentPath])
+  }, [cleanPath, candidateBases, getSessionId, resolveCurrentPath])
 
   const handleTooltipOpenChange = React.useCallback((open: boolean) => {
     if (open) void resolveCurrentPath()
   }, [resolveCurrentPath])
 
   const handleClick = React.useCallback(() => {
-    const sessionId = store.get(currentAgentSessionIdAtom)
-    if (!sessionId) return
+    const resolvedSessionId = getSessionId()
+    if (!resolvedSessionId) return
 
-    openPreview(sessionId, {
+    openPreview(resolvedSessionId, {
       filePath: cleanPath,
       previewOnly: true,
       basePaths: candidateBases.length > 0 ? candidateBases : undefined,
     })
-  }, [store, openPreview, cleanPath, candidateBases])
+  }, [getSessionId, openPreview, cleanPath, candidateBases])
 
   const handleShowInFolder = React.useCallback(() => {
     const bases = candidateBases.length > 0 ? candidateBases : undefined

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -283,14 +283,20 @@ function safeDecode(raw: string): string {
 }
 
 /**
- * 附加 basePaths 上下文 — 用于把会话目录与附加目录穿透到各类文件 chip。
+ * 消息所属会话的路径解析上下文。嵌入显示子会话时，不能借用主会话的授权边界。
  */
-const BasePathsContext = React.createContext<string[] | undefined>(undefined)
+interface MessagePathResolutionContext {
+  basePaths?: string[]
+  sessionId?: string
+}
+
+const BasePathsContext = React.createContext<MessagePathResolutionContext | undefined>(undefined)
 const AgentHistoryQuoteClickContext = React.createContext<((quote: QuotedSelection) => void) | undefined>(undefined)
 
-/** 提供附加目录候选给所有内嵌的 MessageResponse。 */
-export function BasePathsProvider({ basePaths, children }: { basePaths?: string[]; children: React.ReactNode }): React.ReactElement {
-  return <BasePathsContext.Provider value={basePaths}>{children}</BasePathsContext.Provider>
+/** 提供会话与附加目录候选给所有内嵌的 MessageResponse。 */
+export function BasePathsProvider({ basePaths, sessionId, children }: MessagePathResolutionContext & { children: React.ReactNode }): React.ReactElement {
+  const value = React.useMemo(() => ({ basePaths, sessionId }), [basePaths, sessionId])
+  return <BasePathsContext.Provider value={value}>{children}</BasePathsContext.Provider>
 }
 
 /** 仅在普通文本中转换旧引用，避免改写 inline code、fenced code 和缩进代码块。 */
@@ -350,7 +356,8 @@ function SkillMentionLabel({ slug }: { slug: string }): React.ReactElement {
 function MentionChip({ type, value }: { type: MentionType; value: string }): React.ReactElement {
   const style = MENTION_STYLES[type]
   const Icon = style.icon
-  const contextBasePaths = React.useContext(BasePathsContext)
+  const pathResolutionContext = React.useContext(BasePathsContext)
+  const contextBasePaths = pathResolutionContext?.basePaths
   const onAgentHistoryQuoteClick = React.useContext(AgentHistoryQuoteClickContext)
 
   if (type === 'quote') {
@@ -386,7 +393,7 @@ function MentionChip({ type, value }: { type: MentionType; value: string }): Rea
   const decoded = safeDecode(value)
   // 避免用户只能看到文件名而无法查看内容。
   if (type === 'file' && isImageFilePath(decoded)) {
-    return <FilePathChip filePath={decoded} basePaths={contextBasePaths} />
+    return <FilePathChip filePath={decoded} basePaths={contextBasePaths} sessionId={pathResolutionContext?.sessionId} />
   }
 
   const isNamedReference = type === 'session' || type === 'todo' || type === 'calendar_event'
@@ -544,7 +551,8 @@ const MarkdownLink = React.memo(function MarkdownLink({
   ...linkProps
 }: React.AnchorHTMLAttributes<HTMLAnchorElement>): React.ReactElement {
   const agentBrowserLink = useAgentBrowserLink()
-  const contextBasePaths = React.useContext(BasePathsContext)
+  const pathResolutionContext = React.useContext(BasePathsContext)
+  const contextBasePaths = pathResolutionContext?.basePaths
   // mention:// 协议 → 渲染为 MentionChip
   if (href) {
     const mentionMatch = MENTION_URL_RE.exec(href)
@@ -554,7 +562,7 @@ const MarkdownLink = React.memo(function MarkdownLink({
 
     const filePath = safeDecode(href)
     if (isLocalFileReference(filePath)) {
-      return <FilePathChip filePath={filePath} basePaths={contextBasePaths} />
+      return <FilePathChip filePath={filePath} basePaths={contextBasePaths} sessionId={pathResolutionContext?.sessionId} />
     }
   }
 
@@ -574,6 +582,63 @@ const MarkdownLink = React.memo(function MarkdownLink({
       {linkChildren}
     </a>
   )
+})
+
+/**
+ * 将 Agent Markdown 中的本地图片路径转换为经主进程授权的 proma-file URL。
+ *
+ * 浏览器无法直接加载 `~`、绝对本地路径或 Agent cwd 下的相对路径；必须先通过
+ * file:resolve-path 解析，避免把本地路径暴露给 renderer，也保留会话授权边界。
+ */
+const MarkdownImage = React.memo(function MarkdownImage({
+  src,
+  alt = '',
+  ...imageProps
+}: React.ImgHTMLAttributes<HTMLImageElement>): React.ReactElement | null {
+  const pathResolutionContext = React.useContext(BasePathsContext)
+  const contextBasePaths = pathResolutionContext?.basePaths
+  const [resolvedSrc, setResolvedSrc] = React.useState<string | null>(null)
+  const [failed, setFailed] = React.useState(false)
+  const decodedSrc = src ? safeDecode(src) : ''
+  const isLocalSource = isLocalFileReference(decodedSrc)
+
+  React.useEffect(() => {
+    if (!isLocalSource) {
+      setResolvedSrc(null)
+      setFailed(false)
+      return
+    }
+
+    let cancelled = false
+    setResolvedSrc(null)
+    setFailed(false)
+    void window.electronAPI.resolveFilePath(decodedSrc, {
+      sessionId: pathResolutionContext?.sessionId,
+      candidateBasePaths: contextBasePaths?.length ? contextBasePaths : undefined,
+    }).then((result) => {
+      if (cancelled) return
+      if (!result) {
+        setFailed(true)
+        return
+      }
+      setResolvedSrc(result.url)
+    }).catch(() => {
+      if (!cancelled) setFailed(true)
+    })
+
+    return () => { cancelled = true }
+  }, [contextBasePaths, decodedSrc, isLocalSource, pathResolutionContext?.sessionId])
+
+  if (!src) return null
+  if (!isLocalSource) return <img src={src} alt={alt} {...imageProps} />
+  if (!resolvedSrc) {
+    return (
+      <span className="inline-flex max-w-full rounded bg-muted px-2 py-1 text-xs text-muted-foreground" role="img" aria-label={alt || decodedSrc}>
+        {failed ? `图片无法读取：${alt || decodedSrc}` : '正在加载图片…'}
+      </span>
+    )
+  }
+  return <img src={resolvedSrc} alt={alt} {...imageProps} onError={() => { setResolvedSrc(null); setFailed(true) }} />
 })
 
 /** 递归提取纯文本（children 可能是字符串数组） */
@@ -643,7 +708,8 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
   ...codeProps
 }: React.HTMLAttributes<HTMLElement> & { basePath?: string; basePaths?: string[] }): React.ReactElement {
   // 兜底：从 context 读附加 basePaths（避免穿透 SDKMessageRenderer / ContentBlock 等中间层）
-  const ctxBasePaths = React.useContext(BasePathsContext)
+  const pathResolutionContext = React.useContext(BasePathsContext)
+  const ctxBasePaths = pathResolutionContext?.basePaths
   // 本轮「文件名 → 绝对路径」映射：命中时把内联裸文件名补全为绝对路径
   const turnFileMap = React.useContext(TurnFileMapContext)
   if (codeClassName) {
@@ -663,7 +729,7 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
       }
     }
     if (isAbsoluteFilePath(text)) {
-      return <FilePathChip filePath={text.trim()} basePaths={merged.length > 0 ? merged : undefined} />
+      return <FilePathChip filePath={text.trim()} basePaths={merged.length > 0 ? merged : undefined} sessionId={pathResolutionContext?.sessionId} />
     }
     if (merged.length > 0 && isRelativeFilePath(text)) {
       // 命中本轮实际触及文件的映射时，用绝对路径替换裸文件名（保留行号后缀），
@@ -677,10 +743,10 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
         const baseName = pathPart.split(/[\\/]/).pop() || pathPart
         const abs = turnFileMap.get(baseName)
         if (abs) {
-          return <FilePathChip filePath={abs + suffix} basePaths={merged} />
+          return <FilePathChip filePath={abs + suffix} basePaths={merged} sessionId={pathResolutionContext?.sessionId} />
         }
       }
-      return <FilePathChip filePath={trimmed} basePaths={merged} />
+      return <FilePathChip filePath={trimmed} basePaths={merged} sessionId={pathResolutionContext?.sessionId} />
     }
   }
 
@@ -706,6 +772,7 @@ export const MessageResponse = React.memo(
     // 稳定引用的 components 对象，避免 react-markdown 每帧重建组件映射
     const components = React.useMemo(() => ({
       a: MarkdownLink,
+      img: MarkdownImage,
       pre: MarkdownPre,
       code: (props: React.HTMLAttributes<HTMLElement>) => (
         <MarkdownInlineCode {...props} basePath={basePath} basePaths={basePaths} />

--- a/apps/electron/src/renderer/components/diff/preview-open-path.ts
+++ b/apps/electron/src/renderer/components/diff/preview-open-path.ts
@@ -3,7 +3,7 @@ import type { PreviewFile } from '@/atoms/preview-atoms'
 import { arePathsEqual } from '@/lib/session-file-changes'
 
 export function isAbsoluteFilePath(filePath: string): boolean {
-  return filePath.startsWith('/') || filePath.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(filePath)
+  return filePath.startsWith('/') || filePath.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(filePath) || /^~(?:[\\/]|$)/.test(filePath)
 }
 
 function joinFilePath(basePath: string, filePath: string): string {


### PR DESCRIPTION
## Summary
- expand current-user `~` paths consistently across Agent file resolution and previews
- render local Markdown images through authorized token-gated URLs
- preserve embedded sub-session authorization for image and file-chip paths

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`
- `git diff --check`

Performance impact: low. Local image/file resolution performs one asynchronous IPC lookup per mounted unique path and keeps the existing lazy chip-resolution behavior; no stream-level polling or global state update was added.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)