### PR TITLE
fix(sidebar): 优化左栏层级与滚动边界【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.51",
+  "version": "0.19.52",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.49",
+  "version": "0.19.50",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.48",
+  "version": "0.19.49",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.38",
+  "version": "0.19.47",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.47",
+  "version": "0.19.48",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.50",
+  "version": "0.19.51",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -109,6 +109,7 @@ import { CollapsedToolsPopover, type CollapsedToolItem } from '@/components/agen
 import { CollapsedSessionRail, type RailRecentItem } from '@/components/agent/CollapsedSessionRail'
 import { ObsidianIcon } from '@/components/obsidian/obsidian-brand'
 import { VirtualSidebarList, type VirtualSidebarRow } from '@/components/ui/virtual-sidebar-list'
+import { SidebarScrollBoundary } from '@/components/ui/sidebar-scroll-boundary'
 import { LocalProjectBadge } from '@/components/agent/LocalProjectBadge'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
 import {
@@ -2666,7 +2667,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                   aria-expanded={!collapsed}
                   onClick={() => handleToggleArchivedProject(group.id)}
                   className={cn(
-                    'relative flex-1 min-w-0 flex h-[34px] items-center gap-2 pl-2 pr-1 py-1.5 rounded-md text-left transition-[color,background-color] titlebar-no-drag hover:bg-foreground/[0.025]',
+                    'relative flex-1 min-w-0 flex h-[34px] items-center gap-2 pl-[10px] pr-1 py-1.5 rounded-md text-left transition-[color,background-color] titlebar-no-drag hover:bg-foreground/[0.025]',
                     'text-[hsl(var(--sidebar-primary-foreground))] hover:text-[hsl(var(--sidebar-primary-foreground))]',
                   )}
                 >
@@ -3555,20 +3556,24 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         )}
       </div>
 
-      {/* Chat 模式 active 视图：置顶 + 对话历史，结构与 Agent active 视图保持一致 */}
+      {/* 原生与虚拟列表共享顶部反馈，切换视图时不沿用上一列表的滚动状态。 */}
       {mode === 'chat' && viewMode === 'active' ? (
-        <VirtualSidebarList
-          key="chat-active-list"
-          className="flex-1"
-          rows={chatActiveVirtualRows}
-          activeRowId={activeSessionId ? `chat-${activeSessionId}` : null}
-        />
+        <SidebarScrollBoundary key="chat-active-boundary">
+          <VirtualSidebarList
+            key="chat-active-list"
+            className="flex-1"
+            rows={chatActiveVirtualRows}
+            activeRowId={activeSessionId ? `chat-${activeSessionId}` : null}
+          />
+        </SidebarScrollBoundary>
       ) : mode === 'agent' && viewMode === 'active' ? (
-        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin titlebar-no-drag px-2 pb-3">
-          {agentActiveVirtualRows.map((row) => (
-            <React.Fragment key={row.id}>{row.content}</React.Fragment>
-          ))}
-        </div>
+        <SidebarScrollBoundary key="agent-active-boundary">
+          <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin titlebar-no-drag px-2 pb-3">
+            {agentActiveVirtualRows.map((row) => (
+              <React.Fragment key={row.id}>{row.content}</React.Fragment>
+            ))}
+          </div>
+        </SidebarScrollBoundary>
       ) : (
         <>
           {/* 归档视图标题栏 */}
@@ -3582,19 +3587,23 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
           {/* 归档视图：单列表布局 */}
           {mode === 'chat' ? (
-            <VirtualSidebarList
-              key="chat-archived-list"
-              className="flex-1 px-3 pt-2 pb-3"
-              rows={chatArchivedVirtualRows}
-              activeRowId={activeSessionId ? `chat-archived-${activeSessionId}` : null}
-            />
+            <SidebarScrollBoundary key="chat-archived-boundary">
+              <VirtualSidebarList
+                key="chat-archived-list"
+                className="flex-1 px-3 pt-2 pb-3"
+                rows={chatArchivedVirtualRows}
+                activeRowId={activeSessionId ? `chat-archived-${activeSessionId}` : null}
+              />
+            </SidebarScrollBoundary>
           ) : (
-            <VirtualSidebarList
-              key="agent-archived-list"
-              className="flex-1 px-3 pt-2 pb-3"
-              rows={agentArchivedVirtualRows}
-              activeRowId={activeSessionId ? `agent-archived-${activeSessionId}` : null}
-            />
+            <SidebarScrollBoundary key="agent-archived-boundary">
+              <VirtualSidebarList
+                key="agent-archived-list"
+                className="flex-1 px-3 pt-2 pb-3"
+                rows={agentArchivedVirtualRows}
+                activeRowId={activeSessionId ? `agent-archived-${activeSessionId}` : null}
+              />
+            </SidebarScrollBoundary>
           )}
         </>
       )}
