### PR TITLE
fix(file-search): 提升单来源索引上限【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.19.52",
+  "version": "0.19.53",
   "description": "Proma，为专业用户设计的 Agent",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -451,6 +451,7 @@ import { syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
 import { presenceService } from './lib/feishu-presence'
 import { getDingTalkConfig, saveDingTalkConfig, getDecryptedClientSecret, getDingTalkMultiBotConfig, saveDingTalkBotConfig, removeDingTalkBot, getDecryptedBotClientSecret } from './lib/dingtalk-config'
 import { listShallowDirectory } from './lib/directory-listing'
+import { shouldStopWorkspaceFileSearchScan } from './lib/workspace-file-search-limits'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
 import { redactSensitiveLogValue } from './lib/bridge-log-redaction'
 import {
@@ -4578,7 +4579,6 @@ export function registerIpcHandlers(): void {
       const ignoreFiles = new Set(['.DS_Store', '.Spotlight-V100', '.Trashes', 'Thumbs.db', 'desktop.ini'])
       const BROWSE_LIMIT_PER_GROUP = 2000
       const BROWSE_TOTAL_CAP = 3000
-      const INDEX_ENTRY_CAP_PER_GROUP = 10_000
 
       // 按来源分组收集文件
       type Entry = WorkspaceFileSearchEntry
@@ -4593,11 +4593,11 @@ export function registerIpcHandlers(): void {
         useAbsPath: boolean,
         source: 'session' | 'workspace',
       ): void {
-        if (depth > 10 || target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
+        if (shouldStopWorkspaceFileSearchScan(depth, target.length)) return
         try {
           const items = readdirSync(dir, { withFileTypes: true })
           for (const item of items) {
-            if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) break
+            if (shouldStopWorkspaceFileSearchScan(depth, target.length)) break
             if (ignoreFiles.has(item.name)) continue
             if (item.isDirectory() && ignoreDirs.has(item.name)) continue
 
@@ -4620,7 +4620,7 @@ export function registerIpcHandlers(): void {
       }
 
       function addAttachedPath(pathValue: string, target: Entry[], source: 'session' | 'workspace'): void {
-        if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
+        if (shouldStopWorkspaceFileSearchScan(0, target.length)) return
         try {
           const attachedPath = resolve(pathValue)
           const name = basename(attachedPath)
@@ -4628,7 +4628,7 @@ export function registerIpcHandlers(): void {
 
           const stats = statSync(attachedPath)
           if (stats.isFile()) {
-            if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
+            if (shouldStopWorkspaceFileSearchScan(0, target.length)) return
             target.push({
               name,
               path: attachedPath,
@@ -4641,7 +4641,7 @@ export function registerIpcHandlers(): void {
           if (!stats.isDirectory()) return
           if (ignoreDirs.has(name)) return
 
-          if (target.length >= INDEX_ENTRY_CAP_PER_GROUP) return
+          if (shouldStopWorkspaceFileSearchScan(0, target.length)) return
           target.push({
             name: name === 'workspace-files' ? '项目文件' : name,
             path: attachedPath,

--- a/apps/electron/src/main/lib/workspace-file-search-limits.test.ts
+++ b/apps/electron/src/main/lib/workspace-file-search-limits.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test'
+import {
+  WORKSPACE_FILE_SEARCH_INDEX_ENTRY_CAP_PER_GROUP,
+  shouldStopWorkspaceFileSearchScan,
+} from './workspace-file-search-limits'
+
+test('允许在 15,000 条上限前继续收集文件搜索索引', () => {
+  expect(WORKSPACE_FILE_SEARCH_INDEX_ENTRY_CAP_PER_GROUP).toBe(15_000)
+  expect(shouldStopWorkspaceFileSearchScan(10, 14_999)).toBe(false)
+})
+
+test('在达到条目上限或超过既有深度限制时停止收集文件搜索索引', () => {
+  expect(shouldStopWorkspaceFileSearchScan(10, 15_000)).toBe(true)
+  expect(shouldStopWorkspaceFileSearchScan(11, 0)).toBe(true)
+})

--- a/apps/electron/src/main/lib/workspace-file-search-limits.ts
+++ b/apps/electron/src/main/lib/workspace-file-search-limits.ts
@@ -1,0 +1,16 @@
+/**
+ * 右侧文件搜索的扫描边界。
+ *
+ * 搜索在 Electron 主进程中按需同步建立短期索引；边界必须保持有限，
+ * 避免超大工作区的首次搜索长时间阻塞主进程。
+ */
+export const WORKSPACE_FILE_SEARCH_MAX_DEPTH = 10
+export const WORKSPACE_FILE_SEARCH_INDEX_ENTRY_CAP_PER_GROUP = 15_000
+
+/**
+ * 判断文件搜索索引是否已达到递归深度或单来源条目上限。
+ */
+export function shouldStopWorkspaceFileSearchScan(depth: number, entryCount: number): boolean {
+  return depth > WORKSPACE_FILE_SEARCH_MAX_DEPTH
+    || entryCount >= WORKSPACE_FILE_SEARCH_INDEX_ENTRY_CAP_PER_GROUP
+}


### PR DESCRIPTION
## 概述
将右侧“项目文件”搜索的单来源索引上限从 10,000 提升至 15,000，以扩大大型工作区的文件名与路径搜索覆盖范围；最大递归深度仍保持 10 层，缓存、忽略规则和返回结果限制保持不变。

## 改动
- `apps/electron/src/main/lib/workspace-file-search-limits.ts` — 集中定义文件搜索的最大递归深度与单来源条目上限，并提供统一的停止扫描判断。
- `apps/electron/src/main/ipc.ts` — 用统一边界判断替换内联的深度和 10,000 条限制，保持既有 IPC 返回结构不变。
- `apps/electron/src/main/lib/workspace-file-search-limits.test.ts` — 覆盖深度 10/11 与条目 14,999/15,000 的边界行为。
- `apps/electron/package.json` — 将 `@proma/electron` patch 版本从 `0.19.52` 升至 `0.19.53`。

## 测试方法
1. 运行 `bun test apps/electron/src/main/lib/workspace-file-search-limits.test.ts`，确认 2 个边界测试通过。
2. 运行 `bun run --filter='@proma/electron' typecheck`，确认 Electron 包类型检查通过。
3. 运行 `bun run --filter='@proma/electron' build:main`，确认主进程 bundle 构建通过。
4. 在重启后的开发版中，将包含 12,000 个文件的临时目录作为项目级附加目录，搜索索引顺序第 12,000 个文件，确认其能出现在右侧“项目文件”搜索结果中。

## 备注
- 此改动会将未命中缓存时的单来源同步扫描与索引缓存上界提高 50%；建议用 15,000 文件目录记录主进程耗时、事件循环延迟和 RSS，作为运行时压力验证。
- 独立只读审查已完成，未发现 blocker。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
