### PR TITLE
fix(sidebar): 会话行不再为委派状态预留右侧空槽

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -4438,49 +4438,45 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 
           {!editing && (
             <>
-              <div
-                className="flex w-9 shrink-0 items-center justify-end gap-1 text-[11px] leading-4 text-foreground/55"
-                aria-label={delegationSummary ? `子会话：${delegationSummary.settled}/${delegationSummary.total}` : undefined}
-              >
-                {delegationSummary && (
+              {delegationSummary && (
+                <div
+                  className="flex shrink-0 items-center justify-end gap-1 text-[11px] leading-4 text-foreground/55"
+                  aria-label={`子会话：${delegationSummary.settled}/${delegationSummary.total}`}
+                >
                   <span className="shrink-0 tabular-nums">
                     {delegationSummary.settled}/{delegationSummary.total}
                   </span>
-                )}
-              </div>
-              {delegationSummary ? (
-                <SafeTooltip content={delegationSummary.expanded ? '收起子会话' : '展开子会话'} side="top">
-                  <button
-                    type="button"
-                    aria-label={`${delegationSummary.expanded ? '收起' : '展开'}子会话`}
-                    onMouseEnter={preview.closeNow}
-                    onFocus={preview.closeNow}
-                    onMouseDown={(event) => {
-                      event.stopPropagation()
-                      preview.closeNow()
-                    }}
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      preview.closeNow()
-                      delegationSummary.onToggle()
-                    }}
-                    onDoubleClick={(event) => {
-                      event.stopPropagation()
-                      preview.closeNow()
-                    }}
-                    className="session-delegation-toggle flex-shrink-0 inline-flex size-6 -my-1 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
-                  >
-                    <ChevronRight
-                      size={11}
-                      className={cn(
-                        'transition-transform duration-150',
-                        delegationSummary.expanded && 'rotate-90',
-                      )}
-                    />
-                  </button>
-                </SafeTooltip>
-              ) : (
-                <span className="size-6 shrink-0" aria-hidden="true" />
+                  <SafeTooltip content={delegationSummary.expanded ? '收起子会话' : '展开子会话'} side="top">
+                    <button
+                      type="button"
+                      aria-label={`${delegationSummary.expanded ? '收起' : '展开'}子会话`}
+                      onMouseEnter={preview.closeNow}
+                      onFocus={preview.closeNow}
+                      onMouseDown={(event) => {
+                        event.stopPropagation()
+                        preview.closeNow()
+                      }}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        preview.closeNow()
+                        delegationSummary.onToggle()
+                      }}
+                      onDoubleClick={(event) => {
+                        event.stopPropagation()
+                        preview.closeNow()
+                      }}
+                      className="session-delegation-toggle inline-flex size-6 -my-1 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
+                    >
+                      <ChevronRight
+                        size={11}
+                        className={cn(
+                          'transition-transform duration-150',
+                          delegationSummary.expanded && 'rotate-90',
+                        )}
+                      />
+                    </button>
+                  </SafeTooltip>
+                </div>
               )}
               <SessionItemActions
                 updatedAt={session.updatedAt}


### PR DESCRIPTION
#### 问题

左侧会话列表中，没有子会话的会话行仍然固定占用 `36px` 的委派统计位和 `24px` 的展开按钮位。在 240px 最窄侧栏下，这部分空槽把标题压缩到只剩一两个字，「定时任务」合成分组尤其明显。

#### 改动

- 仅当会话确实存在子会话时，才渲染委派数量与展开按钮。
- 把数量与展开按钮合并为一个紧凑的右对齐区域，替代原来两个独立固定槽位。
- 普通会话的标题因此多出约 60px 可用宽度；相对更新时间、归档按钮、更多菜单、星标、工作区 Badge 等既有信息与交互保持不变。

#### 影响范围

- 单文件改动：`apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
- 未修改宽度约束、虚拟列表、项目分组与拖拽逻辑。

#### 性能影响

低风险。未新增状态、订阅、计时器或布局测量；仅把原本恒定渲染的空占位改为条件渲染，减少了每行的 DOM 节点数量。

#### 验证

- `bun run typecheck` 通过
- `bun run build:renderer` 通过
- `git diff --check` 通过

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)