### PR TITLE
feat(input): 支持顶部拖拽缩放输入框【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -32,6 +32,7 @@ import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
 import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
 import { RichTextInput, type RichTextInputHandle } from '@/components/ai-elements/rich-text-input'
+import { useComposerResize } from '@/components/ai-elements/resizable-composer'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { InputToolbarOverflow, type ToolbarItem } from '@/components/ai-elements/InputToolbarOverflow'
 import {
@@ -722,6 +723,7 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
   const pendingFilesRef = React.useRef(pendingFiles)
   // RichTextInput 命令接口 ref（右侧文件面板拖入时插入 @file 引用）
   const richTextInputRef = React.useRef<RichTextInputHandle>(null)
+  const composerResize = useComposerResize(`agent:${sessionId}`)
   const historyQuoteNavigationRequestIdRef = React.useRef(0)
   const [historyQuoteNavigation, setHistoryQuoteNavigation] = React.useState<AgentHistoryQuoteNavigationRequest | null>(null)
   const handleAddHistoryQuote = React.useCallback((quote: QuotedSelection): boolean => {
@@ -2981,32 +2983,37 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
         {/* 临时 Agent 已由右侧 Tab 表明归属，避免在窄面板重复渲染全局标题栏。 */}
         {!embedded && <AgentHeader sessionId={sessionId} />}
 
-        <div className={cn(
-          'flex min-h-0 flex-1 w-full flex-col overflow-hidden',
-          embedded ? 'max-w-none' : 'max-w-[min(72rem,100%)] mx-auto',
-        )}>
+        <div
+          className={cn(
+            'flex min-h-0 flex-1 w-full flex-col overflow-hidden',
+            embedded ? 'max-w-none' : 'max-w-[min(72rem,100%)] mx-auto',
+          )}
+          data-composer-viewport
+        >
         {/* 消息区域 */}
-        <AgentMessages
-          sessionId={sessionId}
-          sessionModelId={agentModelId || undefined}
-          messagesLoaded={messagesLoaded}
-          persistedSDKMessages={persistedSDKMessages}
-          sessionPath={sessionPath}
-          attachedDirs={allAttachedDirs}
-          stoppedByUser={stoppedByUser}
-          onRetry={handleRetry}
-          onRetryInNewSession={handleRetryInNewSession}
-          onRelinkProjectRoot={handleRelinkProjectRoot}
-          onRestoreProjectRoot={handleOpenRestoreProjectRootDialog}
-          onFork={embedded || isLegacyTranscript ? undefined : handleFork}
-          onRewind={isLegacyTranscript ? undefined : handleRewindRequest}
-          onCreateTodo={handleOpenReplyTodoDialog}
-          onCompact={handleCompact}
-          onAddHistoryQuote={handleAddHistoryQuote}
-          explorationEnabled={!embedded}
-          onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
-          historyQuoteNavigation={historyQuoteNavigation}
-        />
+        <div className="flex min-h-0 flex-1 flex-col" data-composer-message-viewport>
+          <AgentMessages
+            sessionId={sessionId}
+            sessionModelId={agentModelId || undefined}
+            messagesLoaded={messagesLoaded}
+            persistedSDKMessages={persistedSDKMessages}
+            sessionPath={sessionPath}
+            attachedDirs={allAttachedDirs}
+            stoppedByUser={stoppedByUser}
+            onRetry={handleRetry}
+            onRetryInNewSession={handleRetryInNewSession}
+            onRelinkProjectRoot={handleRelinkProjectRoot}
+            onRestoreProjectRoot={handleOpenRestoreProjectRootDialog}
+            onFork={embedded || isLegacyTranscript ? undefined : handleFork}
+            onRewind={isLegacyTranscript ? undefined : handleRewindRequest}
+            onCreateTodo={handleOpenReplyTodoDialog}
+            onCompact={handleCompact}
+            onAddHistoryQuote={handleAddHistoryQuote}
+            explorationEnabled={!embedded}
+            onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
+            historyQuoteNavigation={historyQuoteNavigation}
+          />
+        </div>
 
         {/* 权限请求横幅 */}
         <PermissionBanner sessionId={sessionId} />
@@ -3022,8 +3029,9 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
         {!hasBannerOverlay && (
         <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px]" data-input-mode="agent">
           <div
+            ref={composerResize.frameRef}
             className={cn(
-              'rounded-[17px] border-[0.5px] border-border bg-background/70 backdrop-blur-sm transition-all duration-200',
+              'relative flex min-h-0 flex-col overflow-hidden rounded-[17px] border-[0.5px] border-border bg-background/70 backdrop-blur-sm transition-all duration-200',
               (isPlanMode || isPermissionPlanMode) && !isDragOver && 'plan-mode-border',
               isDragOver && 'border-[2px] border-dashed border-primary bg-primary/[0.03]'
             )}
@@ -3032,7 +3040,15 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
             onDrop={handleDrop}
           >
             {(isPlanMode || isPermissionPlanMode) && !isDragOver && <PlanModeDashedBorder />}
-            {isLegacyTranscript && (
+            <div
+              className="group absolute left-4 right-4 top-0 z-20 h-2 cursor-row-resize touch-none"
+              onPointerDown={composerResize.onResizePointerDown}
+              title="拖拽调整输入框高度"
+            >
+              <span className="absolute left-1/2 top-1/2 h-px w-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/40 opacity-0 transition-opacity group-hover:opacity-100" />
+            </div>
+            <div className="min-h-0 shrink overflow-y-auto overscroll-contain" data-composer-chrome>
+              {isLegacyTranscript && (
               <div className="flex items-center justify-between gap-3 px-4 py-2 text-sm text-amber-700 dark:text-amber-300">
                 <span>这是已退役 Claude runtime 的只读历史会话；原对话可查看，但不能继续、分叉或回退。</span>
                 <Button size="sm" variant="outline" onClick={() => void handleRetryInNewSession()} disabled={!agentChannelId}>
@@ -3094,64 +3110,74 @@ export function AgentView({ sessionId, embedded = false }: AgentViewProps): Reac
             />
 
             {/* Agent 建议提示 */}
-            {suggestion && !streaming && (
-              <div className="px-3 pt-2.5 pb-1.5">
-                <button
-                  type="button"
-                  className="group flex items-start gap-2 w-full rounded-lg border border-dashed border-primary/30 bg-primary/[0.03] px-3 py-2.5 text-left text-sm transition-colors hover:border-primary/50 hover:bg-primary/[0.06]"
-                  onClick={() => handleSend(suggestion)}
-                >
-                  <Sparkles className="size-4 shrink-0 mt-0.5 text-primary/60 group-hover:text-primary/80" />
-                  <span className="flex-1 min-w-0 text-foreground/80 group-hover:text-foreground line-clamp-3">{suggestion}</span>
-                  <X
-                    className="size-3.5 shrink-0 mt-0.5 text-muted-foreground/40 hover:text-foreground transition-colors"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setPromptSuggestions((prev) => {
-                        if (!prev.has(sessionId)) return prev
-                        const map = new Map(prev)
-                        map.delete(sessionId)
-                        return map
-                      })
-                    }}
-                  />
-                </button>
-              </div>
-            )}
+              {suggestion && !streaming && (
+                <div className="px-3 pt-2.5 pb-1.5">
+                  <button
+                    type="button"
+                    className="group flex items-start gap-2 w-full rounded-lg border border-dashed border-primary/30 bg-primary/[0.03] px-3 py-2.5 text-left text-sm transition-colors hover:border-primary/50 hover:bg-primary/[0.06]"
+                    onClick={() => handleSend(suggestion)}
+                  >
+                    <Sparkles className="size-4 shrink-0 mt-0.5 text-primary/60 group-hover:text-primary/80" />
+                    <span className="flex-1 min-w-0 text-foreground/80 group-hover:text-foreground line-clamp-3">{suggestion}</span>
+                    <X
+                      className="size-3.5 shrink-0 mt-0.5 text-muted-foreground/40 hover:text-foreground transition-colors"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setPromptSuggestions((prev) => {
+                          if (!prev.has(sessionId)) return prev
+                          const map = new Map(prev)
+                          map.delete(sessionId)
+                          return map
+                        })
+                      }}
+                    />
+                  </button>
+                </div>
+              )}
+            </div>
 
-            <AgentScopedRichTextInput
-              ref={richTextInputRef}
-              sessionId={sessionId}
-              onInputActivity={handleInputActivity}
-              draftSyncDelayMs={300}
-              onSubmit={handleSend}
-              onPasteFiles={handlePasteFiles}
-              onPasteLongText={handlePasteLongText}
-              voiceInputId={agentVoiceInputId}
-              longTextPasteThreshold={longTextPasteAsAttachmentEnabled ? LONG_TEXT_ATTACHMENT_THRESHOLD : undefined}
-              placeholder={
-                agentChannelId && hasAvailableModel
-                  ? sendWithCmdEnter
-                    ? '输入消息...（@ 引用文件，/ 调用 Skill，# 使用 MCP，& 引用会话，～ 引用待办/日程；⌘/Ctrl+Enter 发送）'
-                    : '输入消息...（@ 引用文件，/ 调用 Skill，# 使用 MCP，& 引用会话，～ 引用待办/日程；Enter 发送）'
-                  : !agentChannelId
-                    ? '请先选择模型'
-                    : '暂无可用模型，请先在设置中启用渠道'
-              }
-              disabled={isComposerDisabled}
-              autoFocusTrigger={sessionId}
-              collapsible
-              enableMentions
-              workspacePath={sessionPath}
-              workspaceSlug={workspaceSlug}
-              attachedDirs={workspaceMentionPaths}
-              sessionAttachedDirs={sessionMentionPaths}
-              sendWithCmdEnter={sendWithCmdEnter}
-              onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
-            />
+            <div
+              ref={composerResize.editorRef}
+              className="relative min-h-[101px] shrink-0 overflow-hidden transition-[height] duration-200 ease-out motion-reduce:transition-none"
+              data-composer-editor
+              style={composerResize.editorHeight === null ? undefined : { height: composerResize.editorHeight }}
+            >
+              <AgentScopedRichTextInput
+                ref={richTextInputRef}
+                sessionId={sessionId}
+                onInputActivity={handleInputActivity}
+                draftSyncDelayMs={300}
+                onSubmit={handleSend}
+                onPasteFiles={handlePasteFiles}
+                onPasteLongText={handlePasteLongText}
+                voiceInputId={agentVoiceInputId}
+                longTextPasteThreshold={longTextPasteAsAttachmentEnabled ? LONG_TEXT_ATTACHMENT_THRESHOLD : undefined}
+                placeholder={
+                  agentChannelId && hasAvailableModel
+                    ? sendWithCmdEnter
+                      ? '输入消息...（@ 引用文件，/ 调用 Skill，# 使用 MCP，& 引用会话，～ 引用待办/日程；⌘/Ctrl+Enter 发送）'
+                      : '输入消息...（@ 引用文件，/ 调用 Skill，# 使用 MCP，& 引用会话，～ 引用待办/日程；Enter 发送）'
+                    : !agentChannelId
+                      ? '请先选择模型'
+                      : '暂无可用模型，请先在设置中启用渠道'
+                }
+                disabled={isComposerDisabled}
+                autoFocusTrigger={sessionId}
+                enableMentions
+                workspacePath={sessionPath}
+                workspaceSlug={workspaceSlug}
+                attachedDirs={workspaceMentionPaths}
+                sessionAttachedDirs={sessionMentionPaths}
+                sendWithCmdEnter={sendWithCmdEnter}
+                onAgentHistoryQuoteClick={handleAgentHistoryQuoteClick}
+                fillHeight={composerResize.editorHeight !== null}
+              />
+            </div>
 
             {/* Footer 工具栏 — 容器变窄时尾部按钮自动折叠进「更多」Popover */}
-            <InputToolbarOverflow items={inputToolbarItems} trailing={inputTrailingNode} />
+            <div className="shrink-0" data-composer-footer>
+              <InputToolbarOverflow items={inputToolbarItems} trailing={inputTrailingNode} />
+            </div>
           </div>
         </div>
         )}

--- a/apps/electron/src/renderer/components/ai-elements/composer-resize.ts
+++ b/apps/electron/src/renderer/components/ai-elements/composer-resize.ts
@@ -1,0 +1,93 @@
+export const COMPOSER_MIN_EDITOR_HEIGHT = 101
+export const COMPOSER_MIN_MESSAGE_HEIGHT = 96
+export const COMPOSER_MAX_VIEWPORT_HEIGHT_RATIO = 0.6
+const COMPOSER_HEIGHT_STORAGE_PREFIX = 'proma-composer-height:v1'
+
+export interface ComposerLimits {
+  maxEditorHeight: number
+  maxFrameHeight: number
+}
+
+export function getComposerHeightStorageKey(scope: string): string {
+  return `${COMPOSER_HEIGHT_STORAGE_PREFIX}:${scope}`
+}
+
+export function parseStoredComposerHeight(value: string | null): number | null {
+  if (value === null || value.trim() === '') return null
+  const height = Number(value)
+  return Number.isFinite(height) && height >= 0 ? Math.round(height) : null
+}
+
+export function readStoredComposerHeight(storageKey: string): number | null {
+  try {
+    return parseStoredComposerHeight(localStorage.getItem(storageKey))
+  } catch {
+    return null
+  }
+}
+
+export function writeStoredComposerHeight(storageKey: string, height: number): void {
+  try {
+    localStorage.setItem(storageKey, String(height))
+  } catch {
+    // localStorage 不可用时保持当前会话内的拖拽能力。
+  }
+}
+
+export function getMaximumComposerFrameHeight(
+  availableFrameHeight: number,
+  viewportHeight: number,
+): number {
+  return Math.max(0, Math.min(
+    availableFrameHeight,
+    Math.floor(viewportHeight * COMPOSER_MAX_VIEWPORT_HEIGHT_RATIO),
+  ))
+}
+
+export function getMaximumComposerEditorHeight(
+  maxFrameHeight: number,
+  fixedFrameHeight: number,
+): number {
+  return Math.max(0, maxFrameHeight - Math.max(0, fixedFrameHeight))
+}
+
+export function clampComposerEditorHeight(candidateHeight: number, maxEditorHeight: number): number {
+  const safeMaximum = Math.max(0, maxEditorHeight)
+  const minimum = Math.min(COMPOSER_MIN_EDITOR_HEIGHT, safeMaximum)
+  return Math.round(Math.min(safeMaximum, Math.max(minimum, candidateHeight)))
+}
+
+export function getDraggedComposerEditorHeight(
+  startHeight: number,
+  startClientY: number,
+  currentClientY: number,
+  maxEditorHeight: number,
+): number {
+  return clampComposerEditorHeight(
+    startHeight + startClientY - currentClientY,
+    maxEditorHeight,
+  )
+}
+
+export function measureComposerLimits(frame: HTMLElement): ComposerLimits {
+  const viewport = frame.closest<HTMLElement>('[data-composer-viewport]')
+  const messageViewport = viewport?.querySelector<HTMLElement>('[data-composer-message-viewport]')
+  const chrome = frame.querySelector<HTMLElement>('[data-composer-chrome]')
+  const footer = frame.querySelector<HTMLElement>('[data-composer-footer]')
+  const frameHeight = frame.getBoundingClientRect().height
+  const viewportHeight = viewport?.clientHeight ?? window.innerHeight
+  const availableFrameHeight = messageViewport
+    ? frameHeight + messageViewport.getBoundingClientRect().height - COMPOSER_MIN_MESSAGE_HEIGHT
+    : viewportHeight - COMPOSER_MIN_MESSAGE_HEIGHT
+  const maxFrameHeight = getMaximumComposerFrameHeight(availableFrameHeight, viewportHeight)
+
+  const borderHeight = Math.max(0, frame.offsetHeight - frame.clientHeight)
+  const fixedFrameHeight = (chrome?.getBoundingClientRect().height ?? 0)
+    + (footer?.getBoundingClientRect().height ?? 0)
+    + borderHeight
+
+  return {
+    maxFrameHeight,
+    maxEditorHeight: getMaximumComposerEditorHeight(maxFrameHeight, fixedFrameHeight),
+  }
+}

--- a/apps/electron/src/renderer/components/ai-elements/resizable-composer.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/resizable-composer.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react'
+import {
+  COMPOSER_MIN_EDITOR_HEIGHT,
+  clampComposerEditorHeight,
+  getComposerHeightStorageKey,
+  getDraggedComposerEditorHeight,
+  measureComposerLimits,
+  readStoredComposerHeight,
+  type ComposerLimits,
+  writeStoredComposerHeight,
+} from './composer-resize'
+
+type DragCleanup = (commit: boolean) => void
+
+interface DragSession {
+  updateLimits: (limits: ComposerLimits) => void
+}
+
+export function useComposerResize(storageScope: string) {
+  const frameNodeRef = React.useRef<HTMLDivElement | null>(null)
+  const editorNodeRef = React.useRef<HTMLDivElement | null>(null)
+  const [mountedNodesVersion, bumpMountedNodesVersion] = React.useReducer((version: number) => version + 1, 0)
+  const storageKey = getComposerHeightStorageKey(storageScope)
+  const [editorHeight, setEditorHeight] = React.useState<number | null>(() => readStoredComposerHeight(storageKey))
+  const editorHeightRef = React.useRef(editorHeight)
+  const limitsRef = React.useRef<ComposerLimits | null>(null)
+  const dragCleanupRef = React.useRef<DragCleanup | null>(null)
+  const dragSessionRef = React.useRef<DragSession | null>(null)
+  const focusFrameRef = React.useRef(0)
+
+  const frameRef = React.useCallback((node: HTMLDivElement | null): void => {
+    if (frameNodeRef.current === node) return
+    frameNodeRef.current = node
+    bumpMountedNodesVersion()
+  }, [])
+
+  const editorRef = React.useCallback((node: HTMLDivElement | null): void => {
+    if (editorNodeRef.current === node) return
+    editorNodeRef.current = node
+    bumpMountedNodesVersion()
+  }, [])
+
+  const commitHeight = React.useCallback((height: number): void => {
+    editorHeightRef.current = height
+    setEditorHeight(height)
+    writeStoredComposerHeight(storageKey, height)
+  }, [storageKey])
+
+  React.useLayoutEffect(() => {
+    const frame = frameNodeRef.current
+    const editor = editorNodeRef.current
+    if (!frame || !editor) return
+
+    const restoredHeight = readStoredComposerHeight(storageKey)
+    editorHeightRef.current = restoredHeight
+    setEditorHeight(restoredHeight)
+    editor.style.height = restoredHeight === null ? '' : `${restoredHeight}px`
+    const viewport = frame.closest<HTMLElement>('[data-composer-viewport]')
+    const messageViewport = viewport?.querySelector<HTMLElement>('[data-composer-message-viewport]')
+    const footer = frame.querySelector<HTMLElement>('[data-composer-footer]')
+    let animationFrame = 0
+
+    const applyLimits = (limits: ComposerLimits): void => {
+      limitsRef.current = limits
+      frame.style.maxHeight = `${limits.maxFrameHeight}px`
+      editor.style.minHeight = `${Math.min(COMPOSER_MIN_EDITOR_HEIGHT, limits.maxEditorHeight)}px`
+    }
+
+    const updateLayout = (): void => {
+      animationFrame = 0
+      const limits = measureComposerLimits(frame)
+      applyLimits(limits)
+
+      if (dragSessionRef.current) {
+        dragSessionRef.current.updateLimits(limits)
+        return
+      }
+
+      const currentHeight = editorHeightRef.current
+      if (currentHeight === null) return
+      const nextHeight = clampComposerEditorHeight(currentHeight, limits.maxEditorHeight)
+      editor.style.height = `${nextHeight}px`
+      if (nextHeight !== currentHeight) commitHeight(nextHeight)
+    }
+
+    const scheduleUpdate = (): void => {
+      if (animationFrame === 0) {
+        animationFrame = window.requestAnimationFrame(updateLayout)
+      }
+    }
+
+    const observer = new ResizeObserver(scheduleUpdate)
+    observer.observe(frame)
+    observer.observe(editor)
+    if (viewport) observer.observe(viewport)
+    if (messageViewport) observer.observe(messageViewport)
+    if (footer) observer.observe(footer)
+    window.addEventListener('resize', scheduleUpdate)
+    updateLayout()
+
+    return () => {
+      dragCleanupRef.current?.(false)
+      if (animationFrame !== 0) window.cancelAnimationFrame(animationFrame)
+      if (focusFrameRef.current !== 0) window.cancelAnimationFrame(focusFrameRef.current)
+      observer.disconnect()
+      window.removeEventListener('resize', scheduleUpdate)
+    }
+  }, [commitHeight, mountedNodesVersion, storageKey])
+
+  const onResizePointerDown = React.useCallback((event: React.PointerEvent<HTMLDivElement>): void => {
+    if (event.button !== 0) return
+    const frame = frameNodeRef.current
+    const editor = editorNodeRef.current
+    if (!frame || !editor) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    dragCleanupRef.current?.(true)
+
+    const handle = event.currentTarget
+    const pointerId = event.pointerId
+    const startClientY = event.clientY
+    const initialLimits = measureComposerLimits(frame)
+    limitsRef.current = initialLimits
+    frame.style.maxHeight = `${initialLimits.maxFrameHeight}px`
+    editor.style.minHeight = `${Math.min(COMPOSER_MIN_EDITOR_HEIGHT, initialLimits.maxEditorHeight)}px`
+    const startHeight = clampComposerEditorHeight(
+      editor.getBoundingClientRect().height,
+      initialLimits.maxEditorHeight,
+    )
+    const controller = new AbortController()
+    let currentClientY = startClientY
+    let latestHeight = startHeight
+    let cleaned = false
+    const previous = {
+      bodyCursor: document.body.style.cursor,
+      bodyUserSelect: document.body.style.userSelect,
+      editorTransition: editor.style.transition,
+      frameTransition: frame.style.transition,
+      backdropFilter: frame.style.backdropFilter,
+    }
+
+    const applyDraggedHeight = (limits: ComposerLimits): void => {
+      latestHeight = getDraggedComposerEditorHeight(
+        startHeight,
+        startClientY,
+        currentClientY,
+        limits.maxEditorHeight,
+      )
+      editor.style.height = `${latestHeight}px`
+    }
+
+    const cleanup: DragCleanup = (commit) => {
+      if (cleaned) return
+      cleaned = true
+      controller.abort()
+      if (handle.hasPointerCapture(pointerId)) handle.releasePointerCapture(pointerId)
+      document.body.style.cursor = previous.bodyCursor
+      document.body.style.userSelect = previous.bodyUserSelect
+      editor.style.transition = previous.editorTransition
+      frame.style.transition = previous.frameTransition
+      frame.style.backdropFilter = previous.backdropFilter
+      dragCleanupRef.current = null
+      dragSessionRef.current = null
+
+      if (!commit) {
+        editor.style.height = editorHeightRef.current === null ? '' : `${editorHeightRef.current}px`
+        return
+      }
+
+      const finalLimits = measureComposerLimits(frame)
+      limitsRef.current = finalLimits
+      frame.style.maxHeight = `${finalLimits.maxFrameHeight}px`
+      editor.style.minHeight = `${Math.min(COMPOSER_MIN_EDITOR_HEIGHT, finalLimits.maxEditorHeight)}px`
+      const committedHeight = clampComposerEditorHeight(latestHeight, finalLimits.maxEditorHeight)
+      editor.style.height = `${committedHeight}px`
+      commitHeight(committedHeight)
+      focusFrameRef.current = window.requestAnimationFrame(() => {
+        editor.querySelector<HTMLElement>('.ProseMirror')?.focus()
+      })
+    }
+
+    const finishPointer = (pointerEvent: PointerEvent): void => {
+      if (pointerEvent.pointerId === pointerId) cleanup(true)
+    }
+
+    const movePointer = (pointerEvent: PointerEvent): void => {
+      if (pointerEvent.pointerId !== pointerId) return
+      pointerEvent.preventDefault()
+      currentClientY = pointerEvent.clientY
+      applyDraggedHeight(limitsRef.current ?? measureComposerLimits(frame))
+    }
+
+    editorHeightRef.current = startHeight
+    setEditorHeight(startHeight)
+    editor.style.height = `${startHeight}px`
+    editor.style.transition = 'none'
+    frame.style.transition = 'none'
+    frame.style.backdropFilter = 'none'
+    document.body.style.cursor = 'row-resize'
+    document.body.style.userSelect = 'none'
+    dragCleanupRef.current = cleanup
+    dragSessionRef.current = { updateLimits: applyDraggedHeight }
+
+    const listenerOptions = { signal: controller.signal }
+    handle.addEventListener('pointermove', movePointer, listenerOptions)
+    handle.addEventListener('pointerup', finishPointer, listenerOptions)
+    handle.addEventListener('pointercancel', finishPointer, listenerOptions)
+    handle.addEventListener('lostpointercapture', finishPointer, listenerOptions)
+    window.addEventListener('blur', () => cleanup(true), listenerOptions)
+    handle.setPointerCapture(pointerId)
+  }, [commitHeight])
+
+  return { editorHeight, editorRef, frameRef, onResizePointerDown }
+}

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -163,6 +163,8 @@ interface RichTextInputProps {
   autoFocusTrigger?: string | null
   /** 是否支持手动折叠（内容较长时显示折叠按钮） */
   collapsible?: boolean
+  /** 是否填满由外部 resize 容器提供的固定高度。 */
+  fillHeight?: boolean
   /** 是否启用文件、Skill、MCP、会话和规划引用 chip。 */
   enableMentions?: boolean
   /** 工作区根路径（启用 @ 文件引用功能时需要） */
@@ -226,6 +228,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   disabled = false,
   autoFocusTrigger,
   collapsible = false,
+  fillHeight = false,
   enableMentions,
   workspacePath,
   workspaceSlug,
@@ -1251,22 +1254,28 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   }, [editor, disabled])
 
   // 是否显示折叠按钮：启用 collapsible 且内容已自动扩展
-  const showCollapseToggle = collapsible && isExpanded
+  const showCollapseToggle = collapsible && isExpanded && !fillHeight
 
   return (
     <div
       onKeyDownCapture={(event) => forwardSessionQuickSwitchKeyEvent(event, 'keydown')}
       onKeyUpCapture={(event) => forwardSessionQuickSwitchKeyEvent(event, 'keyup')}
+      data-fill-height={fillHeight ? 'true' : undefined}
       className={cn(
-        'rich-text-input relative w-full overflow-y-auto overscroll-contain scrollbar-thin transition-[max-height] duration-200 ease-in-out',
-        isManuallyCollapsed
-          ? 'max-h-[101px]'
-          : isExpanded ? 'max-h-[500px]' : 'max-h-[200px]',
+        'rich-text-input relative w-full overflow-y-auto overscroll-contain scrollbar-thin',
+        fillHeight
+          ? 'h-full max-h-none'
+          : cn(
+            'transition-[max-height] duration-200 ease-in-out',
+            isManuallyCollapsed
+              ? 'max-h-[101px]'
+              : isExpanded ? 'max-h-[500px]' : 'max-h-[200px]',
+          ),
         disabled && 'opacity-50 cursor-not-allowed',
         className
       )}
     >
-      <EditorContent editor={editor} className="w-full" />
+      <EditorContent editor={editor} className="rich-text-editor-content w-full" />
       {/* 折叠/展开切换按钮 — sticky 悬浮在滚动区域内 */}
       {showCollapseToggle && (
         <Tooltip>
@@ -1293,6 +1302,16 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
           outline: none;
           padding: 9px 15px 0px;
           font-style: normal;
+        }
+        .rich-text-input[data-fill-height='true'] .rich-text-editor-content,
+        .rich-text-input[data-fill-height='true'] .ProseMirror {
+          min-height: 100%;
+        }
+        .rich-text-input[data-fill-height='true'] .rich-text-editor-content {
+          height: 100%;
+        }
+        .rich-text-input[data-fill-height='true'] .ProseMirror {
+          box-sizing: border-box;
         }
         .ProseMirror p {
           font-style: normal;

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -23,6 +23,7 @@ import { ChatThinkingPopover } from './ChatThinkingPopover'
 import { AttachmentPreviewItem } from './AttachmentPreviewItem'
 import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
+import { useComposerResize } from '@/components/ai-elements/resizable-composer'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { InputToolbarOverflow, type ToolbarItem } from '@/components/ai-elements/InputToolbarOverflow'
 import {
@@ -74,6 +75,7 @@ interface ChatInputProps {
 
 export function ChatInput({ conversationId, streaming, pendingAttachments, onSetPendingAttachments, onSend, onStop, onClearContext }: ChatInputProps): React.ReactElement {
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
+  const composerResize = useComposerResize(`chat:${conversationId}`)
   // 从 Map atom 读写草稿
   const draftsMap = useAtomValue(conversationDraftsAtom)
   const setDraftsMap = useSetAtom(conversationDraftsAtom)
@@ -431,8 +433,9 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     >
         {/* 卡片式输入容器 — 对标 Cherry Studio: border-radius 17px, 0.5px border */}
         <div
+          ref={composerResize.frameRef}
           className={cn(
-            'rounded-[17px] border-[0.5px] border-border bg-background/70 backdrop-blur-sm transition-all duration-200',
+            'relative flex min-h-0 flex-col overflow-hidden rounded-[17px] border-[0.5px] border-border bg-background/70 backdrop-blur-sm transition-all duration-200',
             'focus-within:border-foreground/20',
             isDragOver && 'border-[2px] border-dashed border-[#2ecc71] bg-[#2ecc71]/[0.03]'
           )}
@@ -440,48 +443,68 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
-          {/* 附件 + 引用选中文本 Chip（与 Agent 输入框保持一致） */}
-          {(pendingAttachments.length > 0 || currentQuotedSelection) && (
-            <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
-              {pendingAttachments.map((att) => (
-                <AttachmentPreviewItem
-                  key={att.id}
-                  filename={att.filename}
-                  mediaType={att.mediaType}
-                  previewUrl={att.previewUrl}
-                  onRemove={() => handleRemoveAttachment(att.id)}
-                  onEditComplete={(editedDataUrl) => handleEditComplete(att.id, editedDataUrl)}
-                  imageSiblings={imageSiblings}
-                  siblingIndex={imageAttachmentsList.findIndex((a) => a.id === att.id)}
-                />
-              ))}
-              {currentQuotedSelection && (
-                <QuotedSelectionChip
-                  text={currentQuotedSelection.text}
-                  filePath={currentQuotedSelection.filePath}
-                  sourceLabel={currentQuotedSelection.sourceLabel}
-                  onRemove={handleRemoveQuotedSelection}
-                />
-              )}
-            </div>
-          )}
+          <div
+            className="group absolute left-4 right-4 top-0 z-20 h-2 cursor-row-resize touch-none"
+            onPointerDown={composerResize.onResizePointerDown}
+            title="拖拽调整输入框高度"
+          >
+            <span className="absolute left-1/2 top-1/2 h-px w-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/40 opacity-0 transition-opacity group-hover:opacity-100" />
+          </div>
+
+          <div className="min-h-0 shrink overflow-y-auto overscroll-contain" data-composer-chrome>
+            {/* 附件 + 引用选中文本 Chip（与 Agent 输入框保持一致） */}
+            {(pendingAttachments.length > 0 || currentQuotedSelection) && (
+              <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
+                {pendingAttachments.map((att) => (
+                  <AttachmentPreviewItem
+                    key={att.id}
+                    filename={att.filename}
+                    mediaType={att.mediaType}
+                    previewUrl={att.previewUrl}
+                    onRemove={() => handleRemoveAttachment(att.id)}
+                    onEditComplete={(editedDataUrl) => handleEditComplete(att.id, editedDataUrl)}
+                    imageSiblings={imageSiblings}
+                    siblingIndex={imageAttachmentsList.findIndex((a) => a.id === att.id)}
+                  />
+                ))}
+                {currentQuotedSelection && (
+                  <QuotedSelectionChip
+                    text={currentQuotedSelection.text}
+                    filePath={currentQuotedSelection.filePath}
+                    sourceLabel={currentQuotedSelection.sourceLabel}
+                    onRemove={handleRemoveQuotedSelection}
+                  />
+                )}
+              </div>
+            )}
+          </div>
 
           {/* TipTap 富文本编辑器 */}
-          <RichTextInput
-            value={content}
-            onChange={setContentFromEditor}
-            onSubmit={handleSend}
-            onPasteFiles={handlePasteFiles}
-            voiceInputId={chatVoiceInputId}
-            placeholder={sendWithCmdEnter ? '输入消息... (⌘/Ctrl+Enter 发送，Enter 换行)' : '输入消息... (Enter 发送，Shift+Enter 换行)'}
-            autoFocusTrigger={conversationId}
-            draftScopeKey={conversationId}
-            draftSyncVersion={draftSyncVersion}
-            sendWithCmdEnter={sendWithCmdEnter}
-          />
+          <div
+            ref={composerResize.editorRef}
+            className="relative min-h-[101px] shrink-0 overflow-hidden transition-[height] duration-200 ease-out motion-reduce:transition-none"
+            data-composer-editor
+            style={composerResize.editorHeight === null ? undefined : { height: composerResize.editorHeight }}
+          >
+            <RichTextInput
+              value={content}
+              onChange={setContentFromEditor}
+              onSubmit={handleSend}
+              onPasteFiles={handlePasteFiles}
+              voiceInputId={chatVoiceInputId}
+              placeholder={sendWithCmdEnter ? '输入消息... (⌘/Ctrl+Enter 发送，Enter 换行)' : '输入消息... (Enter 发送，Shift+Enter 换行)'}
+              autoFocusTrigger={conversationId}
+              draftScopeKey={conversationId}
+              draftSyncVersion={draftSyncVersion}
+              sendWithCmdEnter={sendWithCmdEnter}
+              fillHeight={composerResize.editorHeight !== null}
+            />
+          </div>
 
           {/* Footer 工具栏 — 容器变窄时尾部按钮自动折叠进「更多」Popover */}
-          <InputToolbarOverflow items={toolbarItems} trailing={trailingNode} />
+          <div className="shrink-0" data-composer-footer>
+            <InputToolbarOverflow items={toolbarItems} trailing={trailingNode} />
+          </div>
         </div>
     </div>
   )

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -678,31 +678,36 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       <div className="flex flex-col h-full flex-1 min-w-0">
         {/* Header 在 max-w 外，按钮可到达最右侧 */}
         <ChatHeader conversation={conversation} />
-        <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
+        <div
+          className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0"
+          data-composer-viewport
+        >
           {/* 中间：消息区域 */}
-          <ChatMessages
-            conversationId={conversationId}
-            messages={messages}
-            messagesLoaded={messagesLoaded}
-            streaming={isStreaming}
-            streamingContent={streamingContent}
-            streamingReasoning={streamingReasoning}
-            streamingModel={streamingModel}
-            startedAt={streamState?.startedAt}
-            toolActivities={toolActivities}
-            contextDividers={contextDividers}
-            hasMore={hasMoreMessages}
-            onDeleteMessage={handleDeleteMessage}
-            onResendMessage={handleResendMessage}
-            onStartInlineEdit={handleStartInlineEdit}
-            onSubmitInlineEdit={handleSubmitInlineEdit}
-            onCancelInlineEdit={handleCancelInlineEdit}
-            inlineEditingMessageId={inlineEditingMessageId}
-            onDeleteDivider={handleDeleteDivider}
-            onLoadMore={handleLoadMore}
-            onLoadMessagesAround={handleLoadMessagesAround}
-            onImageEditComplete={handleImageEditComplete}
-          />
+          <div className="flex min-h-0 flex-1 flex-col" data-composer-message-viewport>
+            <ChatMessages
+              conversationId={conversationId}
+              messages={messages}
+              messagesLoaded={messagesLoaded}
+              streaming={isStreaming}
+              streamingContent={streamingContent}
+              streamingReasoning={streamingReasoning}
+              streamingModel={streamingModel}
+              startedAt={streamState?.startedAt}
+              toolActivities={toolActivities}
+              contextDividers={contextDividers}
+              hasMore={hasMoreMessages}
+              onDeleteMessage={handleDeleteMessage}
+              onResendMessage={handleResendMessage}
+              onStartInlineEdit={handleStartInlineEdit}
+              onSubmitInlineEdit={handleSubmitInlineEdit}
+              onCancelInlineEdit={handleCancelInlineEdit}
+              inlineEditingMessageId={inlineEditingMessageId}
+              onDeleteDivider={handleDeleteDivider}
+              onLoadMore={handleLoadMore}
+              onLoadMessagesAround={handleLoadMessagesAround}
+              onImageEditComplete={handleImageEditComplete}
+            />
+          </div>
 
           {/* 错误提示 */}
           {chatError && (

--- a/docs/plans/2026-09-09-resizable-chat-composer.md
+++ b/docs/plans/2026-09-09-resizable-chat-composer.md
@@ -1,0 +1,62 @@
+# Resizable Chat Composer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task.
+
+**Goal:** Give both Agent and Chat composers a WeChat-style top-edge drag resize with a compact minimum height, without a one-click expansion control.
+
+**Architecture:** Keep TipTap document state untouched and resize only the visual editor region through one shared `useComposerResize` hook. Agent and Chat keep their existing markup and add only the hook refs, handle, and fixed-height style. The initial state remains content-driven; drag gestures set a clamped fixed height. The total maximum is the smaller of the real-layout allowance and 60% of the conversation viewport. One `ResizeObserver` watches the layout boundaries, while pointer moves write height directly to the DOM so dragging does not render React every frame. `RichTextInput.fillHeight` explicitly makes `EditorContent` and `.ProseMirror` fill the resized region.
+
+**Tech Stack:** React 18, TypeScript, Jotai-based renderer architecture, Tailwind CSS, TipTap v3, Bun test runner.
+
+---
+
+### Task 1: Add deterministic composer sizing helpers
+
+**Files:**
+- Create: `apps/electron/src/renderer/components/ai-elements/composer-resize.ts`
+- Test: `apps/electron/src/renderer/components/ai-elements/composer-resize.test.ts`
+
+**Steps:**
+1. Write failing tests for the compact minimum, the 60%-of-viewport maximum, and upward/downward drag deltas.
+2. Run `bun test apps/electron/src/renderer/components/ai-elements/composer-resize.test.ts` and confirm the tests fail because helpers do not exist.
+3. Implement pure functions that calculate editor height from measured frame/editor heights, with a 101px minimum editor region and a viewport-relative maximum.
+4. Re-run the focused test and confirm all sizing cases pass.
+
+### Task 2: Build the shared resize hook
+
+**Files:**
+- Create: `apps/electron/src/renderer/components/ai-elements/resizable-composer.tsx`
+
+**Steps:**
+1. Add a hook that owns frame/editor refs, starts from natural height, and exposes `onResizePointerDown` plus the persisted fixed height.
+2. During pointer drag, use pointer capture and direct DOM height writes, disable text selection, show `row-resize`, temporarily disable backdrop blur/transition, and clean listeners on pointer-up, pointer-cancel, lost capture, window blur, and unmount.
+3. Persist by Agent session ID or Chat conversation ID, reject invalid storage values, and re-clamp restored values before paint.
+4. Cap frame height at the smaller of the real layout allowance and 60% of the conversation viewport; allow the chrome region to shrink and scroll before sacrificing the normal 101px editor minimum.
+5. Use one observer for the composer viewport, message region, frame, editor, and footer so banners, attachments, queues, and window changes re-clamp without parallel state machines.
+
+### Task 3: Integrate Agent and Chat composers
+
+**Files:**
+- Modify: `apps/electron/src/renderer/components/chat/ChatInput.tsx`
+- Modify: `apps/electron/src/renderer/components/agent/AgentView.tsx`
+- Modify: `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx`
+
+**Steps:**
+1. Add frame and editor-region refs to both composer containers.
+2. Render the shared top-edge drag target in both modes.
+3. When a manual/fixed height is active, let `RichTextInput` fill the editor region and scroll internally; in natural mode preserve the existing auto-grow behavior.
+4. Stop enabling the legacy long-content-only bottom-right collapse button in Agent mode to avoid duplicate controls; retain the generic prop for compatibility unless no call sites remain.
+5. Increment `@proma/electron` patch version from `0.19.37` to `0.19.38`.
+
+### Task 4: Verify behavior and regressions
+
+**Files:**
+- Verify all files above.
+
+**Steps:**
+1. Run the focused sizing tests.
+2. Run `bun run --cwd apps/electron typecheck`.
+3. Run `bun run --cwd apps/electron build:renderer`.
+4. Run `git diff --check`.
+5. Review the final diff for duplicated resize logic, leaked listeners, hard-coded colors, duplicate expansion controls, and accidental changes outside the composer feature.
+6. Report the worktree path, changed files, exact validation results, and remaining runtime-only checks. Do not commit or open a PR until the user explicitly requests it.


### PR DESCRIPTION
## 概述
为 Agent 与 Chat 的输入框增加仅通过顶部边缘进行的拖拽缩放能力。高度按 Agent 会话与 Chat 对话分别持久化；输入框总高度始终受真实可用空间与对话 viewport 60% 的较小值限制，避免挤压消息区。

## 改动
- `apps/electron/src/renderer/components/ai-elements/composer-resize.ts` — 新增共享的高度上限、拖拽高度、持久化键和安全 localStorage 读写逻辑。
- `apps/electron/src/renderer/components/ai-elements/resizable-composer.tsx` — 新增 `useComposerResize`，处理顶部 Pointer 拖拽、Pointer Capture、失焦/取消/卸载清理、ResizeObserver 重约束与拖后 TipTap 焦点恢复。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 接入 Agent 会话级 composer 拖拽、内部 chrome 滚动和实际消息视图区测量。
- `apps/electron/src/renderer/components/chat/ChatInput.tsx`、`apps/electron/src/renderer/components/chat/ChatView.tsx` — 接入 Chat 对话级 composer 拖拽及 viewport / 消息区域标记。
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 增加显式 `fillHeight` 高度链，确保放大后 TipTap 的可见编辑区均可点击落光标。
- `docs/plans/2026-09-09-resizable-chat-composer.md` — 记录实现边界与验证路径。

## 测试方法
1. 运行 `bun run --cwd apps/electron typecheck`。
2. 运行 `bun run --cwd apps/electron build:renderer`。
3. 手测 Chat 和 Agent：顶部边缘向上/向下拖拽、会话切换后的独立高度恢复、窗口缩小与 chrome 溢出滚动。
4. 手测 Agent 的 AskUser / ExitPlan 横幅消失后首次挂载、拖拽中 viewport 变化、TipTap 编辑区上下区域点击落光标。

## 备注
- 按需求移除了本次新增的 focused test 文件；本 PR 不新增测试文件。
- 已完成只读本地准 PR 审核；未发现确定性 blocker。GPU / compositor 仍建议在长会话流式输出时以 Chromium Performance + Layers 做运行时 profile。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
