### PR TITLE
fix(model-selector): 扩大模型列表宽度以完整显示模型名称

### DIFF
--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -317,13 +317,14 @@ export function ModelSelector({
         <TooltipContent side="top">渠道：{displayModelInfo?.channelName}</TooltipContent>
       </Tooltip>
 
-      {/* 模型选择 Popover — 锚定触发按钮，向上展开（end 对齐，内容向左上延伸） */}
+      {/* 模型选择 Popover — 锚定触发按钮，向上展开（end 对齐，内容向左上延伸）。
+          宽度优先让模型名称完整显示，并在窄窗口内保留 12px 的安全边距。 */}
       <PopoverContent
         side="top"
         align="end"
         sideOffset={8}
         collisionPadding={12}
-        className="w-[320px] p-0"
+        className="w-[min(400px,calc(100vw-24px))] p-0"
         aria-label="选择模型"
       >
         {/* 搜索栏 */}


### PR DESCRIPTION
#### 问题

展开后的模型选择列表 Popover 宽度固定为 `320px`，左侧模型名称可用空间约 230px，较长的模型名会被截断。

#### 改动

| Before | After |
| --- | --- |
| Popover 固定宽度 `320px` | 宽度上限提升到 `400px`，名称列增加约 80px |
| 窄窗口无额外约束 | 使用 `min(400px, calc(100vw - 24px))`，保留两侧 12px 安全边距 |

涉及文件：`apps/electron/src/renderer/components/chat/ModelSelector.tsx`

#### 验证

- `bun run --filter='@proma/electron' typecheck` 通过
- `git diff --check` 无异常
- 本地 `bun run dev` 实际打开模型列表确认长名称可完整显示

#### 性能影响

无明显性能影响。仅调整一个 Popover 容器的静态宽度约束，不新增渲染、订阅、监听器或状态更新路径。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)