@@ -4786,7 +4795,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         {renamingWorkspace ? (
           <div
             className={cn(
-              'relative flex-1 min-w-0 flex h-[34px] items-center gap-2 pl-2 pr-1 py-1.5 rounded-md text-left titlebar-no-drag',
+              'relative flex-1 min-w-0 flex h-[34px] items-center gap-2 pl-[10px] pr-1 py-1.5 rounded-md text-left titlebar-no-drag',
               'text-[hsl(var(--sidebar-primary-foreground))]',
             )}
           >
@@ -4813,7 +4822,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               onSelectProject(group.workspace.id)
             }}
             className={cn(
-              'relative flex-1 min-w-0 flex h-[34px] cursor-grab items-center gap-2 pl-2 py-1.5 rounded-md text-left transition-[color,background-color] titlebar-no-drag active:cursor-grabbing hover:bg-foreground/[0.025]',
+              'relative flex-1 min-w-0 flex h-[34px] cursor-grab items-center gap-2 pl-[10px] py-1.5 rounded-md text-left transition-[color,background-color] titlebar-no-drag active:cursor-grabbing hover:bg-foreground/[0.025]',
               isAutomationGroup ? 'pr-1' : 'pr-12',
               'text-[hsl(var(--sidebar-primary-foreground))] hover:text-[hsl(var(--sidebar-primary-foreground))]',
             )}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Star, Settings, Plus, CirclePlus, Trash2, Pencil, PanelLeft, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, CalendarDays, ChevronRight, ChevronDown, ChevronUp, ChevronsDownUp, Blocks, Brain, ListTodo, GitBranch, Download, Loader2, RotateCw, Info } from 'lucide-react'
