### PR TITLE
feat(agent): manage OAuth MCP connections

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -363,7 +363,7 @@ import {
 import { movePathSafely } from './lib/file-move-service'
 import { subscribeWorkspaceMemoryChanges } from './lib/workspace-memory-change-watcher'
 import { confirmWorkspaceMemoryWindowClose, markWorkspaceMemoryWindowReady } from './lib/workspace-memory-window'
-import { deleteMcpCredential, startMcpOAuth, saveMcpApiKey } from './lib/mcp-oauth-service'
+import { deleteMcpCredential, startMcpOAuth, saveMcpApiKey, saveMcpOAuthClientSecret } from './lib/mcp-oauth-service'
 
 /** Renderer-scoped subscriptions; disposed on explicit tab cleanup or renderer destruction. */
 const workspaceMemoryWatchSubscriptions = new Map<number, Map<string, () => void>>()
@@ -3219,6 +3219,13 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.START_MCP_OAUTH,
     async (_, input: import('@proma/shared').StartMcpOAuthInput): Promise<import('@proma/shared').McpOAuthStartResult> => {
       return startMcpOAuth(input)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SAVE_MCP_OAUTH_CLIENT_SECRET,
+    (_, input: import('@proma/shared').SaveMcpOAuthClientSecretInput): void => {
+      saveMcpOAuthClientSecret(input)
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -42,6 +42,7 @@ import { downloadInstaller, launchInstaller } from '../installer-downloader'
 import { fetchInstallerManifest, findInstallerSource } from '../installer-manifest'
 import { shouldOfferWindowsShellInstaller } from './windows-shell-installer'
 import { buildPiCollaborationTools } from '../agent-collaboration-tools'
+import { configureWorkspaceMcp, listWorkspaceMcpServers } from '../mcp-configuration-service'
 import { getVisionRelayRouteLabel, inspectImageWithVisionRelay, isVisionRelayConfigured, isVisionRelayEligibleForModel } from '../vision-relay-service'
 import {
   listTodos,
@@ -142,6 +143,82 @@ function defaultTodoDueAt(): number {
   const date = new Date()
   date.setHours(23, 59, 59, 999)
   return date.getTime()
+}
+
+// ===== 工作区 MCP 管理工具 =====
+
+/**
+ * Agent 只能通过受控工具写入无凭据 MCP transport；敏感 headers/env/OAuth 始终由
+ * 现有 UI + Keychain 流程处理。每次启用都会执行真实握手和 listTools 验证。
+ */
+function buildWorkspaceMcpManagementTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinition[] {
+  if (!ctx.workspaceSlug || ctx.triggeredBy === 'automation' || ctx.triggeredBy === 'delegation') return []
+
+  return [
+    sdk.defineTool({
+      name: 'proma_workspace_list_mcp_servers',
+      label: '列出工作区 MCP',
+      description: 'List the current workspace MCP servers and their safe connection status. No credentials, headers, environment values, or endpoint details are returned.',
+      promptSnippet: 'Use this before adding or updating an MCP to avoid overwriting an existing server. If the same server exists with a different connection, ask the user before retrying with replaceExisting=true.',
+      parameters: Type.Object({}),
+      async execute() {
+        return jsonToolResult({ servers: listWorkspaceMcpServers(ctx.workspaceSlug!) })
+      },
+    }),
+    sdk.defineTool({
+      name: 'proma_workspace_configure_mcp_server',
+      label: '配置工作区 MCP',
+      description: 'Create or update a non-sensitive workspace MCP transport and validate it with a real handshake and listTools call. Credentials, authorization headers, and environment secrets are intentionally not accepted; guide the user to the MCP UI for those.',
+      promptSnippet: 'Use only after confirming the official MCP transport. A successful server becomes available in the next user message or new run; tools cannot be hot-added to the current run.',
+      parameters: Type.Object({
+        name: Type.String({ minLength: 1, maxLength: 120, description: 'Stable MCP server name. Reuses and updates an existing server with this exact name.' }),
+        type: Type.Union([Type.Literal('stdio'), Type.Literal('http'), Type.Literal('sse')]),
+        command: Type.Optional(Type.String({ description: 'Required for stdio MCP.' })),
+        args: Type.Optional(Type.Array(Type.String(), { description: 'Optional stdio command arguments.' })),
+        url: Type.Optional(Type.String({ description: 'Required for HTTP or SSE MCP.' })),
+        timeout: Type.Optional(Type.Number({ minimum: 1, maximum: 300, description: 'Optional handshake timeout in seconds for any MCP transport.' })),
+        enabled: Type.Optional(Type.Boolean({ description: 'Defaults to true. When true, Proma enables the server only after handshake and listTools succeed.' })),
+        oauth: Type.Optional(Type.Object({
+          provider: Type.Optional(Type.String({ description: 'Stable, non-secret OAuth provider label, for example github.' })),
+          authorizationEndpoint: Type.Optional(Type.String({ description: 'Public HTTPS OAuth authorization endpoint from official documentation.' })),
+          tokenEndpoint: Type.Optional(Type.String({ description: 'Public HTTPS OAuth token endpoint from official documentation.' })),
+          registrationEndpoint: Type.Optional(Type.String({ description: 'Public HTTPS Dynamic Client Registration endpoint, when the provider supports it.' })),
+          clientId: Type.Optional(Type.String({ description: 'Public OAuth client ID. Never pass a client secret or token.' })),
+          clientSecretRequired: Type.Optional(Type.Boolean({ description: 'Set true only when official documentation requires a client secret; the user will enter it through the encrypted MCP card UI.' })),
+          scopes: Type.Optional(Type.Array(Type.String(), { description: 'Optional OAuth scopes. Never include credentials.' })),
+        }, { description: 'Optional non-sensitive OAuth metadata. After saving, the MCP card lets the user explicitly authorize it in the browser.' })),
+        replaceExisting: Type.Optional(Type.Boolean({ description: 'Set true only after the user explicitly confirms replacing an existing server connection.' })),
+      }),
+      async execute(_toolCallId, params) {
+        const args = params as {
+          name: string
+          type: 'stdio' | 'http' | 'sse'
+          command?: string
+          args?: string[]
+          url?: string
+          timeout?: number
+          enabled?: boolean
+          oauth?: {
+            provider?: string
+            authorizationEndpoint?: string
+            tokenEndpoint?: string
+            registrationEndpoint?: string
+            clientId?: string
+            clientSecretRequired?: boolean
+            scopes?: string[]
+          }
+          replaceExisting?: boolean
+        }
+        const server = await configureWorkspaceMcp(ctx.workspaceSlug!, args)
+        return jsonToolResult({
+          server,
+          nextStep: server.availableNextRun
+            ? `${server.updatedExisting ? 'MCP 已更新' : 'MCP 已创建'}并验证启用；它会在下一条用户消息或新会话中作为工具可用。本轮工具集不会热更新。`
+            : 'MCP 已保存但未启用。请检查连接配置，或在 MCP 管理界面完成凭据配置后重新验证。',
+        })
+      },
+    }),
+  ] as ToolDefinition[]
 }
 
 // ===== Automation 工具 =====
@@ -1487,6 +1564,13 @@ export async function buildPiBuiltinTools(
   })
 
   const tools: ToolDefinition[] = []
+
+  // MCP 管理通过受控工具写入并验证；不要求 Agent 直接编辑 mcp.json。
+  try {
+    tools.push(...buildWorkspaceMcpManagementTools(sdk, ctx))
+  } catch (error) {
+    console.error('[Pi 桥接] 注入 MCP 管理工具失败:', error)
+  }
 
   // 自动化是 Proma 基础运行时能力，不作为可配置 MCP 展示或开关。
   try {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -293,6 +293,7 @@ export class AgentOrchestrator {
           url: entry.url,
           ...(Object.keys(headers).length > 0 && { headers }),
           ...(proxyUrl && { proxyUrl }),
+          startup_timeout_sec: entry.timeout ?? 30,
           required: true,
         }
       } else {

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -145,6 +145,7 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - 项目根：\`${workspace.projectRoot}\`（${workspace.isLocalProject ? '用户本地原始文件' : 'Proma 托管项目文件'}）；cwd：\`${workspace.agentCwd}\`（${workspace.isProjectCwd ? '当前直接在项目根工作' : '会话工作台，不等同项目根'}）。
 - 会话工作台：\`${sessionContextDir}\`，用于本次任务、计划和交接；新会话直接使用 workbench 根，历史会话兼容 \`.context/\`。项目级 Context：\`${projectContextDir}\` 用于跨会话资料。用户指定位置优先；不要随意清理本地项目。
 - Proma 工作区规则：\`${workspace.agentsMd}\`${workspace.workspaceAgentsExists ? '（已加载）' : '（当前未建立；这是候选路径，不要读取）'}；记忆索引：\`${workspace.autoMemoryIndex}\`；MCP：\`${workspace.mcpConfig}\`；Skills：\`${workspace.skillsDir}\`。只使用 Proma 工作区的 MCP/Skills 配置。
+- 配置 MCP 时，先调用 \`proma_workspace_list_mcp_servers\`，再用 \`proma_workspace_configure_mcp_server\` 写入和验证非敏感 transport；不要直接编辑 \`mcp.json\`。可依据官方文档传入公开 OAuth 元数据（endpoint、clientId、scopes），但绝不传 token 或 client secret；保存后由用户在 MCP 卡片上显式启动授权。Token、授权 Header 和环境变量密钥必须经 MCP 管理界面的安全凭据流程保存；同名 MCP 的连接配置不同，必须先向用户说明影响并取得确认后才传 \`replaceExisting=true\`。
 - 需要原文或更多细节时，再按当前任务读取两级 Context、记忆索引或 Skill 元数据；禁止无差别全量扫描。`
       : undefined,
     buildLegacyProjectMigrationRequirement({ sources: ctx.projectInstructions?.sources ?? [] }),

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -710,7 +710,7 @@ export function saveWorkspaceMcpConfig(workspaceSlug: string, config: WorkspaceM
   const mcpPath = getWorkspaceMcpPath(workspaceSlug)
 
   try {
-    writeFileSync(mcpPath, JSON.stringify(normalizeWorkspaceMcpConfig(config), null, 2), 'utf-8')
+    writeJsonFileAtomic(mcpPath, normalizeWorkspaceMcpConfig(config))
     console.log(`[Agent 工作区] 已保存 MCP 配置: ${workspaceSlug}`)
   } catch (error) {
     console.error('[Agent 工作区] 保存 MCP 配置失败:', error)

--- a/apps/electron/src/main/lib/mcp-configuration-policy.ts
+++ b/apps/electron/src/main/lib/mcp-configuration-policy.ts
@@ -1,0 +1,121 @@
+/**
+ * 工作区 MCP 配置的纯策略函数。
+ *
+ * 不依赖 Electron、文件系统或网络，供受控 Agent 配置服务与单元测试共用。
+ */
+
+import type { McpOAuthConfiguration, McpServerEntry, McpTransportType } from '@proma/shared'
+import { RESERVED_BUILTIN_KEYS } from './builtin-mcp/baseline'
+
+export interface ConfigureWorkspaceMcpInput {
+  name: string
+  type: McpTransportType
+  command?: string
+  args?: string[]
+  url?: string
+  timeout?: number
+  /** 默认为 true；启用时会先验证，失败条目会以 disabled 状态保存。 */
+  enabled?: boolean
+  /** Agent 可写入的公开 OAuth 参数；绝不包含 client secret 或 token。 */
+  oauth?: McpOAuthConfiguration
+  /** 仅在用户已确认覆盖已有 MCP 的连接配置时传入。 */
+  replaceExisting?: boolean
+}
+
+export function requireWorkspaceMcpServerName(name: string): string {
+  const normalized = name.trim()
+  if (!normalized) throw new Error('MCP 服务名不能为空')
+  if (RESERVED_BUILTIN_KEYS.has(normalized)) throw new Error(`MCP 服务名 ${normalized} 是 Proma 运行时保留名`)
+  if (normalized.length > 120) throw new Error('MCP 服务名不能超过 120 个字符')
+  if (/\p{C}/u.test(normalized)) throw new Error('MCP 服务名不能包含控制字符')
+  return normalized
+}
+
+function normalizeOAuthConfiguration(oauth: McpOAuthConfiguration | undefined): McpOAuthConfiguration | undefined {
+  if (!oauth) return undefined
+  const normalizeUrl = (value: string | undefined, field: string): string | undefined => {
+    if (!value?.trim()) return undefined
+    let parsed: URL
+    try {
+      parsed = new URL(value.trim())
+    } catch {
+      throw new Error(`OAuth ${field} 不是有效 URL`)
+    }
+    if (parsed.protocol !== 'https:') throw new Error(`OAuth ${field} 必须使用 HTTPS`)
+    return parsed.toString()
+  }
+  const provider = oauth.provider?.trim()
+  const clientId = oauth.clientId?.trim()
+  const scopes = oauth.scopes?.map((scope) => scope.trim()).filter(Boolean)
+  const authorizationEndpoint = normalizeUrl(oauth.authorizationEndpoint, 'authorizationEndpoint')
+  const tokenEndpoint = normalizeUrl(oauth.tokenEndpoint, 'tokenEndpoint')
+  const registrationEndpoint = normalizeUrl(oauth.registrationEndpoint, 'registrationEndpoint')
+  const normalized = {
+    ...(provider ? { provider } : {}),
+    ...(authorizationEndpoint ? { authorizationEndpoint } : {}),
+    ...(tokenEndpoint ? { tokenEndpoint } : {}),
+    ...(registrationEndpoint ? { registrationEndpoint } : {}),
+    ...(clientId ? { clientId } : {}),
+    ...(oauth.clientSecretRequired === true ? { clientSecretRequired: true } : {}),
+    ...(scopes && scopes.length > 0 ? { scopes } : {}),
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+/** 将 Agent 输入收敛为无凭据的 MCP transport 配置。 */
+export function buildWorkspaceMcpEntry(input: ConfigureWorkspaceMcpInput): McpServerEntry {
+  const timeout = input.timeout == null ? undefined : Math.max(1, Math.floor(input.timeout))
+  const oauth = normalizeOAuthConfiguration(input.oauth)
+  if (input.type === 'stdio') {
+    const command = input.command?.trim()
+    if (!command) throw new Error('stdio MCP 需要 command')
+    const args = input.args?.map((arg) => arg.trim()).filter(Boolean)
+    return {
+      type: 'stdio',
+      command,
+      ...(args && args.length > 0 ? { args } : {}),
+      ...(timeout ? { timeout } : {}),
+      ...(oauth ? { oauth } : {}),
+      enabled: input.enabled !== false,
+    }
+  }
+
+  const url = input.url?.trim()
+  if (!url) throw new Error(`${input.type} MCP 需要 url`)
+  try {
+    new URL(url)
+  } catch {
+    throw new Error(`无效的 MCP URL: ${url}`)
+  }
+  return {
+    type: input.type,
+    url,
+    ...(timeout ? { timeout } : {}),
+    ...(oauth ? { oauth } : {}),
+    enabled: input.enabled !== false,
+  }
+}
+
+/**
+ * Agent 输入从不接触密钥；更新同一 transport 时保留 UI/Keychain 管理流程已写入的
+ * env 或 headers，避免一次普通地址更新意外清除现有认证配置。
+ */
+export function preserveSensitiveConnectionFields(previous: McpServerEntry | undefined, next: McpServerEntry): McpServerEntry {
+  if (!previous || previous.type !== next.type) return next
+  if (next.type === 'stdio' && previous.env) return { ...next, env: previous.env }
+  if ((next.type === 'http' || next.type === 'sse') && previous.headers) return { ...next, headers: previous.headers }
+  return next
+}
+
+/** 比较 Agent 有权管理的非敏感 transport 字段，不把凭据和上次测试结果算作变更。 */
+export function hasWorkspaceMcpTransportChanged(previous: McpServerEntry, next: McpServerEntry): boolean {
+  if (previous.type !== next.type || previous.timeout !== next.timeout || JSON.stringify(previous.oauth) !== JSON.stringify(next.oauth)) return true
+  if (next.type === 'stdio') {
+    const previousArgs = previous.args ?? []
+    const nextArgs = next.args ?? []
+    return previous.command !== next.command
+      || previousArgs.length !== nextArgs.length
+      || previousArgs.some((arg, index) => arg !== nextArgs[index])
+  }
+  return previous.url !== next.url
+}

--- a/apps/electron/src/main/lib/mcp-configuration-service.ts
+++ b/apps/electron/src/main/lib/mcp-configuration-service.ts
@@ -1,0 +1,122 @@
+/**
+ * 受控的工作区 MCP 配置服务。
+ *
+ * Agent 通过此服务新增或更新不含凭据的 transport 配置；所有启用请求都会执行
+ * MCP handshake + listTools 验证，并且仅在验证成功后写入 enabled=true。
+ */
+
+import type { McpServerEntry, McpTransportType, WorkspaceMcpConfig } from '@proma/shared'
+import { getWorkspaceMcpConfig, saveWorkspaceMcpConfig } from './agent-workspace-manager'
+import {
+  buildWorkspaceMcpEntry,
+  hasWorkspaceMcpTransportChanged,
+  preserveSensitiveConnectionFields,
+  requireWorkspaceMcpServerName,
+  type ConfigureWorkspaceMcpInput,
+} from './mcp-configuration-policy'
+import { validateMcpServer } from './mcp-validator'
+
+export type { ConfigureWorkspaceMcpInput } from './mcp-configuration-policy'
+
+/** 每个工作区的 MCP 配置变更串行执行，避免并发读-改-写互相覆盖。 */
+const workspaceMcpConfigMutationQueues = new Map<string, Promise<void>>()
+
+async function withWorkspaceMcpConfigMutation<T>(workspaceSlug: string, action: () => Promise<T>): Promise<T> {
+  const previous = workspaceMcpConfigMutationQueues.get(workspaceSlug) ?? Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolve) => { release = resolve })
+  const queued = previous.catch(() => undefined).then(() => current)
+  workspaceMcpConfigMutationQueues.set(workspaceSlug, queued)
+  await previous.catch(() => undefined)
+  try {
+    return await action()
+  } finally {
+    release()
+    if (workspaceMcpConfigMutationQueues.get(workspaceSlug) === queued) {
+      workspaceMcpConfigMutationQueues.delete(workspaceSlug)
+    }
+  }
+}
+
+export interface WorkspaceMcpServerSummary {
+  name: string
+  type: McpTransportType
+  enabled: boolean
+  verified: boolean
+}
+
+export interface ConfigureWorkspaceMcpResult extends WorkspaceMcpServerSummary {
+  /** 本次调用是否基于已有同名条目更新。 */
+  updatedExisting: boolean
+  /** Pi customTools 在 run 启动时构建，因此本轮不会热更新。 */
+  availableNextRun: boolean
+}
+
+function summarize(name: string, entry: McpServerEntry): WorkspaceMcpServerSummary {
+  return {
+    name,
+    type: entry.type,
+    enabled: entry.enabled,
+    verified: entry.lastTestResult?.success === true,
+  }
+}
+
+/** 仅返回无敏感连接详情，供 Agent 判断是否需要更新或引用某个 MCP。 */
+export function listWorkspaceMcpServers(workspaceSlug: string): WorkspaceMcpServerSummary[] {
+  const config = getWorkspaceMcpConfig(workspaceSlug)
+  return Object.entries(config.servers).map(([name, entry]) => summarize(name, entry))
+}
+
+/**
+ * 写入无凭据 transport 配置。启用请求先持久化为 disabled，真实握手和工具发现
+ * 成功后才切换到 enabled，避免无效配置被下一轮 Agent 注入。
+ */
+export async function configureWorkspaceMcp(
+  workspaceSlug: string,
+  input: ConfigureWorkspaceMcpInput,
+): Promise<ConfigureWorkspaceMcpResult> {
+  return withWorkspaceMcpConfigMutation(workspaceSlug, async () => {
+    const name = requireWorkspaceMcpServerName(input.name)
+    const current = getWorkspaceMcpConfig(workspaceSlug)
+    const existing = current.servers[name]
+    // 省略 oauth 表示“不修改既有公开 OAuth 元数据”，以免普通 transport 更新破坏
+    // 已可用的授权卡；显式传 oauth 才会替换该元数据。
+    const requestedEntry: McpServerEntry = {
+      ...buildWorkspaceMcpEntry(input),
+      ...(input.oauth === undefined && existing?.oauth ? { oauth: existing.oauth } : {}),
+    }
+    if (existing && hasWorkspaceMcpTransportChanged(existing, requestedEntry) && input.replaceExisting !== true) {
+      throw new Error(`MCP「${name}」已存在且连接配置不同；请先向用户说明影响并在确认后以 replaceExisting=true 重试`)
+    }
+    const entry = preserveSensitiveConnectionFields(existing, requestedEntry)
+    const pendingEntry: McpServerEntry = { ...entry, enabled: false }
+    const pendingConfig: WorkspaceMcpConfig = {
+      servers: { ...current.servers, [name]: pendingEntry },
+    }
+    saveWorkspaceMcpConfig(workspaceSlug, pendingConfig)
+
+    if (!entry.enabled) {
+      return { ...summarize(name, pendingEntry), updatedExisting: Boolean(existing), availableNextRun: false }
+    }
+
+    const validation = await validateMcpServer(name, entry, workspaceSlug)
+    const resolvedEntry: McpServerEntry = {
+      ...entry,
+      enabled: validation.valid,
+      lastTestResult: {
+        success: validation.valid,
+        message: validation.valid ? (validation.message ?? 'MCP 连接成功') : (validation.reason ?? 'MCP 连接失败'),
+        timestamp: Date.now(),
+      },
+    }
+    saveWorkspaceMcpConfig(workspaceSlug, {
+      servers: { ...getWorkspaceMcpConfig(workspaceSlug).servers, [name]: resolvedEntry },
+    })
+
+    return {
+      ...summarize(name, resolvedEntry),
+      updatedExisting: Boolean(existing),
+      availableNextRun: validation.valid,
+    }
+  })
+}

--- a/apps/electron/src/main/lib/mcp-oauth-service.ts
+++ b/apps/electron/src/main/lib/mcp-oauth-service.ts
@@ -9,7 +9,7 @@ import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { createServer, type Server } from 'node:http'
 import { existsSync, readFileSync } from 'node:fs'
 import { safeStorage, shell } from 'electron'
-import type { McpOAuthProvider, McpOAuthStartResult, StartMcpOAuthInput } from '@proma/shared'
+import type { McpOAuthConfiguration, McpOAuthProvider, McpOAuthStartResult, StartMcpOAuthInput } from '@proma/shared'
 import { getMcpOAuthCredentialsPath } from './config-paths'
 import { writeJsonFileAtomic } from './safe-file'
 import { runWithOAuthProxyScope } from './oauth-proxy-scope'
@@ -47,8 +47,16 @@ interface McpOAuthCredential {
   clientId: string
   tokenEndpoint: string
   accessToken: string
+  /** OAuth client secret is optional and always Keychain-encrypted. */
+  clientSecret?: string
   refreshToken?: string
   expiresAt?: number
+}
+
+interface McpOAuthClientSecretCredential {
+  kind: 'oauth-client-secret'
+  serverUrl: string
+  clientSecret: string
 }
 
 interface McpApiKeyCredential {
@@ -63,7 +71,7 @@ interface McpApiKeyCredential {
   value: string
 }
 
-type McpCredential = McpOAuthCredential | McpApiKeyCredential
+type McpCredential = McpOAuthCredential | McpOAuthClientSecretCredential | McpApiKeyCredential
 
 interface McpOAuthCredentialFile {
   version: 1
@@ -73,7 +81,8 @@ interface McpOAuthCredentialFile {
 interface AuthorizationConfiguration {
   authorizationEndpoint: string
   tokenEndpoint: string
-  registrationEndpoint: string
+  registrationEndpoint?: string
+  clientId?: string
   scopes: string[]
 }
 
@@ -145,12 +154,40 @@ async function discoverAuthorizationConfiguration(serverUrl: string): Promise<Au
   )
   const metadataUrl = authorizationServerMetadataUrl(authorizationServer)
   const metadata = await fetchJson<OAuthAuthorizationServerMetadata>(metadataUrl, '无法读取 OAuth 授权服务器元数据')
+  const registrationEndpoint = typeof metadata.registration_endpoint === 'string' && metadata.registration_endpoint
+    ? ensureHttpsUrl(metadata.registration_endpoint, 'registration_endpoint')
+    : undefined
 
   return {
     authorizationEndpoint: ensureHttpsUrl(parseString(metadata.authorization_endpoint, 'authorization_endpoint'), 'authorization_endpoint'),
     tokenEndpoint: ensureHttpsUrl(parseString(metadata.token_endpoint, 'token_endpoint'), 'token_endpoint'),
-    registrationEndpoint: ensureHttpsUrl(parseString(metadata.registration_endpoint, 'registration_endpoint'), 'registration_endpoint'),
+    ...(registrationEndpoint ? { registrationEndpoint } : {}),
     scopes: parseStringArray(protectedResource.scopes_supported),
+  }
+}
+
+/**
+ * 优先使用工作区配置中由 Agent 根据官方文档写入的公开 OAuth 元数据；缺失字段时
+ * 回退到 RFC 9728 protected-resource discovery。没有 clientId 时仅能使用 DCR。
+ */
+async function resolveAuthorizationConfiguration(
+  serverUrl: string,
+  configured: McpOAuthConfiguration | undefined,
+): Promise<AuthorizationConfiguration> {
+  const hasConfiguredEndpoints = Boolean(configured?.authorizationEndpoint && configured?.tokenEndpoint)
+  const discovered = hasConfiguredEndpoints ? undefined : await discoverAuthorizationConfiguration(serverUrl)
+  const authorizationEndpoint = configured?.authorizationEndpoint ?? discovered?.authorizationEndpoint
+  const tokenEndpoint = configured?.tokenEndpoint ?? discovered?.tokenEndpoint
+  if (!authorizationEndpoint || !tokenEndpoint) {
+    throw new Error('OAuth 缺少 authorizationEndpoint 或 tokenEndpoint；请让 Agent 依据官方文档补全公开 OAuth 参数')
+  }
+  const scopes = configured?.scopes?.filter(Boolean) ?? discovered?.scopes ?? []
+  return {
+    authorizationEndpoint: ensureHttpsUrl(authorizationEndpoint, 'authorizationEndpoint'),
+    tokenEndpoint: ensureHttpsUrl(tokenEndpoint, 'tokenEndpoint'),
+    ...(configured?.registrationEndpoint ? { registrationEndpoint: ensureHttpsUrl(configured.registrationEndpoint, 'registrationEndpoint') } : discovered?.registrationEndpoint ? { registrationEndpoint: discovered.registrationEndpoint } : {}),
+    ...(configured?.clientId?.trim() ? { clientId: configured.clientId.trim() } : {}),
+    scopes,
   }
 }
 
@@ -248,6 +285,7 @@ export async function exchangeAuthorizationCode(input: {
   code: string
   verifier: string
   resource?: string
+  clientSecret?: string
 }): Promise<Pick<McpOAuthCredential, 'accessToken' | 'refreshToken' | 'expiresAt'>> {
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
@@ -257,6 +295,7 @@ export async function exchangeAuthorizationCode(input: {
     code_verifier: input.verifier,
   })
   if (input.resource) body.set('resource', input.resource)
+  if (input.clientSecret) body.set('client_secret', input.clientSecret)
   const response = await fetch(input.tokenEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
@@ -292,6 +331,9 @@ function decryptCredential(encrypted: string): McpCredential | undefined {
   if (!safeStorage.isEncryptionAvailable()) return undefined
   try {
     const parsed = JSON.parse(safeStorage.decryptString(Buffer.from(encrypted, 'base64'))) as Record<string, unknown>
+    if (parsed.kind === 'oauth-client-secret' && typeof parsed.serverUrl === 'string' && typeof parsed.clientSecret === 'string' && parsed.clientSecret) {
+      return { kind: 'oauth-client-secret', serverUrl: parsed.serverUrl, clientSecret: parsed.clientSecret }
+    }
     if (
       parsed.kind === 'api-key' &&
       typeof parsed.serverUrl === 'string' &&
@@ -322,6 +364,7 @@ function decryptCredential(encrypted: string): McpCredential | undefined {
       tokenEndpoint: parsed.tokenEndpoint,
       accessToken: parsed.accessToken,
       ...(typeof parsed.resource === 'string' && parsed.resource ? { resource: parsed.resource } : {}),
+      ...(typeof parsed.clientSecret === 'string' && parsed.clientSecret ? { clientSecret: parsed.clientSecret } : {}),
       ...(typeof parsed.refreshToken === 'string' && parsed.refreshToken ? { refreshToken: parsed.refreshToken } : {}),
       ...(typeof parsed.expiresAt === 'number' ? { expiresAt: parsed.expiresAt } : {}),
     }
@@ -334,6 +377,14 @@ function isMcpApiKeyCredential(credential: McpCredential): credential is McpApiK
   return 'kind' in credential && credential.kind === 'api-key'
 }
 
+function isMcpOAuthClientSecretCredential(credential: McpCredential): credential is McpOAuthClientSecretCredential {
+  return 'kind' in credential && credential.kind === 'oauth-client-secret'
+}
+
+function isMcpOAuthCredential(credential: McpCredential): credential is McpOAuthCredential {
+  return !('kind' in credential)
+}
+
 function saveCredential(workspaceSlug: string, serverName: string, credential: McpCredential): void {
   const file = readCredentialFile()
   file.credentials[credentialKey(workspaceSlug, serverName)] = encryptCredential(credential)
@@ -343,6 +394,20 @@ function saveCredential(workspaceSlug: string, serverName: string, credential: M
 function readCredential(workspaceSlug: string, serverName: string): McpCredential | undefined {
   const encrypted = readCredentialFile().credentials[credentialKey(workspaceSlug, serverName)]
   return encrypted ? decryptCredential(encrypted) : undefined
+}
+
+export function saveMcpOAuthClientSecret(input: {
+  workspaceSlug: string
+  serverName: string
+  serverUrl: string
+  clientSecret: string
+}): void {
+  if (!input.clientSecret.trim()) throw new Error('请输入 OAuth Client Secret')
+  saveCredential(input.workspaceSlug, input.serverName, {
+    kind: 'oauth-client-secret',
+    serverUrl: normalizeMcpResource(input.serverUrl),
+    clientSecret: input.clientSecret.trim(),
+  })
 }
 
 export function deleteMcpCredential(workspaceSlug: string, serverName: string): void {
@@ -361,6 +426,7 @@ export async function refreshCredential(credential: McpOAuthCredential): Promise
     body: (() => {
       const body = new URLSearchParams({ grant_type: 'refresh_token', client_id: credential.clientId, refresh_token: credential.refreshToken })
       if (credential.resource) body.set('resource', credential.resource)
+      if (credential.clientSecret) body.set('client_secret', credential.clientSecret)
       return body
     })(),
   })
@@ -380,11 +446,28 @@ export async function startMcpOAuth(input: StartMcpOAuthInput): Promise<McpOAuth
   const state = base64Url(randomBytes(32))
   const { verifier, challenge } = createPkcePair()
   const callback = await startCallbackServer(state)
+  const storedCredential = readCredential(input.workspaceSlug, input.serverName)
+  const storedClientSecret = storedCredential && isMcpOAuthClientSecretCredential(storedCredential)
+    && storedCredential.serverUrl === normalizeMcpResource(input.serverUrl)
+    ? storedCredential.clientSecret
+    : storedCredential && isMcpOAuthCredential(storedCredential)
+      && storedCredential.serverUrl === normalizeMcpResource(input.serverUrl)
+      ? storedCredential.clientSecret
+      : undefined
 
   try {
     const result = await runWithOAuthProxyScope(async () => {
-      const configuration = await discoverAuthorizationConfiguration(input.serverUrl)
-      const clientId = await registerClient(configuration.registrationEndpoint, callback.redirectUri)
+      const configuration = await resolveAuthorizationConfiguration(input.serverUrl, input.oauth)
+      const clientId = configuration.clientId
+        ?? (configuration.registrationEndpoint
+          ? await registerClient(configuration.registrationEndpoint, callback.redirectUri)
+          : undefined)
+      if (!clientId) {
+        throw new Error('OAuth 服务未提供动态客户端注册；请让 Agent 依据官方文档写入公开 clientId，或在 MCP 卡片中补全 OAuth 配置后重试')
+      }
+      if (input.oauth?.clientSecretRequired && !storedClientSecret) {
+        throw new Error('OAuth 授权码交换需要 Client Secret；请先通过 MCP 卡片安全保存后重试')
+      }
       const authorizationUrl = new URL(configuration.authorizationEndpoint)
       authorizationUrl.searchParams.set('response_type', 'code')
       authorizationUrl.searchParams.set('client_id', clientId)
@@ -405,6 +488,7 @@ export async function startMcpOAuth(input: StartMcpOAuthInput): Promise<McpOAuth
         code,
         verifier,
         resource,
+        clientSecret: storedClientSecret,
       })
       return { configuration, clientId, resource, token }
     })
@@ -414,6 +498,7 @@ export async function startMcpOAuth(input: StartMcpOAuthInput): Promise<McpOAuth
       resource: result.resource,
       clientId: result.clientId,
       tokenEndpoint: result.configuration.tokenEndpoint,
+      ...(storedClientSecret ? { clientSecret: storedClientSecret } : {}),
       ...result.token,
     })
     return { provider: input.provider, serverName: input.serverName, expiresAt: result.token.expiresAt }
@@ -482,6 +567,7 @@ export async function getMcpOAuthHeaders(workspaceSlug: string, serverName: stri
   if (isMcpApiKeyCredential(credential)) {
     return credential.headerName ? { [credential.headerName]: credential.value } : undefined
   }
+  if (!isMcpOAuthCredential(credential)) return undefined
   const oauthCredential = credential
   if (oauthCredential.expiresAt && oauthCredential.expiresAt <= Date.now() + EXPIRY_SKEW_MS) {
     const refreshedCredential = await runWithOAuthProxyScope(() => refreshCredential(oauthCredential))

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -715,6 +715,8 @@ export interface ElectronAPI {
   /** 原子新增 MCP，并在初始启用时条件持久化验证结果。 */
   installMcpAndValidate: (workspaceSlug: string, name: string, entry: import('@proma/shared').McpServerEntry) => Promise<import('@proma/shared').McpInstallMutationResult>
   startMcpOAuth: (input: import('@proma/shared').StartMcpOAuthInput) => Promise<import('@proma/shared').McpOAuthStartResult>
+  /** 将 OAuth client secret 加密保存到系统 Keychain；不会回传给渲染器或 Agent。 */
+  saveMcpOAuthClientSecret: (input: import('@proma/shared').SaveMcpOAuthClientSecretInput) => Promise<void>
 
   /** 将静态 MCP API Key / Token 加密保存到系统 Keychain。 */
   saveMcpApiKey: (input: import('@proma/shared').SaveMcpApiKeyInput) => Promise<void>
@@ -2070,6 +2072,10 @@ const electronAPI: ElectronAPI = {
 
   startMcpOAuth: (input: import('@proma/shared').StartMcpOAuthInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.START_MCP_OAUTH, input)
+  },
+
+  saveMcpOAuthClientSecret: (input: import('@proma/shared').SaveMcpOAuthClientSecretInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SAVE_MCP_OAUTH_CLIENT_SECRET, input)
   },
 
   saveMcpApiKey: (input: import('@proma/shared').SaveMcpApiKeyInput) => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -883,8 +883,12 @@ export const revealChangedWorkspaceComponentAtom = atom(
     ))
 
     const activeTab = get(agentDiffPanelTabAtom).get(sessionId)
-    const preservesUserFocus = get(agentSidePanelOpenAtomFamily(sessionId))
-      && isUserPriorityWorkspaceComponentTab(activeTab)
+    const panelOpen = get(agentSidePanelOpenAtomFamily(sessionId))
+    // MCP 的受控配置成功后必须让 Tab 可见，但配置结果不应打断用户正在阅读
+    // 文件、变更或其他工作区内容。右侧已打开时仅添加 Tab；尚未打开时才以 MCP 打开。
+    if (component === 'mcp' && panelOpen) return
+
+    const preservesUserFocus = panelOpen && isUserPriorityWorkspaceComponentTab(activeTab)
     if (preservesUserFocus) return
 
     set(agentSidePanelOpenAtomFamily(sessionId), true)

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -25,6 +25,7 @@ import { agentPendingPromptAtom, agentSessionDraftHtmlAtom, agentSessionDraftsAt
 import { agentSkillsTabAtom } from '@/atoms/active-view'
 import { useProjectActions } from '@/hooks/useProjectActions'
 import { useCreateSession } from '@/hooks/useCreateSession'
+import { McpServerForm } from '@/components/settings/McpServerForm'
 import { LocalProjectBadge } from '@/components/agent/LocalProjectBadge'
 import { AgentActionHint } from '@/components/agent/AgentActionHint'
 import { queuedTextToParagraphHtml } from '@/lib/agent-message-queue'
@@ -39,6 +40,7 @@ import { WorkspaceMemoryTab } from './WorkspaceMemoryTab'
 import { groupSkills } from './skillGrouping'
 import { EMBEDDED_CATALOG_TWO_COLUMN_MIN_WIDTH, IntegrationCatalog } from './IntegrationCatalog'
 import { CredentialDialog } from './CredentialDialog'
+import { OAuthClientSecretDialog } from './OAuthClientSecretDialog'
 import { buildCatalogMcpGuidePrompt, MCP_INTEGRATION_CATALOG, getCatalogServerNames, isCatalogIntegrationVisible, matchesCatalogSearch, type CatalogCliIntegration, type CatalogCliProbeState, type CatalogCredentialIntegration, type CatalogGuidedIntegration, type CatalogMcpIntegration } from './integration-catalog'
 
 const embeddedMcpSectionContainerQuery = `
@@ -95,15 +97,6 @@ version: "1.0.0"
 - 使用了哪些 group，各自包含哪些 Skill
 - 哪些 Skill 的分类不确定，以及原因
 - 是否有需要用户确认或后续合并同类项的建议`
-}
-
-function buildManualMcpGuidePrompt(): string {
-  return `帮我为当前 Proma 工作区添加一个 MCP 服务器。
-
-1. 先确认服务名和官方文档或 MCP 地址；信息不足时先问，不要猜测配置。
-2. 依据官方文档核验 transport、地址/命令、依赖、认证与权限；安全步骤可直接完成，登录、授权、付费或敏感凭据由我确认或操作。
-3. 写入前读取当前 mcp.json，只新增或更新目标服务，绝不覆盖其他配置；敏感凭据不写入 mcp.json、日志或普通文件。
-4. 完成真实连接验证后再启用；说明结果及下一步。新 MCP 需要在下一条消息或新会话中验证工具可用性。`
 }
 
 export function AgentSkillsView({
@@ -170,6 +163,7 @@ export function AgentSkillsView({
   const [search, setSearch] = React.useState('')
   const [selectedSkillSlug, setSelectedSkillSlug] = React.useState<string | null>(null)
   const [selectedSkillWorkspaceSlug, setSelectedSkillWorkspaceSlug] = React.useState<string | null>(null)
+  const [showCreateMcp, setShowCreateMcp] = React.useState(false)
   const [selectedMcpName, setSelectedMcpName] = React.useState<string | null>(null)
   const [showImport, setShowImport] = React.useState(false)
   const [wsPopoverOpen, setWsPopoverOpen] = React.useState(false)
@@ -178,9 +172,10 @@ export function AgentSkillsView({
   const [isDeletingSkill, setIsDeletingSkill] = React.useState(false)
   const [isDeletingMcp, setIsDeletingMcp] = React.useState(false)
   const [classifyingSkills, setClassifyingSkills] = React.useState(false)
-  const [guidingManualMcp, setGuidingManualMcp] = React.useState(false)
   const [installingCatalogMcpId, setInstallingCatalogMcpId] = React.useState<string | null>(null)
   const [pendingCredentialIntegration, setPendingCredentialIntegration] = React.useState<CatalogCredentialIntegration | null>(null)
+  const [pendingOAuthClientSecret, setPendingOAuthClientSecret] = React.useState<{ name: string; entry: McpServerEntry } | null>(null)
+  const savedOAuthClientSecretsRef = React.useRef(new Set<string>())
 
   const selectSkill = React.useCallback((slug: string): void => {
     setSelectedSkillSlug(slug)
@@ -277,18 +272,6 @@ export function AgentSkillsView({
     })
   }
 
-  const guideManualMcp = React.useCallback((): void => {
-    if (guidingManualMcp) return
-    setGuidingManualMcp(true)
-    try {
-      if (fillCurrentAgentPrompt(buildManualMcpGuidePrompt())) {
-        toast.success('已填入 MCP 配置提示词')
-      }
-    } finally {
-      setGuidingManualMcp(false)
-    }
-  }, [fillCurrentAgentPrompt, guidingManualMcp])
-
   const guideCatalogMcp = React.useCallback((integration: CatalogMcpIntegration): void => {
     if (fillCurrentAgentPrompt(buildCatalogMcpGuidePrompt(integration))) {
       toast.success(`已填入 ${integration.name} 配置提示词`)
@@ -309,11 +292,21 @@ export function AgentSkillsView({
           const installed = await data.installMcp(integration.serverName, integration.entry)
           if (!installed) return
         }
+        const configuredEntry = data.mcpConfig.servers[integration.serverName]
+        const serverUrl = configuredEntry?.type === 'http' || configuredEntry?.type === 'sse'
+          ? configuredEntry.url
+          : integration.entry.url
+        if (!serverUrl) throw new Error('当前 MCP 缺少可授权的远程地址')
+        const oauth = configuredEntry?.oauth ?? integration.entry.oauth
+        if (oauth && !oauth.clientId && !oauth.registrationEndpoint) {
+          throw new Error('OAuth 配置缺少公开 clientId 或 registrationEndpoint；请让 Agent 根据官方文档补全后再授权')
+        }
         await window.electronAPI.startMcpOAuth({
           workspaceSlug: data.workspaceSlug,
           serverName: integration.serverName,
-          provider: integration.oauthProvider,
-          serverUrl: integration.entry.url,
+          provider: oauth?.provider ?? integration.oauthProvider,
+          serverUrl,
+          ...(oauth ? { oauth } : {}),
         })
         const verification = await data.toggleMcp(integration.serverName, true)
         if (!verification.success) {
@@ -346,6 +339,40 @@ export function AgentSkillsView({
       setInstallingCatalogMcpId(null)
     }
   }, [data, guideCatalogMcp, installingCatalogMcpId])
+
+  const authorizeMcp = React.useCallback(async (name: string, entry: McpServerEntry): Promise<void> => {
+    if (installingCatalogMcpId) return
+    if ((entry.type !== 'http' && entry.type !== 'sse') || !entry.url || !entry.oauth) {
+      toast.error('当前 MCP 没有可用的 OAuth 配置')
+      return
+    }
+    if (!entry.oauth.clientId && !entry.oauth.registrationEndpoint) {
+      toast.error('OAuth 参数待补全', { description: '请让 Agent 根据官方文档写入公开 clientId 或 registrationEndpoint；token 和 client secret 不会写入配置。' })
+      return
+    }
+    if (entry.oauth.clientSecretRequired && !savedOAuthClientSecretsRef.current.has(name)) {
+      setPendingOAuthClientSecret({ name, entry })
+      return
+    }
+    setInstallingCatalogMcpId(`oauth:${name}`)
+    try {
+      await window.electronAPI.startMcpOAuth({
+        workspaceSlug: data.workspaceSlug,
+        serverName: name,
+        provider: entry.oauth.provider ?? name,
+        serverUrl: entry.url,
+        oauth: entry.oauth,
+      })
+      const verification = await data.toggleMcp(name, true)
+      if (!verification.success) throw new Error(verification.message || 'OAuth 已完成，但 MCP 握手或工具发现失败')
+      toast.success(`${name} 已完成授权`, { description: 'OAuth token 已安全保存，并已通过真实连接验证。' })
+    } catch (error) {
+      console.error(`[Agent 技能] ${name} OAuth 失败:`, error)
+      toast.error(`${name} 授权失败`, { description: error instanceof Error ? error.message : '请检查 OAuth 配置后重试' })
+    } finally {
+      setInstallingCatalogMcpId(null)
+    }
+  }, [data, installingCatalogMcpId])
 
   const connectCredentialIntegration = React.useCallback(async (integration: CatalogCredentialIntegration, value: string): Promise<void> => {
     if (installingCatalogMcpId) return
@@ -498,6 +525,28 @@ export function AgentSkillsView({
           onOpenFolder={() => openSkillFolder(selectedSkill.slug)}
         />
         {skillDeleteDialog}
+      </div>
+    )
+  }
+
+  if (showCreateMcp) {
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin">
+          <div className="mx-auto w-full max-w-3xl p-5">
+            <McpServerForm
+              server={null}
+              workspaceSlug={data.workspaceSlug}
+              onSaved={() => {
+                setShowCreateMcp(false)
+                void data.refreshMcpConfig()
+                bumpCapabilities((v) => v + 1)
+              }}
+              onChanged={data.refreshMcpConfig}
+              onCancel={() => setShowCreateMcp(false)}
+            />
+          </div>
+        </div>
       </div>
     )
   }
@@ -679,12 +728,11 @@ export function AgentSkillsView({
         {tab === 'mcp' && (
           <button
             type="button"
-            onClick={() => void guideManualMcp()}
-            disabled={guidingManualMcp}
-            title="创建 Agent 会话协助配置 MCP"
+            onClick={() => setShowCreateMcp(true)}
+            title="在 MCP 管理界面添加服务器"
             className="flex h-8 items-center gap-1.5 rounded-lg bg-primary px-3 text-[13px] font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60"
           >
-            {guidingManualMcp ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+            <Plus size={14} />
             <span>添加服务器</span>
           </button>
         )}
@@ -729,6 +777,7 @@ export function AgentSkillsView({
               onOpen={(name) => setSelectedMcpName(name)}
               onToggle={data.toggleMcp}
               onRequestDelete={setPendingDeleteMcpName}
+              onAuthorize={authorizeMcp}
               onInstallCatalogMcp={(integration) => { void installCatalogMcp(integration) }}
               onGuideCatalogCli={guideCatalogCli}
               onDisconnectCatalogCli={(integration) => { void disconnectCatalogCli(integration) }}
@@ -765,6 +814,24 @@ export function AgentSkillsView({
         integration={pendingCredentialIntegration}
         onOpenChange={(open) => { if (!open) setPendingCredentialIntegration(null) }}
         onSave={connectCredentialIntegration}
+      />
+
+      <OAuthClientSecretDialog
+        serverName={pendingOAuthClientSecret?.name ?? null}
+        onOpenChange={(open) => { if (!open) setPendingOAuthClientSecret(null) }}
+        onSave={async (clientSecret) => {
+          const pending = pendingOAuthClientSecret
+          if (!pending || !pending.entry.url) return
+          await window.electronAPI.saveMcpOAuthClientSecret({
+            workspaceSlug: data.workspaceSlug,
+            serverName: pending.name,
+            serverUrl: pending.entry.url,
+            clientSecret,
+          })
+          savedOAuthClientSecretsRef.current.add(pending.name)
+          // 先关闭秘密输入弹窗，再由同一张 MCP 卡片继续用户显式的浏览器授权。
+          queueMicrotask(() => { void authorizeMcp(pending.name, pending.entry) })
+        }}
       />
 
       <ImportSkillDialog
@@ -915,6 +982,7 @@ interface McpTabProps {
   onOpen: (name: string, entry: McpServerEntry) => void
   onToggle: (name: string, enabled: boolean) => void
   onRequestDelete: (name: string) => void
+  onAuthorize: (name: string, entry: McpServerEntry) => void
   onInstallCatalogMcp: (integration: CatalogMcpIntegration) => void
   onGuideCatalogCli: (integration: CatalogCliIntegration) => void
   onDisconnectCatalogCli: (integration: CatalogCliIntegration) => void
@@ -922,7 +990,7 @@ interface McpTabProps {
   onRequestCredential: (integration: CatalogCredentialIntegration) => void
 }
 
-function McpTab({ userEntries, catalogMcps, catalogClis, catalogGuided, catalogCredentials, embedded, installedMcpNames, enabledMcpNames, verifiedMcpNames, activeSkillSlugs, connectedCliIds, cliIntegrationProbeState, installingCatalogMcpId, onOpen, onToggle, onRequestDelete, onInstallCatalogMcp, onGuideCatalogCli, onDisconnectCatalogCli, onGuideCatalogIntegration, onRequestCredential }: McpTabProps): React.ReactElement {
+function McpTab({ userEntries, catalogMcps, catalogClis, catalogGuided, catalogCredentials, embedded, installedMcpNames, enabledMcpNames, verifiedMcpNames, activeSkillSlugs, connectedCliIds, cliIntegrationProbeState, installingCatalogMcpId, onOpen, onToggle, onRequestDelete, onAuthorize, onInstallCatalogMcp, onGuideCatalogCli, onDisconnectCatalogCli, onGuideCatalogIntegration, onRequestCredential }: McpTabProps): React.ReactElement {
   if (userEntries.length === 0 && catalogMcps.length === 0 && catalogClis.length === 0 && catalogGuided.length === 0 && catalogCredentials.length === 0) {
     return <EmptyState icon={<Search className="size-8 text-foreground/30" />} title="没有匹配的 MCP 服务器" hint="试试更换搜索关键词。" />
   }
@@ -939,8 +1007,13 @@ function McpTab({ userEntries, catalogMcps, catalogClis, catalogGuided, catalogC
               onOpen={() => onOpen(name, entry)}
               onToggle={(enabled) => onToggle(name, enabled)}
               onRequestDelete={() => onRequestDelete(name)}
-              statusLabel={entry.enabled ? '已启用' : '已关闭'}
-              statusTone={entry.enabled ? 'success' : 'muted'}
+              onAuthorize={entry.oauth ? () => { void onAuthorize(name, entry) } : undefined}
+              statusLabel={entry.enabled
+                ? '已启用'
+                : entry.lastTestResult?.success === false
+                  ? '待配置'
+                  : '待验证'}
+              statusTone={entry.enabled ? 'success' : entry.lastTestResult?.success === false ? 'warning' : 'muted'}
             />
           ))}
         </McpSection>

--- a/apps/electron/src/renderer/components/agent-skills/McpCard.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/McpCard.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react'
-import { Plug, CheckCircle2, XCircle, Trash2, CircleDashed } from 'lucide-react'
+import { Plug, CheckCircle2, XCircle, Trash2, CircleDashed, KeyRound } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -18,6 +18,8 @@ interface McpCardProps {
   entry: McpServerEntry
   onOpen: () => void
   onToggle?: (enabled: boolean) => void
+  /** 仅 OAuth 元数据完整/待补全的远程 MCP 提供用户显式授权入口。 */
+  onAuthorize?: () => void
   onRequestDelete?: () => void
   description?: string
   targetLabel?: string
@@ -31,6 +33,7 @@ export function McpCard({
   entry,
   onOpen,
   onToggle,
+  onAuthorize,
   onRequestDelete,
   description,
   targetLabel,
@@ -85,6 +88,17 @@ export function McpCard({
         )}
       </div>
 
+      {entry.oauth && !entry.enabled && (
+        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <KeyRound size={12} className="shrink-0" />
+          {!(entry.oauth.clientId || entry.oauth.registrationEndpoint)
+            ? 'OAuth 还需要公开 clientId 或 registrationEndpoint'
+            : entry.oauth.clientSecretRequired
+              ? 'OAuth 还需要用户安全保存 Client Secret 后授权'
+              : '完成 OAuth 授权并验证后即可在 Agent 中使用'}
+        </div>
+      )}
+
       <div className="flex items-center gap-2 border-t border-border/50 pt-2.5">
         {statusLabel && (
           <span
@@ -116,6 +130,16 @@ export function McpCard({
           <span className="rounded-md bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
             内置托管
           </span>
+        )}
+        {!isBuiltin && !readOnly && onAuthorize && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onAuthorize() }}
+            className="ml-auto inline-flex h-7 items-center gap-1 rounded-md bg-primary/10 px-2 text-[11px] font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <KeyRound size={12} />
+            {entry.oauth?.clientId || entry.oauth?.registrationEndpoint ? 'OAuth 授权' : '补全 OAuth'}
+          </button>
         )}
         {!isBuiltin && !readOnly && onRequestDelete && (
           <Tooltip>

--- a/apps/electron/src/renderer/components/agent-skills/OAuthClientSecretDialog.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/OAuthClientSecretDialog.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import { KeyRound, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+interface OAuthClientSecretDialogProps {
+  serverName: string | null
+  onOpenChange: (open: boolean) => void
+  onSave: (clientSecret: string) => Promise<void>
+}
+
+/** 用户显式输入 OAuth client secret 的最小安全入口；值只通过 IPC 送入 Keychain。 */
+export function OAuthClientSecretDialog({ serverName, onOpenChange, onSave }: OAuthClientSecretDialogProps): React.ReactElement {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const [saving, setSaving] = React.useState(false)
+
+  React.useEffect(() => {
+    if (inputRef.current) inputRef.current.value = ''
+    setSaving(false)
+  }, [serverName])
+
+  const handleSave = async (): Promise<void> => {
+    const clientSecret = inputRef.current?.value ?? ''
+    if (!clientSecret.trim() || saving) return
+    setSaving(true)
+    try {
+      await onSave(clientSecret)
+      if (inputRef.current) inputRef.current.value = ''
+      onOpenChange(false)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={Boolean(serverName)} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[560px] p-7" onOpenAutoFocus={(event) => event.preventDefault()}>
+        {serverName && <>
+          <DialogHeader className="space-y-2 text-left">
+            <DialogTitle className="flex items-center gap-2 text-xl font-semibold"><KeyRound size={19} />保存 OAuth Client Secret</DialogTitle>
+            <DialogDescription className="text-[15px] leading-6">
+              {serverName} 的 OAuth 服务要求 Client Secret。它只会加密保存到系统 Keychain，不会写入 mcp.json、显示给 Agent 或回传到页面。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-7">
+            <label htmlFor="oauth-client-secret" className="text-sm font-medium text-foreground">Client Secret <span className="text-destructive">*</span></label>
+            <Input
+              id="oauth-client-secret"
+              autoComplete="off"
+              type="password"
+              className="mt-2 h-12 text-sm"
+              placeholder="粘贴 OAuth 应用的 Client Secret"
+              ref={inputRef}
+              onKeyDown={(event) => { if (event.key === 'Enter') void handleSave() }}
+            />
+          </div>
+          <DialogFooter className="mt-7 gap-3 sm:justify-end">
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>取消</Button>
+            <Button onClick={() => { void handleSave() }} disabled={saving}>
+              {saving && <Loader2 size={15} className="animate-spin" />}
+              安全保存并继续授权
+            </Button>
+          </DialogFooter>
+        </>}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/electron/src/renderer/components/agent-skills/integration-catalog.ts
+++ b/apps/electron/src/renderer/components/agent-skills/integration-catalog.ts
@@ -221,7 +221,6 @@ const HIDDEN_UNTIL_TESTED_INTEGRATION_IDS = new Set([
   'google-calendar-mcp',
   'vercel-mcp',
   'github-cli',
-  'github-mcp',
   'stripe-mcp',
 ])
 
@@ -231,11 +230,20 @@ export function isCatalogIntegrationVisible(integration: CatalogIntegration): bo
 
 export const MCP_INTEGRATION_CATALOG: CatalogIntegration[] = [
   {
-    id: 'github-mcp', name: 'GitHub', iconSlug: 'github', kind: 'mcp', authentication: 'oauth', serverName: 'github',
+    id: 'github-mcp', name: 'GitHub', iconSlug: 'github', kind: 'mcp', authentication: 'oauth', oauthProvider: 'github', serverName: 'github',
     description: '让 Agent 在你的 GitHub 上读取代码上下文，并处理协作与代码质量工作流。',
     capabilities: ['仓库与文件', 'Issue / PR', 'Actions 与安全扫描'],
     setupUrl: 'https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp-in-your-ide/set-up-the-github-mcp-server',
-    entry: remoteMcp('https://api.githubcopilot.com/mcp/'),
+    entry: {
+      ...remoteMcp('https://api.githubcopilot.com/mcp/'),
+      oauth: {
+        provider: 'github',
+        authorizationEndpoint: 'https://github.com/login/oauth/authorize',
+        tokenEndpoint: 'https://github.com/login/oauth/access_token',
+        clientSecretRequired: true,
+        scopes: ['repo', 'read:org', 'read:user', 'user:email', 'read:packages', 'write:packages', 'read:project', 'project', 'gist', 'notifications'],
+      },
+    },
   },
   {
     id: 'notion-mcp', name: 'Notion', iconSlug: 'notion', kind: 'mcp', authentication: 'oauth', oauthProvider: 'notion', serverName: 'notion',
@@ -402,8 +410,14 @@ export const MCP_INTEGRATION_CATALOG: CatalogIntegration[] = [
   },
 ]
 
+/**
+ * 只有实际渲染的目录卡才能占用“目录服务器名”。被暂时隐藏的目录项不能吞掉
+ * Agent 已写入的同名工作区 MCP，否则待 OAuth 的通用连接会既不在目录、也不在“我的 MCP”。
+ */
 export function getCatalogServerNames(): Set<string> {
-  return new Set(MCP_INTEGRATION_CATALOG.flatMap((integration) => 'serverName' in integration && integration.serverName ? [integration.serverName] : []))
+  return new Set(MCP_INTEGRATION_CATALOG
+    .filter(isCatalogIntegrationVisible)
+    .flatMap((integration) => 'serverName' in integration && integration.serverName ? [integration.serverName] : []))
 }
 export function matchesCatalogSearch(integration: CatalogIntegration, query: string): boolean {
   if (!query) return true

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -293,7 +293,7 @@ export function createMcpMentionSuggestion(
     {
       char: '#',
       headerLabel: 'MCP 服务',
-      emptyText: '无匹配 MCP 服务',
+      emptyText: '没有可引用的 MCP；请先在 MCP 管理中完成启用和连接验证。',
       fetchItems: async (slug, q) => {
         const caps = await window.electronAPI.getWorkspaceCapabilities(slug)
         return getMcpMentionItems(caps.mcpServers, q)

--- a/apps/electron/src/renderer/components/settings/McpServerForm.tsx
+++ b/apps/electron/src/renderer/components/settings/McpServerForm.tsx
@@ -10,7 +10,7 @@ import { ArrowLeft, Loader2, CheckCircle2, XCircle, AlertCircle } from 'lucide-r
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import type { McpServerEntry, McpTransportType, WorkspaceMcpConfig } from '@proma/shared'
+import type { McpOAuthConfiguration, McpServerEntry, McpTransportType, WorkspaceMcpConfig } from '@proma/shared'
 import {
   SettingsSection,
   SettingsCard,
@@ -82,6 +82,8 @@ interface McpFormValues {
   enabled: boolean
   testResult: { success: boolean; message: string; timestamp?: number } | null
   isBuiltin: boolean
+  /** OAuth 公开元数据不在此表单编辑，但保存其他字段时必须原样保留。 */
+  oauth?: McpOAuthConfiguration
   command: string
   argsText: string
   envText: string
@@ -96,6 +98,7 @@ function buildEntryFromValues(values: McpFormValues, includeTestResult = false):
     type: values.transportType,
     enabled: values.enabled,
     ...(values.isBuiltin && { isBuiltin: true }),
+    ...(values.oauth && { oauth: values.oauth }),
     ...(includeTestResult && values.testResult && {
       lastTestResult: {
         ...values.testResult,
@@ -127,6 +130,7 @@ function buildEntryFromValues(values: McpFormValues, includeTestResult = false):
 export function McpServerForm({ server, workspaceSlug, onSaved, onChanged, onCancel, closeRequestId, showHeader = true }: McpServerFormProps): React.ReactElement {
   const isEdit = server !== null
   const isBuiltin = server?.entry.isBuiltin === true
+  const oauth = server?.entry.oauth
 
   // 表单状态
   const [name, setName] = React.useState(server?.name ?? '')
@@ -172,13 +176,13 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onChanged, onCan
 
   // 保留最新表单值，供 unmount 时 flush 待保存变更
   const latestValuesRef = React.useRef({
-    name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin,
+    name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin, oauth,
   })
   React.useEffect(() => {
     latestValuesRef.current = {
-      name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin,
+      name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin, oauth,
     }
-  }, [name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin])
+  }, [name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin, oauth])
 
   // 监听配置改变，清空测试结果（避免展示过期的测试结果）
   React.useEffect(() => {
@@ -207,6 +211,7 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onChanged, onCan
         enabled,
         testResult,
         isBuiltin,
+        oauth,
         command,
         argsText,
         envText,

--- a/apps/electron/src/renderer/lib/agent-component-activation.ts
+++ b/apps/electron/src/renderer/lib/agent-component-activation.ts
@@ -26,6 +26,10 @@ const PLANNING_GROUP_MUTATION_TOOLS = new Set([
 ])
 
 const PLANNING_REMINDER_CREATE_TOOL = 'mcp__planning__create_reminder'
+/** 仅受控 MCP 管理工具可触发展示；任意 mcp.json 文件写入仍不抢占用户工作区。 */
+const MCP_MANAGEMENT_MUTATION_TOOLS = new Set([
+  'proma_workspace_configure_mcp_server',
+])
 const FILE_MUTATION_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit'])
 const BASH_MUTATION_PATTERN = /(?:^|[;&|]\s*|\s)(?:rm|mv|mkdir|cp|touch|tee|sed\s+-i)\b|(?:>|>>)/
 
@@ -61,6 +65,7 @@ export function getChangedWorkspaceComponentForTool(
   if (TODO_MUTATION_TOOLS.has(toolName)) return 'todos'
   if (CALENDAR_MUTATION_TOOLS.has(toolName)) return 'calendar'
   if (AUTOMATION_MUTATION_TOOLS.has(toolName)) return 'automations'
+  if (MCP_MANAGEMENT_MUTATION_TOOLS.has(toolName)) return 'mcp'
 
   const input = asRecord(rawInput)
   if (!input) return null

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -944,6 +944,29 @@ export type McpTransportTypeAlias = 'streamableHttp' | 'streamable-http' | 'stre
 /** MCP 传输类型输入；保存和运行前会规范化为 McpTransportType */
 export type McpTransportTypeInput = McpTransportType | McpTransportTypeAlias
 
+/**
+ * MCP 的非敏感 OAuth 客户端元数据。
+ *
+ * Agent 可依据官方文档写入这些公开参数；access token、refresh token、client secret
+ * 等敏感值只能通过用户显式的授权流程保存到系统 Keychain。
+ */
+export interface McpOAuthConfiguration {
+  /** 可选的展示/诊断标识，不参与密钥存储。 */
+  provider?: string
+  /** OAuth authorization endpoint。未提供时尝试从 MCP protected-resource metadata 发现。 */
+  authorizationEndpoint?: string
+  /** OAuth token endpoint。未提供时尝试从 MCP protected-resource metadata 发现。 */
+  tokenEndpoint?: string
+  /** 支持 Dynamic Client Registration 的 registration endpoint。 */
+  registrationEndpoint?: string
+  /** 已公开注册的 OAuth client ID；没有 DCR 时必须提供。 */
+  clientId?: string
+  /** 授权码交换是否要求用户通过安全 UI 保存 OAuth client secret。 */
+  clientSecretRequired?: boolean
+  /** 请求授权时使用的 scope；为空时使用 MCP 声明的 scopes_supported。 */
+  scopes?: string[]
+}
+
 /** MCP 服务器条目 */
 export interface McpServerEntry {
   type: McpTransportType
@@ -961,6 +984,8 @@ export interface McpServerEntry {
   timeout?: number
   /** 是否启用 */
   enabled: boolean
+  /** 非敏感 OAuth 客户端元数据；token 只保存在 Keychain。 */
+  oauth?: McpOAuthConfiguration
   /** 是否为内置 MCP（不可删除，仅可配置 env） */
   isBuiltin?: boolean
   /** 最后一次测试结果 */
@@ -1012,8 +1037,8 @@ export interface McpInstallMutationResult extends McpConnectionMutationResult {
   installed: boolean
 }
 
-/** OAuth-capable remote MCP provider currently supported by the built-in connector flow. */
-export type McpOAuthProvider = 'notion' | 'github'
+/** OAuth provider display/credential namespace. Agent-configured MCP 可使用任意稳定字符串。 */
+export type McpOAuthProvider = string
 
 /** Renderer-to-main request for a remote MCP authorization-code + PKCE flow. */
 export interface StartMcpOAuthInput {
@@ -1021,6 +1046,16 @@ export interface StartMcpOAuthInput {
   serverName: string
   provider: McpOAuthProvider
   serverUrl: string
+  /** Agent 或目录提供的非敏感 OAuth 客户端元数据。 */
+  oauth?: McpOAuthConfiguration
+}
+
+/** Renderer-to-main request to store an OAuth client secret in Keychain; never exposed to Agent/tool results. */
+export interface SaveMcpOAuthClientSecretInput {
+  workspaceSlug: string
+  serverName: string
+  serverUrl: string
+  clientSecret: string
 }
 
 /** OAuth connection result that deliberately excludes all secret material. */
@@ -1866,6 +1901,8 @@ export const AGENT_IPC_CHANNELS = {
   INSTALL_MCP_AND_VALIDATE: 'agent:install-mcp-and-validate',
   /** 启动远程 MCP 的 OAuth PKCE 授权 */
   START_MCP_OAUTH: 'agent:start-mcp-oauth',
+  /** 将 OAuth client secret 加密保存到系统 Keychain。 */
+  SAVE_MCP_OAUTH_CLIENT_SECRET: 'agent:save-mcp-oauth-client-secret',
   /** 安全保存远程 MCP 的静态 API Key / Token */
   SAVE_MCP_API_KEY: 'agent:save-mcp-api-key',
   /** 删除工作区 MCP 对应的系统安全凭据，不返回任何凭据。 */


### PR DESCRIPTION
## Summary
- Add controlled Agent MCP configuration with real handshake validation.
- Surface pending OAuth MCPs in the MCP manager and continue authorization securely from cards.
- Support OAuth metadata, DCR/PKCE, and Keychain-backed client secrets without exposing credentials to Agent tools.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)