### PR TITLE
fix(skills): 将 skills 关闭时的提示变为已关闭而非移除【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -786,7 +786,10 @@ function parseSkillFrontmatter(content: string, slug: string, enabled: boolean):
 
 export function getWorkspaceCapabilities(workspaceSlug: string): WorkspaceCapabilities {
   const mcpConfig = getWorkspaceMcpConfig(workspaceSlug)
-  const skills = getWorkspaceSkills(workspaceSlug)
+  // 能力摘要供 UI 状态展示和变更提示使用；保留 inactive Skill 才能将
+  // skills/ ↔ skills-inactive/ 的移动识别为启用/关闭，而非移除/新增。
+  // Agent 运行时仍只从 skills/ 读取实际启用的 Skill。
+  const skills = getAllWorkspaceSkills(workspaceSlug)
   const builtinMcpServers = listBuiltinMcpServers()
   const memory = getWorkspaceMemorySummary(workspaceSlug)
 

--- a/apps/electron/src/renderer/lib/capabilities-toast.ts
+++ b/apps/electron/src/renderer/lib/capabilities-toast.ts
@@ -10,7 +10,7 @@ const CHANGE_LABELS: Record<CapabilityChange['type'], string> = {
   skill_added: 'Skill 已添加',
   skill_removed: 'Skill 已移除',
   skill_enabled: 'Skill 已启用',
-  skill_disabled: 'Skill 已禁用',
+  skill_disabled: 'Skill 已关闭',
 }
 
 /**


### PR DESCRIPTION
## 概述
修复项目 Skill 被关闭时，能力变化提示被误判为“已移除”的问题。关闭 Skill 会移动到 `skills-inactive/` 并保留配置，能力摘要现在会保留其 `enabled: false` 状态，因此能正确区分关闭、重新启用和真正删除。

## 改动
- `apps/electron/src/main/lib/agent-workspace-manager.ts` — 能力摘要同时纳入活跃与关闭中的 Skill；Agent 运行时继续只从 `skills/` 加载启用中的 Skill。
- `apps/electron/src/renderer/lib/capabilities-toast.ts` — 将 `skill_disabled` 的提示调整为“Skill 已关闭”，保留 `skill_removed` 的“Skill 已移除”语义。

## 测试方法
1. 运行 `bun test packages/shared/src/utils/capabilities-diff.test.ts`。
2. 在 Skills 页面关闭一个启用中的 Skill，确认提示为“Skill 已关闭”，且 Agent 不再加载该 Skill。
3. 重新开启该 Skill，确认提示为“Skill 已启用”，且 Agent 恢复加载。
4. 真正删除一个 Skill，确认提示仍为“Skill 已移除”。

## 备注
- 已完成 Local 准 PR 审核；未发现阻断性缺陷。
- `git diff --check` 已通过。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