+import { Pin, PinOff, Star, Settings, Plus, CirclePlus, Trash2, Pencil, PanelLeft, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, Clock, CalendarDays, ChevronRight, ChevronDown, ChevronUp, ChevronsDownUp, Blocks, Brain, ListTodo, GitBranch, Download, Loader2, RotateCw, Info } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -270,12 +270,12 @@ function WorkspaceComponentSidebarEntry({ label, icon, active, onClick, badge }:
       className={cn(
         'group flex w-full items-center justify-between rounded-md px-3 py-2 text-[13px] transition-colors duration-100 titlebar-no-drag',
         active
-          ? 'bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-          : 'text-foreground/75 hover:bg-accent-foreground/[0.08] hover:text-foreground',
+          ? 'bg-accent-foreground/[0.10] text-[hsl(var(--sidebar-primary-foreground))] shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          : 'text-[hsl(var(--sidebar-primary-foreground))] hover:bg-accent-foreground/[0.08] hover:text-[hsl(var(--sidebar-primary-foreground))]',
       )}
     >
       <span className="flex min-w-0 items-center gap-3">
-        <span className={cn('flex size-[18px] shrink-0 items-center justify-center', active ? 'text-accent-foreground' : 'text-foreground/60')}>
+        <span className={cn('flex size-[18px] shrink-0 items-center justify-center', active ? 'text-accent-foreground' : 'text-[hsl(var(--sidebar-primary-foreground))]')}>
           {icon}
         </span>
         <span className="truncate">{label}</span>
@@ -2529,8 +2529,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     if (pinnedConversations.length > 0) {
       rows.push({
         id: 'chat-pinned-heading',
-        estimateSize: 30,
-        content: <div className="pl-[18px] pr-3.5 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">置顶</div>,
+        estimateSize: 32,
+        content: <div className="pl-[18px] pr-3.5 pt-2 pb-1 text-[15px] font-medium leading-5 text-foreground/45 select-none">置顶</div>,
       })
       for (const conv of pinnedConversations) {
         rows.push({
@@ -2660,31 +2660,20 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         content: (
           <div className="px-2">
             <section className="relative py-0.5 rounded-md">
-              <div className="group/project relative flex translate-x-[2px] items-center">
+              <div className="group/project relative flex items-center">
                 <button
                   type="button"
                   aria-expanded={!collapsed}
                   onClick={() => handleToggleArchivedProject(group.id)}
                   className={cn(
-                    'relative flex-1 min-w-0 flex items-center gap-1 pl-[9px] pr-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 hover:bg-foreground/[0.025]',
-                    isCurrentProject
-                      ? 'agent-project-item-current text-foreground'
-                      : 'text-foreground/65 hover:text-foreground/88',
+                    'relative flex-1 min-w-0 flex items-center gap-2 pl-2 pr-1 py-1 rounded-md text-left transition-[color,background-color] titlebar-no-drag hover:bg-foreground/[0.025]',
+                    'text-[hsl(var(--sidebar-primary-foreground))] hover:text-[hsl(var(--sidebar-primary-foreground))]',
                   )}
                 >
                   {group.kind === 'automation' ? (
                     <Clock size={13} className="flex-shrink-0 text-foreground/40" />
                   ) : (
-                    <>
-                      <FolderOpen size={13} className="flex-shrink-0 text-foreground/40 group-hover/project:hidden" />
-                      <ChevronRight
-                        size={13}
-                        className={cn(
-                          'hidden flex-shrink-0 text-foreground/40 transition-transform duration-150 group-hover/project:block',
-                          collapsed ? '-rotate-90' : 'rotate-90',
-                        )}
-                      />
-                    </>
+                    <FolderOpen size={14} className="flex-shrink-0 text-[hsl(var(--sidebar-primary-foreground)/0.78)] dark:text-[hsl(var(--sidebar-primary-foreground)/0.65)]" />
                   )}
                   <span className="flex min-w-0 items-center gap-1.5">
                     <span className="min-w-0 truncate text-[13px] font-medium leading-[18px]">{group.label}</span>
@@ -2811,7 +2800,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         estimateSize: 34,
         content: (
           <div
-            className="ml-4"
+            className="ml-7"
             onDragOver={projectWorkspaceId ? (event) => handleProjectDragOver(event, projectWorkspaceId) : undefined}
             onDragLeave={projectWorkspaceId ? handleProjectDragLeave : undefined}
             onDrop={projectWorkspaceId ? (event) => handleProjectDrop(event, projectWorkspaceId) : undefined}
@@ -2822,6 +2811,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               indicatorStatus={rowStatus}
               showPinIcon={showPinIcon && !!item.session.pinned}
               disableMiniMap={!sessionHoverPreviewEnabled}
+              suppressAutomationIcon={isAutomationGroup}
               delegationSummary={childCount > 0
                 ? {
                   total: childCount,
@@ -2866,6 +2856,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                   activeDelegationSessionId={activeDelegationSessionId}
                   agentIndicatorMap={agentIndicatorMap}
                   relativeTimeNow={relativeTimeNow}
+                  suppressAutomationIcon={isAutomationGroup}
                   workspaceName={isAutomationGroup && childSession.workspaceId ? workspaceNameMapForRow?.get(childSession.workspaceId) : undefined}
                   onSelect={handleSelectAgentSession}
                   onRequestDelete={handleRequestDelete}
@@ -2885,8 +2876,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     if (pinnedAgentSessionTrees.length > 0) {
       rows.push({
         id: 'agent-pinned-heading',
-        estimateSize: 30,
-        content: <div className="pl-[18px] pr-3.5 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">置顶</div>,
+        estimateSize: 32,
+        content: <div className="pl-[18px] pr-3.5 pt-2 pb-1 text-[15px] font-medium leading-5 text-foreground/45 select-none">置顶</div>,
       })
       for (const item of pinnedAgentSessionTrees) {
         pushSessionTreeRows(item, false, false, workspaceNameMap)
@@ -2897,10 +2888,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
     rows.push({
       id: 'agent-project-heading',
-      estimateSize: 34,
+      estimateSize: 40,
       content: (
         <div className="px-2 pt-2 pb-1 flex items-center justify-between">
-          <span className="px-1.5 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">项目</span>
+          <span className="px-1.5 text-[15px] font-medium leading-5 text-foreground/45 select-none">项目</span>
           <div className="flex items-center gap-0.5">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -2914,10 +2905,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                       return next
                     })
                   }}
-                  className="size-6 flex items-center justify-center rounded-md text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/60 transition-colors titlebar-no-drag disabled:opacity-30 disabled:pointer-events-none"
+                  className="size-7 flex items-center justify-center rounded-md text-[hsl(var(--sidebar-primary-foreground)/0.65)] hover:bg-foreground/[0.06] hover:text-[hsl(var(--sidebar-primary-foreground))] transition-colors titlebar-no-drag disabled:opacity-30 disabled:pointer-events-none"
                   aria-label="折叠所有项目"
                 >
-                  <ChevronsDownUp size={13} />
+                  <ChevronsDownUp size={15} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top">折叠所有项目</TooltipContent>
@@ -2927,10 +2918,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                 <button
                   type="button"
                   onClick={() => void handleCreateProjectFromFolder()}
-                  className="size-6 flex items-center justify-center rounded-md text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                  className="size-7 flex items-center justify-center rounded-md text-[hsl(var(--sidebar-primary-foreground)/0.65)] hover:bg-foreground/[0.06] hover:text-[hsl(var(--sidebar-primary-foreground))] transition-colors titlebar-no-drag"
                   aria-label="从本地文件夹创建项目"
                 >
-                  <FolderInput size={13} />
+                  <FolderInput size={15} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top">从本地文件夹创建项目</TooltipContent>
@@ -2940,10 +2931,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                 <button
                   type="button"
                   onClick={handleStartCreateProject}
-                  className="size-6 flex items-center justify-center rounded-md text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                  className="size-7 flex items-center justify-center rounded-md text-[hsl(var(--sidebar-primary-foreground)/0.65)] hover:bg-foreground/[0.06] hover:text-[hsl(var(--sidebar-primary-foreground))] transition-colors titlebar-no-drag"
                   aria-label="新建空白项目"
                 >
-                  <Plus size={13} />
+                  <Plus size={15} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top">新建空白项目</TooltipContent>
@@ -3045,7 +3036,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           rows.push({
             id: `agent-project-empty-${group.workspace.id}`,
             estimateSize: 28,
-            content: <div className="ml-5 px-1.5 py-0.5 text-[12px] text-foreground/22 select-none">暂无会话</div>,
+            content: <div className="ml-[38px] py-0.5 text-[12px] text-muted-foreground/75 select-none">暂无会话</div>,
           })
         } else {
           for (const item of visible.sessions) pushSessionTreeRows(item, isAuto, true, workspaceNameMap, group.workspace.id)
@@ -3054,7 +3045,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               id: `agent-project-controls-${group.workspace.id}`,
               estimateSize: 34,
               content: (
-                <div className="ml-4 flex items-center gap-0.5 pt-0.5">
+                <div className="ml-7 flex items-center gap-0.5 pt-0.5">
                   {visible.hiddenCount > 0 && (
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -3465,7 +3456,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               type="button"
               aria-label={mode === 'agent' ? '新建任务' : '新建对话'}
               onClick={() => { void (mode === 'agent' ? createAgentSessionInWorkspace() : createChat()) }}
-              className="group flex h-9 min-w-0 flex-1 items-center gap-3 rounded-lg px-3 text-[13px] font-medium text-foreground/70 transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-foreground active:scale-[0.96] titlebar-no-drag"
+              className="group flex h-9 min-w-0 flex-1 items-center gap-3 rounded-lg px-3 text-[13px] text-[hsl(var(--sidebar-primary-foreground))] transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-[hsl(var(--sidebar-primary-foreground))] active:scale-[0.96] titlebar-no-drag"
             >
               <CirclePlus size={16} className="shrink-0" />
               <span>{mode === 'agent' ? '新建任务' : '新建对话'}</span>
@@ -3491,7 +3482,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               type="button"
               onClick={() => setSearchDialogOpen(true)}
               aria-label="搜索"
-              className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-foreground/45 transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-foreground active:scale-[0.96] titlebar-no-drag"
+              className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-[hsl(var(--sidebar-primary-foreground))] transition-[background-color,color,transform] hover:bg-foreground/[0.055] hover:text-[hsl(var(--sidebar-primary-foreground))] active:scale-[0.96] titlebar-no-drag"
             >
               <Search size={16} />
             </button>
@@ -4051,10 +4042,7 @@ const ConversationItem = React.memo(function ConversationItem({
                 maxLength={100}
               />
             ) : (
-              <div className={cn(
-                'truncate text-[13px] leading-[18px] flex items-center gap-1.5',
-                active ? 'text-foreground' : 'text-foreground/80'
-              )}>
+              <div className="truncate text-[13px] leading-[18px] flex items-center gap-1.5 text-[hsl(var(--sidebar-primary-foreground))]">
                 {/* 置顶标记 */}
                 {showPinIcon && (
                   <Pin size={11} className="flex-shrink-0 text-primary/60" />
@@ -4137,6 +4125,8 @@ interface AgentSessionItemProps {
   leftAccent?: SessionLeftAccent
   /** 是否禁用悬浮 Mini 地图 */
   disableMiniMap?: boolean
+  /** 定时任务合成项目内已由项目标题表达来源，隐藏行内重复时钟。 */
+  suppressAutomationIcon?: boolean
   /** 项目名称 Badge（跨项目列表时显示） */
   workspaceName?: string
   /** 用同一个时间戳刷新相对时间，避免每行独立计时 */
@@ -4158,6 +4148,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   delegationSummary,
   leftAccent,
   disableMiniMap,
+  suppressAutomationIcon,
   workspaceName,
   relativeTimeNow,
   onSelect,
@@ -4377,14 +4368,11 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                 maxLength={100}
               />
             ) : (
-              <div className={cn(
-                'truncate text-[13px] leading-[18px] flex items-center gap-1.5',
-                active ? 'text-foreground' : 'text-foreground/80'
-              )}>
+              <div className="truncate text-[13px] leading-[18px] flex items-center gap-1.5 text-[hsl(var(--sidebar-primary-foreground))]">
                 {showPinIcon && (
                   <Pin size={11} className="flex-shrink-0 text-primary/60" />
                 )}
-                {session.sourceAutomationId && !session.sourceDelegationId && (
+                {!suppressAutomationIcon && session.sourceAutomationId && !session.sourceDelegationId && (
                   <Clock size={11} className="flex-shrink-0 text-foreground/40" />
                 )}
                 {session.sourceDelegationId && (
@@ -4435,18 +4423,23 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                     {workspaceName}
                   </span>
                 )}
-                {delegationSummary && (
-                  <span className="flex-shrink-0 text-[11px] leading-4 text-foreground/45">
-                    {delegationSummary.settled}/{delegationSummary.total}
-                  </span>
-                )}
               </div>
             )}
           </div>
 
           {!editing && (
             <>
-              {delegationSummary && (
+              <div
+                className="flex w-9 shrink-0 items-center justify-end gap-1 text-[11px] leading-4 text-foreground/55"
+                aria-label={delegationSummary ? `子会话：${delegationSummary.settled}/${delegationSummary.total}` : undefined}
+              >
+                {delegationSummary && (
+                  <span className="shrink-0 tabular-nums">
+                    {delegationSummary.settled}/{delegationSummary.total}
+                  </span>
+                )}
+              </div>
+              {delegationSummary ? (
                 <SafeTooltip content={delegationSummary.expanded ? '收起子会话' : '展开子会话'} side="top">
                   <button
                     type="button"
@@ -4477,6 +4470,8 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                     />
                   </button>
                 </SafeTooltip>
+              ) : (
+                <span className="size-6 shrink-0" aria-hidden="true" />
               )}
               <SessionItemActions
                 updatedAt={session.updatedAt}
@@ -4519,6 +4514,8 @@ interface DelegatedChildSessionItemProps {
   activeDelegationSessionId: string | null
   agentIndicatorMap: Map<string, SessionIndicatorStatus>
   relativeTimeNow: number
+  /** 定时任务合成项目内隐藏行级时钟。 */
+  suppressAutomationIcon?: boolean
   workspaceName?: string
   onSelect: (id: string, title: string) => void
   onRequestDelete: (id: string) => void
@@ -4535,6 +4532,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
   activeDelegationSessionId,
   agentIndicatorMap,
   relativeTimeNow,
+  suppressAutomationIcon,
   workspaceName,
   onSelect,
   onRequestDelete,
@@ -4556,6 +4554,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
       indicatorStatus={status}
       disableMiniMap={!sessionHoverPreviewEnabled}
       relativeTimeNow={relativeTimeNow}
+      suppressAutomationIcon={suppressAutomationIcon}
       workspaceName={workspaceName}
       onSelect={onSelect}
       onRequestDelete={onRequestDelete}
@@ -4717,7 +4716,6 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   hideSessions = false,
 }: AgentProjectGroupItemProps): React.ReactElement {
   const isCurrent = group.workspace.id === currentWorkspaceId
-  const newSessionShortcutLabel = getAcceleratorDisplay(getActiveAccelerator('new-session'))
   const sessionHoverPreviewEnabled = useAtomValue(sessionHoverPreviewEnabledAtom)
   const hasUnavailableProjectRoot = Boolean(
     group.workspace.projectRootPath
@@ -4784,27 +4782,15 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         <div className="absolute -top-0.5 left-3 right-3 h-0.5 translate-x-[2px] rounded-full bg-primary z-10" />
       )}
 
-      <div className="group/project relative flex translate-x-[2px] items-center">
-        <span
-          draggable
-          onDragStart={(e) => onDragStart(e, group.workspace.id)}
-          title="拖拽排序"
-          className="absolute -left-0.5 top-1/2 z-10 flex size-[18px] -translate-y-1/2 cursor-grab items-center justify-center text-foreground/20 opacity-0 transition-opacity group-hover/project:opacity-100 active:cursor-grabbing"
-          aria-hidden="true"
-        >
-          <GripVertical size={12} />
-        </span>
-
+      <div className="group/project relative flex items-center">
         {renamingWorkspace ? (
           <div
             className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-1 pl-[9px] pr-1 py-1 rounded-md text-left titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11',
-              isCurrent
-                ? 'agent-project-item-current text-foreground'
-                : 'text-foreground/65',
+              'relative flex-1 min-w-0 flex items-center gap-2 pl-2 pr-1 py-1 rounded-md text-left titlebar-no-drag',
+              'text-[hsl(var(--sidebar-primary-foreground))]',
             )}
           >
-            <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+            <FolderOpen size={14} className="flex-shrink-0 text-[hsl(var(--sidebar-primary-foreground)/0.78)] dark:text-[hsl(var(--sidebar-primary-foreground)/0.65)]" />
             <input
               ref={workspaceEditRef}
               value={workspaceEditName}
@@ -4820,31 +4806,22 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
             type="button"
             aria-expanded={!collapsed}
             aria-controls={hideSessions ? undefined : `project-sessions-${group.workspace.id}`}
+            draggable={!renamingWorkspace}
+            onDragStart={(e) => onDragStart(e, group.workspace.id)}
             onClick={(e) => {
               e.stopPropagation()
               onSelectProject(group.workspace.id)
             }}
             className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-1 pl-[9px] py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 hover:bg-foreground/[0.025]',
+              'relative flex-1 min-w-0 flex cursor-grab items-center gap-2 pl-2 py-1 rounded-md text-left transition-[color,background-color] titlebar-no-drag active:cursor-grabbing hover:bg-foreground/[0.025]',
               isAutomationGroup ? 'pr-1' : 'pr-12',
-              isCurrent
-                ? 'agent-project-item-current text-foreground'
-                : 'text-foreground/65 hover:text-foreground/88',
+              'text-[hsl(var(--sidebar-primary-foreground))] hover:text-[hsl(var(--sidebar-primary-foreground))]',
             )}
           >
             {isAutomationGroup ? (
               <Clock size={13} className="flex-shrink-0 text-foreground/40" />
             ) : (
-              <>
-                <FolderOpen size={13} className="flex-shrink-0 text-foreground/40 group-hover/project:hidden" />
-                <ChevronRight
-                  size={13}
-                  className={cn(
-                    'hidden flex-shrink-0 text-foreground/40 transition-transform duration-150 group-hover/project:block',
-                    collapsed ? '-rotate-90' : 'rotate-90',
-                  )}
-                />
-              </>
+              <FolderOpen size={14} className="flex-shrink-0 text-[hsl(var(--sidebar-primary-foreground)/0.78)] dark:text-[hsl(var(--sidebar-primary-foreground)/0.65)]" />
             )}
             <span className="flex min-w-0 items-center gap-1.5">
               <span className="min-w-0 truncate text-[13px] font-medium leading-[18px]">
@@ -4888,7 +4865,10 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
             </button>
           </TooltipTrigger>
           <TooltipContent side="top">
-            {`在此项目中新建会话${newSessionShortcutLabel ? ` (${newSessionShortcutLabel})` : ''}`}
+            <span className="flex items-center gap-2">
+              <span>新建会话</span>
+              <ShortcutKeycaps shortcutId="new-session" keycapClassName="h-5 min-w-5 px-1 text-[11px]" separatorClassName="text-[10px]" />
+            </span>
           </TooltipContent>
         </Tooltip>
         )}
@@ -4965,7 +4945,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
       </div>
 
       {!hideSessions && (
-        <div id={`project-sessions-${group.workspace.id}`} className="ml-4 mt-px">
+        <div id={`project-sessions-${group.workspace.id}`} className="ml-5 mt-px">
         {!collapsed ? (
           treeItems.length > 0 ? (
             <div className="flex flex-col gap-0.5">
@@ -4985,6 +4965,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                       indicatorStatus={rowStatus}
                       showPinIcon={!!item.session.pinned}
                       disableMiniMap={!sessionHoverPreviewEnabled}
+                      suppressAutomationIcon={isAutomationGroup}
                       delegationSummary={childCount > 0
                         ? {
                           total: childCount,
@@ -5015,6 +4996,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                             activeDelegationSessionId={activeDelegationSessionId}
                             agentIndicatorMap={agentIndicatorMap}
                             relativeTimeNow={relativeTimeNow}
+                            suppressAutomationIcon={isAutomationGroup}
                             workspaceName={isAutomationGroup && childSession.workspaceId ? workspaceNameMap?.get(childSession.workspaceId) : undefined}
                             onSelect={onSelectSession}
                             onRequestDelete={onRequestDelete}
@@ -5068,7 +5050,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               )}
             </div>
           ) : (
-            <div className="px-1.5 py-0.5 text-[12px] text-foreground/22 select-none">
+            <div className="pl-2.5 py-0.5 text-[12px] text-muted-foreground/75 select-none">
               暂无会话
             </div>
           )

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2530,7 +2530,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       rows.push({
         id: 'chat-pinned-heading',
         estimateSize: 32,
-        content: <div className="pl-[18px] pr-3.5 pt-2 pb-1 text-[15px] font-medium leading-5 text-foreground/45 select-none">置顶</div>,
+        content: <div className="pl-6 pr-3.5 pt-2 pb-1 text-[15px] font-medium leading-5 text-foreground/45 select-none">置顶</div>,
       })
       for (const conv of pinnedConversations) {
         rows.push({
@@ -2656,9 +2656,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       const isCurrentProject = group.kind === 'workspace' && group.id === currentWorkspaceId
       rows.push({
         id: `agent-archived-project-${group.id}`,
-        estimateSize: 34,
+        estimateSize: 38,
         content: (
-          <div className="px-2">
+          <div className="pl-1 pr-3">
             <section className="relative py-0.5 rounded-md">
               <div className="group/project relative flex items-center">
                 <button
@@ -2666,7 +2666,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                   aria-expanded={!collapsed}
                   onClick={() => handleToggleArchivedProject(group.id)}
                   className={cn(
-                    'relative flex-1 min-w-0 flex items-center gap-2 pl-2 pr-1 py-1 rounded-md text-left transition-[color,background-color] titlebar-no-drag hover:bg-foreground/[0.025]',
+                    'relative flex-1 min-w-0 flex h-[34px] items-center gap-2 pl-2 pr-1 py-1.5 rounded-md text-left transition-[color,background-color] titlebar-no-drag hover:bg-foreground/[0.025]',
                     'text-[hsl(var(--sidebar-primary-foreground))] hover:text-[hsl(var(--sidebar-primary-foreground))]',
                   )}
                 >
@@ -2877,7 +2877,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       rows.push({
         id: 'agent-pinned-heading',
         estimateSize: 32,
-        content: <div className="pl-[18px] pr-3.5 pt-2 pb-1 text-[15px] font-medium leading-5 text-foreground/45 select-none">置顶</div>,
+        content: <div className="pl-4 pr-3.5 pt-2 pb-1 text-[15px] font-medium leading-5 text-foreground/45 select-none">置顶</div>,
       })
       for (const item of pinnedAgentSessionTrees) {
         pushSessionTreeRows(item, false, false, workspaceNameMap)
@@ -2891,7 +2891,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       estimateSize: 40,
       content: (
         <div className="px-2 pt-2 pb-1 flex items-center justify-between">
-          <span className="px-1.5 text-[15px] font-medium leading-5 text-foreground/45 select-none">项目</span>
+          <span className="px-2 text-[15px] font-medium leading-5 text-foreground/45 select-none">项目</span>
           <div className="flex items-center gap-0.5">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -2983,9 +2983,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
       rows.push({
         id: `agent-project-${group.workspace.id}`,
-        estimateSize: 34,
+        estimateSize: 38,
         content: (
-          <div className="px-2">
+          <div className="pl-2">
             <AgentProjectGroupItem
               group={group}
               isAutomationGroup={isAuto}
@@ -4786,7 +4786,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         {renamingWorkspace ? (
           <div
             className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-2 pl-2 pr-1 py-1 rounded-md text-left titlebar-no-drag',
+              'relative flex-1 min-w-0 flex h-[34px] items-center gap-2 pl-2 pr-1 py-1.5 rounded-md text-left titlebar-no-drag',
               'text-[hsl(var(--sidebar-primary-foreground))]',
             )}
           >
@@ -4813,7 +4813,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               onSelectProject(group.workspace.id)
             }}
             className={cn(
-              'relative flex-1 min-w-0 flex cursor-grab items-center gap-2 pl-2 py-1 rounded-md text-left transition-[color,background-color] titlebar-no-drag active:cursor-grabbing hover:bg-foreground/[0.025]',
+              'relative flex-1 min-w-0 flex h-[34px] cursor-grab items-center gap-2 pl-2 py-1.5 rounded-md text-left transition-[color,background-color] titlebar-no-drag active:cursor-grabbing hover:bg-foreground/[0.025]',
               isAutomationGroup ? 'pr-1' : 'pr-12',
               'text-[hsl(var(--sidebar-primary-foreground))] hover:text-[hsl(var(--sidebar-primary-foreground))]',
             )}

--- a/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
+++ b/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
@@ -40,7 +40,7 @@ export function SidebarScrollBoundary({ children }: SidebarScrollBoundaryProps):
       <div
         aria-hidden="true"
         data-sidebar-scroll-boundary={isScrolled ? 'scrolled' : 'top'}
-        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-4 border-t border-[hsl(var(--sidebar-primary-foreground)/0.10)] bg-[linear-gradient(to_bottom,hsl(var(--sidebar-surface)),hsl(var(--sidebar-surface)/0.55)_35%,hsl(var(--sidebar-surface)/0))] transition-opacity duration-150 motion-reduce:transition-none ${isScrolled ? 'opacity-100' : 'opacity-0'}`}
+        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-4 border-t border-[hsl(var(--sidebar-primary-foreground)/0.10)] bg-[linear-gradient(to_bottom,hsl(var(--sidebar-surface))_0%,hsl(var(--sidebar-surface))_85%,hsl(var(--sidebar-surface)/0)_100%)] transition-opacity duration-150 motion-reduce:transition-none ${isScrolled ? 'opacity-100' : 'opacity-0'}`}
       />
     </div>
   )

--- a/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
+++ b/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
@@ -40,7 +40,7 @@ export function SidebarScrollBoundary({ children }: SidebarScrollBoundaryProps):
       <div
         aria-hidden="true"
         data-sidebar-scroll-boundary={isScrolled ? 'scrolled' : 'top'}
-        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-4 border-t border-[hsl(var(--sidebar-primary-foreground)/0.10)] bg-[linear-gradient(to_bottom,hsl(var(--sidebar-surface))_0%,hsl(var(--sidebar-surface))_85%,hsl(var(--sidebar-surface)/0)_100%)] transition-opacity duration-150 motion-reduce:transition-none ${isScrolled ? 'opacity-100' : 'opacity-0'}`}
+        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-4 border-t border-border bg-[linear-gradient(to_bottom,hsl(var(--sidebar-surface))_0%,hsl(var(--sidebar-surface))_20%,hsl(var(--sidebar-surface)/0)_100%)] transition-opacity duration-150 motion-reduce:transition-none ${isScrolled ? 'opacity-100' : 'opacity-0'}`}
       />
     </div>
   )

--- a/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
+++ b/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+
+interface SidebarScrollBoundaryProps {
+  /** 唯一直接 DOM 子元素必须是列表的原生滚动容器。 */
+  children: React.ReactNode
+}
+
+/** 顶部反馈局限在小组件内，滚动不会触发整个 LeftSidebar 重渲染。 */
+export function SidebarScrollBoundary({ children }: SidebarScrollBoundaryProps): React.ReactElement {
+  const rootRef = React.useRef<HTMLDivElement>(null)
+  const scrolledRef = React.useRef(false)
+  const [isScrolled, setIsScrolled] = React.useState(false)
+
+  const syncScrollState = React.useCallback((): void => {
+    const scrollContainer = rootRef.current?.firstElementChild
+    if (!scrollContainer) return
+
+    // 忽略回弹负值和亚像素偏移；只有跨越顶部边界时才调度 React 更新。
+    const nextIsScrolled = scrollContainer.scrollTop > 1
+    if (scrolledRef.current === nextIsScrolled) return
+    scrolledRef.current = nextIsScrolled
+    setIsScrolled(nextIsScrolled)
+  }, [])
+
+  // 挂载、切换内容及列表缩短后同步实际位置，不重置用户的滚动位置。
+  React.useLayoutEffect(syncScrollState)
+
+  const handleScrollCapture = React.useCallback((event: React.UIEvent<HTMLDivElement>): void => {
+    // 忽略会话行内预览等嵌套滚动，虚拟列表的直接根节点就是滚动容器。
+    if (event.target === rootRef.current?.firstElementChild) syncScrollState()
+  }, [syncScrollState])
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative flex min-h-0 flex-1 flex-col"
+      onScrollCapture={handleScrollCapture}
+    >
+      {children}
+      <div
+        aria-hidden="true"
+        data-sidebar-scroll-boundary={isScrolled ? 'scrolled' : 'top'}
+        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-4 border-t border-[hsl(var(--sidebar-primary-foreground)/0.10)] bg-[linear-gradient(to_bottom,hsl(var(--sidebar-surface)),hsl(var(--sidebar-surface)/0.55)_35%,hsl(var(--sidebar-surface)/0))] transition-opacity duration-150 motion-reduce:transition-none ${isScrolled ? 'opacity-100' : 'opacity-0'}`}
+      />
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
+++ b/apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx
@@ -40,7 +40,7 @@ export function SidebarScrollBoundary({ children }: SidebarScrollBoundaryProps):
       <div
         aria-hidden="true"
         data-sidebar-scroll-boundary={isScrolled ? 'scrolled' : 'top'}
-        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-4 border-t border-border bg-[linear-gradient(to_bottom,hsl(var(--sidebar-surface))_0%,hsl(var(--sidebar-surface))_20%,hsl(var(--sidebar-surface)/0)_100%)] transition-opacity duration-150 motion-reduce:transition-none ${isScrolled ? 'opacity-100' : 'opacity-0'}`}
+        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-4 border-t-[0.5px] border-border bg-[linear-gradient(to_bottom,hsl(var(--sidebar-surface)/0.85)_0%,hsl(var(--sidebar-surface)/0)_100%)] transition-opacity duration-150 motion-reduce:transition-none ${isScrolled ? 'opacity-100' : 'opacity-0'}`}
       />
     </div>
   )

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -470,6 +470,8 @@
     /* 基础色 — 现代布局会让内容区铺满屏幕，避免沿用极暗底导致整体发黑 */
     --background: 100 6% 5%;              /* #0d0e0c 侧边栏 */
     --foreground: 90 20% 65%;             /* #acb09f 暖黄绿白 */
+    /* 保持侧栏新主文字 token 与 CRT 磷光色和现有侧栏文字一致。 */
+    --sidebar-primary-foreground: 90 25% 75%;
     --content-area: 100 6% 6%;            /* #0f100e 内容区：比旧版回调再提亮 1% */
     --sidebar-surface: 100 6% 5%;
     --tabbar-surface: 100 6% 5%;
@@ -2102,6 +2104,7 @@
   .theme-terminal-dark [class*="text-foreground"],
   .theme-terminal-dark .crt-sidebar .text-foreground,
   .theme-terminal-dark .crt-sidebar [class*="text-foreground"],
+  .theme-terminal-dark .crt-sidebar [class*="sidebar-primary-foreground"],
   .theme-terminal-dark .model-selector-trigger,
   .theme-terminal-dark .text-primary,
   .theme-terminal-dark [class*="text-primary"] {
@@ -2117,7 +2120,8 @@
 
 /* 侧边栏文字提亮 + 独立辉光 */
 .theme-terminal-dark .crt-sidebar .text-foreground,
-.theme-terminal-dark .crt-sidebar [class*="text-foreground"] {
+.theme-terminal-dark .crt-sidebar [class*="text-foreground"],
+.theme-terminal-dark .crt-sidebar [class*="sidebar-primary-foreground"] {
   color: hsl(90 25% 75%);
   text-shadow: 0 0 3.3px hsl(90 25% 55% / 0.18), 0 0 1.5px hsl(90 25% 55% / 0.28);
 }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -98,6 +98,8 @@
   :root {
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
+    /* 侧栏主文字：中性炭黑，避免特色浅色主题将密集列表染成低对比色。 */
+    --sidebar-primary-foreground: 0 0% 17%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
     --border: 0 0% 89.8%;
@@ -143,6 +145,7 @@
   .dark {
     --background: 0 0% 10%;                /* 侧栏锚点，略亮于内容区 */
     --foreground: 0 0% 98%;
+    --sidebar-primary-foreground: 0 0% 96%;
     --muted: 0 0% 17%;
     --muted-foreground: 0 0% 63.9%;
     --border: 0 0% 22%;


### PR DESCRIPTION
## 概述
优化左侧栏的会话与项目层级，并为滚动列表增加仅在离开顶部后出现的顶部边界反馈。该反馈在四条侧栏列表路径中保持一致，同时避免滚动事件引起整个 `LeftSidebar` 高频重渲染。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 调整项目、会话与子会话的视觉层级和对齐；定时任务组内隐藏重复时钟；让项目标题成为拖拽源；将滚动边界组件接入 Chat/Agent 的活跃与归档四条列表路径。
- `apps/electron/src/renderer/components/ui/sidebar-scroll-boundary.tsx` — 新增局部滚动边界组件，仅在 `scrollTop > 1px` 时显示 0.5px 语义分隔线与 16px 连续渐隐遮罩；状态跨越阈值才更新。
- `apps/electron/src/renderer/styles/globals.css` — 增加侧栏主文字语义 token，提升浅色主题中密集列表的可读性，并保持深色主题可读。
- `apps/electron/package.json` — 将 `@proma/electron` 版本更新至 `0.19.52`。

## 测试方法
1. 执行 `bun install --frozen-lockfile`。
2. 执行 `bun run --filter='@proma/electron' typecheck`。
3. 执行 `bun run --filter='@proma/electron' build:renderer`。
4. 执行 `git diff --check origin/main...HEAD`。
5. 在 Electron 中切换 Chat/Agent 的活跃与归档列表，滚动超过 1px 后确认顶部 0.5px 分隔线与渐隐遮罩出现，回到顶部后消失。
6. 在 DPR 1/2、100%/125%/150% 缩放和各主题下确认细分隔线稳定、文字对比可读；验证项目点击、拖拽排序、项目菜单和定时任务行。

## 备注
- 当前仓库没有 `LeftSidebar` 或 `SidebarScrollBoundary` 的自动化测试文件；本 PR 已完成类型检查、renderer 构建和差异检查，运行态视觉与交互验证仍建议按上述步骤执行。
- 独立只读审查未发现阻塞缺陷；GPU/合成层评估未发现 `backdrop-filter`、大面积 blur、无限动画或高频状态更新引入的可信回归风险。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
